### PR TITLE
(wip) fix flaky unit tests

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -72,7 +72,8 @@ var ErrListViewTaskAddition = errors.New("failure to add task to listview")
 var ErrSessionNotAuthenticated = errors.New("session is not authenticated")
 
 // NewListViewImpl creates a new listView object and starts a goroutine to listen to property collector task updates
-func NewListViewImpl(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter) (*ListViewImpl, error) {
+func NewListViewImpl(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter, isUnitTestRun bool) (*ListViewImpl,
+	error) {
 	log := logger.GetLogger(ctx)
 	t := &ListViewImpl{
 		taskMap:       NewTaskMap(),
@@ -84,7 +85,9 @@ func NewListViewImpl(ctx context.Context, virtualCenter *cnsvsphere.VirtualCente
 		return nil, logger.LogNewErrorf(log, "failed to create a ListView. error: %+v", err)
 	}
 	go t.listenToTaskUpdates()
-	go t.restartContainer()
+	if !isUnitTestRun {
+		go t.restartContainer()
+	}
 	return t, nil
 }
 

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -131,7 +131,7 @@ func getCommonUtilsTest(t *testing.T) *commonUtilsTest {
 			t.Fatal(err)
 		}
 
-		volumeManager, err := cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, "")
+		volumeManager, err := cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, "", true)
 		if err != nil {
 			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -153,9 +153,9 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			return err
 		}
 		vc.Config = vcenterconfig
-		volumeManager, err := cnsvolume.GetManager(ctx, vc, operationStore,
-			true, false,
-			false, cnstypes.CnsClusterFlavorVanilla)
+		volumeManager, err := cnsvolume.GetManager(ctx, vc, operationStore, true,
+			false, false,
+			cnstypes.CnsClusterFlavorVanilla, false)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}
@@ -218,9 +218,9 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 					"err=%v", vcenterconfig.Host, err)
 			}
 			c.managers.VcenterConfigs[vcenterconfig.Host] = vcenterconfig
-			volumeManager, err := cnsvolume.GetManager(ctx, vcenter,
-				operationStore, true, true,
-				multivCenterTopologyDeployment, cnstypes.CnsClusterFlavorVanilla)
+			volumeManager, err := cnsvolume.GetManager(ctx, vcenter, operationStore,
+				true, true, multivCenterTopologyDeployment,
+				cnstypes.CnsClusterFlavorVanilla, false)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 			}

--- a/pkg/csi/service/vanilla/controller_topology_test.go
+++ b/pkg/csi/service/vanilla/controller_topology_test.go
@@ -361,9 +361,8 @@ func getControllerTestWithTopology(t *testing.T) *controllerTestTopology {
 			t.Fatal(err)
 		}
 
-		volumeManager, err := cnsvolume.GetManager(ctxtopology, vcenter,
-			fakeOpStore, true, false,
-			false, cnstypes.CnsClusterFlavorVanilla)
+		volumeManager, err := cnsvolume.GetManager(ctxtopology, vcenter, fakeOpStore, true, false, false,
+			cnstypes.CnsClusterFlavorVanilla, true)
 		if err != nil {
 			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -171,8 +171,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	}
 
 	volumeManager, err := cnsvolume.GetManager(ctx, vcenter, operationStore,
-		idempotencyHandlingEnabled, false,
-		false, cnstypes.CnsClusterFlavorWorkload)
+		idempotencyHandlingEnabled, false, false,
+		cnstypes.CnsClusterFlavorWorkload, false)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 	}
@@ -397,8 +397,8 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 		c.manager.VcenterConfig = newVCConfig
 
 		volumeManager, err := cnsvolume.GetManager(ctx, vcenter, operationStore,
-			idempotencyHandlingEnabled, false,
-			false, cnstypes.CnsClusterFlavorWorkload)
+			idempotencyHandlingEnabled, false, false,
+			cnstypes.CnsClusterFlavorWorkload, false)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -94,7 +94,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}
 		}
 
