### PR TITLE
Add GOTOOLCHAIN=auto for gcb-docker-gcloud to pickup go.mod version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,6 +12,7 @@ steps:
       - TAG=$_GIT_TAG
       - PULL_BASE_REF=$_PULL_BASE_REF
       - DOCKER_BUILDKIT=1
+      - GOTOOLCHAIN=auto
     args:
       - deploy
 substitutions:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-vsphere-csi-driver-push-images/1856483309224202240 is failing with 

```
Status: Downloaded newer image for gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
go: go.mod requires go >= 1.22.8 (running go 1.22.5; GOTOOLCHAIN=local)
go: go.mod requires go >= 1.22.8 (running go 1.22.5; GOTOOLCHAIN=local)
make build-bins
make[1]: Entering directory '/workspace'
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service.Version=1ede8543"' -o .build/bin/vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
go: go.mod requires go >= 1.22.8 (running go 1.22.5; GOTOOLCHAIN=local)
make[1]: Leaving directory '/workspace'
make[1]: *** [Makefile:106: .build/bin/vsphere-csi.linux_amd64] Error 1
make: *** [Makefile:195: deploy] Error 2
ERROR
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36" failed: step exited with non-zero status: 2
```

Based on comments in https://github.com/kubernetes/test-infra/pull/32983#issuecomment-2236655738 and https://github.com/kubernetes-sigs/kueue/pull/2859/files, setting the `GOTOOLCHAIN=auto` will help fix it. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
