### PR TITLE
Refactor tag manager rest client

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -147,7 +147,9 @@ function build_driver_images_linux() {
 
 function build_syncer_image_linux() {
   echo "building ${SYNCER_IMAGE_NAME}:${VERSION} for linux"
-  docker build \
+  docker buildx build \
+      --platform "linux/$ARCH" \
+      --output "${LINUX_IMAGE_OUTPUT}" \
       -f images/syncer/Dockerfile \
       -t "${SYNCER_IMAGE_NAME}":"${VERSION}" \
       --build-arg "VERSION=${VERSION}" \

--- a/pkg/common/cns-lib/vsphere/tagmanager.go
+++ b/pkg/common/cns-lib/vsphere/tagmanager.go
@@ -1,0 +1,29 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/vapi/tags"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// GetTagManager returns tagManager connected to given VirtualCenter.
+func (vc *VirtualCenter) GetTagManager(ctx context.Context) (*tags.Manager, error) {
+	log := logger.GetLogger(ctx)
+	// Validate input.
+	if vc == nil || vc.Client == nil || vc.Client.Client == nil {
+		return nil, fmt.Errorf("vCenter not initialized")
+	}
+
+	if err := vc.Connect(ctx); err != nil {
+		return nil, fmt.Errorf("error connecting to VC: %w", err)
+	}
+
+	vc.tagManager = tags.NewManager(vc.RestClient)
+	if vc.tagManager == nil {
+		return nil, fmt.Errorf("failed to create a tagManager")
+	}
+	log.Infof("New tag manager with useragent '%s'", vc.tagManager.UserAgent)
+	return vc.tagManager, nil
+}

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -2,11 +2,8 @@ package vsphere
 
 import (
 	"context"
-	"crypto/tls"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -14,10 +11,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
-	"github.com/vmware/govmomi/sts"
-	"github.com/vmware/govmomi/vapi/rest"
-	"github.com/vmware/govmomi/vapi/tags"
-	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -302,62 +295,6 @@ func CompareKubernetesMetadata(ctx context.Context, k8sMetaData *cnstypes.CnsKub
 		labelsMatch, spew.Sdump(GetLabelsMapFromKeyValue(k8sMetaData.Labels)),
 		spew.Sdump(GetLabelsMapFromKeyValue(cnsMetaData.Labels)))
 	return labelsMatch
-}
-
-// Signer decodes the certificate and private key and returns SAML token needed
-// for authentication.
-func signer(ctx context.Context, client *vim25.Client, username string, password string) (*sts.Signer, error) {
-	pemBlock, _ := pem.Decode([]byte(username))
-	if pemBlock == nil {
-		return nil, nil
-	}
-	certificate, err := tls.X509KeyPair([]byte(username), []byte(password))
-	if err != nil {
-		return nil, fmt.Errorf("failed to load X509 key pair. Error: %+v", err)
-	}
-	tokens, err := sts.NewClient(ctx, client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create STS client. err: %+v", err)
-	}
-	req := sts.TokenRequest{
-		Certificate: &certificate,
-		Delegatable: true,
-	}
-	signer, err := tokens.Issue(ctx, req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to issue SAML token. err: %+v", err)
-	}
-	return signer, nil
-}
-
-// GetTagManager returns tagManager connected to given VirtualCenter.
-func GetTagManager(ctx context.Context, vc *VirtualCenter) (*tags.Manager, error) {
-	log := logger.GetLogger(ctx)
-	// Validate input.
-	if vc == nil || vc.Client == nil || vc.Client.Client == nil {
-		return nil, fmt.Errorf("vCenter not initialized")
-	}
-
-	restClient := rest.NewClient(vc.Client.Client)
-	signer, err := signer(ctx, vc.Client.Client, vc.Config.Username, vc.Config.Password)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the Signer. Error: %v", err)
-	}
-	if signer == nil {
-		user := url.UserPassword(vc.Config.Username, vc.Config.Password)
-		err = restClient.Login(ctx, user)
-	} else {
-		err = restClient.LoginByToken(restClient.WithSigner(ctx, signer))
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to login for the rest client. Error: %v", err)
-	}
-	tagManager := tags.NewManager(restClient)
-	if tagManager == nil {
-		return nil, fmt.Errorf("failed to create a tagManager")
-	}
-	log.Infof("New tag manager with useragent '%s'", tagManager.UserAgent)
-	return tagManager, nil
 }
 
 // GetCandidateDatastoresInClusters gets the shared datastores and vSAN-direct

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -37,6 +37,8 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -68,6 +70,8 @@ type VirtualCenter struct {
 	Config *VirtualCenterConfig
 	// Client represents the govmomi client instance for the connection.
 	Client *govmomi.Client
+	// RestClient represents the govmomi rest client
+	RestClient *rest.Client
 	// PbmClient represents the govmomi PBM Client instance.
 	PbmClient *pbm.Client
 	// CnsClient represents the CNS client instance.
@@ -76,6 +80,9 @@ type VirtualCenter struct {
 	VsanClient *vsan.Client
 	// VslmClient represents the Vslm client instance.
 	VslmClient *vslm.Client
+	// tagManager represents the tagmanager client instance.
+	tagManager *tags.Manager
+
 	// ClientMutex is used for exclusive connection creation.
 	ClientMutex *sync.Mutex
 }
@@ -151,7 +158,7 @@ type VirtualCenterConfig struct {
 }
 
 // NewClient creates a new govmomi Client instance.
-func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govmomi.Client, error) {
+func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govmomi.Client, *rest.Client, error) {
 	log := logger.GetLogger(ctx)
 	if vc.Config.Scheme == "" {
 		vc.Config.Scheme = DefaultScheme
@@ -160,14 +167,14 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	url, err := soap.ParseURL(net.JoinHostPort(vc.Config.Host, strconv.Itoa(vc.Config.Port)))
 	if err != nil {
 		log.Errorf("failed to parse URL %s with err: %v", url, err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	soapClient := soap.NewClient(url, vc.Config.Insecure)
 	if len(vc.Config.CAFile) > 0 && !vc.Config.Insecure {
 		if err := soapClient.SetRootCAs(vc.Config.CAFile); err != nil {
 			log.Errorf("failed to load CA file: %v", err)
-			return nil, err
+			return nil, nil, err
 		}
 	} else if len(vc.Config.Thumbprint) > 0 && !vc.Config.Insecure {
 		soapClient.SetThumbprint(url.Host, vc.Config.Thumbprint)
@@ -179,13 +186,13 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	vimClient, err := vim25.NewClient(ctx, soapClient)
 	if err != nil {
 		log.Errorf("failed to create new client with err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	err = vimClient.UseServiceVersion("vsan")
 	if err != nil && vc.Config.Host != "127.0.0.1" {
 		// Skipping error for simulator connection for unit tests.
 		log.Errorf("Failed to set vimClient service version to vsan. err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	vimClient.UserAgent = useragent
 	client := &govmomi.Client{
@@ -193,22 +200,24 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 		SessionManager: session.NewManager(vimClient),
 	}
 
-	err = vc.login(ctx, client)
+	restClient := rest.NewClient(client.Client)
+
+	err = vc.login(ctx, client, restClient)
 	if err != nil {
 		log.Errorf("failed to login to vc. err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	s, err := client.SessionManager.UserSession(ctx)
 	if err != nil {
 		log.Errorf("failed to get UserSession. err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	// Refer to this issue - https://github.com/vmware/govmomi/issues/2922
 	// When Session Manager -> UserSession can return nil user session with nil error
 	// so handling the case for nil session.
 	if s == nil {
-		return nil, errors.New("nil session obtained from session manager")
+		return nil, nil, errors.New("nil session obtained from session manager")
 	}
 	log.Infof("New session ID for '%s' = %s", s.UserName, s.Key)
 
@@ -217,19 +226,22 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	}
 	rt := vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(vc.Config.RoundTripperCount))
 	client.RoundTripper = &MetricRoundTripper{"soap", rt}
-	return client, nil
+	return client, restClient, nil
 }
 
 // login calls SessionManager.LoginByToken if certificate and private key are
 // configured. Otherwise, calls SessionManager.Login with user and password.
-func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) error {
+func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client, restClient *rest.Client) error {
 	log := logger.GetLogger(ctx)
 	var err error
 
 	b, _ := pem.Decode([]byte(vc.Config.Username))
 	if b == nil {
-		return client.SessionManager.Login(ctx,
-			neturl.UserPassword(vc.Config.Username, vc.Config.Password))
+		if err := client.SessionManager.Login(ctx, neturl.UserPassword(vc.Config.Username, vc.Config.Password)); err != nil {
+			log.Errorf("error logging soap client: %v", err)
+			return err
+		}
+		return restClient.Login(ctx, neturl.UserPassword(vc.Config.Username, vc.Config.Password))
 	}
 
 	cert, err := tls.X509KeyPair([]byte(vc.Config.Username), []byte(vc.Config.Password))
@@ -246,6 +258,7 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) erro
 
 	req := sts.TokenRequest{
 		Certificate: &cert,
+		Delegatable: true,
 	}
 
 	signer, err := tokens.Issue(ctx, req)
@@ -255,7 +268,11 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) erro
 	}
 
 	header := soap.Header{Security: signer}
-	return client.SessionManager.LoginByToken(client.Client.WithHeader(ctx, header))
+	if err := client.SessionManager.LoginByToken(client.Client.WithHeader(ctx, header)); err != nil {
+		return err
+	}
+
+	return restClient.LoginByToken(restClient.WithSigner(ctx, signer))
 }
 
 // Connect establishes a new connection with vSphere with updated credentials.
@@ -279,6 +296,14 @@ func (vc *VirtualCenter) Connect(ctx context.Context) error {
 					log.Errorf("Could not logout of VC session. Error: %v", logoutErr)
 				}
 			}
+			if vc.RestClient != nil {
+				logoutErr := vc.RestClient.Logout(ctx)
+				if logoutErr != nil {
+					// TODO: On vSphere U3, with a shared session this may return an error as logging
+					// out from Soap also logs out from rest.
+					log.Errorf("Could not logout of VC rest session. Error: %v", logoutErr)
+				}
+			}
 		}()
 	}
 	return err
@@ -295,7 +320,7 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		log.Errorf("failed to get useragent for vCenter session. error: %+v", err)
 		return err
 	}
-	if vc.Client == nil {
+	if vc.Client == nil || vc.RestClient == nil {
 		if vc.Config.ReloadVCConfigForNewClient {
 			err = ReadVCConfigs(ctx, vc)
 			if err != nil {
@@ -303,13 +328,14 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			}
 		}
 		log.Infof("VirtualCenter.connect() creating new client")
-		if vc.Client, err = vc.NewClient(ctx, useragent); err != nil {
+		if vc.Client, vc.RestClient, err = vc.NewClient(ctx, useragent); err != nil {
 			log.Errorf("failed to create govmomi client with err: %v", err)
 			if !vc.Config.Insecure {
 				log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 			}
 			return err
 		}
+
 		log.Infof("VirtualCenter.connect() successfully created new client")
 		return nil
 	}
@@ -335,6 +361,14 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		}
 	}
 
+	if vc.RestClient != nil {
+		// TODO: On U3 shared session this may return an error, if the Soap logout
+		// happened correctly, but can be safely ignored
+		if err := vc.RestClient.Logout(ctx); err != nil {
+			log.Errorf("failed to logout current rest session. still clearing idle sessions. err: %v", err)
+		}
+	}
+
 	// If session has expired, create a new instance.
 	log.Infof("Creating a new client session as the existing one isn't valid or not authenticated")
 	if vc.Config.ReloadVCConfigForNewClient {
@@ -343,7 +377,7 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			return err
 		}
 	}
-	if vc.Client, err = vc.NewClient(ctx, useragent); err != nil {
+	if vc.Client, vc.RestClient, err = vc.NewClient(ctx, useragent); err != nil {
 		log.Errorf("failed to create govmomi client with err: %v", err)
 		if !vc.Config.Insecure {
 			log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
@@ -382,6 +416,12 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		}
 		vc.VsanClient.RoundTripper = &MetricRoundTripper{"vsan", vc.VsanClient.RoundTripper}
 	}
+
+	// Recreate the Tag Manager client if created using timed out Rest client
+	if vc.tagManager != nil {
+		vc.tagManager = tags.NewManager(vc.RestClient)
+	}
+
 	return nil
 }
 
@@ -485,7 +525,14 @@ func (vc *VirtualCenter) Disconnect(ctx context.Context) error {
 		log.Errorf("failed to logout with err: %v", err)
 		return err
 	}
+
+	// We don't return an error here because logging out from Rest failing
+	// can happen on VC shared sessions
+	if err := vc.RestClient.Logout(ctx); err != nil {
+		log.Errorf("failed to logout rest with err: %v", err)
+	}
 	vc.Client = nil
+	vc.RestClient = nil
 	return nil
 }
 

--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -211,7 +211,7 @@ func (vm *VirtualMachine) GetTagManager(ctx context.Context) (*tags.Manager, err
 		log.Errorf("failed to get virtualCenter. Error: %v", err)
 		return nil, err
 	}
-	return GetTagManager(ctx, virtualCenter)
+	return virtualCenter.GetTagManager(ctx)
 }
 
 // GetAncestors returns ancestors of VM.

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -34,6 +34,8 @@ import (
 
 	cnssim "github.com/vmware/govmomi/cns/simulator"
 	pbmsim "github.com/vmware/govmomi/pbm/simulator"
+	_ "github.com/vmware/govmomi/vapi/simulator"
+
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
@@ -412,6 +414,7 @@ func configFromVCSimWithTLS(tlsConfig *tls.Config, vcsimParams VcsimParams, inse
 	if err != nil {
 		log.Fatal(err)
 	}
+	model.Service.RegisterEndpoints = true
 
 	model.Service.TLS = tlsConfig
 	s := model.Service.NewServer()

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -13,6 +13,7 @@ import (
 	cnssim "github.com/vmware/govmomi/cns/simulator"
 	"github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/simulator"
+	_ "github.com/vmware/govmomi/vapi/simulator"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	cnsvolumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -56,6 +57,7 @@ func configFromCustomizedSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool)
 		log.Fatal(err)
 	}
 
+	model.Service.RegisterEndpoints = true
 	model.Service.TLS = tlsConfig
 	s := model.Service.NewServer()
 

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -313,16 +313,11 @@ func refreshPreferentialDatastores(ctx context.Context) error {
 		return logger.LogNewErrorf(log, "failed to get vCenter instance. Error: %+v", err)
 	}
 	// Get tag manager instance.
-	tagMgr, err := cnsvsphere.GetTagManager(ctx, vc)
+	tagMgr, err := vc.GetTagManager(ctx)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create tag manager. Error: %+v", err)
 	}
