### PR TITLE
bump query limit to 10k

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -36,7 +36,7 @@ const (
 	DefaultQuerySnapshotLimit = int64(128)
 	// queryVolumeLimit is the page size, which should be set in the cursor when driver needs to
 	// query many volumes using QueryVolume API
-	queryVolumeLimit = int64(1000)
+	queryVolumeLimit = int64(10000)
 )
 
 // QueryVolumeUtil helps to invoke query volume API based on the feature

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -49,8 +49,8 @@ const (
 
 	// allowedRetriesToPatchStoragePolicyUsage indicates number of retries allowed for patching StoragePolicyUsage CR
 	allowedRetriesToPatchStoragePolicyUsage = 5
-	// volumdIDLimitPerQuery is set to 1000
-	volumdIDLimitPerQuery = 1000
+	// volumdIDLimitPerQuery is set to 10000
+	volumdIDLimitPerQuery = 10000
 )
 
 // getPVsInBoundAvailableOrReleased return PVs in Bound, Available or Released


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
bump query limit to 10k

vCenter is updated to support query page size 10k and volumeIds limit to 10k for query volume API.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
bump query limit to 10k
```
