### PR TITLE
Set dev.version on CNS clients and Vim clients for fetching aggregatedSnapshotCapacity from CNS APIs

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -73,9 +73,6 @@ const (
 
 	// MbInBytes is the number of bytes in one mebibyte.
 	MbInBytes = int64(1024 * 1024)
-
-	// fcdQueryRtinfoSkipRuntimeIosz is the version need to set on vc client
-	cnsDevVersion = "dev.version"
 )
 
 // Manager provides functionality to manage volumes.
@@ -123,7 +120,7 @@ type Manager interface {
 	// should not be nil.
 	ExpandVolume(ctx context.Context, volumeID string, size int64, extraParams interface{}) (string, error)
 	// ResetManager helps set new manager instance and VC configuration.
-	ResetManager(ctx context.Context, vcenter *cnsvsphere.VirtualCenter, isStorageQuotaM2FSSEnabled bool) error
+	ResetManager(ctx context.Context, vcenter *cnsvsphere.VirtualCenter) error
 	// ConfigureVolumeACLs configures net permissions for a given CnsVolumeACLConfigureSpec.
 	ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error
 	// RegisterDisk registers virtual disks as FCDs using Vslm endpoint.
@@ -238,29 +235,11 @@ type createVolumeTaskDetails struct {
 func GetManager(ctx context.Context, vc *cnsvsphere.VirtualCenter,
 	operationStore cnsvolumeoperationrequest.VolumeOperationRequest,
 	idempotencyHandlingEnabled, multivCenterEnabled,
-	multivCenterTopologyDeployment, isStorageQuotaM2FSSEnabled bool,
+	multivCenterTopologyDeployment bool,
 	clusterFlavor cnstypes.CnsClusterFlavor) (Manager, error) {
 	log := logger.GetLogger(ctx)
 	managerInstanceLock.Lock()
-	defer func() {
-		if isStorageQuotaM2FSSEnabled && managerInstance != nil {
-			log.Infof("use version %s for vCenter client", cnsDevVersion)
-			if managerInstance.virtualCenter.Client != nil {
-				log.Infof("Setting version %s to vCenter: %q vim25 client",
-					cnsDevVersion, managerInstance.virtualCenter.Config.Host)
-				managerInstance.virtualCenter.Client.Version = cnsDevVersion
-			}
-			if managerInstance.virtualCenter.CnsClient != nil {
-				log.Infof("Setting version %s to vCenter: %q cns client",
-					cnsDevVersion, managerInstance.virtualCenter.Config.Host)
-				managerInstance.virtualCenter.CnsClient.Version = cnsDevVersion
-				managerInstance.virtualCenter.CnsClient.Client.Version = cnsDevVersion
-			}
-			log.Infof("using CNS API version %s for vCenters %q client ",
-				cnsDevVersion, managerInstance.virtualCenter.Config.Host)
-		}
-		managerInstanceLock.Unlock()
-	}()
+	defer managerInstanceLock.Unlock()
 	if !multivCenterEnabled {
 		if managerInstance != nil {
 			log.Infof("Retrieving existing defaultManager...")
@@ -372,27 +351,11 @@ func ClearInvalidTasksFromListView(multivCenterCSITopologyEnabled bool) {
 }
 
 // ResetManager helps set manager instance with new VC configuration.
-func (m *defaultManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-	isStorageQuotaM2FSSEnabled bool) error {
+func (m *defaultManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.VirtualCenter) error {
 	log := logger.GetLogger(ctx)
 	managerInstanceLock.Lock()
 	defer managerInstanceLock.Unlock()
 	log.Infof("Re-initializing defaultManager.virtualCenter")
-	if isStorageQuotaM2FSSEnabled {
-		log.Infof("use version %s for vCenter client", cnsDevVersion)
-		if managerInstance.virtualCenter.Client != nil {
-			log.Infof("Setting version %s to vCenter: %q vim25 client",
-				cnsDevVersion, managerInstance.virtualCenter.Config.Host)
-			managerInstance.virtualCenter.Client.Version = cnsDevVersion
-		}
-		if managerInstance.virtualCenter.CnsClient != nil {
-			log.Infof("Setting version %s to vCenter: %q cns client",
-				cnsDevVersion, managerInstance.virtualCenter.Config.Host)
-			managerInstance.virtualCenter.CnsClient.Version = cnsDevVersion
-			managerInstance.virtualCenter.CnsClient.Client.Version = cnsDevVersion
-		}
-	}
-
 	managerInstance.virtualCenter = vcenter
 	m.listViewIf.ResetVirtualCenter(ctx, managerInstance.virtualCenter)
 	log.Infof("Done resetting volume.defaultManager")

--- a/pkg/common/cns-lib/vsphere/cns.go
+++ b/pkg/common/cns-lib/vsphere/cns.go
@@ -33,6 +33,14 @@ func NewCnsClient(ctx context.Context, c *vim25.Client) (*cns.Client, error) {
 		return nil, err
 	}
 	cnsClient.RoundTripper = &MetricRoundTripper{"cns", cnsClient.RoundTripper}
+
+	// TODO: remove code to add version to CNS API, once CNS releases the next version.
+	if UseCnsAPIDevVersion {
+		log.Infof("Setting dev.version on new CNS client")
+		cnsClient.Version = cnsDevVersion
+		cnsClient.Client.Version = cnsDevVersion
+	}
+
 	return cnsClient, nil
 }
 

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -60,6 +60,9 @@ const (
 	statusSuccess = "success"
 	// failed request
 	statusFailUnknown = "fail-unknown"
+
+	// cnsDevVersion is the CNS API development version
+	cnsDevVersion = "dev.version"
 )
 
 // VirtualCenter holds details of a virtual center instance.
@@ -97,6 +100,9 @@ var (
 	vCenterInstanceLock = &sync.RWMutex{}
 	// vCenterInstancesLock makes sure only one vCenter being initialized for specific host
 	vCenterInstancesLock = &sync.RWMutex{}
+
+	// UseCnsAPIDevVersion sets dev.version on CNS vim25 and CNS soap clients
+	UseCnsAPIDevVersion bool
 )
 
 func (vc *VirtualCenter) String() string {
@@ -311,6 +317,12 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 			return err
 		}
 		log.Infof("VirtualCenter.connect() successfully created new client")
+
+		// TODO: remove code to add version to CNS API, once CNS releases the next version.
+		if UseCnsAPIDevVersion && vc.Client != nil {
+			log.Infof("CNS vim25 client was nil, setting dev.version on new CNS vim25 client")
+			vc.Client.Version = cnsDevVersion
+		}
 		return nil
 	}
 	if !requestNewSession {
@@ -348,6 +360,10 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 			log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 		}
 		return err
+	}
+	if UseCnsAPIDevVersion && vc.Client != nil {
+		log.Infof("Setting dev.version on new CNS vim25 client")
+		vc.Client.Version = cnsDevVersion
 	}
 	// Recreate PbmClient if created using timed out VC Client.
 	if vc.PbmClient != nil {

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -141,7 +141,7 @@ func TestQuerySnapshotsUtil(t *testing.T) {
 	// Create context
 	commonUtilsTestInstance := getCommonUtilsTest(t)
 
-	volumeManager, err := cnsvolumes.GetManager(ctx, commonUtilsTestInstance.vcenter, nil, false, false, false, false, "")
+	volumeManager, err := cnsvolumes.GetManager(ctx, commonUtilsTestInstance.vcenter, nil, false, false, false, "")
 	if err != nil {
 		t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 	}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -155,7 +155,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		vc.Config = vcenterconfig
 		volumeManager, err := cnsvolume.GetManager(ctx, vc, operationStore,
 			true, false,
-			false, false, cnstypes.CnsClusterFlavorVanilla)
+			false, cnstypes.CnsClusterFlavorVanilla)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}
@@ -220,7 +220,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			c.managers.VcenterConfigs[vcenterconfig.Host] = vcenterconfig
 			volumeManager, err := cnsvolume.GetManager(ctx, vcenter,
 				operationStore, true, true,
-				multivCenterTopologyDeployment, false, cnstypes.CnsClusterFlavorVanilla)
+				multivCenterTopologyDeployment, cnstypes.CnsClusterFlavorVanilla)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 			}
@@ -408,7 +408,7 @@ func (c *controller) ReloadConfiguration() error {
 				return logger.LogNewErrorf(log, "failed to get VirtualCenter. err=%v", err)
 			}
 			vcenter.Config = newVCConfig
-			err := c.managers.VolumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter, false)
+			err := c.managers.VolumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to reset updated VC object in volumemanager for vCenter: %q "+
 					"err=%v", newVCConfig.Host, err)
