### PR TITLE
Skip SV FSS check for Windows Support in guest clusters

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1209,6 +1209,11 @@ func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) 
 	} else if c.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		isPVCSIFSSEnabled := c.IsPVCSIFSSEnabled(ctx, featureName)
 		if isPVCSIFSSEnabled {
+			// Skip SV FSS check for Windows Support since there is no dependency on supervisor
+			if featureName == common.CSIWindowsSupport {
+				log.Info("CSI Windows Suppport is set to true in pvcsi fss configmap. Skipping SV FSS check")
+				return true
+			}
 			return c.IsCNSCSIFSSEnabled(ctx, featureName)
 		}
 		return false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making sure we skip SV FSS check for Windows Support in guest clusters as there is no dependency on Supervisor.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Skip SV FSS check for Windows Support in guest clusters
```
