### PR TITLE
upgrade staticcheck and fix staticcheck linter issues

### DIFF
--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -25,7 +25,7 @@ go version
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-go install honnef.co/go/tools/cmd/staticcheck@2023.1
+go install honnef.co/go/tools/cmd/staticcheck@2024.1
 
 GOOS=linux "$(go env GOPATH)"/bin/staticcheck --version
 

--- a/pkg/apis/storagepool/apis.go
+++ b/pkg/apis/storagepool/apis.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Generate deepcopy for apis
-// go:generate go run ../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go
+//go:generate go run ../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go
 //    -O zz_generated.deepcopy -i ./... -h ../../hack/boilerplate.go.txt
 
 // Package apis contains Kubernetes API groups.

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -177,7 +177,7 @@ func (nodes *Nodes) GetSharedDatastoresInK8SCluster(ctx context.Context) (
 	if len(nodeVMs) == 0 {
 		errMsg := "empty List of Node VMs returned from nodeManager"
 		log.Errorf(errMsg)
-		return make([]*cnsvsphere.DatastoreInfo, 0), fmt.Errorf(errMsg)
+		return make([]*cnsvsphere.DatastoreInfo, 0), fmt.Errorf("%s", errMsg)
 	}
 	sharedDatastores, err := cnsvsphere.GetSharedDatastoresForVMs(ctx, nodeVMs)
 	if err != nil {

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -493,7 +493,7 @@ func validateSnapshotDeleted(ctx context.Context, m *defaultManager, volumeID st
 		return false
 	}
 
-	if querySnapshotResult.Entries == nil || len(querySnapshotResult.Entries) == 0 {
+	if len(querySnapshotResult.Entries) == 0 {
 		log.Infof("failed to validate for snapshot %s on volume %s as the "+
 			"querySnapshotResult.Entries is empty", snapshotID, volumeID)
 		return false

--- a/pkg/common/cns-lib/vsphere/datacenter.go
+++ b/pkg/common/cns-lib/vsphere/datacenter.go
@@ -187,7 +187,7 @@ func (dc *Datacenter) GetVMMoList(ctx context.Context, vmObjList []*VirtualMachi
 	if len(vmObjList) < 1 {
 		msg := "VirtualMachine Object list is empty"
 		log.Errorf(msg+": %v", vmObjList)
-		return nil, fmt.Errorf(msg)
+		return nil, fmt.Errorf("%s", msg)
 	}
 
 	for _, vmObj := range vmObjList {

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -746,7 +746,7 @@ func (vc *VirtualCenter) GetAllVirtualMachines(ctx context.Context,
 	if len(hostObjList) < 1 {
 		msg := "host object list is empty"
 		log.Errorf(msg+": %v", hostObjList)
-		return nil, fmt.Errorf(msg)
+		return nil, fmt.Errorf("%s", msg)
 	}
 
 	properties := []string{"vm"}

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -695,7 +695,7 @@ func GetClusterFlavor(ctx context.Context) (cnstypes.CnsClusterFlavor, error) {
 	}
 	errMsg := "unrecognized value set for CLUSTER_FLAVOR"
 	log.Error(errMsg)
-	return "", fmt.Errorf(errMsg)
+	return "", fmt.Errorf("%s", errMsg)
 }
 
 // GetConfig loads configuration from secret and returns config object.

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -354,7 +354,7 @@ func IsVolumeSnapshotReady(ctx context.Context, client snapshotterClientSet.Inte
 		if waitErr != nil {
 			msg += fmt.Sprintf(": message: %v", waitErr.Error())
 		}
-		return false, nil, fmt.Errorf(msg)
+		return false, nil, fmt.Errorf("%s", msg)
 	}
 
 	return true, svs, nil

--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -661,7 +661,7 @@ func (osUtils *OsUtils) RescanDevice(ctx context.Context, dev *Device) error {
 	if err != nil {
 		msg := fmt.Sprintf("error rescanning block device %q. %v", dev.RealDev, err)
 		log.Error(msg)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 	return nil
 }

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -117,8 +117,8 @@ func (f *FakeNodeManager) GetSharedDatastoresInK8SCluster(ctx context.Context) (
 
 	if len(nodeVMs) == 0 {
 		errMsg := "empty List of Node VMs received from nodeManager"
-		t.Errorf(errMsg)
-		return nil, fmt.Errorf(errMsg)
+		t.Errorf("%s", errMsg)
+		return nil, fmt.Errorf("%s", errMsg)
 	}
 
 	sharedDatastores, err := cnsvsphere.GetSharedDatastoresForVMs(ctx, nodeVMs)

--- a/pkg/syncer/k8scloudoperator/placement.go
+++ b/pkg/syncer/k8scloudoperator/placement.go
@@ -648,11 +648,9 @@ func eliminateNodesWithPvcOfSiblingReplica(ctx context.Context, client kubernete
 			// value will always be defined on the PV. However, the following checks
 			// are needed to avoid nil pointer exceptions.
 			nodeAffinitySpec := pv.Spec.NodeAffinity.Required
-			if nodeAffinitySpec.NodeSelectorTerms != nil && len(nodeAffinitySpec.NodeSelectorTerms) != 0 {
-				if nodeAffinitySpec.NodeSelectorTerms[0].MatchExpressions != nil &&
-					len(nodeAffinitySpec.NodeSelectorTerms[0].MatchExpressions) != 0 {
-					if nodeAffinitySpec.NodeSelectorTerms[0].MatchExpressions[0].Values != nil &&
-						len(nodeAffinitySpec.NodeSelectorTerms[0].MatchExpressions[0].Values) != 0 {
+			if len(nodeAffinitySpec.NodeSelectorTerms) != 0 {
+				if len(nodeAffinitySpec.NodeSelectorTerms[0].MatchExpressions) != 0 {
+					if len(nodeAffinitySpec.NodeSelectorTerms[0].MatchExpressions[0].Values) != 0 {
 						hostName = nodeAffinitySpec.NodeSelectorTerms[0].MatchExpressions[0].Values[0]
 					}
 				}

--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -535,7 +535,7 @@ func (state *intendedState) getStoragePoolError() *v1alpha1.StoragePoolError {
 	if state.allHostsInMM {
 		return v1alpha1.SpErrors[v1alpha1.ErrStateAllHostsInMM]
 	}
-	if state.nodes == nil || len(state.nodes) == 0 {
+	if len(state.nodes) == 0 {
 		return v1alpha1.SpErrors[v1alpha1.ErrStateNoAccessibleHosts]
 	}
 	return nil

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -934,7 +934,7 @@ func verifyCnsVolumeMetadata4GCVol(volumeID string, svcPVCName string, gcPvc *v1
 
 	cnsQueryResult, err := e2eVSphere.queryCNSVolumeWithResult(volumeID)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	if cnsQueryResult.Volumes == nil || len(cnsQueryResult.Volumes) == 0 {
+	if len(cnsQueryResult.Volumes) == 0 {
 		framework.Logf("CNS volume query yielded no results for volume id: " + volumeID)
 		return false
 	}

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -927,7 +927,7 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim,
 		cnsQueryResult, err = multiVCe2eVSphere.queryCNSVolumeWithResultInMultiVC(volumeID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
-	if cnsQueryResult.Volumes == nil || len(cnsQueryResult.Volumes) == 0 {
+	if len(cnsQueryResult.Volumes) == 0 {
 		framework.Logf("CNS volume query yielded no results for volume id: " + volumeID)
 		return false
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
upgrade staticcheck and fix staticcheck linter issues

Linter issues

```
pkg/apis/storagepool/apis.go:18:1: ineffectual compiler directive due to extraneous space: "// go:generate go run ../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go" (SA9009)
pkg/common/cns-lib/node/nodes.go:180:48: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/common/cns-lib/volume/util.go:496:5: should omit nil check; len() for []github.com/vmware/govmomi/cns/types.CnsSnapshotQueryResultEntry is defined as zero (S1009)
pkg/common/cns-lib/vsphere/datacenter.go:190:15: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/common/cns-lib/vsphere/virtualcenter.go:749:15: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/common/config/config.go:698:13: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/csi/service/common/common_controller_helper.go:357:22: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/csi/service/osutils/linux_os_utils.go:664:10: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/csi/service/vanilla/controller_test.go:120:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/csi/service/vanilla/controller_test.go:121:15: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/syncer/k8scloudoperator/placement.go:651:7: should omit nil check; len() for []k8s.io/api/core/v1.NodeSelectorTerm is defined as zero (S1009)
pkg/syncer/k8scloudoperator/placement.go:652:8: should omit nil check; len() for []k8s.io/api/core/v1.NodeSelectorRequirement is defined as zero (S1009)
pkg/syncer/k8scloudoperator/placement.go:654:9: should omit nil check; len() for []string is defined as zero (S1009)
pkg/syncer/storagepool/intended_state.go:538:5: should omit nil check; len() for []string is defined as zero (S1009)
tests/e2e/fullsync_test_for_block_volume.go:937:5: should omit nil check; len() for []github.com/vmware/govmomi/cns/types.CnsVolume is defined as zero (S1009)
tests/e2e/vcp_to_csi_create_delete.go:930:5: should omit nil check; len() for []github.com/vmware/govmomi/cns/types.CnsVolume is defined as zero (S1009)
```




**Testing done**:
Not required. As this is just a linter fixes.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrade staticcheck and fix staticcheck linter issues
```
