### PR TITLE
Set clusterIDforVolumeMetadata in syncer tests

### DIFF
--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -110,6 +110,8 @@ func TestSyncerWorkflows(t *testing.T) {
 
 	// CNS based CSI requires a valid cluster name.
 	csiConfig.Global.ClusterID = testClusterName
+	// Normally set by InitMetadataSyncer
+	clusterIDforVolumeMetadata = testClusterName
 
 	// Init VC configuration.
 	cnsVCenterConfig, err = cnsvsphere.GetVirtualCenterConfig(ctx, csiConfig)


### PR DESCRIPTION
The syncer tests had been invoking CreateVolume without a cluster ID, but later using a QueryFilter with a cluster ID. This volume query would return no results against vcsim https://github.com/vmware/govmomi/pull/3694, causing test failure.

