### PR TITLE
Clean up the cnsvolumemetadata crs after tkc upgrade to non-legacy releases

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -104,6 +104,8 @@ const (
 	TKCAPIVersion = "run.tanzu.vmware.com/v1alpha1"
 	// ClusterIDConfigMapName refers to the name of the immutable ConfigMap used to store cluster ID
 	ClusterIDConfigMapName = "vsphere-csi-cluster-id"
+	// ClusterVersionv1beta1 refers to the api version of non-legacy cluster
+	ClusterVersionv1beta1 = "cluster.x-k8s.io/v1beta1"
 )
 
 // Errors


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Clean up the duplicate CNSVolumeMetadata CR's remain after TKC upgrade from legacy to non-legacy releases

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing performed and attached the logs below

```
root@421101fc6e0295f33c3cbd7ee9b1c56b [ ~ ]# kubectl get cnsvolumemetadata -A
NAMESPACE   NAME                                                                        AGE
test-ns     345bac82-4045-43e2-86cb-abb98948d0b3-22457806-fdba-448d-b7c5-d789ee187f04   26h
test-ns     345bac82-4045-43e2-86cb-abb98948d0b3-f00b6796-993a-4744-9731-140b619107e4   26h
test-ns     a2e8f843-58c1-4998-8a55-2ca4aef814ff-22457806-fdba-448d-b7c5-d789ee187f04   14m
test-ns     a2e8f843-58c1-4998-8a55-2ca4aef814ff-f00b6796-993a-4744-9731-140b619107e4   5m54s
root@421101fc6e0295f33c3cbd7ee9b1c56b [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml
root@421101fc6e0295f33c3cbd7ee9b1c56b [ ~ ]# kubectl edit deploy vsphere-csi-controller -n vmware-system-csi
deployment.apps/vsphere-csi-controller edited
root@421101fc6e0295f33c3cbd7ee9b1c56b [ ~ ]# kubectl get pod -n vmware-system-csi -w
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-86866d4d97-4rbxf   7/7     Running   0             2m9s
vsphere-csi-node-ql8jt                    3/3     Running   0             26h
vsphere-csi-node-rhrd8                    3/3     Running   3 (26h ago)   26h
vsphere-csi-node-rq6zq                    3/3     Running   0             26h
root@421101fc6e0295f33c3cbd7ee9b1c56b [ ~ ]# export KUBECONFIG=
root@421101fc6e0295f33c3cbd7ee9b1c56b [ ~ ]# kubectl get cnsvolumemetadata -A
NAMESPACE   NAME                                                                        AGE
test-ns     345bac82-4045-43e2-86cb-abb98948d0b3-22457806-fdba-448d-b7c5-d789ee187f04   26h
test-ns     345bac82-4045-43e2-86cb-abb98948d0b3-f00b6796-993a-4744-9731-140b619107e4   26h
root@421101fc6e0295f33c3cbd7ee9b1c56b [ ~ ]# 
```

[cnsvolumemetadata_cleanup_testing.log](https://github.com/user-attachments/files/19033489/cnsvolumemetadata_cleanup_testing.log)

[cnsvolmetadata_cleanup_syncer.log](https://github.com/user-attachments/files/19033490/cnsvolmetadata_cleanup_syncer.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Clean up the duplicate CNSVolumeMetadata CR's remain after TKC upgrade from legacy to non-legacy releases

```