@@ -460,7 +460,7 @@ func (c *controller) ReloadConfiguration() error {
 				c.authMgr.ResetvCenterInstance(ctx, vcenter)
 				log.Info("Updated vCenter in auth manager")
 			}
-			err = c.manager.VolumeManager.ResetManager(ctx, vcenter, false)
+			err = c.manager.VolumeManager.ResetManager(ctx, vcenter)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 			}

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -218,7 +218,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 
 		volumeManager, err := cnsvolume.GetManager(ctx, vcenter,
 			fakeOpStore, true, false,
-			false, false, cnstypes.CnsClusterFlavorVanilla)
+			false, cnstypes.CnsClusterFlavorVanilla)
 		if err != nil {
 			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/csi/service/vanilla/controller_topology_test.go
+++ b/pkg/csi/service/vanilla/controller_topology_test.go
@@ -361,14 +361,14 @@ func getControllerTestWithTopology(t *testing.T) *controllerTestTopology {
 
 		volumeManager, err := cnsvolume.GetManager(ctxtopology, vcenter,
 			fakeOpStore, true, false,
-			false, false, cnstypes.CnsClusterFlavorVanilla)
+			false, cnstypes.CnsClusterFlavorVanilla)
 		if err != nil {
 			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 		}
 		// GetManager returns a singleton instance of VolumeManager. So, it could be pointing
 		// to old VC instance as part of previous unit test run from same folder.
 		// Call ResetManager to get new VolumeManager instance with current VC configuration.
-		err = volumeManager.ResetManager(ctxtopology, vcenter, false)
+		err = volumeManager.ResetManager(ctxtopology, vcenter)
 		if err != nil {
 			t.Fatalf("failed to reset volume manager with new vcenter. err=%v", err)
 		}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -154,8 +154,6 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		common.WorkloadDomainIsolation)
 	idempotencyHandlingEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.CSIVolumeManagerIdempotency)
