### PR TITLE
Update csi-snapshotter image to v8.2.0 for Guest cluster

### DIFF
--- a/manifests/guestcluster/1.32/pvcsi.yaml
+++ b/manifests/guestcluster/1.32/pvcsi.yaml
@@ -355,7 +355,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update csi-snapshotter image to v8.2.0 for Guest cluster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

**Special notes for your reviewer**:

**Release note**:
```release-note
Update csi-snapshotter image to v8.2.0 for Guest cluster
```
