### PR TITLE
Allow passing BASE_IMAGE as input to while building docker images

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -62,6 +62,9 @@ LINUX_IMAGE_OUTPUT="type=docker"
 
 REGISTRY=
 
+# Base image if not given already
+BASE_IMAGE=photon:4.0
+
 # The manifest command is still experimental as of Docker 18.09.3
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
@@ -138,6 +141,7 @@ function build_driver_images_linux() {
    --build-arg "GOPROXY=${GOPROXY}" \
    --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
    --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" \
+   --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
    .
 }
 
@@ -150,7 +154,8 @@ function build_syncer_image_linux() {
       --build-arg "GOPROXY=${GOPROXY}" \
       --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
       --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" \
-  .
+      --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+      .
 
   if [ "${LATEST}" ]; then
     echo "tagging image ${SYNCER_IMAGE_NAME}:${VERSION} as latest"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR provides way to use custom base image for building docker images for driver and syncer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
make images works fine and uses BASE_IMAGE as set by user 

```
$ echo $BASE_IMAGE
dockerhub.artifactory.vcfd.broadcom.net/library/photon:4.0

$ make images
...
+ docker buildx build --platform linux/amd64 --output type=docker --file images/driver/Dockerfile --tag us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver-linux-amd64:c4513d79 --build-arg ARCH=amd64 --build-arg VERSION=c4513d79 --build-arg GOPROXY=https://proxy.golang.org --build-arg GIT_COMMIT=c4513d794f3aa891e30a7e9d0a2306b5868a2646 --build-arg GOLANG_IMAGE=golang:1.22 --build-arg BASE_IMAGE=dockerhub.artifactory.vcfd.broadcom.net/library/photon:4.0 .
[+] Building 64.5s (17/17) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                         0.0s
 => => transferring dockerfile: 3.06kB                                                                                                                                                                       0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 29)                                                                                                                              0.0s
 => [internal] load metadata for dockerhub.artifactory.vcfd.broadcom.net/library/photon:4.0                                                                                                                  2.3s
 => [internal] load metadata for docker.io/library/golang:1.22                                                                      
...

$ echo $BASE_IMAGE

$ make images
...
+ docker buildx build --platform linux/amd64 --output type=docker --file images/driver/Dockerfile --tag us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver-linux-amd64:7f5c0783 --build-arg ARCH=amd64 --build-arg VERSION=7f5c0783 --build-arg GOPROXY=https://proxy.golang.org --build-arg GIT_COMMIT=7f5c078332298e4ac9ec8a2861fbc9537cd4025d --build-arg GOLANG_IMAGE=golang:1.22 --build-arg BASE_IMAGE=photon:4.0 .
[+] Building 40.7s (12/16)
[+] Building 41.0s (13/16)
[+] Building 41.1s (13/16)
[+] Building 41.3s (13/16)
[+] Building 41.4s (13/16)
[+] Building 41.6s (14/16)
 => [internal] load build definition from Dockerfile                                                                                                                                                         0.0s
 => => transferring dockerfile: 3.06kB                                                                                                                                                                       0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 29)                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/photon:4.0                                                                                                                                                2.0s
 => [internal] load metadata for docker.io/library/golang:1.22               
```                                 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow passing BASE_IMAGE as input to while building docker images
```
