### PR TITLE
Fix syncer issues with added checks for storageclass and claimref

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1265,7 +1265,7 @@ func calculateVMServiceStoragePolicyUsageReservedForNamespace(ctx context.Contex
 			}
 			if storagePolicyUsage.Status.ResourceTypeLevelQuotaUsage == nil {
 				log.Infof("calculateVMServiceStoragePolicyUsageReservedForNamespace: StoragePolicyUsage"+
-					" status not populated, continuing processing others Name: %q, Namespace: %q",
+					" status not populated, continue processing other PVCs Name: %q, Namespace: %q",
 					storagePolicyUsage.Name, storagePolicyUsage.Namespace)
 				continue
 			}
@@ -1305,6 +1305,11 @@ func calculatePVCReservedForNamespace(ctx context.Context, volumeMap map[string]
 		if pvc.Status.Phase == "" {
 			log.Infof("calculatePVCReservedForNamespace: pvc status not populated, continuing processing others"+
 				" Name: %q, Namespace: %q", pvc.Name, pvc.Namespace)
+			continue
+		}
+		if pvc.Spec.StorageClassName == nil {
+			log.Infof("calculatePVCReservedForNamespace: storageclass is not provided for pvc,"+
+				" continue processing other PVCs Name: %q, Namespace: %q", pvc.Name, pvc.Namespace)
 			continue
 		}
 		if storagePolicyID, ok := scToStoragePolicyIDMap[*pvc.Spec.StorageClassName]; ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR intent to fix syncer code by adding checks for storageclass and claimref to avoid code panics

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual testing performed
verified change by deploying vsphere-csi manually on testbed.

```
root@42109f97d934765ce3a2100382eccd0a [ ~ ]# kubectl get sc | grep default
root@42109f97d934765ce3a2100382eccd0a [ ~ ]# 

root@42109f97d934765ce3a2100382eccd0a [ ~ ]# kubectl get pvc -A
NAMESPACE   NAME                    STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
dkinni-ns   example-raw-block-pvc   Pending                                                                                                    <unset>                 8m44s
dkinni-ns   pvc-1                   Bound     pvc-d0500161-a053-485e-9a1f-884a0131b682   1Gi        RWO            wcpglobal-storage-profile   <unset>                 2d11h
dkinni-ns   pvc-2                   Bound     pvc-48a30523-4c4b-483b-85dc-40860e32b0a2   1Gi        RWO            wcpglobal-storage-profile   <unset>                 33h

root@42109f97d934765ce3a2100382eccd0a [ ~ ]# kubectl get pvc example-raw-block-pvc -n dkinni-ns -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"example-raw-block-pvc","namespace":"dkinni-ns"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}},"volumeMode":"Block"}}
  creationTimestamp: "2025-02-07T09:23:01Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: example-raw-block-pvc
  namespace: dkinni-ns
  resourceVersion: "3193613"
  uid: c08f27f4-c8e7-4f1e-98ce-ba3d8d46cc5c
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  volumeMode: Block
status:
  phase: Pending
root@42109f97d934765ce3a2100382eccd0a [ ~ ]# 
```

syncer logs:  
 [syncer.log](https://github.com/user-attachments/files/18704568/syncer.log)


```
{"level":"info","time":"2025-02-07T09:33:26.09019806Z","caller":"syncer/metadatasyncer.go:1298","msg":"calculatePVCReservedForNamespace: Processing PersistentVolumeClaim Name: \"example-raw-block-pvc\", Namespace: \"dkinni-ns\"","TraceId":"88af9ead-eb1d-4fa1-9961-91d21e915223"}
{"level":"info","time":"2025-02-07T09:33:26.090263786Z","caller":"syncer/metadatasyncer.go:1311","msg":"calculatePVCReservedForNamespace: storageclass is not provided for pvc, continuing processing others Name: \"example-raw-block-pvc\", Namespace: \"dkinni-ns\"","TraceId":"88af9ead-eb1d-4fa1-9961-91d21e915223"}
```
workarounds:
1. update pvc and set valid storageClassName to one which is assigned to namespace 
2. other option will be to delete problematic PVC.
```
root@42109f97d934765ce3a2100382eccd0a [ ~ ]# kubectl apply -f nikpvc.yaml -n dkinni-ns
persistentvolumeclaim/example-raw-block-pvc created
root@42109f97d934765ce3a2100382eccd0a [ ~ ]# kubectl get pvc -n dkinni-ns
NAME                    STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc   Pending                                                                                                    <unset>                 4s
pvc-1                   Bound     pvc-d0500161-a053-485e-9a1f-884a0131b682   1Gi        RWO            wcpglobal-storage-profile   <unset>                 2d23h
pvc-2                   Bound     pvc-48a30523-4c4b-483b-85dc-40860e32b0a2   1Gi        RWO            wcpglobal-storage-profile   <unset>                 46h
root@42109f97d934765ce3a2100382eccd0a [ ~ ]# kubectl edit pvc example-raw-block-pvc -n dkinni-ns
Edit cancelled, no changes made.
root@42109f97d934765ce3a2100382eccd0a [ ~ ]# kubectl edit pvc example-raw-block-pvc -n dkinni-ns
persistentvolumeclaim/example-raw-block-pvc edited
root@42109f97d934765ce3a2100382eccd0a [ ~ ]# kubectl get pvc -n dkinni-ns
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc   Bound    pvc-cd7329ff-4c49-4276-bfab-0056fcc5c561   5Gi        RWO            wcpglobal-storage-profile   <unset>                 52s
pvc-1                   Bound    pvc-d0500161-a053-485e-9a1f-884a0131b682   1Gi        RWO            wcpglobal-storage-profile   <unset>                 2d23h
pvc-2                   Bound    pvc-48a30523-4c4b-483b-85dc-40860e32b0a2   1Gi        RWO            wcpglobal-storage-profile   <unset>                 46h
root@42109f97d934765ce3a2100382eccd0a [ ~ ]# 

```

Logs:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adding checks for storageclass and claimref to avoid code panics
```
