### PR TITLE
Build Syncer on AMD64 image

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -136,7 +136,6 @@ function build_driver_images_linux() {
    --output "${LINUX_IMAGE_OUTPUT}" \
    --file images/driver/Dockerfile \
    --tag "${tag}" \
-   --build-arg ARCH=amd64 \
    --build-arg "VERSION=${VERSION}" \
    --build-arg "GOPROXY=${GOPROXY}" \
    --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
@@ -150,7 +149,9 @@ function build_syncer_image_linux() {
   docker build \
       -f images/syncer/Dockerfile \
       -t "${SYNCER_IMAGE_NAME}":"${VERSION}" \
+      --platform "linux/$ARCH" \
       --build-arg "VERSION=${VERSION}" \
+      --build-arg "ARCH=linux/amd64" \
       --build-arg "GOPROXY=${GOPROXY}" \
       --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
       --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" \

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -22,7 +22,7 @@ ARG BASE_IMAGE=photon:4.0
 ################################################################################
 ##                              BUILD STAGE                                   ##
 ################################################################################
-FROM ${GOLANG_IMAGE} as builder
+FROM --platform=linux/amd64 ${GOLANG_IMAGE} as builder
 
 # This build arg is the version to embed in the CSI binary
 ARG VERSION=unknown
@@ -41,7 +41,7 @@ ENV CGO_ENABLED=0
 
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
 
-RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.Version=${VERSION}" -o vsphere-syncer ./cmd/syncer
+RUN GOARCH=amd64 go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.Version=${VERSION}" -o vsphere-syncer ./cmd/syncer
 
 ################################################################################
 ##                               MAIN STAGE                                   ##


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Build Syncer on AMD64 image at all times on all dev workspace's ARCH

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Build Syncer on AMD64 image at all times on all dev workspaces
```
