### PR TITLE
Update logging to debug to reduce spew

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -455,7 +455,7 @@ func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clu
 	if len(sharedDatastores) == 0 && len(vsanDirectDatastores) == 0 {
 		return nil, nil, fmt.Errorf("no candidates datastores found in the Kubernetes cluster")
 	}
-	log.Infof("Found shared datastores: %+v and vSAN Direct datastores: %+v", sharedDatastores,
+	log.Debugf("Found shared datastores: %+v and vSAN Direct datastores: %+v", sharedDatastores,
 		vsanDirectDatastores)
 	return sharedDatastores, vsanDirectDatastores, nil
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -72,14 +72,14 @@ func GetKubeConfig(ctx context.Context) (*restclient.Config, error) {
 	var err error
 	kubecfgPath := getKubeConfigPath(ctx)
 	if kubecfgPath != "" {
-		log.Infof("k8s client using kubeconfig from %s", kubecfgPath)
+		log.Debugf("k8s client using kubeconfig from %s", kubecfgPath)
 		config, err = clientcmd.BuildConfigFromFlags("", kubecfgPath)
 		if err != nil {
 			log.Errorf("BuildConfigFromFlags failed %v", err)
 			return nil, err
 		}
 	} else {
-		log.Info("k8s client using in-cluster config")
+		log.Debug("k8s client using in-cluster config")
 		config, err = restclient.InClusterConfig()
 		if err != nil {
 			log.Errorf("InClusterConfig failed %v", err)
@@ -102,24 +102,24 @@ func getKubeConfigPath(ctx context.Context) string {
 		flagValue := kubecfgFlag.Value.String()
 		if flagValue != "" {
 			kubecfgPath = flagValue
-			log.Infof("Kubeconfig path obtained from kubeconfig flag: %q", kubecfgPath)
+			log.Debugf("Kubeconfig path obtained from kubeconfig flag: %q", kubecfgPath)
 		} else {
-			log.Info("Kubeconfig flag is set but empty, checking environment variable value")
+			log.Debug("Kubeconfig flag is set but empty, checking environment variable value")
 		}
 	} else {
-		log.Info("Kubeconfig flag not set, checking environment variable value")
+		log.Debug("Kubeconfig flag not set, checking environment variable value")
 	}
 	if kubecfgPath == "" {
 		// Get the Kubeconfig path from the environment variable
 		kubecfgPath = os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-		log.Infof("Kubeconfig path obtained from environment variable %q: %q",
+		log.Debugf("Kubeconfig path obtained from environment variable %q: %q",
 			clientcmd.RecommendedConfigPathEnvVar, kubecfgPath)
 	}
 	// Final logging of the Kubeconfig path used
 	if kubecfgPath == "" {
-		log.Info("No Kubeconfig path found, either from environment variable or flag")
+		log.Debug("No Kubeconfig path found, either from environment variable or flag")
 	} else {
-		log.Infof("Final Kubeconfig path used: %q", kubecfgPath)
+		log.Debugf("Final Kubeconfig path used: %q", kubecfgPath)
 	}
 	return kubecfgPath
 }
@@ -431,7 +431,7 @@ func getClientThroughput(ctx context.Context, isSupervisorClient bool) (float32,
 			burst = value
 		}
 	}
-	log.Infof("Setting client QPS to %f and Burst to %d.", qps, burst)
+	log.Debugf("Setting client QPS to %f and Burst to %d.", qps, burst)
 	return qps, burst
 }
 

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -779,7 +779,7 @@ func validateAndCorrectVolumeInfoSnapshotDetails(ctx context.Context,
 			continue
 		}
 		if cnsVol, ok := cnsVolumeMap[cnsvolumeinfo.Spec.VolumeID]; ok {
-			log.Infof("validate volume info for storage details for volume %s", cnsVol.VolumeId.Id)
+			log.Debugf("validate volume info for storage details for volume %s", cnsVol.VolumeId.Id)
 			var aggregatedSnapshotCapacity int64
 			if cnsVol.BackingObjectDetails != nil &&
 				cnsVol.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails) != nil {
@@ -787,12 +787,16 @@ func validateAndCorrectVolumeInfoSnapshotDetails(ctx context.Context,
 				if ok {
 					aggregatedSnapshotCapacity = val.AggregatedSnapshotCapacityInMb
 				}
-				log.Infof("Received aggregatedSnapshotCapacity %d for volume %q",
-					aggregatedSnapshotCapacity, cnsVol.VolumeId.Id)
+				if aggregatedSnapshotCapacity > 0 {
+					log.Infof("Received aggregatedSnapshotCapacity %d for volume %q",
+						aggregatedSnapshotCapacity, cnsVol.VolumeId.Id)
+				}
 				if cnsvolumeinfo.Spec.AggregatedSnapshotSize == nil || aggregatedSnapshotCapacity !=
 					cnsvolumeinfo.Spec.AggregatedSnapshotSize.Value() {
 					// use current time as snapshot completion time is not available in fullsync.
-					log.Infof("Update aggregatedSnapshotCapacity for volume %q", cnsVol.VolumeId.Id)
+					log.Infof("Update aggregatedSnapshotCapacity for volume %q from %d to %d",
+						cnsVol.VolumeId.Id, cnsvolumeinfo.Spec.AggregatedSnapshotSize.Value(),
+						aggregatedSnapshotCapacity)
 					currentTime := time.Now()
 					cnsSnapInfo := &volumes.CnsSnapshotInfo{
 						SourceVolumeID:                      cnsvolumeinfo.Spec.VolumeID,
@@ -1214,7 +1218,7 @@ func fullSyncGetVolumeSpecs(ctx context.Context, vCenterVersion string, pvList [
 				log.Infof("FullSync for VC %s: update is required for volume: %q", vc, volumeHandle)
 				operationType = "updateVolume"
 			} else {
-				log.Infof("FullSync for VC %s: update is not required for volume: %q", vc, volumeHandle)
+				log.Debugf("FullSync for VC %s: update is not required for volume: %q", vc, volumeHandle)
 			}
 		}
 		switch operationType {

--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -217,7 +217,7 @@ func isRemoteVsan(ctx context.Context, dsprops *dsProps,
 		return false, nil
 	}
 
-	log.Infof("vSAN Datastore %s is remote to this cluster", dsprops.dsName)
+	log.Debugf("vSAN Datastore %s is remote to this cluster", dsprops.dsName)
 	return true, nil
 }
 
@@ -228,7 +228,7 @@ func newIntendedVsanSNAState(ctx context.Context, scWatchCntlr *StorageClassWatc
 	nodes := make([]string, 0)
 	nodes = append(nodes, node)
 
-	log.Infof("creating vsan sna sp %q", node)
+	log.Debugf("creating vsan sna sp %q", node)
 	compatSC := make([]string, 0)
 	for _, scName := range vsan.compatSC {
 		if scWatchCntlr.isHostLocal(scName) {
@@ -356,7 +356,7 @@ func (c *SpController) applyIntendedState(ctx context.Context, state *intendedSt
 	} else {
 		// StoragePool already exists, so Update it. We don't expect
 		// ConflictErrors since updates are synchronized with a lock.
-		log.Infof("Updating StoragePool instance for %s", state.spName)
+		log.Debugf("Updating StoragePool instance for %s", state.spName)
 		sp := state.updateUnstructuredStoragePool(ctx, sp)
 		newSp, err := spClient.Resource(*spResource).Update(ctx, sp, metav1.UpdateOptions{})
 		if err != nil {

--- a/pkg/syncer/storagepool/listener.go
+++ b/pkg/syncer/storagepool/listener.go
@@ -122,7 +122,7 @@ func initListener(ctx context.Context, scWatchCntlr *StorageClassWatch,
 			err := property.WaitForUpdatesEx(ctx, p, filter, func(updates []types.ObjectUpdate) bool {
 				ctx := logger.NewContextWithLogger(ctx)
 				log = logger.GetLogger(ctx)
-				log.Infof("Got %d property collector update(s)", len(updates))
+				log.Debugf("Got %d property collector update(s)", len(updates))
 				reconcileAllScheduled := false
 				for _, update := range updates {
 					propChange := update.ChangeSet

--- a/pkg/syncer/storagepool/util.go
+++ b/pkg/syncer/storagepool/util.go
@@ -90,7 +90,7 @@ func getDatastoreProperties(ctx context.Context, d *cnsvsphere.DatastoreInfo) *d
 		freeSpace:   resource.NewQuantity(ds.Summary.FreeSpace, resource.DecimalSI),
 	}
 
-	log.Infof("Datastore %s properties: %v", d.Info.Name, p)
+	log.Debugf("Datastore %s properties: %v", d.Info.Name, p)
 	return &p
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
While triaging Perf bug, noticed the whole syncer logs littered with info level messages regarding kubeconfig. Reducing it to debug level.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
syncer logs:
```
{"level":"info","time":"2024-09-27T17:49:01.398998633Z","caller":"storagepool/intended_state.go:359","msg":"Updating StoragePool instance for storagepool-vsandatastore-cluster1","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"bc58fa87-6d56-4473-8785-262283067d95"}
{"level":"info","time":"2024-09-27T17:49:01.405006792Z","caller":"kubernetes/kubernetes.go:107","msg":"Kubeconfig flag is set but empty, checking environment variable value","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"bc58fa87-6d56-4473-8785-262283067d95"}
{"level":"info","time":"2024-09-27T17:49:01.405045154Z","caller":"kubernetes/kubernetes.go:115","msg":"Kubeconfig path obtained from environment variable \"KUBECONFIG\": \"\"","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"bc58fa87-6d56-4473-8785-262283067d95"}
{"level":"info","time":"2024-09-27T17:49:01.405055714Z","caller":"kubernetes/kubernetes.go:120","msg":"No Kubeconfig path found, either from environment variable or flag","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"bc58fa87-6d56-4473-8785-262283067d95"}
{"level":"info","time":"2024-09-27T17:49:01.4050643Z","caller":"kubernetes/kubernetes.go:82","msg":"k8s client using in-cluster config","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"bc58fa87-6d56-4473-8785-262283067d95"}
{"level":"info","time":"2024-09-27T17:49:01.405222678Z","caller":"kubernetes/kubernetes.go:434","msg":"Setting client QPS to 200.000000 and Burst to 200.","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"bc58fa87-6d56-4473-8785-262283067d95"}
{"level":"info","time":"2024-09-27T17:49:01.408598523Z","caller":"kubernetes/kubernetes.go:107","msg":"Kubeconfig flag is set but empty, checking environment variable value","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"bc58fa87-6d56-4473-8785-262283067d95"}
{"level":"info","time":"2024-09-27T17:49:01.408633639Z","caller":"kubernetes/kubernetes.go:115","msg":"Kubeconfig path obtained from environment variable \"KUBECONFIG\": \"\"","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"bc58fa87-6d56-4473-8785-262283067d95"}



{"level":"info","time":"2024-09-27T17:47:00.688865991Z","caller":"syncer/fullsync.go:1217","msg":"FullSync for VC w1hs5-testvc3.eng.vmware.com: update is not required for volume: \"cee3ba3d-12e9-4bd6-b1fe-78c43cd7a556\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:47:00.689138304Z","caller":"syncer/fullsync.go:1217","msg":"FullSync for VC w1hs5-testvc3.eng.vmware.com: update is not required for volume: \"6b45b9e5-8291-48ab-becf-1f11543dbcff\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:47:00.68941762Z","caller":"syncer/fullsync.go:1217","msg":"FullSync for VC w1hs5-testvc3.eng.vmware.com: update is not required for volume: \"4ea84130-313d-4091-bbac-4b9b90b0a9cb\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:47:00.689695583Z","caller":"syncer/fullsync.go:1217","msg":"FullSync for VC w1hs5-testvc3.eng.vmware.com: update is not required for volume: \"5d043629-9832-4a95-8181-0481e3ba9d11\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:47:00.689962005Z","caller":"syncer/fullsync.go:1217","msg":"FullSync for VC w1hs5-testvc3.eng.vmware.com: update is not required for volume: \"e3e22883-6cde-4c4a-a4aa-dee28d01a121\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}


{"level":"info","time":"2024-09-27T17:46:58.265800406Z","caller":"syncer/fullsync.go:790","msg":"Received aggregatedSnapshotCapacity 0 for volume \"daa35fda-2321-4d61-be4e-2871a514a3de\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:46:58.265827377Z","caller":"syncer/fullsync.go:782","msg":"validate volume info for storage details for volume 6e254da9-57a1-4e04-a637-77bfe43daa93","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:46:58.26583473Z","caller":"syncer/fullsync.go:790","msg":"Received aggregatedSnapshotCapacity 0 for volume \"6e254da9-57a1-4e04-a637-77bfe43daa93\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:46:58.265863695Z","caller":"syncer/fullsync.go:782","msg":"validate volume info for storage details for volume fa46ef09-bed3-4f02-94b2-406d52e08431","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:46:58.26587154Z","caller":"syncer/fullsync.go:790","msg":"Received aggregatedSnapshotCapacity 0 for volume \"fa46ef09-bed3-4f02-94b2-406d52e08431\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:46:58.265899162Z","caller":"syncer/fullsync.go:782","msg":"validate volume info for storage details for volume f495b2d0-9b99-4156-b901-8bc29e3b8963","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:46:58.265905143Z","caller":"syncer/fullsync.go:790","msg":"Received aggregatedSnapshotCapacity 0 for volume \"f495b2d0-9b99-4156-b901-8bc29e3b8963\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:46:58.265931483Z","caller":"syncer/fullsync.go:782","msg":"validate volume info for storage details for volume 8bf32915-022d-43f4-938a-f4451b95399f","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:46:58.265937564Z","caller":"syncer/fullsync.go:790","msg":"Received aggregatedSnapshotCapacity 0 for volume \"8bf32915-022d-43f4-938a-f4451b95399f\"","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}
{"level":"info","time":"2024-09-27T17:46:58.265965006Z","caller":"syncer/fullsync.go:782","msg":"validate volume info for storage details for volume b01ee2ca-45d0-409f-97f2-a5085bdaf525","TraceId":"43fdb55e-db1f-4740-a2c0-3e15b91b1eaa"}

{"level":"info","time":"2024-09-27T17:21:58.849709366Z","caller":"storagepool/intended_state.go:326","msg":"Host w1-hs5-b0209.eng.vmware.com has capacity &{Capacity:11522235432960 CapacityReserved:94136958976 CapacityUsed:265617512857 HostMoID:host-22}","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"f263a631-00b0-4db7-bc9f-5c04f17f862f"}
{"level":"info","time":"2024-09-27T17:21:58.870455693Z","caller":"storagepool/intended_state.go:326","msg":"Host w1-hs5-b0207.eng.vmware.com has capacity &{Capacity:11522235432960 CapacityReserved:59437481984 CapacityUsed:252187351449 HostMoID:host-13}","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"f263a631-00b0-4db7-bc9f-5c04f17f862f"}
{"level":"info","time":"2024-09-27T17:21:58.870473897Z","caller":"storagepool/intended_state.go:231","msg":"creating vsan sna sp \"w1-hs5-b0208.eng.vmware.com\"","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"f263a631-00b0-4db7-bc9f-5c04f17f862f"}
{"level":"info","time":"2024-09-27T17:21:58.873814679Z","caller":"storagepool/intended_state.go:359","msg":"Updating StoragePool instance for storagepool-vsandatastore-cluster1-w1-hs5-b0208.eng.vmware.com","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"f263a631-00b0-4db7-bc9f-5c04f17f862f"}
{"level":"info","time":"2024-09-27T17:21:58.878843776Z","caller":"storagepool/intended_state.go:231","msg":"creating vsan sna sp \"w1-hs5-b0209.eng.vmware.com\"","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"f263a631-00b0-4db7-bc9f-5c04f17f862f"}
{"level":"info","time":"2024-09-27T17:21:58.882279125Z","caller":"storagepool/intended_state.go:359","msg":"Updating StoragePool instance for storagepool-vsandatastore-cluster1-w1-hs5-b0209.eng.vmware.com","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"f263a631-00b0-4db7-bc9f-5c04f17f862f"}
{"level":"info","time":"2024-09-27T17:21:58.888026588Z","caller":"storagepool/intended_state.go:231","msg":"creating vsan sna sp \"w1-hs5-b0207.eng.vmware.com\"","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"f263a631-00b0-4db7-bc9f-5c04f17f862f"}
{"level":"info","time":"2024-09-27T17:21:58.891290837Z","caller":"storagepool/intended_state.go:359","msg":"Updating StoragePool instance for storagepool-vsandatastore-cluster1-w1-hs5-b0207.eng.vmware.com","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"f263a631-00b0-4db7-bc9f-5c04f17f862f"}
{"level":"info","time":"2024-09-27T17:21:58.903848556Z","caller":"storagepool/listener.go:210","msg":"Scheduled ReconcileAllStoragePools completed","TraceId":"99b6da0e-87b5-4888-8891-ed851adca593","TraceId":"f263a631-00b0-4db7-bc9f-5c04f17f862f"}
{"level":"info","time":"2024-09-27T17:21:59.373867534Z","caller":"syncer/volume_health.go:127","msg":"GetVolumeHealthStatus: end","TraceId":"8f542ddd-b57b-4ffe-a1ac-128bd294fd90"}
```

Unit tests.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
