### PR TITLE
Handle vc reboot session invalid for listview

### DIFF
--- a/pkg/common/cns-lib/volume/listview_if.go
+++ b/pkg/common/cns-lib/volume/listview_if.go
@@ -24,4 +24,9 @@ type ListViewIf interface {
 	// MarkTaskForDeletion marks a given task MoRef for deletion by a cleanup goroutine
 	// use case: failure to remove task due to a vc issue
 	MarkTaskForDeletion(ctx context.Context, taskMoRef types.ManagedObjectReference) error
+	// IsListViewReady returns the status of the listview + property collector mechanism
+	IsListViewReady() bool
+	// SetListViewNotReady explicitly states the listview state as not ready
+	// use case: unit tests
+	SetListViewNotReady(ctx context.Context)
 }

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -145,6 +145,11 @@ type Manager interface {
 		string, error)
 	// GetOperationStore returns the VolumeOperationRequest interface
 	GetOperationStore() cnsvolumeoperationrequest.VolumeOperationRequest
+	// IsListViewReady returns the status of the listview + property collector mechanism
+	IsListViewReady() bool
+	// SetListViewNotReady explicitly states the listview state as not ready
+	// use case: unit tests
+	SetListViewNotReady(ctx context.Context)
 }
 
 // CnsVolumeInfo hold information related to volume created by CNS.
@@ -3019,4 +3024,17 @@ func (m *defaultManager) getAggregatedSnapshotSize(ctx context.Context, volumeID
 		}
 	}
 	return aggregatedSnapshotCapacity, nil
+}
+
+func (m *defaultManager) IsListViewReady() bool {
+	if m.listViewIf == nil {
+		return false
+	}
+	return m.listViewIf.IsListViewReady()
+}
+
+func (m *defaultManager) SetListViewNotReady(ctx context.Context) {
+	if m.listViewIf != nil {
+		m.listViewIf.SetListViewNotReady(ctx)
+	}
 }

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -341,9 +341,11 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 
 	log.Infof("logging out current session and clearing idle sessions")
 
-	err = vc.Client.Logout(ctx)
-	if err != nil {
-		log.Errorf("failed to logout current session. still clearing idle sessions. err: %v", err)
+	if vc.Client != nil && vc.Client.Client != nil {
+		err = vc.Client.Logout(ctx)
+		if err != nil {
+			log.Errorf("failed to logout current session. still clearing idle sessions. err: %v", err)
+		}
 	}
 
 	// If session has expired, create a new instance.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR refactors the listview session logic. 

A new `isReady` boolean represents the status of the listview + property collector mechanism. When this is true, the property collector is listening, when this is false, it's in the process of being created/re-created. 

`ResetVirtualCenter` will store the latest VirtualCenter object reference when a credential change happens but not invalidate the ongoing property collector connection. 

`isSessionValid` will check if the ongoing session is valid. If it's invalid, it will set the `isReady` to false and cancel the context on which the property collector is running. This will cause the listview object and property collector to be re-created but this time with the most updated credentials. 

`AddTask` & `RemoveTask` will first check if the `isReady` state before performing any other operations. Even after checking if `isReady` is true and session is valid  but adding task to listview returns an error, this means that the credentials with which the listview object was created is no longer valid. So, it will set the `isReady` to false, cancel the property collector context, return failure and let listenToTaskUpdates() re-create the listview object and start listening again. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

### session killed from VC
```
{"level":"error","time":"2024-10-11T17:53:39.853251518Z","caller":"volume/listview.go:334","msg":"WaitForUpdates returned err: destroy property filter failed with ServerFaultCode: The session is not authenticated. after failing to wait for updates: ServerFaultCode: The task was canceled by a user. for vc: sc2-10-212-76-196.nimbus.eng.vmware.com","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume.(*ListViewImpl).listenToTaskUpdates\n\t/build/pkg/common/cns-lib/volume/listview.go:334"}
{"level":"info","time":"2024-10-11T17:53:39.855328528Z","caller":"volume/listview.go:338","msg":"waiting for lock","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:39.855382396Z","caller":"volume/listview.go:340","msg":"setting listview ready state to false. current ready state: true","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:39.855669607Z","caller":"volume/listview.go:342","msg":"listview ready state is false","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:39.873438166Z","caller":"vsphere/virtualcenter.go:330","msg":"logging out current session and clearing idle sessions","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"error","time":"2024-10-11T17:53:39.894861336Z","caller":"vsphere/virtualcenter.go:335","msg":"failed to logout current session. still clearing idle sessions. err: ServerFaultCode: The session is not authenticated.","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere.(*VirtualCenter).connect\n\t/build/pkg/common/cns-lib/vsphere/virtualcenter.go:335\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere.(*VirtualCenter).Connect\n\t/build/pkg/common/cns-lib/vsphere/virtualcenter.go:270\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume.(*ListViewImpl).isConnected\n\t/build/pkg/common/cns-lib/volume/listview.go:269\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume.(*ListViewImpl).listenToTaskUpdates\n\t/build/pkg/common/cns-lib/volume/listview.go:286"}
{"level":"info","time":"2024-10-11T17:53:39.897345568Z","caller":"vsphere/virtualcenter.go:340","msg":"Creating a new client session as the existing one isn't valid or not authenticated","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:40.076817656Z","caller":"vsphere/virtualcenter.go:213","msg":"New session ID for 'VSPHERE.LOCAL\\wcp-storage-user-66a68fad-7ddc-4980-a47d-8c44b0ae9faa-e37e61cd-fdc0-4f3a-b9c9-359b7c79c24b' = 52d9b959-3589-bcb3-1f8e-36a40c861986","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:40.084088176Z","caller":"volume/listview.go:291","msg":"connection to vc successful","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:40.084445873Z","caller":"volume/listview.go:294","msg":"attempting lock before ","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:40.084479217Z","caller":"volume/listview.go:297","msg":"re-creating the listView object","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:40.11002682Z","caller":"volume/listview.go:103","msg":"created listView object ListView:session[52f2780b-478c-55b1-2bc5-18f2aed7521b]5296bda8-d591-a205-2d8d-b7133e0abd31 for virtualCenter: sc2-10-212-76-196.nimbus.eng.vmware.com","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:40.111001425Z","caller":"volume/listview.go:310","msg":"Starting listening for task updates...","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:40.111061607Z","caller":"volume/listview.go:311","msg":"waitForUpdatesContext context.Background.WithCancel","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
{"level":"info","time":"2024-10-11T17:53:40.11107162Z","caller":"volume/listview.go:314","msg":"listview ready state is true","TraceId":"083664d8-85fe-4a1e-acc3-5e2c183f2c3a"}
```

2/2 passing for snapshot restore during VC reboot test but logs not captured and setup is now cleaned up. 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