-	isStorageQuotaM2FSSEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
-		common.StorageQuotaM2)
 	if idempotencyHandlingEnabled {
 		log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
 		operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx,
@@ -171,7 +169,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 
 	volumeManager, err := cnsvolume.GetManager(ctx, vcenter, operationStore,
 		idempotencyHandlingEnabled, false,
-		false, isStorageQuotaM2FSSEnabled, cnstypes.CnsClusterFlavorWorkload)
+		false, cnstypes.CnsClusterFlavorWorkload)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 	}
@@ -377,8 +375,6 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 		}
 		idempotencyHandlingEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.CSIVolumeManagerIdempotency)
-		isStorageQuotaM2FSSEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
-			common.StorageQuotaM2)
 		if idempotencyHandlingEnabled {
 			log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
 			operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx,
@@ -391,7 +387,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 				return err
 			}
 		}
-		err := c.manager.VolumeManager.ResetManager(ctx, vcenter, isStorageQuotaM2FSSEnabled)
+		err := c.manager.VolumeManager.ResetManager(ctx, vcenter)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 		}
@@ -399,7 +395,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 
 		volumeManager, err := cnsvolume.GetManager(ctx, vcenter, operationStore,
 			idempotencyHandlingEnabled, false,
-			false, isStorageQuotaM2FSSEnabled, cnstypes.CnsClusterFlavorWorkload)
+			false, cnstypes.CnsClusterFlavorWorkload)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -117,6 +117,12 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			"Setting correct CA file: %q", config.Global.CAFile, cnsconfig.SupervisorCAFilePath)
 		config.Global.CAFile = cnsconfig.SupervisorCAFilePath
 	}
