### PR TITLE
Remove supervisor pvc labels during pvcsi pvc delete

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2396,7 +2396,7 @@ func pvcDeleted(obj interface{}, metadataSyncer *metadataSyncInformer) {
 	}
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		// Invoke volume deleted method for pvCSI.
-		pvcsiVolumeDeleted(ctx, string(pvc.GetUID()), metadataSyncer)
+		pvcsiVolumeDeleted(ctx, string(pvc.GetUID()), metadataSyncer, pv)
 	} else {
 		csiPVCDeleted(ctx, pvc, pv, metadataSyncer)
 	}
@@ -2535,7 +2535,7 @@ func pvDeleted(obj interface{}, metadataSyncer *metadataSyncInformer) {
 	}
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		// Invoke volume deleted method for pvCSI.
-		pvcsiVolumeDeleted(ctx, string(pv.GetUID()), metadataSyncer)
+		pvcsiVolumeDeleted(ctx, string(pv.GetUID()), metadataSyncer, pv)
 	} else {
 		csiPVDeleted(ctx, pv, metadataSyncer)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For PVCSI volumes created with reclaim policy set to Retain, we can cleanup/remove the supervisor pvc labels during pvcsi pvc delete. This PR is addressing the label removal operation from PVCSI metadatasyncer.

**Testing done**:

Create a PVC in Guest cluster

```
kubectl create -f pvc.yaml
persistentvolumeclaim/example-rwo-pvc created
```

Verify the SV PVC has GC labels:

```
kubectl describe pvc -n test-ns     30fad55e-2a73-4d1f-9efa-9252275903f3-b573dd67-d535-4308-966a-fe691d832ed8
Name:          30fad55e-2a73-4d1f-9efa-9252275903f3-b573dd67-d535-4308-966a-fe691d832ed8
Namespace:     test-ns
StorageClass:  wcpglobal-storage-profile
Status:        Bound
Volume:        pvc-c5e33ed1-5917-4d2b-8f3b-598b53b904f5
Labels:        wl-antrea/TKGService=30fad55e-2a73-4d1f-9efa-9252275903f3. <<<<< GC LABEL ADDED>>>>>>>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      50Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age   From                                                                                          Message
  ----    ------                 ----  ----    
```


Patch the PVC to ReclaimPolicy Retain

```
kubectl patch pv pvc-b573dd67-d535-4308-966a-fe691d832ed8 -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Retain\"}}"
```

```
kubectl get pv -A
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                               STORAGECLASS                REASON   AGE
pvc-c5e33ed1-5917-4d2b-8f3b-598b53b904f5   50Mi       RWO            Retain           Released    test-ns/30fad55e-2a73-4d1f-9efa-9252275903f3-b573dd67-d535-4308-966a-fe691d832ed8   wcpglobal-storage-profile            58s
```


Verify the Label is removed on the SV PVC:

```
kubectl describe pvc 30fad55e-2a73-4d1f-9efa-9252275903f3-b573dd67-d535-4308-966a-fe691d832ed8 -n test-ns
Name:          30fad55e-2a73-4d1f-9efa-9252275903f3-b573dd67-d535-4308-966a-fe691d832ed8
Namespace:     test-ns
StorageClass:  wcpglobal-storage-profile
Status:        Bound
Volume:        pvc-c5e33ed1-5917-4d2b-8f3b-598b53b904f5
Labels:        <none>.  <<<<< GC LABEL REMOVED >>>>>>>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Wed Jan 15 19:13:48 UTC 2025
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      50Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age    From                                                                                          Message
```

Verify CNS UI does not have GC labels on the SV PVC:

<img width="979" alt="Screenshot 2025-01-15 at 11 29 16 AM" src="https://github.com/user-attachments/assets/b2733df0-05a1-4c1f-8073-c9aed15de7ee" />


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove supervisor pvc labels during pvcsi pvc delete
```
