### PR TITLE
add dynamic workload isolation fss enablement for PVCSI

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -101,6 +101,18 @@ func (c *FakeK8SOrchestrator) IsFSSEnabled(ctx context.Context, featureName stri
 	return false
 }
 
+// IsCNSCSIFSSEnabled returns the FSS values for a given feature in CNS-CSI
+func (c *FakeK8SOrchestrator) IsCNSCSIFSSEnabled(ctx context.Context, featureName string) bool {
+	// TODO: add featureStates map for CNSCSI for Unit tests
+	return c.IsFSSEnabled(ctx, featureName)
+}
+
+// IsPVCSIFSSEnabled returns the FSS values for a given feature in PV-CSI
+func (c *FakeK8SOrchestrator) IsPVCSIFSSEnabled(ctx context.Context, featureName string) bool {
+	// TODO: add featureStates map for PVCSI for Unit tests
+	return c.IsFSSEnabled(ctx, featureName)
+}
+
 func (c *FakeK8SOrchestrator) EnableFSS(ctx context.Context, featureName string) error {
 	c.featureStates[featureName] = "true"
 	return nil

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -41,6 +41,10 @@ type COCommonInterface interface {
 	// IsFSSEnabled checks if feature state switch is enabled for the given feature indicated
 	// by featureName.
 	IsFSSEnabled(ctx context.Context, featureName string) bool
+	// IsCNSCSIFSSEnabled checks if feature state switch is enabled in the CNSCSI
+	IsCNSCSIFSSEnabled(ctx context.Context, featureName string) bool
+	// IsPVCSIFSSEnabled checks if feature state switch is enabled in the PVCSI
+	IsPVCSIFSSEnabled(ctx context.Context, featureName string) bool
 	// EnableFSS helps enable feature state switch in the FSS config map
 	EnableFSS(ctx context.Context, featureName string) error
 	// DisableFSS helps disable feature state switch in the FSS config map


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR enables Workload Management Isolation feature in PVCSI upon detecting FSS enablement.


**Testing done**:


**<ins>Log message when FSS is enabled in `internal-feature-states.csi.vsphere.vmware.com` and later enabled in `csi-feature-states configmap`</ins>**

{"level":"info","time":"2024-11-09T00:19:08.480087802Z","caller":"k8sorchestrator/k8sorchestrator.go:1203","msg":"workload-domain-isolation feature state is set to false in csi-feature-states ConfigMap","TraceId":"0bb12f08-a793-4f77-8f5a-8e923d03b758","TraceId":"1b68da63-1607-4362-bd33-5db7f0b0b334"}
{"level":"info","time":"2024-11-09T00:19:08.512622933Z","caller":"k8sorchestrator/k8sorchestrator.go:769","msg":"Observed Configmap update for \"csi-feature-states\" in namespace \"vmware-system-csi\""}
{"level":"info","time":"2024-11-09T00:19:08.516643054Z","caller":"k8sorchestrator/k8sorchestrator.go:789","msg":"Detected Enablement of FSS: \"workload-domain-isolation\". Restarting Container."}

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add dynamic workload isolation fss enablement for PVCSI
```
