### PR TITLE
Update RBAC and sync interval for storageQuotaPeriodicSync in cns-csi.yaml

### DIFF
--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -79,6 +79,12 @@ rules:
     resources: ["storagepolicyusages/status"]
     verbs: ["update", "patch"]
   - apiGroups: ["cns.vmware.com"]
+    resources: ["storagequotaperiodicsyncs"]
+    verbs: ["create", "get", "list", "patch", "delete" ,"watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagequotaperiodicsyncs/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cns.vmware.com"]
     resources: ["storagepolicyquotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
@@ -377,6 +383,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--storagequota-sync-interval=10m"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -79,6 +79,12 @@ rules:
     resources: ["storagepolicyusages/status"]
     verbs: ["update", "patch"]
   - apiGroups: ["cns.vmware.com"]
+    resources: ["storagequotaperiodicsyncs"]
+    verbs: ["create", "get", "list", "patch", "delete" ,"watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagequotaperiodicsyncs/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cns.vmware.com"]
     resources: ["storagepolicyquotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
@@ -377,6 +383,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--storagequota-sync-interval=10m"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -383,7 +383,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
-            - "--storagequota-sync-interval=30m"
+            - "--storagequota-sync-interval=10m"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -853,6 +853,11 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 
 func initStorageQuotaPeriodicSync(ctx context.Context, metadataSyncer *metadataSyncInformer) error {
 	log := logger.GetLogger(ctx).WithOptions()
+	if int(PeriodicSyncIntervalInMin.Minutes()) == 0 {
+		log.Info("initStorageQuotaPeriodicSync: sync interval is set to 0, " +
+			"will skip the Periodic Sync for storage quota")
+		return nil
+	}
 	// create storagequotaperiodicsync CR
 
 	log.Info("initStorageQuotaPeriodicSync: Initialize the storage quota periodic sync")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This MR adds RBAC for storagequotaperiodicsync CR in cns-csi.yaml for WCP version 1.28-1.30, with sync interval time updated to 10 min.
This also adds minor changes under https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3081


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested fix on the setup where syncer was crashing due to missing RBAC, and later pods came to running state

Before fix :

root@422a5584452ed95937062cf0861b089a [ ~ ]# k get pods -n vmware-system-csi
NAME                                      READY   STATUS             RESTARTS          AGE
vsphere-csi-controller-75858f4bf4-7xrgk   6/7     CrashLoopBackOff   205 (2m38s ago)   13h
vsphere-csi-controller-75858f4bf4-pv5kz   7/7     Running            228 (5m25s ago)   13h
vsphere-csi-webhook-578d97774b-t9q86      1/1     Running            1 (13h ago)       13h
vsphere-csi-webhook-578d97774b-zv5v2      1/1     Running            0                 13h

After fix :

root@422a5584452ed95937062cf0861b089a [ ~ ]# k get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-75858f4bf4-2gslq   7/7     Running   0             14m
vsphere-csi-controller-75858f4bf4-jfh7f   7/7     Running   0             14m
vsphere-csi-webhook-578d97774b-t9q86      1/1     Running   1 (13h ago)   13h
vsphere-csi-webhook-578d97774b-zv5v2      1/1     Running   0             13h
root@422a5584452ed95937062cf0861b089a [ ~ ]#

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update RBAC and sync interval for storageQuotaPeriodicSync in cns-csi.yaml
```
