### PR TITLE
Bumping up csi sidecar version for k8s 1.31

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -240,7 +240,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -259,7 +259,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -330,7 +330,7 @@ spec:
             periodSeconds: 180
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -448,7 +448,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -531,7 +531,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -593,7 +593,7 @@ spec:
       serviceAccountName: vsphere-csi-node
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -673,7 +673,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bumping up csi sidecar version for k8s 1.31  and updating sidecars to below versions:

   csi-attacher:v4.7.0
   csi-resizer:v1.12.0
   livenessprobe:v2.14.0
   csi-node-driver-registrar:v2.12.0
   


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running pipeline

Manual testing:
logs for manual testing performed are attached below,
[test-sidecar-update.log](https://github.com/user-attachments/files/17909009/test-sidecar-update.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bumping up csi sidecar version for k8s 1.31
```
