### PR TITLE
remove validation for topologyrequirement for vdpp-on-stretched-supervisor

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -546,10 +546,6 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal,
 					"volume provisioning request received without topologyRequirement.")
 			}
-			if isVdppOnStretchedSVEnabled {
-				return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal,
-					"volume provisioning request received without topologyRequirement.")
-			}
 			if len(clusterComputeResourceMoIds) > 1 {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
 					"stretched supervisor cluster does not support creating volumes "+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We do not need to check topologyrequirement is empty when `vdpp-on-stretched-supervisor` FSS is enabled.
We may have a case where supervisor is upgraded, but VKS is not upgraded and supervisor is having 1 AZ. 

For this case PVC request for non-vdpp workload can come to CSI controller without topology requirement.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
remove validation for topologyrequirement for vdpp-on-stretched-supervisor
```
