### PR TITLE
Fix assigning of policies to WCP namespace in case of policy driven v…

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -6266,9 +6266,7 @@ func assignPolicyToWcpNamespace(client clientset.Interface, ctx context.Context,
 	curlCmd := fmt.Sprintf(`curl -s -o /dev/null -w "%s" -k -X PATCH`+
 		` 'https://%s/api/vcenter/namespaces/instances/%s' -H `+
 		`'vmware-api-session-id: %s' -H 'Content-type: application/json' -d `+
-		`'{ "access_list": [ { "domain": "", "role": "OWNER", "subject": "", "subject_type": "USER" } ], `+
-		`"description": "", "resource_spec": { }, "storage_specs": [ %s ], `+
-		`"vm_service_spec": { } }'`, httpCodeStr, vcIp, namespace, sessionId, curlStr)
+		`'{"storage_specs": [ %s ]}'`, httpCodeStr, vcIp, namespace, sessionId, curlStr)
 
 	framework.Logf("Running command: %s", curlCmd)
 	result, err := fssh.SSH(ctx, curlCmd, vcAddress, framework.TestContext.Provider)


### PR DESCRIPTION
Fix assigning of policies to WCP namespace in case of policy driven volume provisioning testcases

**What this PR does / why we need it**: Accomodating changes to make test fix to assign policies created in test to WCP namespace and set required storage policy quota by using storagePolicy Quota API.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/3f71d7efc9d3a9c8ae77ac4a83578013



