### PR TITLE
Restore the manifest related to snapshot validating webhook, as this is referred by older release branches

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -1,0 +1,99 @@
+# Requires k8s 1.20+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-webhook
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-webhook-runner
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-webhook
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: snapshot-webhook-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: snapshot-validation-service
+  namespace: kube-system
+spec:
+  selector:
+    app: snapshot-validation
+  ports:
+    - protocol: TCP
+      port: 443 # Change if needed
+      targetPort: 443 # Change if the webserver image expects a different port
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "validation-webhook.snapshot.storage.k8s.io"
+webhooks:
+  - name: "validation-webhook.snapshot.storage.k8s.io"
+    rules:
+      - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["volumesnapshots", "volumesnapshotcontents", "volumesnapshotclasses"]
+        scope:       "*"
+    clientConfig:
+      service:
+        namespace: kube-system
+        name: "snapshot-validation-service"
+        path: "/volumesnapshot"
+      caBundle: ${CA_BUNDLE}
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Ignore # We recommend switching to Fail only after successful installation of the webhook server and webhook.
+    timeoutSeconds: 2 # This will affect the latency and performance. Finetune this value based on your application's tolerance.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snapshot-validation-deployment
+  namespace: kube-system
+  labels:
+    app: snapshot-validation
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: snapshot-validation
+  template:
+    metadata:
+      labels:
+        app: snapshot-validation
+    spec:
+      serviceAccountName: snapshot-webhook
+      containers:
+        - name: snapshot-validation
+          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v7.0.2 # change the image if you wish to use your own custom validation server image
+          imagePullPolicy: IfNotPresent
+          args: ['--tls-cert-file=/run/secrets/tls/tls.crt', '--tls-private-key-file=/run/secrets/tls/tls.key']
+          ports:
+            - containerPort: 443 # change the port as needed
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /run/secrets/tls
+              readOnly: true
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: snapshot-webhook-certs


### PR DESCRIPTION
**What this PR does / why we need it**:
Restore the manifest related to snapshot validating webhook, as this is referred by older release branches.

csi-snapshot-validatingwebhook.yaml this file was removed from master branch, as it is no more required with snapshotter version v8.2.0. But this file is referred by older release branches from the path of master (https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/vanilla/csi-snapshot-validatingwebhook.yaml).
Hence, restoring this file in master branch.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
No impact, we are just restoring the yaml file. It is not referred by master code, but being referred by older release branches.

**Special notes for your reviewer**:

**Release note**:
```release-note
Restore the manifest related to snapshot validating webhook, as this is referred by older branches.
```
