### PR TITLE
Inlude VolumeSnapshot with no Status set in Quota periodic sync calculation

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1286,24 +1286,19 @@ func calculateVolumeSnapshotReservedForNamespace(ctx context.Context,
 	volumeMap := make(map[string]*v1.PersistentVolumeClaim)
 	storagePolicyIdToReservedMap := make(map[string]*resource.Quantity)
 	for _, vs := range vsList.Items {
-		if vs.Status == nil {
-			log.Infof("calculateVolumeSnapshotReservedForNamespace: volumesnapshot status is unset for "+
-				"Name: %q, Namespace: %q", vs.Name, vs.Namespace)
-			continue
-		}
 		if vs.DeletionTimestamp != nil {
 			log.Infof("calculateVolumeSnapshotReservedForNamespace: volumesnapshot is marked for deletion,"+
 				" ignoring Name: %q, Namespace: %q",
 				vs.Name, vs.Namespace)
 			continue
 		}
-		if *vs.Status.ReadyToUse {
+		if vs.Status != nil && *vs.Status.ReadyToUse {
 			log.Infof("calculateVolumeSnapshotReservedForNamespace: skipping volumesnapshot"+
 				" as it is ready to use, ignoring Name: %q, Namespace: %q", vs.Name, vs.Namespace)
 			continue
 		} else {
 			log.Infof("calculateVolumeSnapshotReservedForNamespace: Processing VolumeSnapshot"+
-				" Name: %q, Namespace: %q readyToUse %q", vs.Name, vs.Namespace, vs.Status.ReadyToUse)
+				" Name: %q, Namespace: %q", vs.Name, vs.Namespace)
 			if len(pvcList.Items) == 0 {
 				log.Infof("calculateVolumeSnapshotReservedForNamespace: Fetching PersistentVolumeClaim "+
 					" for Namespace: %q", vs.Namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:
The existing code skips VolumeSnapshots without Status from quota periodic sync calculation. If the status is unset, its equivalent to VolumeSnapshot with ReadyToUse as false. This change fixes this.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
make test.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