+
+	// TODO: remove code to add version to CNS API, once CNS releases the next version.
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.StorageQuotaM2) {
+		cnsvsphere.UseCnsAPIDevVersion = true
+	}
+
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
 		clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
 		if err != nil {

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -114,7 +114,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 
 		volumeManager, err := cnsvolume.GetManager(ctx, vcenter,
 			fakeOpStore, true, false,
-			false, false, cnstypes.CnsClusterFlavorWorkload)
+			false, cnstypes.CnsClusterFlavorWorkload)
 		if err != nil {
 			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -323,6 +323,13 @@ func InitCommonModules(ctx context.Context, clusterFlavor cnstypes.CnsClusterFla
 		log.Errorf("failed to create CO agnostic interface. Err: %v", err)
 		return err
 	}
+
+	// TODO: remove code to add version to CNS API, once CNS releases the next version.
+	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.StorageQuotaM2) {
+		cnsvsphere.UseCnsAPIDevVersion = true
+	}
+
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TriggerCsiFullSync) {
 		log.Infof("Triggerfullsync feature enabled")
 		err := k8s.CreateCustomResourceDefinitionFromManifest(ctx, internalapiscnsoperatorconfig.EmbedTriggerCsiFullSync,

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -94,7 +94,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}
 		}
 
-		volumeManager, err = volumes.GetManager(ctx, vCenter, nil, false, false, false, false, clusterFlavor)
+		volumeManager, err = volumes.GetManager(ctx, vCenter, nil, false, false, false, clusterFlavor)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -317,7 +317,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
 
 		volumeManager, err := volumes.GetManager(ctx, vCenter,
-			nil, false, false, false, isStorageQuotaM2FSSEnabled, metadataSyncer.clusterFlavor)
+			nil, false, false, false, metadataSyncer.clusterFlavor)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}
@@ -383,7 +383,8 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			volumeInfoCrDeletionMap[metadataSyncer.host] = make(map[string]bool)
 			volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
 
-			volumeManager, err := volumes.GetManager(ctx, vCenter, nil, false, false, false, false, metadataSyncer.clusterFlavor)
+			volumeManager, err := volumes.GetManager(ctx, vCenter, nil, false, false, false,
+				metadataSyncer.clusterFlavor)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 			}
@@ -407,7 +408,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				}
 				volumeManager, err := volumes.GetManager(ctx, vCenter,
 					nil, false, true,
-					multivCenterTopologyDeployment, false, metadataSyncer.clusterFlavor)
+					multivCenterTopologyDeployment, metadataSyncer.clusterFlavor)
 				if err != nil {
 					return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 				}
@@ -1527,7 +1528,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 						return logger.LogNewErrorf(log, "failed to get VirtualCenter. err=%v", err)
 					}
 					vcenter.Config = newVCConfig
-					err := metadataSyncer.volumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter, isStorageQuotaM2FSSEnabled)
+					err := metadataSyncer.volumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter)
 					if err != nil {
 						return logger.LogNewErrorf(log, "failed to reset updated VC object in volumemanager for vCenter: %q "+
 							"err=%v", newVCConfig.Host, err)
@@ -1562,7 +1563,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 					return logger.LogNewErrorf(log, "failed to get VirtualCenter. err=%v", err)
 				}
 				vcenter.Config = newVCConfig
