### PR TITLE
Complete deletion of CnsFileAccessConfig instance if associated nodeVM instance is not found

### DIFF
--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -47,7 +47,7 @@ rules:
     verbs: ["create", "get", "list", "update", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfilevolumeclients"]
-    verbs: ["get", "update", "create", "delete"]
+    verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes", "cnsunregistervolumes"]
     verbs: ["get", "list", "watch", "update", "delete"]

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -47,7 +47,7 @@ rules:
     verbs: ["create", "get", "list", "update", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfilevolumeclients"]
-    verbs: ["get", "update", "create", "delete"]
+    verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes", "cnsunregistervolumes"]
     verbs: ["get", "list", "watch", "update", "delete"]

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -47,7 +47,7 @@ rules:
     verbs: ["create", "get", "list", "update", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfilevolumeclients"]
-    verbs: ["get", "update", "create", "delete"]
+    verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes", "cnsunregistervolumes"]
     verbs: ["get", "list", "watch", "update", "delete"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains following changes:
1. If nodeVM instance is deleted and later we get request to delete CnsFileAccessConfig instance, then currently we return error and CnsFileAccessConfig instance never gets deleted.
Updating code to proceed with the deletion of CnsFileAccessConfig instance if the associated nodeVM instance is not found (already deleted). To fetch VM IP which is required to configure ACL, we get it from CnsFileVolumeClient CR.
2. Adding finaliser on CnsFileVolumeClient CR during creation, so that it doesn't get deleted abruptly (since we are using it from CnsFileAccessConfig reconciler).
3. Deleting the finaliser on CnsFileVolumeClient CR just before when we delete the instance.
4. Now, during upgrade from older WCP version to current WCP version, we need to add finaliser on existing CnsFileVolumeClient CRs. Added a code in syncer start to add finalisers on all existing CnsFileVolumeClient CRs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
`make check` and `make test` are passing.

Verified that namespace deletion is succeeding now when file volume is attached to the pod in namespace.

followed below mentioned steps:
1. Create a WCP Namespace "test", assign storage policy, VM class, TKG library
2. Create a TKG test-cluster-e2e-script - in the above namespace
3. Create a "test" namespace inside TKG, Create a workload (CSI File Volume, and attach/mount it to Pod)
4. Wait for the Pod with File volume to be up and running
Verify the CRD cnsfileaccessconfigs.cns.vmware.com is created
5. Delete Namespace test-gc-e2e-demo-ns from VC UI

Logs for reference:

```
GC:

# k get pvc -A
NAMESPACE   NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
test        example-vanilla-file-pvc   Bound    pvc-b2968c0f-5a4c-407b-8c5c-d650beaa9ad7   100Mi      RWX            test-policy    <unset>                 38s

# k get pods -n test
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-file-pod1   1/1     Running   0          41s


WCP: 

# k get cluster -A
NAMESPACE   NAME                      CLUSTERCLASS             PHASE         AGE   VERSION
test        test-cluster-e2e-script   builtin-generic-v3.1.0   Provisioned   24m   v1.31.4+vmware.1-fips

# k get cnsfilevolumeclient -n test -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsFileVolumeClient
  metadata:
    creationTimestamp: "2025-02-05T14:09:12Z"
    finalizers:
    - cns.vmware.com
    generation: 1
    name: 8bd9c3f4-fe7d-407e-9f5e-d456ab664ef8-b2968c0f-5a4c-407b-8c5c-d650beaa9ad7
    namespace: test
    resourceVersion: "8483851"
    uid: 2803e72f-28a9-4540-af57-47f85744b4bd
  spec:
    externalIPtoClientVms:
      166.168.16.44:
      - test-cluster-e2e-script-node-pool-1-qwblx-lg2bf-7qszx
kind: List
metadata:
  resourceVersion: ""


# k get cnsfileaccessconfig -A -oyaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsFileAccessConfig
  metadata:
    creationTimestamp: "2025-02-05T14:09:05Z"
    finalizers:
    - cns.vmware.com
    generation: 2
    name: test-cluster-e2e-script-node-pool-1-qwblx-lg2bf-7qszx-8bd9c3f4-fe7d-407e-9f5e-d456ab664ef8-b2968c0f-5a4c-407b-8c5c-d650beaa9ad7
    namespace: test
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-qwblx-lg2bf-7qszx
      uid: cac71469-97b1-45f2-9b48-4c2607f00bed
    resourceVersion: "8483852"
    uid: 1a4f5c7e-b0af-46a9-b8f6-cba3d6dba526
  spec:
    pvcName: 8bd9c3f4-fe7d-407e-9f5e-d456ab664ef8-b2968c0f-5a4c-407b-8c5c-d650beaa9ad7
    vmName: test-cluster-e2e-script-node-pool-1-qwblx-lg2bf-7qszx
  status:
    accessPoints:
      NFSv3: host10.cibgst.com:/525978d8-2bd6-40d8-2859-36dc5210c436
      NFSv4.1: host10.cibgst.com:/vsanfs/525978d8-2bd6-40d8-2859-36dc5210c436
    done: true
kind: List
metadata:
  resourceVersion: ""


# k describe ns test
Name:         test
Labels:       kubernetes.io/metadata.name=test
              vSphereClusterID=domain-c10
Annotations:  vmware-system-resource-pool-cpu-limit: 
              vmware-system-resource-pool-memory-limit: 
Status:       Active
...


//// Delete namespace from VC UI

# k get pvc -n test
No resources found in test namespace.

# k get pod -n test
No resources found in test namespace.

# k get cnsfileaccessconfig -n test 
No resources found in test namespace.

# k get cnsfilevolumeclient -n test 
No resources found in test namespace.

# k describe ns test
Error from server (NotFound): namespaces "test" not found
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Complete deletion of CnsFileAccessConfig instance if associated nodeVM instance is not found
```
