### PR TITLE
Remove hardcoded vmodl version in e2e tests

### DIFF
--- a/tests/e2e/connection.go
+++ b/tests/e2e/connection.go
@@ -100,7 +100,6 @@ func newClient(ctx context.Context, vs *vSphere) *govmomi.Client {
 	err = client.UseServiceVersion(vsanNamespace)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(roundTripperDefaultCount))
-	client.Version = cnsDevVersion
 	return client
 }
 
@@ -118,8 +117,6 @@ func connectCns(ctx context.Context, vs *vSphere) error {
 	if vs.CnsClient == nil {
 		vs.CnsClient, err = newCnsClient(ctx, vs.Client.Client)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		vs.CnsClient.Version = cnsDevVersion
-		vs.CnsClient.Client.Version = cnsDevVersion
 	}
 	return nil
 }

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -60,8 +60,6 @@ var (
 const (
 	providerPrefix  = "vsphere://"
 	virtualDiskUUID = "virtualDiskUUID"
-	// cnsDevVersion is the CNS API development version
-	cnsDevVersion = "dev.version"
 )
 
 // queryCNSVolumeWithResult Call CnsQueryVolume and returns CnsQueryResult to client


### PR DESCRIPTION
Seems use of dev.version with a GA vCenter build prevents PropertyCollector
from returning task results from internal methods (such as CnsQuerySnapshots).
The e2e/newClient function already calls UseServiceVersion(), which returns
the appropriate version when vCenter build is GA/release or dev.version for
builds from main.


