### PR TITLE
Removing dev.version from CNS and Vim clients

### DIFF
--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -467,7 +467,7 @@ data:
   "tkgs-ha": "true"
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
-  "storage-quota-m2": "false"
+  "storage-quota-m2": "true"
   "vdpp-on-stretched-supervisor": "false"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -504,7 +504,7 @@ data:
   "tkgs-ha": "true"
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
-  "storage-quota-m2": "false"
+  "storage-quota-m2": "true"
   "vdpp-on-stretched-supervisor": "false"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -504,7 +504,7 @@ data:
   "tkgs-ha": "true"
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
-  "storage-quota-m2": "false"
+  "storage-quota-m2": "true"
   "vdpp-on-stretched-supervisor": "false"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -504,7 +504,7 @@ data:
   "tkgs-ha": "true"
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
-  "storage-quota-m2": "false"
+  "storage-quota-m2": "true"
   "vdpp-on-stretched-supervisor": "false"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"

--- a/pkg/common/cns-lib/vsphere/cns.go
+++ b/pkg/common/cns-lib/vsphere/cns.go
@@ -34,13 +34,6 @@ func NewCnsClient(ctx context.Context, c *vim25.Client) (*cns.Client, error) {
 	}
 	cnsClient.RoundTripper = &MetricRoundTripper{"cns", cnsClient.RoundTripper}
 
-	// TODO: remove code to add version to CNS API, once CNS releases the next version.
-	if UseCnsAPIDevVersion {
-		log.Infof("Setting dev.version on new CNS client")
-		cnsClient.Version = cnsDevVersion
-		cnsClient.Client.Version = cnsDevVersion
-	}
-
 	return cnsClient, nil
 }
 

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -60,9 +60,6 @@ const (
 	statusSuccess = "success"
 	// failed request
 	statusFailUnknown = "fail-unknown"
-
-	// cnsDevVersion is the CNS API development version
-	cnsDevVersion = "dev.version"
 )
 
 // VirtualCenter holds details of a virtual center instance.
@@ -100,9 +97,6 @@ var (
 	vCenterInstanceLock = &sync.RWMutex{}
 	// vCenterInstancesLock makes sure only one vCenter being initialized for specific host
 	vCenterInstancesLock = &sync.RWMutex{}
-
-	// UseCnsAPIDevVersion sets dev.version on CNS vim25 and CNS soap clients
-	UseCnsAPIDevVersion bool
 )
 
 func (vc *VirtualCenter) String() string {
@@ -317,12 +311,6 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 			return err
 		}
 		log.Infof("VirtualCenter.connect() successfully created new client")
-
-		// TODO: remove code to add version to CNS API, once CNS releases the next version.
-		if UseCnsAPIDevVersion && vc.Client != nil {
-			log.Infof("CNS vim25 client was nil, setting dev.version on new CNS vim25 client")
-			vc.Client.Version = cnsDevVersion
-		}
 		return nil
 	}
 	if !requestNewSession {
@@ -362,10 +350,6 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 			log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 		}
 		return err
-	}
-	if UseCnsAPIDevVersion && vc.Client != nil {
-		log.Infof("Setting dev.version on new CNS vim25 client")
-		vc.Client.Version = cnsDevVersion
 	}
 	// Recreate PbmClient if created using timed out VC Client.
 	if vc.PbmClient != nil {

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -118,11 +118,6 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		config.Global.CAFile = cnsconfig.SupervisorCAFilePath
 	}
 
-	// TODO: remove code to add version to CNS API, once CNS releases the next version.
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.StorageQuotaM2) {
-		cnsvsphere.UseCnsAPIDevVersion = true
-	}
-
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
 		clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
 		if err != nil {

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -325,12 +325,6 @@ func InitCommonModules(ctx context.Context, clusterFlavor cnstypes.CnsClusterFla
 		return err
 	}
 
-	// TODO: remove code to add version to CNS API, once CNS releases the next version.
-	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
-		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.StorageQuotaM2) {
-		cnsvsphere.UseCnsAPIDevVersion = true
-	}
-
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TriggerCsiFullSync) {
 		log.Infof("Triggerfullsync feature enabled")
 		err := k8s.CreateCustomResourceDefinitionFromManifest(ctx, internalapiscnsoperatorconfig.EmbedTriggerCsiFullSync,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removing dev.version from CNS and Vim clients which was temporarily added for fetching aggregatedSnapshotCapacity from CNS APIs.
And enable storage-quota-m2 FSS.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
`make test` and `make check` are working fine.

Created a snapshot on setup with these changes and verified that aggregatedSnapshotCapacity is getting generated.

```
# k get pvc -n e2e2
NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       VOLUMEATTRIBUTESCLASS   AGE
pvc-9s4ps   Bound    pvc-638d565a-af5f-42fd-8981-3b93e03fa28e   2Gi        RWO            shared-ds-policy   <unset>                 5h46m

# k get vs -n e2e2
NAME                                      READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
example-vanilla-rwo-filesystem-snapshot   true         pvc-9s4ps                           2Gi           volumesnapshotclass-delete   snapcontent-cd85015d-bb7f-4f76-9580-6e0ac4ae51e7   9m18s          9m19s


#  k get cnsvolumeinfo 44e7333c-e372-4431-92eb-fe3ccdfab987 -n vmware-system-csi -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CNSVolumeInfo
metadata:
  creationTimestamp: "2024-12-10T05:19:18Z"
  generation: 3
  name: 44e7333c-e372-4431-92eb-fe3ccdfab987
  namespace: vmware-system-csi
  resourceVersion: "1644962"
  uid: 0b2da524-1591-406a-b62b-4f8654315f5f
spec:
  aggregatedsnapshotsize: 96Mi    <<<<<
  capacity: 2Gi
  namespace: e2e2
  snapshotlatestoperationcompletetime: "2024-12-10T11:03:34Z"
  ...
  
# k get storagepolicyquota -n e2e2 -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha2
  kind: StoragePolicyQuota
...
  status:
    extensions:
    - extensionName: volume.cns.vsphere.vmware.com
      extensionQuotaUsage:
      - scQuotaUsage:
          reserved: "0"
          used: 2Gi
        storageClassName: shared-ds-policy
      - scQuotaUsage:
          reserved: "0"
          used: "0"
        storageClassName: shared-ds-policy-latebinding
    - extensionName: snapshot.cns.vsphere.vmware.com
      extensionQuotaUsage:
      - scQuotaUsage:
          reserved: "0"
          used: "0"
        storageClassName: shared-ds-policy-latebinding
      - scQuotaUsage:
          reserved: "0"
          used: 96Mi                      <<<<<
        storageClassName: shared-ds-policy
...
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Removing dev.version from CNS and Vim clients which was temporarily added for fetching aggregatedSnapshotCapacity from CNS APIs.
```
