### PR TITLE
[WIP] Adapt the CSI FvT e2e testsuite code to support new changes for both private network isolated testbeds and public network Nimbus testbeds.

### DIFF
--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 # Fetching ginkgo for running the test
 export GO111MODULE=on
-export ACK_GINKGO_DEPRECATIONS=2.11.0
+export ACK_GINKGO_DEPRECATIONS=2.19.0
 if ! (go mod vendor && go install github.com/onsi/ginkgo/v2/ginkgo@v2.11.0)
 then
     echo "go mod vendor or go install ginkgo error"

--- a/tests/e2e/config_change_test.go
+++ b/tests/e2e/config_change_test.go
@@ -25,6 +25,7 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 		cancel               context.CancelFunc
 		nimbusGeneratedVcPwd string
 		clientIndex          int
+		vcAddress            string
 	)
 	const (
 		configSecret = "vsphere-config-secret"
@@ -41,6 +42,13 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
 		bootstrap()
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
 		scParameters = make(map[string]string)
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 		var cancel context.CancelFunc
@@ -77,7 +85,7 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 		// Create Storage class and PVC
 		ginkgo.By("Creating Storage Class and PVC")
 		_, pvc, err := createPVCAndStorageClass(ctx, client, namespace, nil,
-			scParameters, "", nil, "", true, "", storagePolicyName)
+			scParameters, "", nil, "", false, "", storagePolicyName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
@@ -100,7 +108,7 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintln("Changing password on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		username := vsphereCfg.Global.User
 		currentPassword := vsphereCfg.Global.Password
 		newPassword := e2eTestPassword

--- a/tests/e2e/csi_cns_telemetry_statefulsets.go
+++ b/tests/e2e/csi_cns_telemetry_statefulsets.go
@@ -108,9 +108,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor]
 			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
 			scParameters = nil
 			clusterDistributionValue = vanillaClusterDistribution
-			storageClassName = "nginx-sc-telemtery"
 
-			scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+			scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 			sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/tests/e2e/csi_cns_telemetry_vc_reboot.go
+++ b/tests/e2e/csi_cns_telemetry_vc_reboot.go
@@ -62,7 +62,13 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 			// Reset the cluster distribution value to default value "CSI-Vanilla".
 			setClusterDistribution(ctx, client, vanillaClusterDistribution)
 		}
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
 	})
 	ginkgo.AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/csi_snapshot_negative.go
