### PR TITLE
Fix syncing the aggregated snapshot size between CNSVolumeInfo and CNS query result

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/fsnotify/fsnotify v1.7.0
+	github.com/go-logr/zapr v1.2.4
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -675,12 +676,16 @@ go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v8
 go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 h1:+FNtrFTmVw0YZGpBGX56XDee331t6JAXeK2bcyhLOOc=
 go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
+go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
 go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -455,7 +455,7 @@ func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clu
 	if len(sharedDatastores) == 0 && len(vsanDirectDatastores) == 0 {
 		return nil, nil, fmt.Errorf("no candidates datastores found in the Kubernetes cluster")
 	}
-	log.Infof("Found shared datastores: %+v and vSAN Direct datastores: %+v", sharedDatastores,
+	log.Debugf("Found shared datastores: %+v and vSAN Direct datastores: %+v", sharedDatastores,
 		vsanDirectDatastores)
 	return sharedDatastores, vsanDirectDatastores, nil
 }

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -180,7 +180,7 @@ func (authManager *AuthManager) refreshFSEnabledClustersToDsMap() {
 		defer authManager.rwMutex.Unlock()
 
 		authManager.fsEnabledClusterToDsMap = newFsEnabledClusterToDsMap
-		log.Infof("auth manager: newFsEnabledClusterToDsMap is updated to %v for vCenter %q",
+		log.Debugf("auth manager: newFsEnabledClusterToDsMap is updated to %v for vCenter %q",
 			newFsEnabledClusterToDsMap, vcenterHost)
 	} else {
 		log.Warnf("auth manager: failed to get updated datastoreMapForFileVolumes for vCenter %q, Err: %v",
@@ -502,7 +502,7 @@ func getFSEnabledClustersWithPriv(ctx context.Context, vc *cnsvsphere.VirtualCen
 			log.Debugf("vSAN file service is enabled for cluster: %+v and vCenter: %q.",
 				cluster, vc.Config.Host)
 		} else {
-			log.Infof("vSAN file service is disabled for cluster: %+v and vCenter: %q.",
+			log.Debugf("vSAN file service is disabled for cluster: %+v and vCenter: %q.",
 				cluster, vc.Config.Host)
 		}
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -72,14 +72,14 @@ func GetKubeConfig(ctx context.Context) (*restclient.Config, error) {
 	var err error
 	kubecfgPath := getKubeConfigPath(ctx)
 	if kubecfgPath != "" {
-		log.Infof("k8s client using kubeconfig from %s", kubecfgPath)
+		log.Debugf("k8s client using kubeconfig from %s", kubecfgPath)
 		config, err = clientcmd.BuildConfigFromFlags("", kubecfgPath)
 		if err != nil {
 			log.Errorf("BuildConfigFromFlags failed %v", err)
 			return nil, err
 		}
 	} else {
-		log.Info("k8s client using in-cluster config")
+		log.Debug("k8s client using in-cluster config")
 		config, err = restclient.InClusterConfig()
 		if err != nil {
 			log.Errorf("InClusterConfig failed %v", err)
@@ -102,24 +102,24 @@ func getKubeConfigPath(ctx context.Context) string {
 		flagValue := kubecfgFlag.Value.String()
 		if flagValue != "" {
 			kubecfgPath = flagValue
-			log.Infof("Kubeconfig path obtained from kubeconfig flag: %q", kubecfgPath)
+			log.Debugf("Kubeconfig path obtained from kubeconfig flag: %q", kubecfgPath)
 		} else {
-			log.Info("Kubeconfig flag is set but empty, checking environment variable value")
+			log.Debug("Kubeconfig flag is set but empty, checking environment variable value")
 		}
 	} else {
-		log.Info("Kubeconfig flag not set, checking environment variable value")
+		log.Debug("Kubeconfig flag not set, checking environment variable value")
 	}
 	if kubecfgPath == "" {
 		// Get the Kubeconfig path from the environment variable
 		kubecfgPath = os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-		log.Infof("Kubeconfig path obtained from environment variable %q: %q",
+		log.Debugf("Kubeconfig path obtained from environment variable %q: %q",
 			clientcmd.RecommendedConfigPathEnvVar, kubecfgPath)
 	}
 	// Final logging of the Kubeconfig path used
 	if kubecfgPath == "" {
-		log.Info("No Kubeconfig path found, either from environment variable or flag")
+		log.Debug("No Kubeconfig path found, either from environment variable or flag")
 	} else {
-		log.Infof("Final Kubeconfig path used: %q", kubecfgPath)
+		log.Debugf("Final Kubeconfig path used: %q", kubecfgPath)
 	}
 	return kubecfgPath
 }
@@ -431,7 +431,7 @@ func getClientThroughput(ctx context.Context, isSupervisorClient bool) (float32,
 			burst = value
 		}
 	}
-	log.Infof("Setting client QPS to %f and Burst to %d.", qps, burst)
+	log.Debugf("Setting client QPS to %f and Burst to %d.", qps, burst)
 	return qps, burst
 }
 

--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -217,7 +217,7 @@ func isRemoteVsan(ctx context.Context, dsprops *dsProps,
 		return false, nil
 	}
 
-	log.Infof("vSAN Datastore %s is remote to this cluster", dsprops.dsName)
+	log.Debugf("vSAN Datastore %s is remote to this cluster", dsprops.dsName)
 	return true, nil
 }
 
@@ -228,7 +228,7 @@ func newIntendedVsanSNAState(ctx context.Context, scWatchCntlr *StorageClassWatc
 	nodes := make([]string, 0)
 	nodes = append(nodes, node)
 
-	log.Infof("creating vsan sna sp %q", node)
+	log.Debugf("creating vsan sna sp %q", node)
 	compatSC := make([]string, 0)
 	for _, scName := range vsan.compatSC {
 		if scWatchCntlr.isHostLocal(scName) {
@@ -356,7 +356,7 @@ func (c *SpController) applyIntendedState(ctx context.Context, state *intendedSt
 	} else {
 		// StoragePool already exists, so Update it. We don't expect
 		// ConflictErrors since updates are synchronized with a lock.
-		log.Infof("Updating StoragePool instance for %s", state.spName)
+		log.Debugf("Updating StoragePool instance for %s", state.spName)
 		sp := state.updateUnstructuredStoragePool(ctx, sp)
 		newSp, err := spClient.Resource(*spResource).Update(ctx, sp, metav1.UpdateOptions{})
 		if err != nil {

--- a/pkg/syncer/storagepool/listener.go
+++ b/pkg/syncer/storagepool/listener.go
@@ -122,7 +122,7 @@ func initListener(ctx context.Context, scWatchCntlr *StorageClassWatch,
 			err := property.WaitForUpdatesEx(ctx, p, filter, func(updates []types.ObjectUpdate) bool {
 				ctx := logger.NewContextWithLogger(ctx)
 				log = logger.GetLogger(ctx)
-				log.Infof("Got %d property collector update(s)", len(updates))
+				log.Debugf("Got %d property collector update(s)", len(updates))
 				reconcileAllScheduled := false
 				for _, update := range updates {
 					propChange := update.ChangeSet

--- a/pkg/syncer/storagepool/util.go
+++ b/pkg/syncer/storagepool/util.go
@@ -90,7 +90,7 @@ func getDatastoreProperties(ctx context.Context, d *cnsvsphere.DatastoreInfo) *d
 		freeSpace:   resource.NewQuantity(ds.Summary.FreeSpace, resource.DecimalSI),
 	}
 
-	log.Infof("Datastore %s properties: %v", d.Info.Name, p)
+	log.Debugf("Datastore %s properties: %v", d.Info.Name, p)
 	return &p
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix syncing the aggregated snapshot size between CNSVolumeInfo and CNS query result

General Changes:
1. Reduces logging. I observed a perf bug with a lot of log spew. Changed it to debug.
2. Improved logging for quota. Changed the display to readable values instead of bytes.

Bug Fixes:
1. Fixed bugs that synced CNSVolumeInfo with CNS query result:
2. validateAndCorrectVolumeInfoSnapshotDetails should not error out, this will prevent other parts of full sync from running
3. If there are failures we proceed to syncing other volumes rather than erroring out
4. CNS always returned value in Mb, while CNSVolumeInfo always held in bytes, there was always a mismatch and there would always be patching, this was incorrect.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Changed logging for easier reading
```
{"level":"info","time":"2024-09-30T20:09:17.190657406Z","caller":"syncer/metadatasyncer.go:3518","msg":"cnsVolumeInfoCRUpdated: aggregated snapshot size increased by 108Mi, increased Used field for storagepolicyusage CR: vsan-default-storage-policy-snapshot-usage","TraceId":"9c668ef6-c4f5-4db6-8229-ab582a3b62f3"}
{"level":"info","time":"2024-09-30T20:09:17.198981664Z","caller":"syncer/metadatasyncer.go:3518","msg":"cnsVolumeInfoCRUpdated: aggregated snapshot size increased by 108Mi, increased Used field for storagepolicyusage CR: vsan-default-storage-policy-snapshot-usage","TraceId":"751d9b7f-69bd-4288-9b37-3d601b93de8d"}
{"level":"info","time":"2024-09-30T20:09:17.206634972Z","caller":"syncer/metadatasyncer.go:3518","msg":"cnsVolumeInfoCRUpdated: aggregated snapshot size increased by 108Mi, increased Used field for storagepolicyusage CR: vsan-default-storage-policy-snapshot-usage","TraceId":"9f4df210-aabe-443a-9461-3fce41546aed"}
```


Deployed changes on live setup and ensured that CNSVolumeInfo was being fixed appropriately.

```
{"level":"info","time":"2024-09-30T20:09:17.072054174Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:304","msg":"attempt: 1, Successfully patched the cnsvolumeinfo \"57268eaa-adff-4c9b-a466-62b43b9d21da\" namespace \"vmware-system-csi\"","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
{"level":"info","time":"2024-09-30T20:09:17.072079011Z","caller":"syncer/fullsync.go:841","msg":"Updated CNSvolumeInfo with Snapshot details successfully for volume 57268eaa-adff-4c9b-a466-62b43b9d21da","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
{"level":"info","time":"2024-09-30T20:09:17.072179479Z","caller":"syncer/fullsync.go:799","msg":"Aggregated Snapshot size mismatch for volume 96210bac-bc06-4229-9a35-6783e4fce39a, 0 in CnsVolumeInfo and 108MB in CNS","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
{"level":"info","time":"2024-09-30T20:09:17.072189017Z","caller":"syncer/fullsync.go:811","msg":"Update aggregatedSnapshotCapacity for volume 96210bac-bc06-4229-9a35-6783e4fce39a to 108MB","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
{"level":"info","time":"2024-09-30T20:09:17.072197192Z","caller":"syncer/fullsync.go:820","msg":"snapshot operation completion time unavailable for volumeID 96210bac-bc06-4229-9a35-6783e4fce39a, will use current time 2024-09-30 20:09:17.072194117 +0000 UTC m=+1.245091382 instead","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
{"level":"info","time":"2024-09-30T20:09:17.072204676Z","caller":"common/util.go:459","msg":"retrieved aggregated snapshot capacity 108 for volume \"96210bac-bc06-4229-9a35-6783e4fce39a\"","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
{"level":"info","time":"2024-09-30T20:09:17.077780548Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:304","msg":"attempt: 1, Successfully patched the cnsvolumeinfo \"96210bac-bc06-4229-9a35-6783e4fce39a\" namespace \"vmware-system-csi\"","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
{"level":"info","time":"2024-09-30T20:09:17.077791137Z","caller":"syncer/metadatasyncer.go:3518","msg":"cnsVolumeInfoCRUpdated: aggregated snapshot size increased by 144Mi, increased Used field for storagepolicyusage CR: vsan-default-storage-policy-snapshot-usage","TraceId":"eccd165f-ff82-4559-b603-b7ccc5cb1891"}
{"level":"info","time":"2024-09-30T20:09:17.077801948Z","caller":"syncer/fullsync.go:841","msg":"Updated CNSvolumeInfo with Snapshot details successfully for volume 96210bac-bc06-4229-9a35-6783e4fce39a","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
```

Verified that volumes that were not in sync was determined correctly
```
{"level":"info","time":"2024-09-30T20:09:17.077810253Z","caller":"syncer/fullsync.go:847","msg":"Number of volumes with synced aggregated snapshot size with CNS 957","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
{"level":"info","time":"2024-09-30T20:09:17.077818228Z","caller":"syncer/fullsync.go:848","msg":"Number of volumes with out-of-sync aggregated snapshot size with CNS 67","TraceId":"f42ac652-413b-4429-b818-91f91fcef2af"}
```

Incorrect SPU before fix:
```
apiVersion: cns.vmware.com/v1alpha2
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-09-26T22:53:32Z"
  generation: 1
  name: vsan-default-storage-policy-snapshot-usage
  namespace: ns1
  resourceVersion: "3726520"
  uid: 66340f39-712b-4300-869d-cae84edbb5f4
spec:
  resourceApiGroup: snapshot.storage.k8s.io
  resourceExtensionName: snapshot.cns.vsphere.vmware.com
  resourceKind: VolumeSnapshot
  storageClassName: vsan-default-storage-policy
  storagePolicyId: aa6d5a82-1c88-45da-85d3-3d74b91a5bad
status:
  quotaUsage:
    reserved: "0"
    used: "0"
```

Corrected SPU after fix:
```
apiVersion: cns.vmware.com/v1alpha2
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-09-26T22:53:32Z"
  generation: 1
  name: vsan-default-storage-policy-snapshot-usage
  namespace: ns1
  resourceVersion: "3752696"
  uid: 66340f39-712b-4300-869d-cae84edbb5f4
spec:
  resourceApiGroup: snapshot.storage.k8s.io
  resourceExtensionName: snapshot.cns.vsphere.vmware.com
  resourceKind: VolumeSnapshot
  storageClassName: vsan-default-storage-policy
  storagePolicyId: aa6d5a82-1c88-45da-85d3-3d74b91a5bad
status:
  quotaUsage:
    reserved: "0"
    used: 8172Mi
```

Verified that next cycle of full sync detects that the usage is correct
```
{"level":"info","time":"2024-09-30T20:39:16.709799502Z","caller":"syncer/fullsync.go:847","msg":"Number of volumes with synced aggregated snapshot size with CNS 1024","TraceId":"92e8af49-9cd0-48ca-a95c-6cee81cac6b6"}
{"level":"info","time":"2024-09-30T20:39:16.709836211Z","caller":"syncer/fullsync.go:848","msg":"Number of volumes with out-of-sync aggregated snapshot size with CNS 0","TraceId":"92e8af49-9cd0-48ca-a95c-6cee81cac6b6"}
{
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
