### PR TITLE
revert volumdIDLimitPerQuery limit to 1k from 10k

### DIFF
--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -49,8 +49,8 @@ const (
 
 	// allowedRetriesToPatchStoragePolicyUsage indicates number of retries allowed for patching StoragePolicyUsage CR
 	allowedRetriesToPatchStoragePolicyUsage = 5
-	// volumdIDLimitPerQuery is set to 10000
-	volumdIDLimitPerQuery = 10000
+	// volumdIDLimitPerQuery is set to 1000
+	volumdIDLimitPerQuery = 1000
 )
 
 // getPVsInBoundAvailableOrReleased return PVs in Bound, Available or Released


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
On vCenter VolumeID limit per query is reverted back to 1k.
This PR is addressing the API requirement to not send more than 1K volume in the QueryFilter.


volumdIDLimitPerQuery was increased to 10k with this PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3047 


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
revert volumdIDLimitPerQuery limit to 1k from 10k
```
