### PR TITLE
Remove reconcile-sync time of 10 min from csi-attacher sidecar

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -273,7 +273,6 @@ spec:
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
             - "--worker-threads=100"
-            - "--reconcile-sync=10m"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -252,7 +252,6 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--worker-threads=100"
-            - "--reconcile-sync=10m"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Remove reconcile-sync time of 10 min from csi-attacher sidecar. 

We have removed it from other files from PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3047, so removing it from all relevant files.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove reconcile-sync time of 10 min from csi-attacher sidecar
```
