### PR TITLE
Storage Pool - avoid extensive info logging

### DIFF
--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -323,7 +323,7 @@ func (c *SpController) getVsanHostCapacities(ctx context.Context) (map[string]*c
 			log.Error(err)
 			continue
 		}
-		log.Infof("Host %s has capacity %+v", nodeName, capacity)
+		log.Debugf("Host %s has capacity %+v", nodeName, capacity)
 		out[nodeName] = capacity
 	}
 	return out, nil


### PR DESCRIPTION
As part of this [MR](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3202) we converted a few Info logs to Debug. This MR converts another commonly logged line that is bloating up the syncer logs.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Storage Pool - avoid extensive info logging 
```