-	defer func() {
-		err := tagMgr.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout tagManager. Error: %v", err)
-		}
-	}()
+
 	// Get tags for category reserved for preferred datastore tagging.
 	tagIds, err := tagMgr.ListTagsForCategory(ctx, common.PreferredDatastoresCategory)
 	if err != nil {

--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -82,16 +82,10 @@ func DiscoverTagEntities(ctx context.Context) error {
 				vcenterCfg.Host, err)
 		}
 		// Get tag manager instance.
-		tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+		tagManager, err := vcenter.GetTagManager(ctx)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create tagManager. Error: %v", err)
 		}
-		defer func() {
-			err := tagManager.Logout(ctx)
-			if err != nil {
-				log.Errorf("failed to logout tagManager. Error: %v", err)
-			}
-		}()
 		for _, cat := range categories {
 			topoTags, err := tagManager.GetTagsForCategory(ctx, cat)
 			if err != nil {
@@ -439,17 +433,12 @@ func RefreshPreferentialDatastoresForMultiVCenter(ctx context.Context) error {
 				vcConfig.Host, err)
 		}
 		// Get tag manager instance.
-		tagMgr, err := cnsvsphere.GetTagManager(ctx, vc)
+		tagMgr, err := vc.GetTagManager(ctx)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create tag manager for vCenter %q. Error: %+v",
 				vcConfig.Host, err)
 		}
