### PR TITLE
POST API request for generating the SSL thumbprint, which is required for the Content Library creation

### DIFF
--- a/tests/e2e/snapshot_vmservice_vm.go
+++ b/tests/e2e/snapshot_vmservice_vm.go
@@ -71,7 +71,6 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 		restConfig                 *restclient.Config
 		snapc                      *snapclient.Clientset
 		pandoraSyncWaitTime        int
-		err                        error
 		dsRef                      types.ManagedObjectReference
 		labelsMap                  map[string]string
 	)
@@ -117,8 +116,9 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 		storageProfileId = e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 
 		// creating/reading content library
-		contentLibId := createAndOrGetContentlibId4Url(vcRestSessionId, GetAndExpectStringEnvVar(envContentLibraryUrl),
-			dsRef.Value, GetAndExpectStringEnvVar(envContentLibraryUrlSslThumbprint))
+		contentLibId, err := createAndOrGetContentlibId4Url(vcRestSessionId, GetAndExpectStringEnvVar(envContentLibraryUrl),
+			dsRef.Value)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		vmClass = os.Getenv(envVMClass)
 		if vmClass == "" {

--- a/tests/e2e/vm_service_vsan_stretch_cluster.go
+++ b/tests/e2e/vm_service_vsan_stretch_cluster.go
@@ -99,8 +99,9 @@ var _ bool = ginkgo.Describe("[vsan-stretch-vmsvc] vm service with csi vol tests
 		framework.Logf("dsmoId: %v", dsRef.Value)
 
 		storageProfileId = e2eVSphere.GetSpbmPolicyID(storagePolicyName)
-		contentLibId := createAndOrGetContentlibId4Url(vcRestSessionId, GetAndExpectStringEnvVar(envContentLibraryUrl),
-			dsRef.Value, GetAndExpectStringEnvVar(envContentLibraryUrlSslThumbprint))
+		contentLibId, err := createAndOrGetContentlibId4Url(vcRestSessionId, GetAndExpectStringEnvVar(envContentLibraryUrl),
+			dsRef.Value)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Create a WCP namespace for the test")
 		vmClass = os.Getenv(envVMClass)

--- a/tests/e2e/vmservice_vm.go
+++ b/tests/e2e/vmservice_vm.go
@@ -100,14 +100,16 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		framework.Logf("dsmoId: %v", dsRef.Value)
 
 		storageProfileId = e2eVSphere.GetSpbmPolicyID(storagePolicyName)
-		contentLibId := createAndOrGetContentlibId4Url(vcRestSessionId, GetAndExpectStringEnvVar(envContentLibraryUrl),
-			dsRef.Value, GetAndExpectStringEnvVar(envContentLibraryUrlSslThumbprint))
+		contentLibId, err := createAndOrGetContentlibId4Url(vcRestSessionId, GetAndExpectStringEnvVar(envContentLibraryUrl),
+			dsRef.Value)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Create a WCP namespace for the test")
 		vmClass = os.Getenv(envVMClass)
 		if vmClass == "" {
 			vmClass = vmClassBestEffortSmall
 		}
+
 		namespace = createTestWcpNs(
 			vcRestSessionId, storageProfileId, vmClass, contentLibId, getSvcId(vcRestSessionId))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Created a util for POST API request for generating the SSL thumbprint, which is required for the Content Library creation 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Yes
[testlogs.txt](https://github.com/user-attachments/files/18883748/testlogs.txt)

**Special notes for your reviewer**:

sipriya@C02CR8ENMD6M vsphere-csi-driver %  golangci-lint run --enable=lll
sipriya@C02CR8ENMD6M vsphere-csi-driver % make golangci-lint             
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.59.1'
golangci/golangci-lint info found version: 1.59.1 for v1.59.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO golangci-lint has version 1.59.1 built with go1.22.3 from 1a55854a on 2024-06-09T18:08:33Z 
INFO [config_reader] Config search paths: [./ /Users/sipriya/vmservice-thumbprint/vsphere-csi-driver /Users/sipriya/vmservice-thumbprint /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 8 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck unused] 
