### PR TITLE
Update go.mod to 1.22.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/vsphere-csi-driver/v3
 
-go 1.21
+go 1.22.8
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.3.1

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -49,7 +49,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=<docker-registry>/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.21
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.22
 
 ARCH=amd64
 OSVERSION=1809

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.21
+ARG GOLANG_IMAGE=golang:1.22
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.21
+ARG GOLANG_IMAGE=golang:1.22
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:4.0

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.21
+ARG GOLANG_IMAGE=golang:1.22
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:4.0

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.21
+ARG GOLANG_IMAGE=golang:1.22
 ARG OSVERSION
 ARG ARCH=amd64
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Update go.mod to 1.22.8

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
make check

```
(vsphere-csi-driver) $ make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
+ go version
go version go1.22.8 darwin/amd64
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2024.1
go: honnef.co/go/tools@v0.5.0 requires go >= 1.22.1; switching to go1.22.8
++ go env GOPATH
+ GOOS=linux
+ /Users/adkulkarni/go/bin/staticcheck --version
staticcheck 2024.1 (0.5.0)
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/adkulkarni/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v3/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v3/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsunregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagequotaperiodicsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/placementengine sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v3/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.59.1'
golangci/golangci-lint info found version: 1.59.1 for v1.59.1/darwin/amd64
golangci/golangci-lint info installed /Users/adkulkarni/go/bin/golangci-lint
INFO golangci-lint has version 1.59.1 built with go1.22.3 from 1a55854a on 2024-06-09T18:08:33Z
INFO [config_reader] Config search paths: [./ /Users/adkulkarni/GolandProjects/vsphere-csi-driver /Users/adkulkarni/GolandProjects /Users/adkulkarni /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 8 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck unused]
INFO [loader] Go packages loading at mode 575 (name|deps|files|imports|types_sizes|compiled_files|exports_file) took 2.87879374s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 273.629518ms
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 143, after processing: 0
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 52/143, exclude-rules: 1/52, filename_unadjuster: 143/143, invalid_issue: 143/143, exclude: 52/52, skip_files: 143/143, skip_dirs: 143/143, cgo: 143/143, nolint: 0/1, path_prettifier: 143/143, identifier_marker: 52/52
INFO [runner] processing took 27.90178ms with stages: nolint: 21.130896ms, autogenerated_exclude: 3.434182ms, identifier_marker: 1.954606ms, path_prettifier: 687.789µs, exclude-rules: 399.928µs, skip_dirs: 240.321µs, invalid_issue: 22.55µs, cgo: 19.472µs, filename_unadjuster: 6.865µs, max_same_issues: 1.218µs, fixer: 544ns, uniq_by_line: 455ns, sort_results: 367ns, diff: 366ns, exclude: 361ns, source_code: 331ns, path_shortener: 320ns, max_from_linter: 316ns, skip_files: 306ns, severity-rules: 220ns, max_per_file_from_linter: 191ns, path_prefixer: 176ns
INFO [runner] linters took 1.797462065s with stages: goanalysis_metalinter: 1.769422919s
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 51 samples, avg is 49.7MB, max is 85.0MB
INFO Execution took 4.998927357s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
