### PR TITLE
enable supervisor fss when supervisor capability is enabled

### DIFF
--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -10,8 +10,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -10,8 +10,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -10,8 +10,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -101,6 +101,15 @@ func (c *FakeK8SOrchestrator) IsFSSEnabled(ctx context.Context, featureName stri
 	return false
 }
 
+func (c *FakeK8SOrchestrator) EnableFSS(ctx context.Context, featureName string) error {
+	c.featureStates[featureName] = "true"
+	return nil
+}
+func (c *FakeK8SOrchestrator) DisableFSS(ctx context.Context, featureName string) error {
+	c.featureStates[featureName] = "false"
+	return nil
+}
+
 // IsFakeAttachAllowed checks if the passed volume can be fake attached and mark it as fake attached.
 func (c *FakeK8SOrchestrator) IsFakeAttachAllowed(
 	ctx context.Context,

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -41,6 +41,11 @@ type COCommonInterface interface {
 	// IsFSSEnabled checks if feature state switch is enabled for the given feature indicated
 	// by featureName.
 	IsFSSEnabled(ctx context.Context, featureName string) bool
+	// EnableFSS helps enable feature state switch in the FSS config map
+	EnableFSS(ctx context.Context, featureName string) error
+	// DisableFSS helps disable feature state switch in the FSS config map
+	// This method is added for Unit tests coverage
+	DisableFSS(ctx context.Context, featureName string) error
 	// IsFakeAttachAllowed checks if the passed volume can be fake attached.
 	IsFakeAttachAllowed(ctx context.Context, volumeID string, volumeManager cnsvolume.Manager) (bool, error)
 	// MarkFakeAttached marks the volume as fake attached.

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -259,7 +259,16 @@ func TestWCPCreateVolumeWithStoragePolicy(t *testing.T) {
 // but not storage topology type. It is a negative case.
 func TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType(t *testing.T) {
 	ct := getControllerTest(t)
-
+	err := commonco.ContainerOrchestratorUtility.DisableFSS(ctx, "Workload_Domain_Isolation_Supported")
+	if err != nil {
+		t.Fatal("failed to disable Workload_Domain_Isolation_Supported FSS")
+	}
+	defer func() {
+		err := commonco.ContainerOrchestratorUtility.EnableFSS(ctx, "Workload_Domain_Isolation_Supported")
+		if err != nil {
+			t.Fatal("failed to enable Workload_Domain_Isolation_Supported FSS back to true")
+		}
+	}()
 	// Create.
 	params := make(map[string]string)
 

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -273,6 +273,21 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		}
 		IsWorkloadDomainIsolationSupported = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.WorkloadDomainIsolation)
+
+		if IsWorkloadDomainIsolationSupported {
+			log.Infof("Supervisor Capability: %q is enabled", common.WorkloadDomainIsolation)
+			if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) {
+				log.Infof("Supervisor CNS-CSI FSS: %q is disabled", common.WorkloadDomainIsolationFSS)
+				err = commonco.ContainerOrchestratorUtility.EnableFSS(ctx, common.WorkloadDomainIsolationFSS)
+				if err != nil {
+					return logger.LogNewErrorf(log, "failed to enable CNS-CSI FSS %q, err: %+v",
+						common.WorkloadDomainIsolationFSS, err)
+				}
+				log.Infof("Successfully updated CNS-CSI FSS: %q to true", common.WorkloadDomainIsolationFSS)
+			} else {
+				log.Infof("Supervisor CNS-CSI FSS: %q is enabled", common.WorkloadDomainIsolationFSS)
+			}
+		}
 		if IsWorkloadDomainIsolationSupported {
 			volumeTopologyService, err = commonco.ContainerOrchestratorUtility.InitTopologyServiceInController(ctx)
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Summary of change
- Add RBAC rule to allow updating configmap
- Added function EnableCNSCSIFSS to update csi-feature-states configmap in vmware-system-csi
namespace to enable FSS for `workload-domain-isolation`
- During the init of metdatasyncer if supervisor capability `Workload_Domain_Isolation_Supported` is enabled but FSS `workload-domain-isolation`  is disabled in csi-feature-states configmap then set  `workload-domain-isolation` FSS as true in the csi-feature-states configmap.
- Remove reading and caching FSS in init in CNS-CSI  controllers. 

Test logs for the case when supervisor capability is enabled but FSS is disabled
---------

{"level":"info","time":"2024-11-06T23:29:23.266398329Z","caller":"k8sorchestrator/k8sorchestrator.go:1083","msg":"Feature \"Workload_Domain_Isolation_Supported\" is a WCP defined feature state. Reading the \"wcp-cluster-capabilities\" configmap in \"kube-system\" namespace.","TraceId":"84a544a1-c3c7-421e-92b2-38918422c8f0"}
{"level":"info","time":"2024-11-06T23:29:23.270140896Z","caller":"k8sorchestrator/k8sorchestrator.go:1083","msg":"Feature \"Workload_Domain_Isolation_Supported\" is a WCP defined feature state. Reading the \"wcp-cluster-capabilities\" configmap in \"kube-system\" namespace.","TraceId":"857f3727-b9c3-413f-beb8-4fde71314f81"}
{"level":"info","time":"2024-11-06T23:29:23.274904894Z","caller":"k8sorchestrator/wcp_node.go:70","msg":"createCSINode: vmware-system/csi-create-csinode-object annotation exists: false with value: false on the node 4230670c2305ae4e8181205b03aebbf1","TraceId":"03a3041c-4fed-4115-9ad3-576fe539f8ec"}
{"level":"info","time":"2024-11-06T23:29:23.275058776Z","caller":"k8sorchestrator/k8sorchestrator.go:1083","msg":"Feature \"Workload_Domain_Isolation_Supported\" is a WCP defined feature state. Reading the \"wcp-cluster-capabilities\" configmap in \"kube-system\" namespace.","TraceId":"d3fd48bd-109a-4fa8-b8b9-1a5b8a220c8d"}
{"level":"warn","time":"2024-11-06T23:29:23.283733016Z","caller":"k8sorchestrator/k8sorchestrator.go:732","msg":"configMapUpdated: Supervisor feature state values from \"csi-feature-states\" stored successfully: map[async-query-volume:true block-volume-snapshot:true cns-unregister-volume:false cnsmgr-suspend-create-volume:true csi-sv-feature-states-replication:true fake-attach:true file-volume:true improved-csi-idempotency:true list-volumes:true online-volume-extend:true sibling-replica-bound-pvc-check:true storage-quota-m2:false tkgs-ha:true trigger-csi-fullsync:false vdpp-on-stretched-supervisor:false volume-extend:true volume-health:true workload-domain-isolation:true]","TraceId":"e9a72b0e-b10f-41c8-a99d-def7e47d8eb5"}
{"level":"info","time":"2024-11-06T23:29:23.284110737Z","caller":"k8sorchestrator/k8sorchestrator.go:1196","msg":"Successfully updated configmap: \"csi-feature-states\" in namespace: \"vmware-system-csi\" to enable FSS \"workload-domain-isolation\". ConfigMapData: map[async-query-volume:true block-volume-snapshot:true cns-unregister-volume:false cnsmgr-suspend-create-volume:true csi-sv-feature-states-replication:true fake-attach:true file-volume:true improved-csi-idempotency:true list-volumes:true online-volume-extend:true sibling-replica-bound-pvc-check:true storage-quota-m2:false tkgs-ha:true trigger-csi-fullsync:false vdpp-on-stretched-supervisor:false volume-extend:true volume-health:true workload-domain-isolation:true]","TraceId":"2c3b901a-fdfb-474b-af5a-5a07767a8831"}
{"level":"info","time":"2024-11-06T23:29:23.284144495Z","caller":"syncer/metadatasyncer.go:286","msg":"Successfully updated CNS-CSI FSS: \"workload-domain-isolation\"","TraceId":"2c3b901a-fdfb-474b-af5a-5a07767a8831"}

Test logs for the case when both supervisor capability and FSS are enabled
---
{"level":"info","time":"2024-11-06T23:40:31.304113851Z","caller":"syncer/metadatasyncer.go:278","msg":"Supervisor Capability: \"Workload_Domain_Isolation_Supported\" is enabled","TraceId":"3ddcf963-d1c8-456a-bcac-8b1b34187f0d"}
{"level":"info","time":"2024-11-06T23:40:31.304169092Z","caller":"syncer/metadatasyncer.go:288","msg":"Supervisor CNS-CSI FSS: \"workload-domain-isolation\" is enabled","TraceId":"3ddcf963-d1c8-456a-bcac-8b1b34187f0d"}



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
enable supervisor fss when supervisor capability is enabled
```
