### PR TITLE
Use local type for CnsOperatorEntityReference to ensure correct deseralization

### DIFF
--- a/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
+++ b/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
@@ -131,7 +131,12 @@ const (
 	CnsOperatorEntityTypePOD = CnsOperatorEntityType(cnstypes.CnsKubernetesEntityTypePOD)
 )
 
-type CnsOperatorEntityReference cnstypes.CnsKubernetesEntityReference
+type CnsOperatorEntityReference struct {
+	EntityType string
+	EntityName string
+	Namespace  string
+	ClusterID  string
+}
 
 // CreateCnsVolumeMetadataSpec returns a cnsvolumemetadata object from the
 // input parameters.


### PR DESCRIPTION
**What this PR does / why we need it**:
Using `cnstypes.CnsKubernetesEntityReference` serializes the CnsOperatorEntityReference based on the new JSON tag introduced in https://github.com/vmware/govmomi/pull/3662. Deserialization will not work if the serialization happened without the tags.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
PR 3488216

**Testing done**:
Created PVC, ensured CnsVolumeMetadata is processed correctly.

Before fix:
```
Serialized without the json tags

root@422f3b00d1105e81afa218b083ab6bab [ ~ ]# kubectl get cnsvolumemetadata -n test-gc-e2e-demo-ns 4483d2f0-48d8-41c1-85a2-7cb49567b9d8-c0b9bc0a-50cb-4924-bc65-401d01e75717 -o json
{
    "apiVersion": "cns.vmware.com/v1alpha1",
    "kind": "CnsVolumeMetadata",
    "metadata": {
        "creationTimestamp": "2025-02-14T05:50:12Z",
        "generation": 1,
        "name": "4483d2f0-48d8-41c1-85a2-7cb49567b9d8-c0b9bc0a-50cb-4924-bc65-401d01e75717",
        "namespace": "test-gc-e2e-demo-ns",
        "ownerReferences": [
            {
                "apiVersion": "cluster.x-k8s.io/v1beta1",
                "blockOwnerDeletion": true,
                "controller": true,
                "kind": "Cluster",
                "name": "test-cluster-e2e-script",
                "uid": "4483d2f0-48d8-41c1-85a2-7cb49567b9d8"
            }
        ],
        "resourceVersion": "1940700",
        "uid": "122ce0bf-3c8f-4477-b5c3-cdcece702056"
    },
    "spec": {
        "clusterdistribution": "TKGService",
        "entityname": "dkinni-pvc-2",
        "entityreferences": [
            {
                "ClusterID": "4483d2f0-48d8-41c1-85a2-7cb49567b9d8",
                "EntityName": "pvc-c0b9bc0a-50cb-4924-bc65-401d01e75717",
                "EntityType": "PERSISTENT_VOLUME",
                "Namespace": ""
            }
        ],
        "entitytype": "PERSISTENT_VOLUME_CLAIM",
        "guestclusterid": "4483d2f0-48d8-41c1-85a2-7cb49567b9d8",
        "namespace": "test",
        "volumenames": [
            "4483d2f0-48d8-41c1-85a2-7cb49567b9d8-c0b9bc0a-50cb-4924-bc65-401d01e75717"
        ]
    },
    "status": {}
}

The controller couldn't deserialize it correctly.

{"level":"error","time":"2025-02-14T01:17:47.709295329Z","caller":"cnsvolumemetadata/cnsvolumemetadata_controller.go:514","msg":"ReconcileCnsVolumeMetadata: Failed to validate reconcile request with error: PERSISTENT_VOLUME in
stances can only refer to PERSISTENT_VOLUME_CLAIM instances","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsvolumemetadata.recordEvent\n\t/build/pkg/syncer/cnsoperator/controller/cnsvolume
metadata/cnsvolumemetadata_controller.go:514\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsvolumemetadata.(*ReconcileCnsVolumeMetadata).Reconcile\n\t/build/pkg/syncer/cnsoperator/controller/cnsvolumem
etadata/cnsvolumemetadata_controller.go:218\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:116\n
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/int
ernal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...])
.Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:224"}

```

After fix:

```
The controller deserialized it correctly and processed the cnsvolumemetadata, the status is populated now

root@422f3b00d1105e81afa218b083ab6bab [ ~ ]# kubectl get cnsvolumemetadata -n test-gc-e2e-demo-ns 4483d2f0-48d8-41c1-85a2-7cb49567b9d8-c0b9bc0a-50cb-4924-bc65-401d01e75717 -o json
{
    "apiVersion": "cns.vmware.com/v1alpha1",
    "kind": "CnsVolumeMetadata",
    "metadata": {
        "creationTimestamp": "2025-02-14T05:50:12Z",
        "finalizers": [
            "cns.vmware.com"
        ],
        "generation": 2,
        "name": "4483d2f0-48d8-41c1-85a2-7cb49567b9d8-c0b9bc0a-50cb-4924-bc65-401d01e75717",
        "namespace": "test-gc-e2e-demo-ns",
        "ownerReferences": [
            {
                "apiVersion": "cluster.x-k8s.io/v1beta1",
                "blockOwnerDeletion": true,
                "controller": true,
                "kind": "Cluster",
                "name": "test-cluster-e2e-script",
                "uid": "4483d2f0-48d8-41c1-85a2-7cb49567b9d8"
            }
        ],
        "resourceVersion": "1954217",
        "uid": "122ce0bf-3c8f-4477-b5c3-cdcece702056"
    },
    "spec": {
        "clusterdistribution": "TKGService",
        "entityname": "dkinni-pvc-2",
        "entityreferences": [
            {
                "ClusterID": "4483d2f0-48d8-41c1-85a2-7cb49567b9d8",
                "EntityName": "pvc-c0b9bc0a-50cb-4924-bc65-401d01e75717",
                "EntityType": "PERSISTENT_VOLUME",
                "Namespace": ""
            }
        ],
        "entitytype": "PERSISTENT_VOLUME_CLAIM",
        "guestclusterid": "4483d2f0-48d8-41c1-85a2-7cb49567b9d8",
        "namespace": "test",
        "volumenames": [
            "4483d2f0-48d8-41c1-85a2-7cb49567b9d8-c0b9bc0a-50cb-4924-bc65-401d01e75717"
        ]
    },
    "status": {
        "volumestatus": [
            {
                "updated": true,
                "volumename": "4483d2f0-48d8-41c1-85a2-7cb49567b9d8-c0b9bc0a-50cb-4924-bc65-401d01e75717"
            }
        ]
    }
}
```


**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
