### PR TITLE
fix: set volumeid for file volume response from cns response

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -870,7 +870,6 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 		zoneLabelPresent     bool
 		err                  error
 		volumeInfo           *cnsvolume.CnsVolumeInfo
-		volumeID             string
 		faultType            string
 	)
 
@@ -1036,12 +1035,17 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 			"failed to create volume. Error: %+v", err)
 	}
 
+	if volumeInfo == nil {
+		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
+			"nil response for volumeInfo")
+	}
+
 	attributes := make(map[string]string)
 	attributes[common.AttributeDiskType] = common.DiskTypeFileVolume
 
 	resp := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      volumeID,
+			VolumeId:      volumeInfo.VolumeID.Id,
 			CapacityBytes: int64(units.FileSize(volSizeMB * common.MbInBytes)),
 			VolumeContext: attributes,
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixes regression from https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3009 where we were returning empty volume handle as response to provisioner causing PVC to not go into bound state. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
root@4203cd5b838ec14743e125450cb17eab [ ~ ]# k --kubeconfig kubeconfig get pvc
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-vanilla-file-pvc   Bound    pvc-fd5943c0-4c6e-4170-9ff9-81f91cf67ba9   5Gi        RWX            wcpglobal-storage-profile   <unset>                 116m
root@4203cd5b838ec14743e125450cb17eab [ ~ ]# k -n adi-ns get pvc
NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
94b87033-1f61-41d0-ab77-50106dc2c552-fd5943c0-4c6e-4170-9ff9-81f91cf67ba9   Bound    pvc-5ef92bf6-43f5-4e2c-af34-e4e72c5ff4bb   5Gi        RWX            wcpglobal-storage-profile   <unset>                 67m
root@4203cd5b838ec14743e125450cb17eab [ ~ ]# k get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                              STORAGECLASS                VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-5ef92bf6-43f5-4e2c-af34-e4e72c5ff4bb   5Gi        RWX            Delete           Bound    adi-ns/94b87033-1f61-41d0-ab77-50106dc2c552-fd5943c0-4c6e-4170-9ff9-81f91cf67ba9   wcpglobal-storage-profile   <unset>                          66m
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
