### PR TITLE
Fix Windows vanilla deployment - add missing service account

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -590,6 +590,8 @@ spec:
       priorityClassName: system-node-critical
       nodeSelector:
         kubernetes.io/os: windows
+      dnsPolicy: "ClusterFirstWithHostNet"
+      serviceAccountName: vsphere-csi-node
       securityContext:
         windowsOptions:
           hostProcess: true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update Windows Daemonset by adding missing service account, to fix vsphere-csi windows pods CLBO issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual testing performed

After updating vsphere-csi windows daemonSet with missing service Acc, windows pods are up and running

volume provision and mount logs: 
[testing_win_pod_clbo.log](https://github.com/user-attachments/files/19636924/testing_win_pod_clbo.log)


```
ubuntu@10:~$ kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-7745d57d57-dwmm2   7/7     Running   0             46h
vsphere-csi-node-n85c9                    3/3     Running   3 (46h ago)   46h
vsphere-csi-node-windows-77m4x            3/3     Running   0             11m
vsphere-csi-node-windows-n6b98            3/3     Running   0             11m
vsphere-csi-node-windows-vsnt5            3/3     Running   0             11m
ubuntu@10:~$ kubectl get ds -n vmware-system-csi
NAME                       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR              AGE
vsphere-csi-node           1         1         1       1            1           kubernetes.io/os=linux     46h
vsphere-csi-node-windows   3         3         3       3            3           kubernetes.io/os=windows   46h
ubuntu@10:~$ kubectl get deploy -n vmware-system-csi
NAME                     READY   UP-TO-DATE   AVAILABLE   AGE
vsphere-csi-controller   1/1     1            1           46h
ubuntu@10:~$ 

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix Windows Vanilla Daemonset yaml 
```
