### PR TITLE
check cnsfilevolumeclients.cns.vmware.com instance is present before listing and patching instances

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1013,10 +1013,10 @@ func addFinalizerOnCnsFileVolumeClientCRs(ctx context.Context) error {
 		return err
 	}
 	_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Get(ctx,
-		"cnsfileaccessconfigs.cns.vmware.com", metav1.GetOptions{})
+		"cnsfilevolumeclients.cns.vmware.com", metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Infof("CR instance is not registered. " +
+			log.Infof("CR instance cnsfilevolumeclients.cns.vmware.com is not registered. " +
 				"skipping to add finalizer on CNSFileVolumeClient Instances")
 			return nil
 		} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->


**What this PR does / why we need it**:
check cnsfilevolumeclients.cns.vmware.com instance is present before listing and patching instances


**Which issue this PR fixes** 
Without this fix, syncer container is crashing in green field deployment

Logs

```
{"level":"error","time":"2025-02-20T16:29:31.373657833Z","caller":"syncer/metadatasyncer.go:1036","msg":"failed to list CnsFileVolumeClient CRs from all supervisor namespaces. Error: no matches for kind \"CnsFileVolumeClient\" in version \"cns.vmware.com/v1alpha1\"","TraceId":"0df4296c-ff99-4448-9b63-67a0ab8767bb","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.addFinalizerOnCnsFileVolumeClientCRs\n\t/build/mts/release/bora-24575588/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/metadatasyncer.go:1036\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.InitMetadataSyncer\n\t/build/mts/release/bora-24575588/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/metadatasyncer.go:299\nmain.main.initSyncerComponents.func8\n\t/build/mts/release/bora-24575588/cayman_vsphere_csi_driver/vsphere_csi_driver/src/cmd/syncer/main.go:384\nmain.main.func5\n\t/build/mts/release/bora-24575588/cayman_vsphere_csi_driver/vsphere_csi_driver/src/cmd/syncer/main.go:216"}
{"level":"error","time":"2025-02-20T16:29:31.373804507Z","caller":"syncer/metadatasyncer.go:301","msg":"Failed to add finalizer on CnsFileVolumeClient CRs. Error: no matches for kind \"CnsFileVolumeClient\" in version \"cns.vmware.com/v1alpha1\"","TraceId":"0df4296c-ff99-4448-9b63-67a0ab8767bb","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.InitMetadataSyncer\n\t/build/mts/release/bora-24575588/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/metadatasyncer.go:301\nmain.main.initSyncerComponents.func8\n\t/build/mts/release/bora-24575588/cayman_vsphere_csi_driver/vsphere_csi_driver/src/cmd/syncer/main.go:384\nmain.main.func5\n\t/build/mts/release/bora-24575588/cayman_vsphere_csi_driver/vsphere_csi_driver/src/cmd/syncer/main.go:216"}
{"level":"error","time":"2025-02-20T16:29:31.373873518Z","caller":"syncer/main.go:385","msg":"Error initializing Metadata Syncer. Error: no matches for kind \"CnsFileVolumeClient\" in version \"cns.vmware.com/v1alpha1\"","TraceId":"0df4296c-ff99-4448-9b63-67a0ab8767bb","stacktrace":"main.main.initSyncerComponents.func8\n\t/build/mts/release/bora-24575588/cayman_vsphere_csi_driver/vsphere_csi_driver/src/cmd/syncer/main.go:385\nmain.main.func5\n\t/build/mts/release/bora-24575588/cayman_vsphere_csi_driver/vsphere_csi_driver/src/cmd/syncer/main.go:216"}
{"level":"info","time":"2025-02-20T16:29:31.373889276Z","caller":"utils/utils.go:236","msg":"Logging out all vCenter sessions","TraceId":"0df4296c-ff99-4448-9b63-67a0ab8767bb"}
{"level":"info","time":"2025-02-20T16:29:31.3756199Z","caller":"utils/utils.go:251","msg":"Successfully logged out vCenter sessions","TraceId":"0df4296c-ff99-4448-9b63-67a0ab8767bb"}
```

**Testing done**:
Verified the fix. syncer is skipping to list and patch cnsfilevolumeclients.cns.vmware.com instances when CRD is not registered.

Logs after fix

```
{"level":"info","time":"2025-02-20T20:34:22.585479552Z","caller":"syncer/metadatasyncer.go:1019","msg":"CR instance cnsfilevolumeclients.cns.vmware.com is not registered. skipping to add finalizer on CNSFileVolumeClient Instances","TraceId":"da4cf90f-86a0-449b-b04b-3974cc91d2b2"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
check cnsfilevolumeclients.cns.vmware.com instance is present before listing and patching instances
```