-				err := metadataSyncer.volumeManager.ResetManager(ctx, vcenter, isStorageQuotaM2FSSEnabled)
+				err := metadataSyncer.volumeManager.ResetManager(ctx, vcenter)
 				if err != nil {
 					return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 				}
@@ -1613,12 +1614,12 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 				}
 				vcenter.Config = newVCConfig
 			}
-			err := metadataSyncer.volumeManager.ResetManager(ctx, vcenter, isStorageQuotaM2FSSEnabled)
+			err := metadataSyncer.volumeManager.ResetManager(ctx, vcenter)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 			}
 			volumeManager, err := volumes.GetManager(ctx, vcenter, nil, false, false, false,
-				isStorageQuotaM2FSSEnabled, metadataSyncer.clusterFlavor)
+				metadataSyncer.clusterFlavor)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 			}

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -105,7 +105,7 @@ func (w *DiskDecommController) detachVolumes(ctx context.Context, storagePoolNam
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to get cluster flavor. Error: %v", err)
 	}
-	volManager, err := volume.GetManager(ctx, &vc, nil, false, false, false, false, clusterFlavor)
+	volManager, err := volume.GetManager(ctx, &vc, nil, false, false, false, clusterFlavor)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 	}

--- a/pkg/syncer/storagepool/migrationController.go
+++ b/pkg/syncer/storagepool/migrationController.go
@@ -84,7 +84,7 @@ func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID st
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to get cluster flavor. Error: %v", err)
 	}
-	volManager, err := volume.GetManager(ctx, m.vc, nil, false, false, false, false, clusterFlavor)
+	volManager, err := volume.GetManager(ctx, m.vc, nil, false, false, false, clusterFlavor)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 	}

--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -189,24 +189,6 @@ func ResetVC(ctx context.Context, vc *cnsvsphere.VirtualCenter) {
 		log.Errorf("Failed to connect to SPBM service. Err: %+v", err)
 		return
 	}
-	// TODO remove code to add version to CNS API, once CNS releases the next version.
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.StorageQuotaM2) {
-		cnsDevVersion := "dev.version"
-		log.Infof("use version %s for vCenter client", cnsDevVersion)
-		if vc.Client != nil {
-			log.Infof("Setting version %s to vCenter: %q vim25 client",
-				cnsDevVersion, vc.Config.Host)
-			vc.Client.Version = cnsDevVersion
-		}
-		if vc.CnsClient != nil {
-			log.Infof("Setting version %s to vCenter: %q cns client",
-				cnsDevVersion, vc.Config.Host)
-			vc.CnsClient.Version = cnsDevVersion
-			vc.CnsClient.Client.Version = cnsDevVersion
-		}
-		log.Infof("using CNS API version %s for vCenters %q client ",
-			cnsDevVersion, vc.Config.Host)
-	}
 	log.Info("Resetting VC connection in StoragePool service")
 	defaultStoragePoolServiceLock.Lock()
 	defer defaultStoragePoolServiceLock.Unlock()

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -140,12 +140,12 @@ func TestSyncerWorkflows(t *testing.T) {
 		}
 	}()
 
-	volumeManager, err = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, false, "")
+	volumeManager, err = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, "")
 	if err != nil {
 		t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 	}
 
