### PR TITLE
Fix BASE_IMAGE initialization in release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -63,9 +63,7 @@ LINUX_IMAGE_OUTPUT="type=docker"
 REGISTRY=
 
 # set base image if not given already
-if [ ! "${BASE_IMAGE}" ]; then
-	BASE_IMAGE=photon:4.0
-fi
+BASE_IMAGE="${BASE_IMAGE:=photon:4.0}"
 
 # The manifest command is still experimental as of Docker 18.09.3
 export DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: `make images` fails with `BASE_IMAGE: unbound variable` error without this fix

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran ./hack/check-shell.sh successfully.

`make images` does not fail.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix BASE_IMAGE initialization in release.sh
```
