### PR TITLE
restart guest controller when workload domain isolation fss is enabled

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -598,7 +598,8 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface,
 		// Update.
 		func(oldObj interface{}, newObj interface{}) {
 			if controllerClusterFlavor == cnstypes.CnsClusterFlavorGuest &&
-				operationMode == "METADATA_SYNC" &&
+				operationMode != "WEBHOOK_SERVER" &&
+				serviceMode != "node" &&
 				k8sOrchestratorInstance.IsPVCSIFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) &&
 				!k8sOrchestratorInstance.IsCNSCSIFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) {
 				handleEnablementOfWLDIFSS(oldObj, newObj)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
restart guest controller when workload domain isolation fss is enabled

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
restart guest controller when workload domain isolation fss is enabled
```