-		defer func() {
-			err := tagMgr.Logout(ctx)
-			if err != nil {
-				log.Errorf("failed to logout tagManager for vCenter %q. Error: %v", vcConfig.Host, err)
-			}
-		}()
+
 		// Get tags for category reserved for preferred datastore tagging.
 		tagIds, err := tagMgr.ListTagsForCategory(ctx, PreferredDatastoresCategory)
 		if err != nil {

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -505,17 +505,11 @@ func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine,
 	}
 
 	// Get tag manager instance.
-	tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+	tagManager, err := vcenter.GetTagManager(ctx)
 	if err != nil {
 		log.Errorf("failed to create tagManager. Error: %v", err)
 		return nil, err
 	}
-	defer func() {
-		err := tagManager.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout tagManager. Error: %v", err)
-		}
-	}()
 
 	// Create a map of TopologyCategories with category as key and value as empty string.
 	var isZoneRegion bool


### PR DESCRIPTION
**What this PR does / why we need it**: Refactor the tagManager client to be behind the VirtualCenter structure


**Testing done**:
* Created a new cluster with topology enabled, tags added to DC and Cluster
* Created a new workload + PVC
* Verified that the anti affinity rules have been added to the PV
```
csi:
    driver: csi.vsphere.vmware.com
    fsType: ext4
    volumeAttributes:
      storage.kubernetes.io/csiProvisionerIdentity: 1741963184335-5917-csi.vsphere.vmware.com
      type: vSphere CNS Block Volume
    volumeHandle: acb38d2a-2e97-44bc-ba8f-4dd434302de1
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: topology.csi.vmware.com/k8s-zone
          operator: In
          values:
          - cluster-2
        - key: topology.csi.vmware.com/k8s-region
          operator: In
          values:
          - DC-1
```
* Verified that CSINode has the labels
```
kubectl get csinodes -o jsonpath='{range .items[*]}{.metadata.name} {.spec}{"\n"}{end}'
csitopo-kh6m9 {"drivers":[{"allocatable":{"count":59},"name":"csi.vsphere.vmware.com","nodeID":"4217bc99-e2d4-ee1f-29b4-d4a87019442e","topologyKeys":["topology.csi.vmware.com/k8s-region","topology.csi.vmware.com/k8s-zone"]}]}
csitopo-r6lnn {"drivers":[{"allocatable":{"count":59},"name":"csi.vsphere.vmware.com","nodeID":"4217432c-83fe-a42c-967c-cfdf77fa8a33","topologyKeys":["topology.csi.vmware.com/k8s-region","topology.csi.vmware.com/k8s-zone"]}]}
csitopo-sc2xj {"drivers":[{"allocatable":{"count":59},"name":"csi.vsphere.vmware.com","nodeID":"4217164a-515a-2f4e-d006-93edb66d1dc4","topologyKeys":["topology.csi.vmware.com/k8s-region","topology.csi.vmware.com/k8s-zone"]}]}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Refactor rest.Client and tagManager client
```
