### PR TITLE
Writing data into the volume from Pod code fix

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -3420,22 +3420,19 @@ func GetPodSpecByUserID(ns string, nodeSelector map[string]string, pvclaims []*v
 
 // writeDataOnFileFromPod writes specified data from given Pod at the given.
 func writeDataOnFileFromPod(namespace string, podName string, filePath string, data string) {
-	var shellExec, cmdArg string
+	var shellExec, cmdArg, syncCmd string
 	if windowsEnv {
 		shellExec = "Powershell.exe"
 		cmdArg = "-Command"
 	} else {
 		shellExec = "/bin/sh"
 		cmdArg = "-c"
+		syncCmd = fmt.Sprintf("echo '%s' >> %s && sync", data, filePath)
 	}
-	wrtiecmd := []string{"exec", podName, "--namespace=" + namespace, "--", shellExec, cmdArg,
-		fmt.Sprintf(" echo '%s' >>  %s ", data, filePath)}
-	e2ekubectl.RunKubectlOrDie(namespace, wrtiecmd...)
 
-	data2 := "fsync"
-	wrtiecmd2 := []string{"exec", podName, "--namespace=" + namespace, "--", shellExec, cmdArg,
-		fmt.Sprintf(" echo '%s' >>  %s ", data2, filePath)}
-	e2ekubectl.RunKubectlOrDie(namespace, wrtiecmd2...)
+	// Command to write data and sync it
+	wrtiecmd := []string{"exec", podName, "--namespace=" + namespace, "--", shellExec, cmdArg, syncCmd}
+	e2ekubectl.RunKubectlOrDie(namespace, wrtiecmd...)
 }
 
 // readFileFromPod read data from given Pod and the given file.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes writing data to the volume from the pod and corrects the code for syncing data into the volume.

**Testing done**:
Yes
[writingPod.txt](https://github.com/user-attachments/files/17517935/writingPod.txt)

sipriya@C02CR8ENMD6M vsphere-csi-driver % 
sipriya@C02CR8ENMD6M vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@C02CR8ENMD6M vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.59.1'
golangci/golangci-lint info found version: 1.59.1 for v1.59.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO golangci-lint has version 1.59.1 built with go1.22.3 from 1a55854a on 2024-06-09T18:08:33Z 
INFO [config_reader] Config search paths: [./ /Users/sipriya/spherelet/vsphere-csi-driver /Users/sipriya/spherelet /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 8 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck unused]
