### PR TITLE
Storage Pool - avoid extensive info logging

### DIFF
--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -190,7 +190,7 @@ func isRemoteVsan(ctx context.Context, dsprops *dsProps,
 	log := logger.GetLogger(ctx).Named("isRemoteVsan")
 	// If datastore type is not vsan, then return false.
 	if dsprops.dsType != vsanDsType {
-		log.Infof("Datastore %s is not a vSAN datastore", dsprops.dsName)
+		log.Debugf("Datastore %s is not a vSAN datastore", dsprops.dsName)
 		return false, nil
 	}
 
@@ -213,7 +213,7 @@ func isRemoteVsan(ctx context.Context, dsprops *dsProps,
 	log.Debugf("Verifying whether vSAN Datastore %s with containerID: %s is local to cluster uuid %s",
 		dsprops.dsName, dsContainerID, vsanClsUUID)
 	if dsContainerID == vsanClsUUID {
-		log.Infof("vSAN Datastore %s is not remote to this cluster", dsprops.dsName)
+		log.Debugf("vSAN Datastore %s is not remote to this cluster", dsprops.dsName)
 		return false, nil
 	}
 

--- a/pkg/syncer/storagepool/util.go
+++ b/pkg/syncer/storagepool/util.go
@@ -160,7 +160,7 @@ func findAccessibleNodes(ctx context.Context, datastore *object.Datastore,
 		nodes[thisName] = inMM
 	}
 
-	log.Infof("Accessible nodes in MM for datastore %s: %v", datastore.Reference().Value, nodes)
+	log.Debugf("Accessible nodes in MM for datastore %s: %v", datastore.Reference().Value, nodes)
 	return nodes, nil
 }
 


### PR DESCRIPTION
**Summary:**

During testing, we have observed that the logs in the syncer container were getting rolled over too quickly which was making troubleshooting tougher. This MR converts logs related to Storage Pools to Debug.

**Testing done**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Storage Pool - avoid extensive info logging 
```
