### PR TITLE
Added BYOK support for Supervisor Cluster v1.28

### DIFF
--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -114,6 +114,9 @@ rules:
   - apiGroups: ["crd.nsx.vmware.com"]
     resources: ["networkinfos"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["encryption.vmware.com"]
+    resources: ["encryptionclasses"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -193,6 +196,30 @@ subjects:
 roleRef:
   kind: Role
   name: vsphere-csi-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: vmware-system-csi
+  name: vsphere-csi-configmap-writer
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vsphere-csi-controller-configmap-writer
+  namespace: vmware-system-csi
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: vmware-system-csi
+roleRef:
+  kind: Role
+  name: vsphere-csi-configmap-writer
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Deployment
@@ -481,6 +508,7 @@ data:
   "vdpp-on-stretched-supervisor": "false"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
+  "WCP_VMService_BYOK": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states
@@ -572,6 +600,31 @@ webhooks:
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail
 ---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: vmware-system-csi-mutating-webhook-configuration
+  labels:
+    app: vsphere-csi-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: vmware-system-csi/vmware-system-csi-serving-cert
+webhooks:
+  - name: mutation.csi.vsphere.vmware.com
+    clientConfig:
+      service:
+        name: vmware-system-csi-webhook-service
+        namespace: vmware-system-csi
+        path: "/mutate"
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1", "v1beta1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["persistentvolumeclaims"]
+        scope: "Namespaced"
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -583,6 +636,12 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["encryption.vmware.com"]
+    resources: ["encryptionclasses"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**:
Registering validation/mutation webhooks for EncryptionClass

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
N/A

**Special notes for your reviewer**:
BYOK support was already added for v1.30 and v1.29

**Release note**:
```release-note
```
