### PR TITLE
WorkloadDomainIsolation: Storage capacity support to prevent volume provisioning in prohibited zones

### DIFF
--- a/manifests/guestcluster/1.28/pvcsi.yaml
+++ b/manifests/guestcluster/1.28/pvcsi.yaml
@@ -74,6 +74,9 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csistoragecapacities" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch" ]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -318,10 +321,17 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=-1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -380,6 +390,7 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  storageCapacity: true
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/manifests/guestcluster/1.29/pvcsi.yaml
+++ b/manifests/guestcluster/1.29/pvcsi.yaml
@@ -74,6 +74,9 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csistoragecapacities" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch" ]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -318,10 +321,17 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=-1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -380,6 +390,7 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  storageCapacity: true
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/manifests/guestcluster/1.30/pvcsi.yaml
+++ b/manifests/guestcluster/1.30/pvcsi.yaml
@@ -74,6 +74,9 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csistoragecapacities" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch" ]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -318,10 +321,17 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=-1"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -380,6 +390,7 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  storageCapacity: true
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/codes"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	restclient "k8s.io/client-go/rest"
 
 	cnssim "github.com/vmware/govmomi/cns/simulator"
 	pbmsim "github.com/vmware/govmomi/pbm/simulator"
@@ -327,6 +328,19 @@ func (c *FakeK8SOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string,
 
 // InitializeCSINodes creates CSINode instances for each K8s node with the appropriate topology keys.
 func (c *FakeK8SOrchestrator) InitializeCSINodes(ctx context.Context) error {
+	return nil
+}
+
+// StartZonesInformer starts a dynamic informer which listens on Zones CR in
+// topology.tanzu.vmware.com/v1alpha1 API group.
+func (c *FakeK8SOrchestrator) StartZonesInformer(ctx context.Context, restClientConfig *restclient.Config,
+	namespace string) error {
+	return nil
+}
+
+// GetZonesForNamespace fetches the zones associated with a namespace when
+// WorkloadDomainIsolation is supported in supervisor.
+func (c *FakeK8SOrchestrator) GetZonesForNamespace(ns string) map[string]struct{} {
 	return nil
 }
 

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -22,9 +22,9 @@ import (
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	storagev1 "k8s.io/api/storage/v1"
+	restclient "k8s.io/client-go/rest"
 
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
-
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
@@ -86,6 +86,12 @@ type COCommonInterface interface {
 	GetPVNameFromCSIVolumeID(volumeID string) (string, bool)
 	// InitializeCSINodes creates CSINode instances for each K8s node with the appropriate topology keys.
 	InitializeCSINodes(ctx context.Context) error
+	// StartZonesInformer starts a dynamic informer which listens on Zones CR in
+	// topology.tanzu.vmware.com/v1alpha1 API group.
+	StartZonesInformer(ctx context.Context, restClientConfig *restclient.Config, namespace string) error
+	// GetZonesForNamespace fetches the zones associated with a namespace when
+	// WorkloadDomainIsolation is supported in supervisor.
+	GetZonesForNamespace(ns string) map[string]struct{}
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: When a zone is marked is removal, CSI should prevent new volume provisioning to be scheduled on that zone. We will use the StorageCapacity feature to prevent pods using WFFC volumes from being scheduled on zones marked for removal.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

# Before marking zone for removal

Logs

```
{"level":"info","time":"2024-09-12T07:33:54.73200315Z","caller":"k8sorchestrator/topology.go:1816","msg":"Informer to watch on Zones CR starting..","TraceId":"dcc45613-0693-453e-8e2b-645f952a9dd3"}
{"level":"info","time":"2024-09-12T07:33:54.790902166Z","caller":"k8sorchestrator/topology.go:1833","msg":"Zone \"zone-1\" added to namespace \"test-csi\""}
{"level":"info","time":"2024-09-12T07:33:54.791019431Z","caller":"k8sorchestrator/topology.go:1833","msg":"Zone \"zone-2\" added to namespace \"test-csi\""}
{"level":"info","time":"2024-09-12T07:33:54.791957394Z","caller":"k8sorchestrator/topology.go:1833","msg":"Zone \"zone-3\" added to namespace \"test-csi\""}
...
{"level":"info","time":"2024-09-12T07:40:40.849556243Z","caller":"wcpguest/controller.go:1360","msg":"GetCapacity: called with args {VolumeCapabilities:[mount:<> access_mode:<> ] Parameters:map[StorageTopologyType:Zonal svStorageClass:zonal-policy] AccessibleTopology:segments:<key:\"[topology.kubernetes.io/zone\](http://topology.kubernetes.io/zone%5C)" value:\"zone-2\" >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"1180ae04-28a7-4a74-be6a-6d4ef3a4e31b"}
{"level":"info","time":"2024-09-12T07:40:40.858109177Z","caller":"wcpguest/controller.go:1360","msg":"GetCapacity: called with args {VolumeCapabilities:[mount:<> access_mode:<> ] Parameters:map[StorageTopologyType:Zonal svStorageClass:zonal-policy] AccessibleTopology:segments:<key:\"[topology.kubernetes.io/zone\](http://topology.kubernetes.io/zone%5C)" value:\"zone-3\" >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"d545c12f-2724-47a5-bde1-79e731db424d"}
```

```
# kubectl describe csistoragecapacities.storage.k8s.io -n vmware-system-csi
Name:                 csisc-cwsk4
Namespace:            vmware-system-csi
Labels:               csi.storage.k8s.io/drivername=csi.vsphere.vmware.com
                      csi.storage.k8s.io/managed-by=external-provisioner
Annotations:          <none>
API Version:          storage.k8s.io/v1
Capacity:             9223372036854775807
Kind:                 CSIStorageCapacity
Maximum Volume Size:  9223372036854775807
Metadata:
  Creation Timestamp:  2024-09-12T07:37:33Z
  Generate Name:       csisc-
  Resource Version:    27856
  UID:                 2b752697-34aa-4b99-9c45-f0feaa9b8844
Node Topology:
  Match Labels:
    topology.kubernetes.io/zone:  zone-2
Storage Class Name:               zonal-policy-latebinding
Events:                           <none>


Name:                 csisc-tknx8
Namespace:            vmware-system-csi
Labels:               csi.storage.k8s.io/drivername=csi.vsphere.vmware.com
                      csi.storage.k8s.io/managed-by=external-provisioner
Annotations:          <none>
API Version:          storage.k8s.io/v1
Capacity:             9223372036854775807
Kind:                 CSIStorageCapacity
Maximum Volume Size:  9223372036854775807
Metadata:
  Creation Timestamp:  2024-09-12T07:37:33Z
  Generate Name:       csisc-
  Resource Version:    27855
  UID:                 230c3c1f-6538-4a4e-b1dd-f45a81c6c0bc
Node Topology:
  Match Labels:
    topology.kubernetes.io/zone:  zone-3
Storage Class Name:               zonal-policy-latebinding
Events:                           <none>
```

# After marking zone for removal

Logs

```
{"level":"info","time":"2024-09-12T13:41:44.74989956Z","caller":"k8sorchestrator/topology.go:1844","msg":"Zone \"zone-2\" removed from namespace \"test-csi\""}
```

```
# kubectl describe csistoragecapacities.storage.k8s.io -n vmware-system-csi
Name:                 csisc-cwsk4
Namespace:            vmware-system-csi
Labels:               csi.storage.k8s.io/drivername=csi.vsphere.vmware.com
                      csi.storage.k8s.io/managed-by=external-provisioner
Annotations:          <none>
API Version:          storage.k8s.io/v1
Capacity:             0
Kind:                 CSIStorageCapacity
Maximum Volume Size:  0
Metadata:
  Creation Timestamp:  2024-09-12T07:37:33Z
  Generate Name:       csisc-
  Resource Version:    79686
  UID:                 2b752697-34aa-4b99-9c45-f0feaa9b8844
Node Topology:
  Match Labels:
    topology.kubernetes.io/zone:  zone-2
Storage Class Name:               zonal-policy-latebinding
Events:                           <none>


Name:                 csisc-tknx8
Namespace:            vmware-system-csi
Labels:               csi.storage.k8s.io/drivername=csi.vsphere.vmware.com
                      csi.storage.k8s.io/managed-by=external-provisioner
Annotations:          <none>
API Version:          storage.k8s.io/v1
Capacity:             9223372036854775807
Kind:                 CSIStorageCapacity
Maximum Volume Size:  9223372036854775807
Metadata:
  Creation Timestamp:  2024-09-12T07:37:33Z
  Generate Name:       csisc-
  Resource Version:    27855
  UID:                 230c3c1f-6538-4a4e-b1dd-f45a81c6c0bc
Node Topology:
  Match Labels:
    topology.kubernetes.io/zone:  zone-3
Storage Class Name:               zonal-policy-latebinding
Events:                           <none>
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
WorkloadDomainIsolation: Storage capacity support to prevent volume provisioning in prohibited zones
```
