### PR TITLE
check for nil readytouse value from volumesnapshot status

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1378,7 +1378,7 @@ func calculateVolumeSnapshotReservedForNamespace(ctx context.Context,
 				vs.Name, vs.Namespace)
 			continue
 		}
-		if vs.Status != nil && *vs.Status.ReadyToUse {
+		if vs.Status != nil && vs.Status.ReadyToUse != nil && *vs.Status.ReadyToUse {
 			log.Debugf("calculateVolumeSnapshotReservedForNamespace: skipping volumesnapshot"+
 				" as it is ready to use, ignoring Name: %q, Namespace: %q", vs.Name, vs.Namespace)
 			continue


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PR intent to handle nil value for VolumeSnapshot Status.ReadyToUse, to fix the code panics.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing Performed

Logs:
Before fix:
[readytouse_panic_before_fix.log](https://github.com/user-attachments/files/19463840/readytouse_panic_before_fix.log)
 
 After Fix
[readytouse_panic_fixed.log](https://github.com/user-attachments/files/19463892/readytouse_panic_fixed.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Check for nil readytouse from volumesnapshot status
```