+++ b/tests/e2e/csi_snapshot_negative.go
@@ -61,6 +61,7 @@ var _ = ginkgo.Describe("[block-snapshot-negative] Volume Snapshot Fault-Injecti
 		serviceName            string
 		pandoraSyncWaitTime    int
 		storagePolicyName      string
+		vcAddress              string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -76,6 +77,12 @@ var _ = ginkgo.Describe("[block-snapshot-negative] Volume Snapshot Fault-Injecti
 		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
 		// Get snapshot client using the rest config
@@ -163,7 +170,6 @@ var _ = ginkgo.Describe("[block-snapshot-negative] Volume Snapshot Fault-Injecti
 					startHostDOnHost(ctx, hostIP)
 				}
 			} else {
-				vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
 				err := invokeVCenterServiceControl(ctx, startOperation, serviceName, vcAddress)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -320,6 +326,8 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 	scParameters := make(map[string]string)
 
 	storagePolicyName := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
+	vcAddress, _, err := readVcAddress()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	if vanillaCluster {
 		ginkgo.By("Create storage class")
@@ -477,7 +485,6 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 
 	} else {
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = true
@@ -604,7 +611,6 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 
 		} else {
 			ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			isServiceStopped = true
@@ -730,7 +736,6 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 
 		} else {
 			ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			isServiceStopped = true

--- a/tests/e2e/ds_rename.go
+++ b/tests/e2e/ds_rename.go
@@ -55,7 +55,12 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		bootstrap()
 		scParameters = make(map[string]string)
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 
 		govmomiClient := newClient(ctx, &e2eVSphere)
 		pc = newPbmClient(ctx, govmomiClient)
@@ -127,7 +132,7 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		if vanillaCluster {
 			scParameters = map[string]string{}
 			scParameters[scParamStoragePolicyName] = storagePolicyName
-			scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+			scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 			sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {
@@ -277,7 +282,7 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		if vanillaCluster {
 			scParameters = map[string]string{}
 			scParameters[scParamStoragePolicyName] = storagePolicyName
-			scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+			scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 			sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {
@@ -442,7 +447,7 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		if vanillaCluster {
 			scParameters = map[string]string{}
 			scParameters[scParamStoragePolicyName] = storagePolicyName
-			scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+			scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 			sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {
@@ -603,7 +608,7 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		if vanillaCluster {
 			scParameters = map[string]string{}
 			scParameters[scParamStoragePolicyName] = storagePolicyName
-			scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+			scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 			sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {
@@ -760,7 +765,7 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		if vanillaCluster {
 			scParameters = map[string]string{}
 			scParameters[scParamStoragePolicyName] = storagePolicyName
-			scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+			scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 			sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {
@@ -891,7 +896,7 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		if vanillaCluster {
 			scParameters = map[string]string{}
 			scParameters[scParamStoragePolicyName] = storagePolicyName
-			scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", true)
+			scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", true)
 			sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {
@@ -1054,7 +1059,7 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		if vanillaCluster {
 			scParameters = map[string]string{}
 			scParameters[scParamStoragePolicyName] = policyName
-			scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+			scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 			sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {
@@ -1254,7 +1259,7 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		if vanillaCluster {
 			scParameters = map[string]string{}
 			scParameters[scParamStoragePolicyName] = policyName
-			scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+			scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 			sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -193,7 +193,6 @@ const (
 	oneMinuteWaitTimeInSeconds                = 60
 	spsServiceName                            = "sps"
 	snapshotterContainerName                  = "csi-snapshotter"
-	sshdPort                                  = "22"
 	sshSecretName                             = "SSH_SECRET_NAME"
 	svcRunningMessage                         = "Running"
 	svcMasterIP                               = "SVC_MASTER_IP"
@@ -350,6 +349,19 @@ var (
 // For busybox pod image
 var (
 	busyBoxImageOnGcr = "busybox"
+)
+
+// Private network and public network ports read for master vm and vcenter for nimbus testbed
+var (
+	defaultShhdPortNum      = "22"
+	envMasterIp1            = "MASTER_IP1"
+	envMasterIp2            = "MASTER_IP2"
+	envMasterIp3            = "MASTER_IP3"
+	envMasterIP1SshdPortNum = "MASTER_IP1_SSHD_PORT_NUM"
+	envMasterIP2SshdPortNum = "MASTER_IP2_SSHD_PORT_NUM"
+	envMasterIP3SshdPortNum = "MASTER_IP3_SSHD_PORT_NUM"
+	envVcSshdPortNum        = "VC_SSHD_PORT_NUM"
+	envEsxPortNum           = "ESX_SSHD_PORT_NUM"
 )
 
 // For VCP to CSI migration tests.

--- a/tests/e2e/file_volume_statefulsets.go
+++ b/tests/e2e/file_volume_statefulsets.go
@@ -19,8 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"math/rand"
-	"strconv"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -91,18 +89,11 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 	*/
 	ginkgo.It("Statefulset with file volume testing with default "+
 		"podManagementPolicy", ginkgo.Label(p0, file, vanilla, core), func() {
-		curtime := time.Now().Unix()
-		randomValue := rand.Int()
-		val := strconv.FormatInt(int64(randomValue), 10)
-		val = string(val[1:3])
-		curtimestring := strconv.FormatInt(curtime, 10)
-		scName := "nginx-sc-default-" + curtimestring + val
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scParameters[scParamFsType] = nfs4FSType
-		scSpec := getVSphereStorageClassSpec(scName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -120,7 +111,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Spec.StorageClassName = &scName
+			Spec.StorageClassName = &sc.Name
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -255,19 +246,12 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 	*/
 	ginkgo.It("Statefulset with file volume testing with parallel "+
 		"podManagementPolicy", ginkgo.Label(p0, file, vanilla, core), func() {
-		curtime := time.Now().Unix()
-		randomValue := rand.Int()
-		val := strconv.FormatInt(int64(randomValue), 10)
-		val = string(val[1:3])
-		curtimestring := strconv.FormatInt(curtime, 10)
-		scName := "nginx-sc-parallel-" + curtimestring + val
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scParameters[scParamFsType] = nfs4FSType
 
-		scSpec := getVSphereStorageClassSpec(scName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -287,7 +271,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Spec.StorageClassName = &scName
+			Spec.StorageClassName = &sc.Name
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -418,18 +402,11 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 	*/
 	ginkgo.It("Statefulset with file volume testing scale-up first and "+
 		"scale-down", ginkgo.Label(p0, file, vanilla, core), func() {
-		curtime := time.Now().Unix()
-		randomValue := rand.Int()
-		val := strconv.FormatInt(int64(randomValue), 10)
-		val = string(val[1:3])
-		curtimestring := strconv.FormatInt(curtime, 10)
-		scName := "nginx-sc-default-" + curtimestring + val
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scParameters[scParamFsType] = nfs4FSType
-		scSpec := getVSphereStorageClassSpec(scName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -447,7 +424,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Spec.StorageClassName = &scName
+			Spec.StorageClassName = &sc.Name
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -534,19 +511,13 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 	*/
 	ginkgo.It("Statefulset with file volume testing with CSI daemonset "+
 		"restart", ginkgo.Label(p1, file, vanilla, core), func() {
-		curtime := time.Now().Unix()
-		randomValue := rand.Int()
-		val := strconv.FormatInt(int64(randomValue), 10)
-		val = string(val[1:3])
-		curtimestring := strconv.FormatInt(curtime, 10)
-		scName := "nginx-sc-default-" + curtimestring + val
-		ignoreLabels := make(map[string]string)
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		ignoreLabels := make(map[string]string)
+
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scParameters[scParamFsType] = nfs4FSType
-		scSpec := getVSphereStorageClassSpec(scName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -564,7 +535,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Spec.StorageClassName = &scName
+			Spec.StorageClassName = &sc.Name
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -725,13 +696,6 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 
 	*/
 	ginkgo.It("List-volumeResponseFor-fileVolumes", ginkgo.Label(p1, listVolume, file, vanilla, core), func() {
-		curtime := time.Now().Unix()
-		randomValue := rand.Int()
-		val := strconv.FormatInt(int64(randomValue), 10)
-		val = string(val[1:3])
-		curtimestring := strconv.FormatInt(curtime, 10)
-		scName := "nginx-sc-default-" + curtimestring + val
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var volumesBeforeScaleUp []string
@@ -752,7 +716,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scParameters[scParamFsType] = nfs4FSType
-		scSpec := getVSphereStorageClassSpec(scName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -77,6 +77,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		storagePolicyName          string
 		scParameters               map[string]string
 		isVsanHealthServiceStopped bool
+		vcAddress                  string
+		err                        error
 	)
 
 	const (
@@ -91,6 +93,13 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
 		nodeList, err := fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
@@ -126,7 +135,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		if isVsanHealthServiceStopped {
@@ -175,7 +183,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -264,7 +271,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -365,7 +371,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}
 		gomega.Expect(datastore).NotTo(gomega.BeNil())
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -436,7 +441,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 			pvs = append(pvs, pvList[0])
 		}
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -569,7 +573,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -654,7 +657,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		framework.ExpectNoError(fpv.WaitOnPVandPVC(ctx, client, f.Timeouts, namespace, pv, pvc))
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -834,7 +836,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Stopping vsan-health on the vCenter host")
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/fullsync_test_for_file_volume.go
+++ b/tests/e2e/fullsync_test_for_file_volume.go
@@ -55,6 +55,8 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 		labelValue                 string
 		fullSyncWaitTime           int
 		isVsanHealthServiceStopped bool
+		vcAddress                  string
+		err                        error
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -62,6 +64,13 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 		namespace = getNamespaceToRunTests(f)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
 		nodeList, err := fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
@@ -86,7 +95,6 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 	ginkgo.AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		if isVsanHealthServiceStopped {
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
@@ -140,7 +148,6 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 		}()
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		defer func() {

--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -392,7 +392,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scParameters[svStorageClassName] = storagePolicyName
-		sc, err := createStorageClass(client, scParameters, nil, "", "", false, "nginx-sc")
+		sc, err := createStorageClass(client, scParameters, nil, "", "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/gc_rwx_service_down.go
+++ b/tests/e2e/gc_rwx_service_down.go
@@ -46,6 +46,8 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		volHealthCheck             bool
 		isVsanHealthServiceStopped bool
 		fullSyncWaitTime           int
+		vcAddress                  string
+		err                        error
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -61,6 +63,13 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		bootstrap()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
 		nodeList, err := fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
@@ -86,7 +95,6 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 
 		if isVsanHealthServiceStopped {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
 		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
@@ -134,7 +142,6 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -210,7 +217,6 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -347,7 +353,6 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/gc_rwx_syncer.go
+++ b/tests/e2e/gc_rwx_syncer.go
@@ -46,6 +46,8 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Test for label updates", func
 		storagePolicyName          string
 		volHealthCheck             bool
 		isVsanHealthServiceStopped bool
+		vcAddress                  string
+		err                        error
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -61,6 +63,13 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Test for label updates", func
 		bootstrap()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
 		nodeList, err := fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
@@ -74,7 +83,6 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Test for label updates", func
 		defer cancel()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 		if isVsanHealthServiceStopped {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}

--- a/tests/e2e/improved_csi_idempotency.go
+++ b/tests/e2e/improved_csi_idempotency.go
@@ -58,6 +58,8 @@ var _ = ginkgo.Describe("Improved CSI Idempotency Tests", func() {
 		serviceName       string
 		csiReplicaCount   int32
 		deployment        *appsv1.Deployment
+		vcAddress         string
+		err               error
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -69,6 +71,13 @@ var _ = ginkgo.Describe("Improved CSI Idempotency Tests", func() {
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
 		nodeList, err := fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 
@@ -144,7 +153,6 @@ var _ = ginkgo.Describe("Improved CSI Idempotency Tests", func() {
 					startHostDOnHost(ctx, hostIP)
 				}
 			} else {
-				vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
 				err := invokeVCenterServiceControl(ctx, startOperation, serviceName, vcAddress)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -463,6 +471,10 @@ func createVolumeWithServiceDown(serviceName string, namespace string, client cl
 	var fullSyncWaitTime int
 	pvclaims = make([]*v1.PersistentVolumeClaim, volumeOpsScale)
 
+	// reading vc address with port num
+	vcAddress, _, err := readVcAddress()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 	// Decide which test setup is available to run
 	if vanillaCluster {
 		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
@@ -648,7 +660,6 @@ func createVolumeWithServiceDown(serviceName string, namespace string, client cl
 		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
 	} else {
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = true
@@ -727,6 +738,10 @@ func extendVolumeWithServiceDown(serviceName string, namespace string, client cl
 	var err error
 	var fullSyncWaitTime int
 	pvclaims = make([]*v1.PersistentVolumeClaim, volumeOpsScale)
+
+	var vcAddress string
+	vcAddress, _, err = readVcAddress()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// Decide which test setup is available to run
 	if vanillaCluster {
@@ -905,7 +920,6 @@ func extendVolumeWithServiceDown(serviceName string, namespace string, client cl
 		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
 	} else {
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = true

--- a/tests/e2e/mgmt_wrkld_domain_isolation.go
+++ b/tests/e2e/mgmt_wrkld_domain_isolation.go
@@ -74,7 +74,9 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 		bootstrap()
 
 		// reading vc session id
-		vcRestSessionId = createVcSession4RestApis(ctx)
+		if vcRestSessionId == "" {
+			vcRestSessionId = createVcSession4RestApis(ctx)
+		}
 
 		// reading topology map set for management doamin and workload domain
 		topologyMap := GetAndExpectStringEnvVar(envTopologyMap)

--- a/tests/e2e/multi_svc_test.go
+++ b/tests/e2e/multi_svc_test.go
@@ -110,13 +110,18 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 
 		// Getting all env variables here
 		csiNamespace = GetAndExpectStringEnvVar(envCSINamespace)
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		dataCenter = GetAndExpectStringEnvVar(datacenter)
 		computeCluster = GetAndExpectStringEnvVar(envComputeClusterName)
 		datastoreName = GetAndExpectStringEnvVar(envNfsDatastoreName)
 		datastoreIP = GetAndExpectStringEnvVar(envNfsDatastoreIP)
 		kubeconfig = GetAndExpectStringEnvVar("KUBECONFIG")
 		kubeconfig1 = GetAndExpectStringEnvVar("KUBECONFIG1")
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 
 		ginkgo.By("Getting User and Supervisor-Id for both the supervisors")
 		// Iterating through number of svc to read it's config secret to get supervisor id and service account user

--- a/tests/e2e/no_hci_mesh_rwx_singlevc_topology.go
+++ b/tests/e2e/no_hci_mesh_rwx_singlevc_topology.go
@@ -69,7 +69,6 @@ var _ = ginkgo.Describe("[rwx-nohci-singlevc-positive] RWX-Topology-NoHciMesh-Si
 		clusterId                string
 		csiNamespace             string
 		csiReplicas              int32
-		allMasterIps             []string
 		masterIp                 string
 		err                      error
 		topologySetupType        string
@@ -136,9 +135,10 @@ var _ = ginkgo.Describe("[rwx-nohci-singlevc-positive] RWX-Topology-NoHciMesh-Si
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		csiReplicas = *csiDeployment.Spec.Replicas
 
-		// fetch list of master IPs
-		allMasterIps = getK8sMasterIPs(ctx, client)
-		masterIp = allMasterIps[0]
+		// reading K8sMasterIP
+		if masterIp == "" {
+			masterIp, _, _, _ = GetMasterIpPortMap(ctx, client)
+		}
 
 		/* Reading the topology setup type (Level 2 or Level 5), and based on the selected setup type,
 		executing the test case on the corresponding setup */

--- a/tests/e2e/no_hci_mesh_rwx_singlevc_topology_disruptive.go
+++ b/tests/e2e/no_hci_mesh_rwx_singlevc_topology_disruptive.go
@@ -61,6 +61,7 @@ var _ = ginkgo.Describe("[rwx-nohci-singlevc-disruptive] RWX-Topology-NoHciMesh-
 		sshClientConfig         *ssh.ClientConfig
 		nodeList                *v1.NodeList
 		clusterComputeResource  []*object.ClusterComputeResource
+		sshdPortNum             string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -78,6 +79,11 @@ var _ = ginkgo.Describe("[rwx-nohci-singlevc-disruptive] RWX-Topology-NoHciMesh-
 		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		// reading K8sMasterIP port number
+		if sshdPortNum == "" {
+			_, sshdPortNum, _, _ = GetMasterIpPortMap(ctx, client)
 		}
 
 		sc, err := client.StorageV1().StorageClasses().Get(ctx, defaultNginxStorageClassName, metav1.GetOptions{})
@@ -333,7 +339,8 @@ var _ = ginkgo.Describe("[rwx-nohci-singlevc-disruptive] RWX-Topology-NoHciMesh-
 			len(hostsInCluster))
 		defer func() {
 			ginkgo.By("Verifying k8s node status after site recovery")
-			err = verifyK8sNodeStatusAfterSiteRecovery(client, ctx, sshClientConfig, nodeList)
+			err = verifyK8sNodeStatusAfterSiteRecovery(client, ctx, sshClientConfig,
+				nodeList, sshdPortNum)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -394,7 +401,8 @@ var _ = ginkgo.Describe("[rwx-nohci-singlevc-disruptive] RWX-Topology-NoHciMesh-
 		}
 
 		ginkgo.By("Verifying k8s node status after site recovery")
-		err = verifyK8sNodeStatusAfterSiteRecovery(client, ctx, sshClientConfig, nodeList)
+		err = verifyK8sNodeStatusAfterSiteRecovery(client, ctx, sshClientConfig,
+			nodeList, sshdPortNum)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Verify all the workload Pods are in up and running state
@@ -586,7 +594,8 @@ var _ = ginkgo.Describe("[rwx-nohci-singlevc-disruptive] RWX-Topology-NoHciMesh-
 		}
 
 		ginkgo.By("Verifying k8s node status after site recovery")
-		err = verifyK8sNodeStatusAfterSiteRecovery(client, ctx, sshClientConfig, nodeList)
+		err = verifyK8sNodeStatusAfterSiteRecovery(client, ctx, sshClientConfig,
+			nodeList, sshdPortNum)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PVC Bound state and CNS side verification")
@@ -806,7 +815,8 @@ var _ = ginkgo.Describe("[rwx-nohci-singlevc-disruptive] RWX-Topology-NoHciMesh-
 		}
 
 		ginkgo.By("Verifying k8s node status after site recovery")
-		err = verifyK8sNodeStatusAfterSiteRecovery(client, ctx, sshClientConfig, nodeList)
+		err = verifyK8sNodeStatusAfterSiteRecovery(client, ctx, sshClientConfig,
+			nodeList, sshdPortNum)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PVC Bound state and CNS side verification")

--- a/tests/e2e/nodes_scaleup_scaledown.go
+++ b/tests/e2e/nodes_scaleup_scaledown.go
@@ -19,9 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"math/rand"
-	"strconv"
-	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -82,13 +79,6 @@ var _ = ginkgo.Describe("[csi-file-vanilla] [csi-block-vanilla-serialized] Nodes
 		12. Delete the storage class.
 	*/
 	ginkgo.It("Statefulset with Nodes Scale-up and Scale-down", func() {
-		curtime := time.Now().Unix()
-		randomValue := rand.Int()
-		val := strconv.FormatInt(int64(randomValue), 10)
-		val = string(val[1:3])
-		curtimestring := strconv.FormatInt(curtime, 10)
-		scName := "nginx-sc-default-" + curtimestring + val
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -109,7 +99,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] [csi-block-vanilla-serialized] Nodes
 		if rwxAccessMode {
 			scParameters[scParamFsType] = nfs4FSType
 		}
-		scSpec := getVSphereStorageClassSpec(scName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -132,7 +122,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] [csi-block-vanilla-serialized] Nodes
 		}
 
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Spec.StorageClassName = &scName
+			Spec.StorageClassName = &sc.Name
 		CreateStatefulSet(namespace, statefulset, client)
 
 		defer func() {

--- a/tests/e2e/raw_block_volume.go
+++ b/tests/e2e/raw_block_volume.go
@@ -806,7 +806,7 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		}()
 
 		ginkgo.By("Increase PVC size and verify online volume resize")
-		increaseSizeOfPvcAttachedToPod(f, client, namespace, pvc, pod)
+		increaseSizeOfPvcAttachedToPod(f, ctx, client, namespace, pvc, pod)
 
 		ginkgo.By("Wait for block device size to be updated inside pod after expansion")
 		isPvcExpandedInsidePod := false

--- a/tests/e2e/snapshot_vmservice_vm.go
+++ b/tests/e2e/snapshot_vmservice_vm.go
@@ -73,6 +73,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 		pandoraSyncWaitTime        int
 		dsRef                      types.ManagedObjectReference
 		labelsMap                  map[string]string
+		err                        error
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -98,9 +99,16 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 			storagePolicyName = GetAndExpectStringEnvVar(envZonalStoragePolicyName)
 		}
 
-		// fetching vc ip and creating creating vc session
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		vcRestSessionId = createVcSession4RestApis(ctx)
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// reading vc session id
+		if vcRestSessionId == "" {
+			vcRestSessionId = createVcSession4RestApis(ctx)
+		}
 
 		// reading storage class name for wcp setup "wcpglobal_storage_profile"
 		storageClassName = strings.ReplaceAll(storagePolicyName, "_", "-") // since this is a wcp setup

--- a/tests/e2e/statefulset_with_topology.go
+++ b/tests/e2e/statefulset_with_topology.go
@@ -92,7 +92,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		}()
 
 		ginkgo.By("Creating statefulset with single replica")
-		statefulset, service, err := createStatefulSetWithOneReplica(client, manifestPath, namespace)
+		statefulset, service, err := createStatefulSetWithOneReplica(client,
+			manifestPath, namespace, sc)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			deleteService(namespace, client, service)

--- a/tests/e2e/statefulset_xfs.go
+++ b/tests/e2e/statefulset_xfs.go
@@ -54,10 +54,9 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] st
 	f := framework.NewDefaultFramework("e2e-vsphere-statefulset")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		namespace        string
-		client           clientset.Interface
-		scParameters     map[string]string
-		storageClassName string
+		namespace    string
+		client       clientset.Interface
+		scParameters map[string]string
 	)
 	ginkgo.BeforeEach(func() {
 		namespace = getNamespaceToRunTests(f)
@@ -79,8 +78,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] st
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset with fstype set to xfs")
 		scParameters[scParamFsType] = xfsFSType
-		storageClassName = "nginx-sc-default"
-		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -97,7 +95,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] st
 		ginkgo.By("Creating statefulset")
 		statefulset := GetStatefulSetFromManifest(namespace)
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Spec.StorageClassName = &storageClassName
+			Spec.StorageClassName = &sc.Name
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready

--- a/tests/e2e/svmotion_volumes.go
+++ b/tests/e2e/svmotion_volumes.go
@@ -1081,7 +1081,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 		ginkgo.By("Adding labels to volume and writing IO to pod whle relocating volume")
 		var wg sync.WaitGroup
 		wg.Add(3)
-		go writeKnownData2PodInParallel(f, client, pods[0], testdataFile, &wg)
+		go writeKnownData2PodInParallel(f, ctx, client, pods[0], testdataFile, &wg)
 		go updatePvcLabelsInParallel(ctx, client, namespace, labels, pvcs, &wg)
 		go updatePvLabelsInParallel(ctx, client, namespace, labels, pvs, &wg)
 		wg.Wait()
@@ -1110,7 +1110,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify the data on the PVCs match what was written in step 7")
-		verifyKnownDataInPod(f, client, pods[0], testdataFile)
+		verifyKnownDataInPod(f, ctx, client, pods[0], testdataFile)
 
 		storagePolicyMatches, err = e2eVSphere.VerifySpbmPolicyOfVolume(volumeID, policyNames[0])
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1312,7 +1312,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 		lock := &sync.Mutex{}
 		var wg sync.WaitGroup
 		wg.Add(2)
-		go writeKnownData2PodInParallel(f, client, pods[0], testdataFile, &wg)
+		go writeKnownData2PodInParallel(f, ctx, client, pods[0], testdataFile, &wg)
 		go createSnapshotInParallel(ctx, namespace, snapc, pvclaim.Name, volumeSnapshotClass.Name,
 			ch, lock, &wg)
 		go func() {
@@ -1369,7 +1369,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify the data on the PVCs match what was written in step 7")
-		verifyKnownDataInPod(f, client, pods[0], testdataFile)
+		verifyKnownDataInPod(f, ctx, client, pods[0], testdataFile)
 
 		storagePolicyMatches, err = e2eVSphere.VerifySpbmPolicyOfVolume(volumeID, policyNames[0])
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/tkgs_ha_site_down.go
+++ b/tests/e2e/tkgs_ha_site_down.go
@@ -228,7 +228,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 
 		ginkgo.By("Verify if sts pods of zone-1 are in Terminating state")
 		for _, podName := range podNames {
-			err = waitForPodsToBeInTerminatingPhase(sshWcpConfig, svcMasterIp,
+			err = waitForPodsToBeInTerminatingPhase(ctx, client, sshWcpConfig, svcMasterIp,
 				podName, namespace, pollTimeout*2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
@@ -375,7 +375,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 		time.Sleep(5 * time.Minute)
 
 		framework.Logf("Verify wcp apiserrver is unreachable as other apiservers are down")
-		err = waitForPodsToBeInTerminatingPhase(sshWcpConfig, svcMasterIp,
+		err = waitForPodsToBeInTerminatingPhase(ctx, client, sshWcpConfig, svcMasterIp,
 			podList[0].Name, namespace, pollTimeout)
 		if strings.Contains(err.Error(), "was refused") ||
 			strings.Contains(err.Error(), "Unable to connect to the server") {
@@ -387,7 +387,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 			powerOnEsxiHostByCluster(powerOffHostsList1[i])
 		}
 		ginkgo.By("Waiting for apiserver of zone-3 to be reachable and fully up")
-		err = waitForApiServerToBeUp(svcMasterIp, sshWcpConfig, pollTimeout*3)
+		err = waitForApiServerToBeUp(ctx, client, svcMasterIp, sshWcpConfig, pollTimeout*3)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		time.Sleep(5 * time.Minute)
 
@@ -398,7 +398,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 
 		ginkgo.By("Verify if sts pods of zone-2 are in Terminating state")
 		for _, podName := range podNames {
-			err = waitForPodsToBeInTerminatingPhase(sshWcpConfig, svcMasterIp,
+			err = waitForPodsToBeInTerminatingPhase(ctx, client, sshWcpConfig, svcMasterIp,
 				podName, namespace, pollTimeout*2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
@@ -932,7 +932,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 
 		ginkgo.By("Verify if sts pods of zone-1 are in Terminating state")
 		for _, podName := range podNames {
-			err = waitForPodsToBeInTerminatingPhase(sshWcpConfig, svcMasterIp,
+			err = waitForPodsToBeInTerminatingPhase(ctx, client, sshWcpConfig, svcMasterIp,
 				podName, namespace, pollTimeout*2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}

--- a/tests/e2e/topology_aware_node_poweroff.go
+++ b/tests/e2e/topology_aware_node_poweroff.go
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 			GetAndExpectStringEnvVar(envRegionZoneWithSharedDS))
 
 		ginkgo.By("Creating StorageClass for Statefulset")
-		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", nil, allowedTopologies, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -115,7 +115,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		}()
 
 		ginkgo.By("Creating statefulset with single replica")
-		statefulset, service, err := createStatefulSetWithOneReplica(client, manifestPath, namespace)
+		statefulset, service, err := createStatefulSetWithOneReplica(client, manifestPath, namespace, sc)
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Spec.StorageClassName = &sc.Name
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			deleteService(namespace, client, service)
@@ -241,7 +243,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		regionValues, zoneValues, allowedTopologies = topologyParameterForStorageClass(topologyValue)
 
 		ginkgo.By("Creating StorageClass for Statefulset")
-		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", nil, allowedTopologies, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -256,7 +258,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		}()
 
 		ginkgo.By("Creating statefulset with single replica")
-		statefulset, service, err := createStatefulSetWithOneReplica(client, manifestPath, namespace)
+		statefulset, service, err := createStatefulSetWithOneReplica(client, manifestPath, namespace, sc)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			deleteService(namespace, client, service)

--- a/tests/e2e/topology_site_down_cases.go
+++ b/tests/e2e/topology_site_down_cases.go
@@ -59,6 +59,8 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 		noOfHostToBringDown     int
 		sshClientConfig         *ssh.ClientConfig
 		nimbusGeneratedK8sVmPwd string
+		sshdPortNum             string
+		masterIp                string
 	)
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
@@ -76,6 +78,12 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
+
+		// reading K8sMasterIP and port number
+		if sshdPortNum == "" || masterIp == "" {
+			masterIp, sshdPortNum, _, _ = GetMasterIpPortMap(ctx, client)
+		}
+
 		bindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 		topologyMap := GetAndExpectStringEnvVar(envTopologyMap)
 		topologyAffinityDetails, topologyCategories = createTopologyMapLevel5(topologyMap)
@@ -150,7 +158,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 		// Create SC with WFC BindingMode
 		ginkgo.By("Creating Storage Class with WFC Binding Mode and allowed topolgies of 5 levels")
 		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
-			bindingMode, false, "nginx-sc")
+			bindingMode, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -166,7 +174,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 
 		// Create multiple StatefulSets Specs in parallel
 		ginkgo.By("Creating multiple StatefulSets specs in parallel")
-		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, statefulSetReplicaCount)
+		statefulSets := createParallelStatefulSetSpec(storageclass, namespace, sts_count, statefulSetReplicaCount)
 
 		// Trigger multiple StatefulSets creation in parallel.
 		ginkgo.By("Trigger multiple StatefulSets creation in parallel")
@@ -360,7 +368,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 		// Create SC with WFC BindingMode
 		ginkgo.By("Creating Storage Class with WFC Binding Mode and allowed topolgies of 5 levels")
 		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
-			bindingMode, false, "nginx-sc")
+			bindingMode, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -376,7 +384,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 
 		// Create multiple StatefulSets Specs in parallel
 		ginkgo.By("Creating multiple StatefulSets specs in parallel")
-		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, statefulSetReplicaCount)
+		statefulSets := createParallelStatefulSetSpec(storageclass, namespace, sts_count, statefulSetReplicaCount)
 
 		// Trigger multiple StatefulSets creation in parallel.
 		ginkgo.By("Trigger multiple StatefulSets creation in parallel")
@@ -561,7 +569,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 		// Create SC with WFC BindingMode
 		ginkgo.By("Creating Storage Class with WFC Binding Mode and allowed topolgies of 5 levels")
 		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
-			bindingMode, false, "nginx-sc")
+			bindingMode, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -577,7 +585,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 
 		// Create multiple StatefulSets Specs in parallel
 		ginkgo.By("Creating multiple StatefulSets specs in parallel")
-		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, statefulSetReplicaCount)
+		statefulSets := createParallelStatefulSetSpec(storageclass, namespace, sts_count, statefulSetReplicaCount)
 
 		// Trigger multiple StatefulSets creation in parallel.
 		ginkgo.By("Trigger multiple StatefulSets creation in parallel")
@@ -762,7 +770,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 		// Create SC with WFC BindingMode
 		ginkgo.By("Creating Storage Class with WFC Binding Mode and allowed topolgies of 5 levels")
 		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
-			bindingMode, false, "nginx-sc")
+			bindingMode, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -778,7 +786,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 
 		// Create multiple StatefulSets Specs in parallel
 		ginkgo.By("Creating multiple StatefulSets specs in parallel")
-		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, statefulSetReplicaCount)
+		statefulSets := createParallelStatefulSetSpec(storageclass, namespace, sts_count, statefulSetReplicaCount)
 
 		// Trigger multiple StatefulSets creation in parallel.
 		ginkgo.By("Trigger multiple StatefulSets creation in parallel")
@@ -959,7 +967,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 		// Create SC with WFC BindingMode
 		ginkgo.By("Creating Storage Class with WFC Binding Mode and allowed topolgies of 5 levels")
 		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
-			bindingMode, false, "nginx-sc")
+			bindingMode, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -975,7 +983,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 
 		// Create multiple StatefulSets Specs in parallel
 		ginkgo.By("Creating multiple StatefulSets specs in parallel")
-		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, statefulSetReplicaCount)
+		statefulSets := createParallelStatefulSetSpec(storageclass, namespace, sts_count, statefulSetReplicaCount)
 
 		// Trigger multiple StatefulSets creation in parallel.
 		ginkgo.By("Trigger multiple StatefulSets creation in parallel")
@@ -1154,7 +1162,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 		// Create SC with WFC BindingMode
 		ginkgo.By("Creating Storage Class with WFC Binding Mode and allowed topolgies of 5 levels")
 		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
-			bindingMode, false, "nginx-sc")
+			bindingMode, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
@@ -1171,7 +1179,7 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 
 		// Create multiple StatefulSets Specs in parallel
 		ginkgo.By("Creating multiple StatefulSets specs in parallel")
-		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, statefulSetReplicaCount)
+		statefulSets := createParallelStatefulSetSpec(storageclass, namespace, sts_count, statefulSetReplicaCount)
 
 		// Trigger multiple StatefulSets creation in parallel.
 		ginkgo.By("Trigger multiple StatefulSets creation in parallel")
@@ -1210,16 +1218,15 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 			for i := 0; i < len(powerOffHostsList); i++ {
 				powerOnEsxiHostByCluster(powerOffHostsList[i])
 			}
-			k8sMasterIPs := getK8sMasterIPs(ctx, client)
 			checkNodesStatus := "kubectl get nodes | grep NotReady |  awk '{print $1}'"
-			framework.Logf("Invoking command '%v' on host %v", checkNodesStatus, k8sMasterIPs[0])
-			result, err := sshExec(sshClientConfig, k8sMasterIPs[0], checkNodesStatus)
+			framework.Logf("Invoking command '%v' on host %v", checkNodesStatus, masterIp)
+			result, err := sshExec(sshClientConfig, masterIp, checkNodesStatus, sshdPortNum)
 			nodeNames := strings.Split(result.Stdout, "\n")
 			if err != nil && result.Code != 0 {
 				fssh.LogResult(result)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 					fmt.Sprintf("command failed/couldn't execute command: %s on host: %v", checkNodesStatus,
-						k8sMasterIPs[0]))
+						masterIp))
 			}
 			if len(nodeNames) != 0 {
 				ginkgo.By("Bring up all K8s nodes which got disconnected due to powered off esxi hosts")
@@ -1256,16 +1263,15 @@ var _ = ginkgo.Describe("[topology-sitedown] Topology-SiteDown", func() {
 		}
 
 		ginkgo.By("Bring up all K8s nodes which got disconnected due to powered off esxi hosts")
-		k8sMasterIPs := getK8sMasterIPs(ctx, client)
 		checkNodesStatus := "kubectl get nodes | grep NotReady |  awk '{print $1}'"
-		framework.Logf("Invoking command '%v' on host %v", checkNodesStatus, k8sMasterIPs[0])
-		result, err := sshExec(sshClientConfig, k8sMasterIPs[0], checkNodesStatus)
+		framework.Logf("Invoking command '%v' on host %v", checkNodesStatus, masterIp)
+		result, err := sshExec(sshClientConfig, masterIp, checkNodesStatus, sshdPortNum)
 		nodeNames := strings.Split(result.Stdout, "\n")
 		if err != nil && result.Code != 0 {
 			fssh.LogResult(result)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 				fmt.Sprintf("command failed/couldn't execute command: %s on host: %v", checkNodesStatus,
-					k8sMasterIPs[0]))
+					masterIp))
 		}
 		for _, nodeName := range nodeNames {
 			if nodeName != "" {

--- a/tests/e2e/topology_snapshot.go
+++ b/tests/e2e/topology_snapshot.go
@@ -340,7 +340,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology-Snapshot", func() {
 
 		scParameters["datastoreurl"] = sharedDataStoreUrlBetweenClusters
 		storageclass, err := createStorageClass(client, scParameters, allowedTopologyForSC,
-			"", "", false, "nginx-sc")
+			"", "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,

--- a/tests/e2e/vc_reboot_volume_lifecycle.go
+++ b/tests/e2e/vc_reboot_volume_lifecycle.go
@@ -58,7 +58,12 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
 
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
 		scParameters = make(map[string]string)
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 

--- a/tests/e2e/vm_service_vsan_stretch_cluster.go
+++ b/tests/e2e/vm_service_vsan_stretch_cluster.go
@@ -86,9 +86,15 @@ var _ bool = ginkgo.Describe("[vsan-stretch-vmsvc] vm service with csi vol tests
 		readVcEsxIpsViaTestbedInfoJson(GetAndExpectStringEnvVar(envTestbedInfoJsonPath))
 		initialiseFdsVar(ctx)
 
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		vcRestSessionId = createVcSession4RestApis(ctx)
-		//csiNs = GetAndExpectStringEnvVar(envCSINamespace)
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		if vcRestSessionId == "" {
+			vcRestSessionId = createVcSession4RestApis(ctx)
+		}
 
 		storageClassName = strings.ReplaceAll(storagePolicyName, " ", "-") // since this is a wcp setup
 		storageClassName = strings.ToLower(storageClassName)

--- a/tests/e2e/vmservice_vm.go
+++ b/tests/e2e/vmservice_vm.go
@@ -90,8 +90,16 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		bootstrap()
 		isVsanHealthServiceStopped = false
 		isSPSserviceStopped = false
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		vcRestSessionId = createVcSession4RestApis(ctx)
+
+		// reading vc address with port num
+		if vcAddress == "" {
+			vcAddress, _, err = readVcAddress()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		if vcRestSessionId == "" {
+			vcRestSessionId = createVcSession4RestApis(ctx)
+		}
 
 		storageClassName = strings.ReplaceAll(storagePolicyName, "_", "-") // since this is a wcp setup
 
@@ -130,7 +138,6 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		gomega.Expect(vmi).NotTo(gomega.BeEmpty())
 
 		if supervisorCluster || stretchedSVC {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			//if isQuotaValidationSupported is true then quotaValidation is considered in tests
 			vcVersion = getVCversion(ctx, vcAddress)
 			isQuotaValidationSupported = isVersionGreaterOrEqual(vcVersion, quotaSupportedVCVersion)

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -161,7 +161,7 @@ var _ = ginkgo.Describe("[topology-positive] Topology-Positive", func() {
 
 		// Creating StorageClass when no topology details are specified using WFC Binding mode
 		ginkgo.By("Creating StorageClass for Statefulset")
-		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+		scSpec := getVSphereStorageClassSpec("", nil, nil, "",
 			bindingMode, false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -177,6 +177,9 @@ var _ = ginkgo.Describe("[topology-positive] Topology-Positive", func() {
 
 		// Creating StatefulSet with replica count 3 using default pod management policy
 		statefulset := GetStatefulSetFromManifest(namespace)
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Spec.StorageClassName = &sc.Name
+
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -237,7 +240,7 @@ var _ = ginkgo.Describe("[topology-positive] Topology-Positive", func() {
 
 		// Creating StorageClass when no topology details are specified using WFC Binding mode
 		ginkgo.By("Creating StorageClass for Statefulset")
-		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+		scSpec := getVSphereStorageClassSpec("", nil, nil, "",
 			bindingMode, false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -333,7 +336,7 @@ var _ = ginkgo.Describe("[topology-positive] Topology-Positive", func() {
 
 		// Create StorageClass with allowed Topologies
 		ginkgo.By("Creating StorageClass for Statefulset")
-		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologyForSC,
+		scSpec := getVSphereStorageClassSpec("", nil, allowedTopologyForSC,
 			"", bindingMode, false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -433,7 +436,7 @@ var _ = ginkgo.Describe("[topology-positive] Topology-Positive", func() {
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 		scParameters["storagepolicyname"] = storagePolicyName
 		storageclass, err := createStorageClass(client, scParameters, allowedTopologyForSC, "",
-			"", false, "nginx-sc")
+			"", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
@@ -449,6 +452,8 @@ var _ = ginkgo.Describe("[topology-positive] Topology-Positive", func() {
 
 		// Creating StatefulSet with replica count 3 using default pod management policy
 		statefulset := GetStatefulSetFromManifest(namespace)
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Spec.StorageClassName = &storageclass.Name
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -537,7 +542,7 @@ var _ = ginkgo.Describe("[topology-positive] Topology-Positive", func() {
 		scParameters := make(map[string]string)
 		scParameters["datastoreurl"] = sharedDataStoreUrlBetweenClusters
 		storageclass, err := createStorageClass(client, scParameters, allowedTopologyForSC,
-			"", "", false, "nginx-sc")
+			"", "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
@@ -719,7 +724,7 @@ var _ = ginkgo.Describe("[topology-positive] Topology-Positive", func() {
 
 		// Create SC with WFC BindingMode with allowed topology details.
 		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
-			bindingMode, false, "nginx-sc")
+			bindingMode, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
@@ -735,6 +740,8 @@ var _ = ginkgo.Describe("[topology-positive] Topology-Positive", func() {
 
 		// Creating StatefulSet with replica count 3 using default pod management policy
 		statefulset := GetStatefulSetFromManifest(namespace)
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Spec.StorageClassName = &storageclass.Name
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)

--- a/tests/e2e/vsphere_file_volume_basic_mount.go
+++ b/tests/e2e/vsphere_file_volume_basic_mount.go
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] Verify Two Pods can read write files
 		scParameters := map[string]string{}
 		scParameters[scParamFsType] = xfsFSType
 
-		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -223,7 +223,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] Verify Two Pods can read write files
 		scParameters := map[string]string{}
 		scParameters[scParamFsType] = ext4FSType
 
-		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {

--- a/tests/e2e/vsphere_volume_disksize.go
+++ b/tests/e2e/vsphere_volume_disksize.go
@@ -43,7 +43,7 @@ import (
 */
 
 var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor] [csi-guest] "+
-	"[csi-block-vanilla-parallelized] Volume Disk Size ", func() {
+	"[csi-block-vanilla-parallelized] Volume Disk Size", func() {
 	f := framework.NewDefaultFramework("volume-disksize")
 	var (
 		client            clientset.Interface

--- a/tests/e2e/vsphere_volume_fstype.go
+++ b/tests/e2e/vsphere_volume_fstype.go
@@ -119,7 +119,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] Volume Filesystem Type Test", func(
 		scParameters := map[string]string{}
 		scParameters[scParamFsType] = nfs4FSType
 
-		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec("", scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces changes for the Nimbus testbed, allowing deployment on a private network/isolated network, or public network.

    In a public network setup, the port numbers for vCenter (VC), Master, Worker VMs, and ESXi remain the same.

    In a private network setup, the port numbers vary for each vSphere resource component.

Key changes in this PR include:

    Resolving the vCenter address dynamically with its corresponding port number.

    Mapping master IPs to their respective port numbers.

    Removing hardcoded storage class names.

    Reading port numbers and master IPs at runtime.

    Dynamically determining the vCenter address (IP + PortNo) based on the specified network type (public or private).
    
    removal of unnecessary duplicate code
    
    Increase in the pvc creation timeout from 1 min to 5 mins


**Testing done**:
In progress

**Special notes for your reviewer**:
ps031044@P2XQC4DXP0 vsphere-csi-driver % golangci-lint run --enable=lll 
ps031044@P2XQC4DXP0 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.59.1'
golangci/golangci-lint info found version: 1.59.1 for v1.59.1/darwin/arm64
golangci/golangci-lint info installed /Users/ps031044/go/bin/golangci-lint
INFO golangci-lint has version 1.59.1 built with go1.22.3 from 1a55854a on 2024-06-09T18:08:33Z 
INFO [config_reader] Config search paths: [./ /Users/ps031044/public-private-network/vsphere-csi-driver /Users/ps031044/public-private-network /Users/ps031044 /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 8 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck unused] 