-		volumeManager, err = volumes.GetManager(ctx, vCenter, nil, false, false, false, clusterFlavor)
+		volumeManager, err = volumes.GetManager(ctx, vCenter, nil, false, false, false, clusterFlavor, false)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -50,6 +50,7 @@ import (
 
 	"github.com/go-logr/zapr"
 	cr_log "sigs.k8s.io/controller-runtime/pkg/log"
+
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
 	sqperiodicsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagequotaperiodicsync/v1alpha1"
@@ -98,7 +99,7 @@ var (
 	// isMultiVCenterFssEnabled is true if the Multi VC support FSS is enabled, false otherwise.
 	isMultiVCenterFssEnabled bool
 
-	//IsMigrationEnabled is true when in-tree to CSI Migration FSS is enabled for the driver, false otherwise.
+	// IsMigrationEnabled is true when in-tree to CSI Migration FSS is enabled for the driver, false otherwise.
 	IsMigrationEnabled bool
 	// nodeMgr stores the manager to interact with nodeVMs.
 	nodeMgr node.Manager
@@ -463,8 +464,9 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		volumeInfoCrDeletionMap[metadataSyncer.host] = make(map[string]bool)
 		volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
 
-		volumeManager, err := volumes.GetManager(ctx, vCenter,
-			nil, false, false, false, metadataSyncer.clusterFlavor)
+		volumeManager, err := volumes.GetManager(ctx, vCenter, nil,
+			false, false,
+			false, metadataSyncer.clusterFlavor, false)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}
@@ -538,8 +540,9 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			volumeInfoCrDeletionMap[metadataSyncer.host] = make(map[string]bool)
 			volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
 
-			volumeManager, err := volumes.GetManager(ctx, vCenter, nil, false, false, false,
-				metadataSyncer.clusterFlavor)
+			volumeManager, err := volumes.GetManager(ctx, vCenter, nil,
+				false, false,
+				false, metadataSyncer.clusterFlavor, false)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 			}
@@ -561,9 +564,9 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 					return logger.LogNewErrorf(log, "failed to get vCenterInstance for vCenter Host: %q, err: %v",
 						vcconfig.Host, err)
 				}
-				volumeManager, err := volumes.GetManager(ctx, vCenter,
-					nil, false, true,
-					multivCenterTopologyDeployment, metadataSyncer.clusterFlavor)
+				volumeManager, err := volumes.GetManager(ctx, vCenter, nil,
+					false, true,
+					multivCenterTopologyDeployment, metadataSyncer.clusterFlavor, false)
 				if err != nil {
 					return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 				}
@@ -2222,8 +2225,9 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 			}
-			volumeManager, err := volumes.GetManager(ctx, vcenter, nil, false, false, false,
-				metadataSyncer.clusterFlavor)
+			volumeManager, err := volumes.GetManager(ctx, vcenter, nil,
+				false, false,
+				false, metadataSyncer.clusterFlavor, false)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 			}

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -105,7 +105,7 @@ func (w *DiskDecommController) detachVolumes(ctx context.Context, storagePoolNam
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to get cluster flavor. Error: %v", err)
 	}
-	volManager, err := volume.GetManager(ctx, &vc, nil, false, false, false, clusterFlavor)
+	volManager, err := volume.GetManager(ctx, &vc, nil, false, false, false, clusterFlavor, false)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 	}

--- a/pkg/syncer/storagepool/migrationController.go
+++ b/pkg/syncer/storagepool/migrationController.go
@@ -84,7 +84,7 @@ func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID st
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to get cluster flavor. Error: %v", err)
 	}
-	volManager, err := volume.GetManager(ctx, m.vc, nil, false, false, false, clusterFlavor)
+	volManager, err := volume.GetManager(ctx, m.vc, nil, false, false, false, clusterFlavor, false)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 	}

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -140,7 +140,7 @@ func TestSyncerWorkflows(t *testing.T) {
 		}
 	}()
 
-	volumeManager, err = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, "")
+	volumeManager, err = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, "", false)
 	if err != nil {
 		t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3083 introduced a goroutine for restarting the container after a specified amount of time in case listview is not up and session is valid. 

This PR prevents running this goroutine during unit tests as it's not required for unit tests and can cause some flakiness.  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
