### PR TITLE
fixes for 50k volume support

### DIFF
--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -273,7 +273,6 @@ spec:
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
             - "--worker-threads=100"
-            - "--reconcile-sync=10m"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -273,7 +273,6 @@ spec:
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
             - "--worker-threads=100"
-            - "--reconcile-sync=10m"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -273,7 +273,6 @@ spec:
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
             - "--worker-threads=100"
-            - "--reconcile-sync=10m"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -49,8 +49,8 @@ const (
 
 	// allowedRetriesToPatchStoragePolicyUsage indicates number of retries allowed for patching StoragePolicyUsage CR
 	allowedRetriesToPatchStoragePolicyUsage = 5
-	// volumdIDLimitPerQuery is set to 1000
-	volumdIDLimitPerQuery = 1000
+	// volumdIDLimitPerQuery is set to 10000
+	volumdIDLimitPerQuery = 10000
 )
 
 // getPVsInBoundAvailableOrReleased return PVs in Bound, Available or Released


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. This PR is reverting the `--reconcile-sync=10m` interval set on the CSI controller. This change was made when QueryAll volume API was replaced with QueryVolume API with pagination. We no longer need this change, as we will not be supporting 50k volumes per supervisor cluster.  

2.  QueryAllVolumesForCluster func should be using QueryAll volume API and not QueryVolume API as all the placed we are using this API need single snapshot of volumes in the CNS.

3. Increasing volumdIDLimitPerQuery limit from 1k to 10k, as vCenter has support for taking 10k volumeIDs. Initially we added this limit to 1k to avoid sqldump, but now vCenter has support for 10k volumeid as input in the queryfilter, bumping up limit to 10k.



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixes for 50k volume support
```