-	err = volumeManager.ResetManager(ctx, virtualCenter, false)
+	err = volumeManager.ResetManager(ctx, virtualCenter)
 	if err != nil {
 		t.Fatalf("failed to reset volume manager with new vcenter. err=%v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Set dev.version on CNS clients and Vim clients for fetching aggregatedSnapshotCapacity from CNS APIs (these CNS APIs are currently under development).
We added changes to set dev.version earlier but those were missed at few places. Reverting earlier changes and adding changes at centralised place now.
Note that these changes are temporary and will be removed once new CNS API version is published.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Performed manual testing and things seem to be working fine.

```
# k apply -f snapshottest.yaml -n test-aggrsize 
volumesnapshot.snapshot.storage.k8s.io/snapshot-aggr created

# kubectl get vs -n test-aggrsize  
NAME            READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
snapshot-aggr   true         pvc-aggr                            1Gi           volumesnapshotclass-delete   snapcontent-9febcacb-af66-40de-9b83-7a2bc81b981a   11s            12s


# k get cnsvolumeinfo  576201d4-f4bc-4f05-be0e-759162af4ad3 -n vmware-system-csi -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CNSVolumeInfo
metadata:
  creationTimestamp: "2024-09-25T10:38:53Z"
  generation: 3
  name: 576201d4-f4bc-4f05-be0e-759162af4ad3
  namespace: vmware-system-csi
  resourceVersion: "9443626"
  uid: ecfd8fb9-7236-405e-b07f-d967c79b6599
spec:
  aggregatedsnapshotsize: 294Mi          <<<<<< 
  capacity: 1Gi
  namespace: test-aggrsize
  snapshotlatestoperationcompletetime: "2024-09-25T10:41:11Z"
  storageClassName: zonal-ds-policy-785
  storagePolicyID: 65155c13-8c80-456e-8296-a20cbff4ec77
  vCenterServer: sc2-10-43-160-201.nimbus.eng.vmware.com
  validaggregatedsnapshotsize: true
  volumeID: 576201d4-f4bc-4f05-be0e-759162af4ad3
```

Detailed logs are attached in the file 
[logs_aggr_test.log](https://github.com/user-attachments/files/17129904/logs_aggr_test.log)


Testing with password rotation has been completed by Kavya on setup with these changes. We are getting correct values of aggregatedSnapshotSize after password rotation as well now.

Syncer Logs:
```
"level":"error","time":"2024-09-30T07:02:08.255237591Z","caller":"vsphere/virtualcenter.go:204","msg":"failed to login to vc. err: ServerFaultCode: Cannot complete login due to an incorrect user name or password.","TraceId":"d40c5d95-a01e-4c8e-84ef-87fe21ff894a",....

"level":"info","time":"2024-09-30T07:03:08.29401704Z","caller":"volume/listview.go:263","msg":"connection to vc successful","TraceId":"d40c5d95-a01e-4c8e-84ef-87fe21ff894a"}
{"level":"info","time":"2024-09-30T07:03:08.299135085Z","caller":"volume/listview.go:267","msg":"re-creating the listView object","TraceId":"d40c5d95-a01e-4c8e-84ef-87fe21ff894a"}
{"level":"info","time":"2024-09-30T07:03:08.325847057Z","caller":"volume/listview.go:102","msg":"created listView object ListView:session[52d8a898-e75e-743c-fd94-a32a4645e657]5246752c-13dd-2bf4-83d4-c1c082c23dde for virtualCenter: sc2-10-43-160-201.nimbus.eng.vmware.com","TraceId":"d40c5d95-a01e-4c8e-84ef-87fe21ff894a"}
...

{"level":"info","time":"2024-09-30T07:03:11.411832927Z","caller":"syncer/fullsync.go:63","msg":"FullSync for VC sc2-10-43-160-201.nimbus.eng.vmware.com: start","TraceId":"764dc0a8-4d72-45b9-93b1-c0e6b1189f81"}
...
{"level":"info","time":"2024-09-30T07:03:12.063903574Z","caller":"syncer/fullsync.go:790","msg":"Received aggregatedSnapshotCapacity 130 for volume \"b387b17d-1e29-43d6-ad34-45c46f2395fd\"","TraceId":"764dc0a8-4d72-45b9-93b1-c0e6b1189f81"}
{"level":"info","time":"2024-09-30T07:03:12.063925092Z","caller":"syncer/fullsync.go:795","msg":"Update aggregatedSnapshotCapacity for volume \"b387b17d-1e29-43d6-ad34-45c46f2395fd\"","TraceId":"764dc0a8-4d72-45b9-93b1-c0e6b1189f81"}
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Set dev.version on CNS clients and Vim clients for fetching aggregatedSnapshotCapacity from CNS APIs
```
