### PR TITLE
Workload domain isolation - pvc creation with requested topology annotation

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -472,8 +472,9 @@ var (
 	envZonal2StoragePolicyName            = "ZONAL2_STORAGE_POLICY_IMM"
 	envZonal2StoragePolicyNameLateBidning = "ZONAL2_STORAGE_POLICY_WFFC"
 	envZonal1StoragePolicyName            = "ZONAL1_STORAGE_POLICY_IMM"
+	envZonal3StoragePolicyName            = "ZONAL3_STORAGE_POLICY_IMM"
 	topologyDomainIsolation               = "Workload_Management_Isolation"
-	envSharedStoragePolicyName            = "SHARED_STORAGE_POLICY"
+	envIsolationSharedStoragePolicyName   = "WORKLOAD_ISOLATION_SHARED_STORAGE_POLICY"
 )
 
 // GetAndExpectStringEnvVar parses a string from env variable.


### PR DESCRIPTION
**What this PR does / why we need it**:
Workload domain isolation - A usecase and couple of helper utils to create pvc with requested topology annotation


**Testing done**:
Yes
[tc13.txt](https://github.com/user-attachments/files/19483740/tc13.txt)


**Special notes for your reviewer**:
ps031044@P2XQC4DXP0 vsphere-csi-driver % golangci-lint run --enable=lll
ps031044@P2XQC4DXP0 vsphere-csi-driver % 
ps031044@P2XQC4DXP0 vsphere-csi-driver %  make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.59.1'
golangci/golangci-lint info found version: 1.59.1 for v1.59.1/darwin/arm64
golangci/golangci-lint info installed /Users/ps031044/go/bin/golangci-lint
INFO golangci-lint has version 1.59.1 built with go1.22.3 from 1a55854a on 2024-06-09T18:08:33Z 
INFO [config_reader] Config search paths: [./ /Users/ps031044/isolation-part3/vsphere-csi-driver /Users/ps031044/isolation-part3 /Users/ps031044 /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 8 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck unused] 
INFO [loader] Go packages loading at mode 575 (imports|name|types_sizes|compiled_files|deps|exports_file|files) took 8.131794458s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 158.328167ms 
