### PR TITLE
Terminate the elected syncer when failed to initialize

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -25,7 +25,6 @@ import (
 	"os/signal"
 	"regexp"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -35,7 +34,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/sample-controller/pkg/signals"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -250,19 +248,11 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 		log := logger.GetLogger(ctx)
 		// Disconnect vCenter sessions on restart
 		defer func() {
+			log.Info("Cleaning up vc sessions syncer components")
 			if r := recover(); r != nil {
-				fmt.Printf("panic: %+v", r)
 				cleanupSessions(ctx, r)
 			}
 		}()
-
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithCancel(ctx)
-		defer cancel()
-
-		errChan := make(chan error, 4)
-		defer close(errChan)
-
 		if err := manager.InitCommonModules(ctx, clusterFlavor, coInitParams); err != nil {
 			log.Errorf("Error initializing common modules for all flavors. Error: %+v", err)
 			os.Exit(1)
@@ -284,13 +274,9 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 			}
 		}
 
-		wg := sync.WaitGroup{}
-
 		// Initialize CNS Operator for Supervisor clusters.
 		if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-			wg.Add(1)
 			go func() {
-				defer wg.Done()
 				defer func() {
 					log.Info("Cleaning up vc sessions storage pool service")
 					if r := recover(); r != nil {
@@ -362,64 +348,43 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 			}
 		}
 
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
 			defer func() {
+				log.Info("Cleaning up vc sessions cns operator")
 				if r := recover(); r != nil {
 					cleanupSessions(ctx, r)
 				}
 			}()
 			if err := manager.InitCnsOperator(ctx, clusterFlavor, configInfo, coInitParams); err != nil {
-				errChan <- fmt.Errorf("failed to initialize CNS operator: %w", err)
+				log.Errorf("Error initializing Cns Operator. Error: %+v", err)
+				utils.LogoutAllvCenterSessions(ctx)
+				os.Exit(0)
 			}
 		}()
+
 		if clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
 			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WCP_VMService_BYOK) {
 			// Start BYOK Operator for Supervisor clusters.
-			wg.Add(1)
 			go func() {
-				defer wg.Done()
 				defer func() {
+					log.Info("Cleaning up vc sessions BYOK operator")
 					if r := recover(); r != nil {
 						cleanupSessions(ctx, r)
 					}
 				}()
 				if err := startByokOperator(ctx, clusterFlavor, configInfo); err != nil {
-					errChan <- fmt.Errorf("failed to run BYOK operator: %w", err)
+					log.Errorf("Error initializing BYOK Operator. Error: %+v", err)
+					utils.LogoutAllvCenterSessions(ctx)
+					os.Exit(0)
 				}
 			}()
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					cleanupSessions(ctx, r)
-				}
-			}()
-			syncer.PeriodicSyncIntervalInMin = *periodicSyncIntervalInMin
-			if err := syncer.InitMetadataSyncer(ctx, clusterFlavor, configInfo); err != nil {
-				errChan <- fmt.Errorf("failed to initialize Metadata Syncer: %w", err)
-			}
-		}()
-
-		defer func() {
-			utils.LogoutAllvCenterSessions(context.Background())
-		}()
-
-		defer func() {
-			log.Info("Terminating syncer components")
-			cancel()
-			wg.Wait()
-		}()
-
-		select {
-		case <-ctx.Done():
-		case <-signals.SetupSignalHandler().Done():
-		case err := <-errChan:
-			log.Error(err)
+		syncer.PeriodicSyncIntervalInMin = *periodicSyncIntervalInMin
+		if err := syncer.InitMetadataSyncer(ctx, clusterFlavor, configInfo); err != nil {
+			log.Errorf("Error initializing Metadata Syncer. Error: %+v", err)
+			utils.LogoutAllvCenterSessions(ctx)
+			os.Exit(0)
 		}
 	}
 }

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -26,6 +26,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/sample-controller/pkg/signals"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
@@ -76,7 +77,7 @@ func NewInformer(ctx context.Context, client clientset.Interface, inClusterClnt 
 	if informerInstance == nil {
 		informerInstance = &InformerManager{
 			client:          client,
-			stopCh:          ctx.Done(),
+			stopCh:          signals.SetupSignalHandler().Done(),
 			informerFactory: informers.NewSharedInformerFactory(client, noResyncPeriodFunc()),
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
During Supervisor initialization, the CSI driver starts and must wait for all dependent components to become available. 
The syncer component contains faulty logic that assumes all dependencies (e.g., vCenter configuration) are immediately present.

This fix restores the original behavior, ensuring that the leader-elected syncer terminates the process if an error occurs during initialization phase.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
N/A

**Testing done**:
End-to-end testing:

- Verify PVC is encrypted with EC.
- Verify PVC is encrypted with the default EC.
- Verify PVC is recrypted when setting new EC.
- Verify PVC is recrypted when associated EC has its key rotated.
- Verify PVC creation fails when associated with EC and SC not supporting encryption.
- Verify VM encrypted with EC, PVC is not encrypted.
- Verify VM and PVC are encrypted with EC.
- Verify VM and attached PVC are encrypted with default EncryptionClass.
- Verify VM and attached PVC are encrypted with different keys.
- Verify VM and attached PVC are encrypted with EncryptionClass, key is rotated.

Manual testing:

- Creation of 2 PVCs and attaching them to a VM.
- Creation / deletion of 100 PVCs in parallel.

**Special notes for your reviewer**:
The bug was introduced in the following commit: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3106/files#diff-5d2e84d5f40cb607c43d24d93465d8b0a7ae5fee7922a72e9b79c537b500a405

While this is not relevant with the Encryption Management (BYOK), the changes in the MR above also attempt (unsuccessfully) to improve the initialization logic where multiple goroutines are running potentially failing.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
