### PR TITLE
Query configmap if capability found disabled in the cached config-map

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -75,7 +75,8 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 				"storage-quota-m2":                  "false",
 				"workload-domain-isolation":         "true",
 				// Adding FSS from `wcp-cluster-capabilities` configmap in supervisor here for simplicity.
-				"Workload_Domain_Isolation_Supported": "true",
+				// TODO: Enable FSS for unit tests after mockControllerVolumeTopology interfaces are implemented
+				"Workload_Domain_Isolation_Supported": "false",
 			},
 		}
 		return fakeCO, nil

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -439,3 +439,11 @@ var WCPFeatureStates = map[string]struct{}{
 	WorkloadDomainIsolation:    {},
 	VPCCapabilitySupervisor:    {},
 }
+
+// WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
+// after CSI upgrade
+// During FSS check if driver detects that the capabilities is disabled in the cached configmap,
+// it will re-fetch the configmap and update the cached configmap.
+var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
+	WorkloadDomainIsolation: {},
+}

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -259,16 +259,20 @@ func TestWCPCreateVolumeWithStoragePolicy(t *testing.T) {
 // but not storage topology type. It is a negative case.
 func TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType(t *testing.T) {
 	ct := getControllerTest(t)
-	err := commonco.ContainerOrchestratorUtility.DisableFSS(ctx, "Workload_Domain_Isolation_Supported")
-	if err != nil {
-		t.Fatal("failed to disable Workload_Domain_Isolation_Supported FSS")
-	}
-	defer func() {
-		err := commonco.ContainerOrchestratorUtility.EnableFSS(ctx, "Workload_Domain_Isolation_Supported")
+	// TODO: Add following code back when FSS for Workload_Domain_Isolation_Supported is enabled for unit tests
+	/*
+		err := commonco.ContainerOrchestratorUtility.DisableFSS(ctx, "Workload_Domain_Isolation_Supported")
 		if err != nil {
-			t.Fatal("failed to enable Workload_Domain_Isolation_Supported FSS back to true")
+			t.Fatal("failed to disable Workload_Domain_Isolation_Supported FSS")
 		}
-	}()
+		defer func() {
+			err := commonco.ContainerOrchestratorUtility.EnableFSS(ctx, "Workload_Domain_Isolation_Supported")
+			if err != nil {
+				t.Fatal("failed to enable Workload_Domain_Isolation_Supported FSS back to true")
+			}
+		}()
+	*/
+
 	// Create.
 	params := make(map[string]string)
 
@@ -365,7 +369,16 @@ func TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType(t *testing.T) 
 // default value of FileVolumeActivated as "true".
 func TestWCPCreateVolumeWithoutZoneLabelPresentForFileVolume(t *testing.T) {
 	ct := getControllerTest(t)
-
+	err := commonco.ContainerOrchestratorUtility.EnableFSS(ctx, "Workload_Domain_Isolation_Supported")
+	if err != nil {
+		t.Fatal("failed to enable Workload_Domain_Isolation_Supported FSS")
+	}
+	defer func() {
+		err := commonco.ContainerOrchestratorUtility.DisableFSS(ctx, "Workload_Domain_Isolation_Supported")
+		if err != nil {
+			t.Fatal("failed to disable Workload_Domain_Isolation_Supported FSS")
+		}
+	}()
 	// Create.
 	params := make(map[string]string)
 
@@ -456,7 +469,16 @@ func TestWCPCreateVolumeWithoutZoneLabelPresentForFileVolume(t *testing.T) {
 // default value of FileVolumeActivated as "true".
 func TestWCPCreateVolumeWithHostLabelPresentForFileVolume(t *testing.T) {
 	ct := getControllerTest(t)
-
+	err := commonco.ContainerOrchestratorUtility.EnableFSS(ctx, "Workload_Domain_Isolation_Supported")
+	if err != nil {
+		t.Fatal("failed to enable Workload_Domain_Isolation_Supported FSS")
+	}
+	defer func() {
+		err := commonco.ContainerOrchestratorUtility.DisableFSS(ctx, "Workload_Domain_Isolation_Supported")
+		if err != nil {
+			t.Fatal("failed to disable Workload_Domain_Isolation_Supported FSS")
+		}
+	}()
 	// Create.
 	params := make(map[string]string)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses the issue where the Workload_Domain_Isolation_Supported WCP capability is enabled after the CSI is upgraded, but the cached WCP capability configmap may not reflect this change.

With this update, when the driver checks the Workload_Domain_Isolation_Supported FeatureState, If the driver detects that the FSS is disabled in the cached configmap, it will re-fetch the configmap, update the cached version, and recheck the state to confirm whether the FSS is still disabled or has been enabled.

This deeper check ensures that the CSI controller properly detects and enables the capability if it was enabled after the initial CSI upgrade, preventing failures that occur when the capability is not activated due to stale cached configuration data.


**Testing done**:

Logs

Started controller when `Workload_Domain_Isolation_Supported` capability was false.
Capability got enabled while controller is running.
Created PVC after that and Controller fetched capability again from the configmap.

```
root@421e1ba2adfa2714127121b8013dec4f [ ~ ]# kubectl  logs vsphere-csi-controller-6b5f697969-t5q55 -n vmware-system-csi -c vsphere-csi-controller |grep "WCP cluster capabilities map -"
{"level":"info","time":"2024-11-21T05:05:19.911987936Z","caller":"k8sorchestrator/k8sorchestrator.go:1146","msg":"WCP cluster capabilities map - map[Add_NSX_Day2_M1_Supported:false CSI_Detach_Supported:true Control_Plane_Backup_Restore_Supported:true Foundation_Load_Balancer_Supported:true Fronting_CPVM_Services_Via_LB_Supported:false Import_OVF_In_Namespace_CL_Supported:true Load_Balancer_Supported:true MultipleCL_For_TKG_Supported:true Only_Generate_Http_Proxy_Secret:true PodVM_On_DHCP_VDS_Supported:true PodVM_On_Stretched_Supervisor_Supported:true PodVM_On_VDS_Supported:true Resume_Failed_Supervisor_Upgrade_Supported:true Supervisor_New_Folder_Hierarchy_Supported:true TKG_SupervisorService_Supported:true Tanzu_Topology_CR_Supported:true VMImage_ResourceNamingStrategy_Supported:true VPC_Supported:false Vdpp_On_Stretched_Supervisor:false Workload_Domain_Isolation_Supported:false supports_Supervisor_Service_allow_list:true supports_max_concurrent_dns_forwards:true supports_secure_Supervisor_Service_platform:false supports_supervisor_VCFOps_integration:false supports_supervisor_async_upgrade:true]","TraceId":"0fcd41f2-0e7a-4e98-93ec-9748c7c4a520"}
{"level":"info","time":"2024-11-21T05:10:55.091710321Z","caller":"k8sorchestrator/k8sorchestrator.go:1173","msg":"WCP cluster capabilities map - map[Add_NSX_Day2_M1_Supported:false CSI_Detach_Supported:true Control_Plane_Backup_Restore_Supported:true Foundation_Load_Balancer_Supported:true Fronting_CPVM_Services_Via_LB_Supported:false Import_OVF_In_Namespace_CL_Supported:true Load_Balancer_Supported:true MultipleCL_For_TKG_Supported:true Only_Generate_Http_Proxy_Secret:true PodVM_On_DHCP_VDS_Supported:true PodVM_On_Stretched_Supervisor_Supported:true PodVM_On_VDS_Supported:true Resume_Failed_Supervisor_Upgrade_Supported:true Supervisor_New_Folder_Hierarchy_Supported:true TKG_SupervisorService_Supported:true Tanzu_Topology_CR_Supported:true VMImage_ResourceNamingStrategy_Supported:true VPC_Supported:false Vdpp_On_Stretched_Supervisor:false Workload_Domain_Isolation_Supported:true supports_Supervisor_Service_allow_list:true supports_max_concurrent_dns_forwards:true supports_secure_Supervisor_Service_platform:false supports_supervisor_VCFOps_integration:false supports_supervisor_async_upgrade:true]","TraceId":"1bf8ec3b-31a4-418b-9ef6-fc8e5e7ab326"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Query configmap if capability found disabled in the cached config-map
```
