### PR TITLE
Set BASE_IMAGE only if not given by user

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -62,8 +62,10 @@ LINUX_IMAGE_OUTPUT="type=docker"
 
 REGISTRY=
 
-# Base image if not given already
-BASE_IMAGE=photon:4.0
+# set base image if not given already
+if [ ! "${BASE_IMAGE}" ]; then
+	BASE_IMAGE=photon:4.0
+fi
 
 # The manifest command is still experimental as of Docker 18.09.3
 export DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Changes done via https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3127 reset the BASE_IMAGE if set by user to default of photon:4.0, which breaks the intended behavior. This PR ensures that BASE_IMAGE if set by user does not get reset to default.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Without BASE_IMAGE set:

```
$ export BASE_IMAGE=
$ make images
...
+ BASE_IMAGE=
+ '[' '!' ']'
+ echo 'using base image'
using base image
+ BASE_IMAGE=photon:4.0
...
+ docker buildx build --platform linux/amd64 --output type=docker --file images/driver/Dockerfile --tag us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver-linux-amd64:c9c0da42 --build-arg ARCH=amd64 --build-arg VERSION=c9c0da42 --build-arg GOPROXY=https://proxy.golang.org --build-arg GIT_COMMIT=c9c0da420661f34595c8ad8c40f62f1fe8e3e032 --build-arg GOLANG_IMAGE=golang:1.22 --build-arg BASE_IMAGE=photon:4.0 .
```

With user setting BASE_IMAGE:

```
$ export BASE_IMAGE=dockerhub.artifactory.vcfd.broadcom.net/library/photon:4.0
$ make images
...
+ REGISTRY=
+ BASE_IMAGE=dockerhub.artifactory.vcfd.broadcom.net/library/photon:4.0
+ '[' '!' dockerhub.artifactory.vcfd.broadcom.net/library/photon:4.0 ']'
...
+ docker buildx build --platform linux/amd64 --output type=docker --file images/driver/Dockerfile --tag us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver-linux-amd64:c9c0da42 --build-arg ARCH=amd64 --build-arg VERSION=c9c0da42 --build-arg GOPROXY=https://proxy.golang.org --build-arg GIT_COMMIT=c9c0da420661f34595c8ad8c40f62f1fe8e3e032 --build-arg GOLANG_IMAGE=golang:1.22 --build-arg BASE_IMAGE=dockerhub.artifactory.vcfd.broadcom.net/library/photon:4.0 .
```




**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set BASE_IMAGE only if not given by user
```
