### PR TITLE
Go code fixes to correctly read public and private port numbers for different hosts and VMs.

### DIFF
--- a/tests/e2e/config_change_test.go
+++ b/tests/e2e/config_change_test.go
@@ -100,7 +100,6 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintln("Changing password on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		username := vsphereCfg.Global.User
 		currentPassword := vsphereCfg.Global.Password
 		newPassword := e2eTestPassword

--- a/tests/e2e/connection.go
+++ b/tests/e2e/connection.go
@@ -91,8 +91,13 @@ func connect(ctx context.Context, vs *vSphere, forceRefresh ...bool) {
 
 // newClient creates a new client for vSphere connection.
 func newClient(ctx context.Context, vs *vSphere) *govmomi.Client {
+	isPrivateNetwork := GetBoolEnvVarOrDefault("IS_PRIVATE_NETWORK", false)
+	vCenterIp := vs.Config.Global.VCenterHostname
+	if isPrivateNetwork {
+		vCenterIp = GetStringEnvVarOrDefault("LOCAL_HOST_IP", defaultlocalhostIP)
+	}
 	url, err := neturl.Parse(fmt.Sprintf("https://%s:%s/sdk",
-		vs.Config.Global.VCenterHostname, vs.Config.Global.VCenterPort))
+		vCenterIp, vs.Config.Global.VCenterPort))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	url.User = neturl.UserPassword(vs.Config.Global.User, vs.Config.Global.Password)
 	client, err := govmomi.NewClient(ctx, url, true)

--- a/tests/e2e/crypto.go
+++ b/tests/e2e/crypto.go
@@ -152,7 +152,6 @@ var _ = ginkgo.Describe("[csi-supervisor] [encryption] Block volume encryption",
 
 		if isVsanHealthServiceStopped {
 			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			err := invokeVCenterServiceControl(ctx, startOperation, vsanhealthServiceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again", vsanHealthServiceWaitTime))
@@ -604,7 +603,6 @@ var _ = ginkgo.Describe("[csi-supervisor] [encryption] Block volume encryption",
 		validateVolumeToBeEncryptedWithKey(ctx, pvc.Spec.VolumeName, keyProviderID, keyID1)
 
 		ginkgo.By("7. Stop Vsan-health service")
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
 		isVsanHealthServiceStopped = true
 		err := invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)

--- a/tests/e2e/csi_cns_telemetry_vc_reboot.go
+++ b/tests/e2e/csi_cns_telemetry_vc_reboot.go
@@ -43,7 +43,6 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 	var (
 		client       clientset.Interface
 		namespace    string
-		vcAddress    string
 		isVcRebooted bool
 	)
 	ginkgo.BeforeEach(func() {
@@ -62,8 +61,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 			// Reset the cluster distribution value to default value "CSI-Vanilla".
 			setClusterDistribution(ctx, client, vanillaClusterDistribution)
 		}
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 	})
+
 	ginkgo.AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -161,7 +160,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		err = invokeVCenterReboot(ctx, vcAddress)
 		isVcRebooted = true
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 
@@ -200,7 +199,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
@@ -303,7 +302,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		err = invokeVCenterReboot(ctx, vcAddress)
 		isVcRebooted = true
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}

--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -73,7 +73,6 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		isVsanHealthServiceStopped bool
 		labels_ns                  map[string]string
 		isVcRebooted               bool
-		vcAddress                  string
 		labelsMap                  map[string]string
 		scName                     string
 		volHandle                  string
@@ -104,9 +103,6 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		if err == nil && service != nil {
 			deleteService(namespace, client, service)
 		}
-
-		// reading vc credentials
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 
 		// reading operation scale value
 		if os.Getenv("VOLUME_OPS_SCALE") != "" {
@@ -168,7 +164,6 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			setStoragePolicyQuota(ctx, restConfig, storagePolicyName, namespace, rqLimit)
 
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			//if isQuotaValidationSupported is true then quotaValidation is considered in tests
 			vcVersion = getVCversion(ctx, vcAddress)
 			isQuotaValidationSupported = isVersionGreaterOrEqual(vcVersion, quotaSupportedVCVersion)
@@ -3895,7 +3890,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			err = invokeVCenterReboot(ctx, vcAddress)
 			isVcRebooted = true
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+			err = waitForHostToBeUp(vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.By("Done with reboot")
 			essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
@@ -3914,7 +3909,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		err = invokeVCenterReboot(ctx, vcAddress)
 		isVcRebooted = true
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
@@ -4006,7 +4001,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		err = invokeVCenterReboot(ctx, vcAddress)
 		isVcRebooted = true
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
@@ -6988,7 +6983,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		err = invokeVCenterReboot(ctx, vcAddress)
 		isVcRebooted = true
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		var essentialServices []string

--- a/tests/e2e/csi_snapshot_negative.go
+++ b/tests/e2e/csi_snapshot_negative.go
@@ -163,7 +163,6 @@ var _ = ginkgo.Describe("[block-snapshot-negative] Volume Snapshot Fault-Injecti
 					startHostDOnHost(ctx, hostIP)
 				}
 			} else {
-				vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
 				err := invokeVCenterServiceControl(ctx, startOperation, serviceName, vcAddress)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -477,7 +476,6 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 
 	} else {
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = true
@@ -604,7 +602,6 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 
 		} else {
 			ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			isServiceStopped = true
@@ -730,7 +727,6 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 
 		} else {
 			ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			isServiceStopped = true

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -146,7 +146,6 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		}
 
 		if supervisorCluster || stretchedSVC {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			//if isQuotaValidationSupported is true then quotaValidation is considered in tests
 			vcVersion = getVCversion(ctx, vcAddress)
 			isQuotaValidationSupported = isVersionGreaterOrEqual(vcVersion, quotaSupportedVCVersion)
@@ -155,7 +154,6 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Performing test cleanup")
@@ -1387,7 +1385,6 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
 		isVsanHealthServiceStopped = true
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
@@ -1469,7 +1466,6 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 
 		ginkgo.By(fmt.Sprintln("Stopping sps on the vCenter host"))
 		isSPSserviceStopped = true
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, spsServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow sps to completely shutdown", vsanHealthServiceWaitTime))
@@ -2258,7 +2254,6 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
 		isVsanHealthServiceStopped = true
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = waitVCenterServiceToBeInState(ctx, vsanhealthServiceName, vcAddress, svcStoppedMessage)

--- a/tests/e2e/ds_rename.go
+++ b/tests/e2e/ds_rename.go
@@ -39,7 +39,6 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		snapc                      *snapclient.Clientset
 		isVsanHealthServiceStopped bool
 		isSPSServiceStopped        bool
-		vcAddress                  string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -55,7 +54,6 @@ var _ bool = ginkgo.Describe("ds-rename", func() {
 		bootstrap()
 		scParameters = make(map[string]string)
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 
 		govmomiClient := newClient(ctx, &e2eVSphere)
 		pc = newPbmClient(ctx, govmomiClient)

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -17,12 +17,14 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 
 	"github.com/onsi/gomega"
 )
@@ -477,6 +479,19 @@ var (
 	envIsolationSharedStoragePolicyName   = "WORKLOAD_ISOLATION_SHARED_STORAGE_POLICY"
 )
 
+// GetAndExpectEnvVar returns the value of an environment variable or fails the regression if it's not set.
+func GetAndExpectEnvVar(varName string) string {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	log := logger.GetLogger(ctx)
+
+	varValue, exists := os.LookupEnv(varName)
+	if !exists {
+		log.Fatalf("Required environment variable not found: %s", varName)
+	}
+	return varValue
+}
+
 // GetAndExpectStringEnvVar parses a string from env variable.
 func GetAndExpectStringEnvVar(varName string) string {
 	varValue := os.Getenv(varName)
@@ -492,12 +507,43 @@ func GetAndExpectIntEnvVar(varName string) int {
 	return varIntValue
 }
 
-// GetAndExpectBoolEnvVar parses a boolean from env variable.
-func GetAndExpectBoolEnvVar(varName string) bool {
-	varValue := GetAndExpectStringEnvVar(varName)
+// GetBoolEnvVarOrDefault returns the boolean value of an environment variable or return default if it's not set
+func GetBoolEnvVarOrDefault(varName string, defaultVal bool) bool {
+	varValue, exists := os.LookupEnv(varName)
+	if !exists {
+		return defaultVal
+	}
+
 	varBoolValue, err := strconv.ParseBool(varValue)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Error Parsing "+varName)
+	if err != nil {
+		ctx := context.Background()
+		log := logger.GetLogger(ctx)
+		log.Warnf("Invalid boolean value for %s: '%s'. Using default: %v", varName, varValue, defaultVal)
+		return defaultVal
+	}
+
 	return varBoolValue
+}
+
+// GetStringEnvVarOrDefault returns the string value of an environment variable or return default if it's not set
+func GetStringEnvVarOrDefault(varName string, defaultVal string) string {
+	varValue, exists := os.LookupEnv(varName)
+	if !exists || strings.TrimSpace(varValue) == "" {
+		return defaultVal
+	}
+	return varValue
+}
+
+/*
+GetorIgnoreStringEnvVar, retrieves the value of an environment variable while logging
+a warning if the variable is not set.
+*/
+func GetorIgnoreStringEnvVar(varName string) string {
+	varValue, exists := os.LookupEnv(varName)
+	if !exists {
+		missingEnvVars = append(missingEnvVars, varName)
+	}
+	return varValue
 }
 
 // setClusterFlavor sets the boolean variables w.r.t the Cluster type.
@@ -544,5 +590,174 @@ func setClusterFlavor(clusterFlavor cnstypes.CnsClusterFlavor) {
 	testbedType := os.Getenv("STRETCHED_SVC")
 	if strings.TrimSpace(string(testbedType)) == "1" {
 		stretchedSVC = true
+	}
+}
+
+var (
+	// reading port numbers for VC, Master VM and ESXi from export variables
+	envVc1SshdPortNum       = "VC1_SSHD_PORT_NUM"
+	envVc2SshdPortNum       = "VC2_SSHD_PORT_NUM"
+	envVc3SshdPortNum       = "VC3_SSHD_PORT_NUM"
+	envMasterIP1SshdPortNum = "MASTER_IP1_SSHD_PORT_NUM"
+	envMasterIP2SshdPortNum = "MASTER_IP2_SSHD_PORT_NUM"
+	envMasterIP3SshdPortNum = "MASTER_IP3_SSHD_PORT_NUM"
+	envEsx1PortNum          = "ESX1_SSHD_PORT_NUM"
+	envEsx2PortNum          = "ESX2_SSHD_PORT_NUM"
+	envEsx3PortNum          = "ESX3_SSHD_PORT_NUM"
+	envEsx4PortNum          = "ESX4_SSHD_PORT_NUM"
+	envEsx5PortNum          = "ESX5_SSHD_PORT_NUM"
+	envEsx6PortNum          = "ESX6_SSHD_PORT_NUM"
+	envEsx7PortNum          = "ESX7_SSHD_PORT_NUM"
+	envEsx8PortNum          = "ESX8_SSHD_PORT_NUM"
+	envEsx9PortNum          = "ESX9_SSHD_PORT_NUM"
+	envEsx10PortNum         = "ESX10_SSHD_PORT_NUM"
+
+	// reading IPs for VC, Master VM and ESXi from export variables
+	envVcIP1     = "VC_IP1"
+	envVcIP2     = "VC_IP2"
+	envVcIP3     = "VC_IP3"
+	envMasterIP1 = "MASTER_IP1"
+	envMasterIP2 = "MASTER_IP2"
+	envMasterIP3 = "MASTER_IP3"
+	envEsxIp1    = "ESX1_IP"
+	envEsxIp2    = "ESX2_IP"
+	envEsxIp3    = "ESX3_IP"
+	envEsxIp4    = "ESX4_IP"
+	envEsxIp5    = "ESX5_IP"
+	envEsxIp6    = "ESX6_IP"
+	envEsxIp7    = "ESX7_IP"
+	envEsxIp8    = "ESX8_IP"
+	envEsxIp9    = "ESX9_IP"
+	envEsxIp10   = "ESX10_IP"
+
+	// default port declaration for each IP
+	vcIp1SshPortNum       = sshdPort
+	vcIp2SshPortNum       = sshdPort
+	vcIp3SshPortNum       = sshdPort
+	esxIp1PortNum         = sshdPort
+	esxIp2PortNum         = sshdPort
+	esxIp3PortNum         = sshdPort
+	esxIp4PortNum         = sshdPort
+	esxIp5PortNum         = sshdPort
+	esxIp6PortNum         = sshdPort
+	esxIp7PortNum         = sshdPort
+	esxIp8PortNum         = sshdPort
+	esxIp9PortNum         = sshdPort
+	esxIp10PortNum        = sshdPort
+	k8sMasterIp1PortNum   = sshdPort
+	k8sMasterIp2PortNum   = sshdPort
+	k8sMasterIp3PortNum   = sshdPort
+	defaultVcAdminPortNum = "443"
+
+	// global variables declared
+	esxIp1             = ""
+	esxIp2             = ""
+	esxIp3             = ""
+	esxIp4             = ""
+	esxIp5             = ""
+	esxIp6             = ""
+	esxIp7             = ""
+	esxIp8             = ""
+	esxIp9             = ""
+	esxIp10            = ""
+	vcAddress          = ""
+	vcAddress2         = ""
+	vcAddress3         = ""
+	masterIP1          = ""
+	masterIP2          = ""
+	masterIP3          = ""
+	ipPortMap          = make(map[string]string)
+	missingEnvVars     []string
+	defaultlocalhostIP = "127.0.0.1"
+)
+
+/*
+The setSShdPort function dynamically configures SSH port mappings for a vSphere test environment by reading
+environment variables and adapting to the network type and topology.
+It sets up SSH access to vCenter servers, ESXi hosts, and Kubernetes masters based on the environment configuration.
+*/
+func safeInsertToMap(key, value string) {
+	if key != "" && value != "" {
+		ipPortMap[key] = value
+	}
+}
+
+func setSShdPort() {
+	vcAddress = GetAndExpectEnvVar(envVcIP1)
+	isPrivateNetwork := GetBoolEnvVarOrDefault("IS_PRIVATE_NETWORK", false)
+
+	if multivc {
+		vCenterHostnames := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+		if len(vCenterHostnames) >= 3 {
+			vcAddress = vCenterHostnames[0]
+			vcAddress2 = vCenterHostnames[1]
+			vcAddress3 = vCenterHostnames[2]
+		}
+	}
+
+	if isPrivateNetwork {
+		if multivc {
+			vcAddress2 = GetorIgnoreStringEnvVar(envVcIP2)
+			vcIp2SshPortNum = GetorIgnoreStringEnvVar(envVc2SshdPortNum)
+			vcAddress3 = GetorIgnoreStringEnvVar(envVcIP3)
+			vcIp3SshPortNum = GetorIgnoreStringEnvVar(envVc3SshdPortNum)
+
+			safeInsertToMap(vcAddress2, vcIp2SshPortNum)
+			safeInsertToMap(vcAddress3, vcIp3SshPortNum)
+		}
+
+		// reading masterIP and its port number
+		masterIP1 = GetorIgnoreStringEnvVar(envMasterIP1)
+		masterIP2 = GetorIgnoreStringEnvVar(envMasterIP2)
+		masterIP3 = GetorIgnoreStringEnvVar(envMasterIP3)
+		k8sMasterIp1PortNum = GetorIgnoreStringEnvVar(envMasterIP1SshdPortNum)
+		k8sMasterIp2PortNum = GetorIgnoreStringEnvVar(envMasterIP2SshdPortNum)
+		k8sMasterIp3PortNum = GetorIgnoreStringEnvVar(envMasterIP3SshdPortNum)
+
+		vcIp1SshPortNum = GetorIgnoreStringEnvVar(envVc1SshdPortNum)
+
+		// reading esxi ip and its port
+		esxIp1 = GetorIgnoreStringEnvVar(envEsxIp1)
+		esxIp1PortNum = GetorIgnoreStringEnvVar(envEsx1PortNum)
+		esxIp2PortNum = GetorIgnoreStringEnvVar(envEsx2PortNum)
+		esxIp3PortNum = GetorIgnoreStringEnvVar(envEsx3PortNum)
+		esxIp4PortNum = GetorIgnoreStringEnvVar(envEsx4PortNum)
+		esxIp5PortNum = GetorIgnoreStringEnvVar(envEsx5PortNum)
+		esxIp6PortNum = GetorIgnoreStringEnvVar(envEsx6PortNum)
+		esxIp7PortNum = GetorIgnoreStringEnvVar(envEsx7PortNum)
+		esxIp8PortNum = GetorIgnoreStringEnvVar(envEsx8PortNum)
+		esxIp9PortNum = GetorIgnoreStringEnvVar(envEsx9PortNum)
+		esxIp10PortNum = GetorIgnoreStringEnvVar(envEsx10PortNum)
+
+		esxIp2 = GetorIgnoreStringEnvVar(envEsxIp2)
+		esxIp3 = GetorIgnoreStringEnvVar(envEsxIp3)
+		esxIp4 = GetorIgnoreStringEnvVar(envEsxIp4)
+		esxIp5 = GetorIgnoreStringEnvVar(envEsxIp5)
+		esxIp6 = GetorIgnoreStringEnvVar(envEsxIp6)
+		esxIp7 = GetorIgnoreStringEnvVar(envEsxIp7)
+		esxIp8 = GetorIgnoreStringEnvVar(envEsxIp8)
+		esxIp9 = GetorIgnoreStringEnvVar(envEsxIp9)
+		esxIp10 = GetorIgnoreStringEnvVar(envEsxIp10)
+
+		safeInsertToMap(vcAddress, vcIp1SshPortNum)
+		safeInsertToMap(masterIP1, k8sMasterIp1PortNum)
+		safeInsertToMap(masterIP2, k8sMasterIp2PortNum)
+		safeInsertToMap(masterIP3, k8sMasterIp3PortNum)
+		safeInsertToMap(esxIp1, esxIp1PortNum)
+		safeInsertToMap(esxIp2, esxIp2PortNum)
+		safeInsertToMap(esxIp3, esxIp3PortNum)
+		safeInsertToMap(esxIp4, esxIp4PortNum)
+		safeInsertToMap(esxIp5, esxIp5PortNum)
+		safeInsertToMap(esxIp6, esxIp6PortNum)
+		safeInsertToMap(esxIp7, esxIp7PortNum)
+		safeInsertToMap(esxIp8, esxIp8PortNum)
+		safeInsertToMap(esxIp9, esxIp9PortNum)
+		safeInsertToMap(esxIp10, esxIp10PortNum)
+	}
+
+	if len(missingEnvVars) > 0 {
+		ctx := context.Background()
+		log := logger.GetLogger(ctx)
+		log.Warnf("Missing environment variables: %v", strings.Join(missingEnvVars, ", "))
 	}
 }

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -126,7 +126,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		if isVsanHealthServiceStopped {
@@ -175,7 +174,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -264,7 +262,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -365,7 +362,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}
 		gomega.Expect(datastore).NotTo(gomega.BeNil())
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -436,7 +432,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 			pvs = append(pvs, pvList[0])
 		}
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -569,7 +564,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -654,7 +648,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		framework.ExpectNoError(fpv.WaitOnPVandPVC(ctx, client, f.Timeouts, namespace, pv, pvc))
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -834,7 +827,6 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Stopping vsan-health on the vCenter host")
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/fullsync_test_for_file_volume.go
+++ b/tests/e2e/fullsync_test_for_file_volume.go
@@ -80,13 +80,11 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 
 		labelKey = "app"
 		labelValue = "e2e-fullsync"
-
 	})
 
 	ginkgo.AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		if isVsanHealthServiceStopped {
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
@@ -140,7 +138,6 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 		}()
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		defer func() {

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -131,13 +131,11 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		// Get restConfig.
 		restConfig = getRestConfigClient()
 		isGCCSIDeploymentPODdown = false
-
 	})
 
 	ginkgo.AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		if isVsanHealthServiceStopped {
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
@@ -711,7 +709,6 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// TODO: need to add this test under destuctive test [csi-guest-destructive]
 	ginkgo.It("Verify volume expansion eventually succeeds when CNS is unavailable during initial expansion", func() {
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
@@ -752,7 +749,6 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		ginkgo.By("Waiting for controller volume resize to finish")
@@ -812,7 +808,6 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	ginkgo.It("Verify while CNS is down the volume expansion can be triggered and "+
 		"the volume can deleted with pending resize operation", func() {
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
@@ -824,7 +819,6 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		defer func() {
 			if isVsanHealthServiceStopped {
 				ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host (cleanup)"))
-				vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 			}
 		}()
@@ -858,7 +852,6 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		ginkgo.By("Verify volume is deleted in Supervisor Cluster")

--- a/tests/e2e/gc_metadata_syncer.go
+++ b/tests/e2e/gc_metadata_syncer.go
@@ -95,7 +95,6 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		if isVsanHealthServiceStopped {
@@ -941,7 +940,6 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 		gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1019,7 +1017,6 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/gc_rwx_service_down.go
+++ b/tests/e2e/gc_rwx_service_down.go
@@ -86,7 +86,6 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 
 		if isVsanHealthServiceStopped {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
 		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
@@ -134,7 +133,6 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -210,7 +208,6 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -347,7 +344,6 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/gc_rwx_syncer.go
+++ b/tests/e2e/gc_rwx_syncer.go
@@ -74,7 +74,6 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Test for label updates", func
 		defer cancel()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 		if isVsanHealthServiceStopped {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}

--- a/tests/e2e/gc_rwx_volume_health.go
+++ b/tests/e2e/gc_rwx_volume_health.go
@@ -71,7 +71,6 @@ var _ = ginkgo.Describe("File Volume Test volume health plumbing", func() {
 		defer cancel()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 		if isVsanHealthServiceStopped {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
@@ -292,7 +291,6 @@ var _ = ginkgo.Describe("File Volume Test volume health plumbing", func() {
 			CapacityInMb == newSizeInMb).To(gomega.BeTrue(), "Volume Capaticy is not matching")
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/hci_mesh_rwx_disruptive.go
+++ b/tests/e2e/hci_mesh_rwx_disruptive.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -139,8 +138,6 @@ var _ = ginkgo.Describe("[rwx-hci-singlevc-disruptive] RWX-Topology-HciMesh-Sing
 		k8sVersion = v.Major + "." + v.Minor
 
 		if isVsanHealthServiceStopped {
-			vCenterHostname := strings.Split(e2eVSphere.Config.Global.VCenterHostname, ",")
-			vcAddress := vCenterHostname[0] + ":" + sshdPort
 			framework.Logf("Bringing vsanhealth up before terminating the test")
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
@@ -2218,7 +2215,6 @@ var _ = ginkgo.Describe("[rwx-hci-singlevc-disruptive] RWX-Topology-HciMesh-Sing
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		defer func() {

--- a/tests/e2e/improved_csi_idempotency.go
+++ b/tests/e2e/improved_csi_idempotency.go
@@ -144,7 +144,6 @@ var _ = ginkgo.Describe("Improved CSI Idempotency Tests", func() {
 					startHostDOnHost(ctx, hostIP)
 				}
 			} else {
-				vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
 				err := invokeVCenterServiceControl(ctx, startOperation, serviceName, vcAddress)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -648,7 +647,6 @@ func createVolumeWithServiceDown(serviceName string, namespace string, client cl
 		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
 	} else {
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = true
@@ -905,7 +903,6 @@ func extendVolumeWithServiceDown(serviceName string, namespace string, client cl
 		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
 	} else {
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = true

--- a/tests/e2e/mgmt_wrkld_domain_isolation.go
+++ b/tests/e2e/mgmt_wrkld_domain_isolation.go
@@ -684,9 +684,6 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 		// statefulset replica count
 		replicas = 3
 
-		//vc ip
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-
 		// expected status code while add/removing the zones from NS
 		expectedStatusCodes := []int{status_code_failure, status_code_success}
 

--- a/tests/e2e/multi_master_k8s.go
+++ b/tests/e2e/multi_master_k8s.go
@@ -292,7 +292,9 @@ var _ = ginkgo.Describe("[csi-multi-master-block-e2e]", func() {
 			nodeNameOfvSphereCSIControllerPod, nodeNameIPMap[nodeNameOfvSphereCSIControllerPod]))
 
 		sshCmd := "systemctl stop kubelet.service"
-		host := nodeNameIPMap[nodeNameOfvSphereCSIControllerPod] + ":22"
+		ip, portNum, err := getPortNumAndIP(nodeNameOfvSphereCSIControllerPod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		host := nodeNameIPMap[ip] + ":" + portNum
 		ginkgo.By(fmt.Sprintf("Invoking command %+v on host %+v", sshCmd, host))
 		result, err := fssh.SSH(ctx, sshCmd, host, framework.TestContext.Provider)
 		ginkgo.By(fmt.Sprintf("%s returned result %s", sshCmd, result.Stdout))

--- a/tests/e2e/multi_svc_test.go
+++ b/tests/e2e/multi_svc_test.go
@@ -53,7 +53,6 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 		kubeconfig1           string
 		computeCluster        string
 		computeClusterPaths   []string
-		vcAddress             string
 		supervisorIds         []string
 		wcpServiceAccUsers    []string
 		datastoreName         string
@@ -110,7 +109,6 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 
 		// Getting all env variables here
 		csiNamespace = GetAndExpectStringEnvVar(envCSINamespace)
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		dataCenter = GetAndExpectStringEnvVar(datacenter)
 		computeCluster = GetAndExpectStringEnvVar(envComputeClusterName)
 		datastoreName = GetAndExpectStringEnvVar(envNfsDatastoreName)
@@ -136,7 +134,6 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 			},
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}
-
 	})
 
 	ginkgo.AfterEach(func() {

--- a/tests/e2e/multi_vc.go
+++ b/tests/e2e/multi_vc.go
@@ -159,15 +159,11 @@ var _ = ginkgo.Describe("[multivc-positive] MultiVc-Topology-Positive", func() {
 		}
 
 		if isVsanHealthServiceStopped {
-			vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-			vcAddress := vCenterHostname[0] + ":" + sshdPort
 			framework.Logf("Bringing vsanhealth up before terminating the test")
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
 
 		if isSPSServiceStopped {
-			vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-			vcAddress := vCenterHostname[0] + ":" + sshdPort
 			framework.Logf("Bringing sps up before terminating the test")
 			startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)
 			isSPSServiceStopped = false
@@ -1421,12 +1417,10 @@ var _ = ginkgo.Describe("[multivc-positive] MultiVc-Topology-Positive", func() {
 		}()
 
 		ginkgo.By("Rebooting VC1")
-		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		vcAddress := vCenterHostname[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		err = invokeVCenterReboot(ctx, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(vCenterHostname[0])
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 
@@ -1518,12 +1512,10 @@ var _ = ginkgo.Describe("[multivc-positive] MultiVc-Topology-Positive", func() {
 		}()
 
 		ginkgo.By("Rebooting VC1")
-		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		vcAddress := vCenterHostname[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		err = invokeVCenterReboot(ctx, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(vCenterHostname[0])
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 
@@ -1658,8 +1650,6 @@ var _ = ginkgo.Describe("[multivc-positive] MultiVc-Topology-Positive", func() {
 		}()
 
 		ginkgo.By("Bring down Vsan-health service on VC1")
-		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		vcAddress := vCenterHostname[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1816,8 +1806,6 @@ var _ = ginkgo.Describe("[multivc-positive] MultiVc-Topology-Positive", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Bring down SPS service")
-		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		vcAddress := vCenterHostname[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		err = invokeVCenterServiceControl(ctx, stopOperation, spsServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/multi_vc_config_secret.go
+++ b/tests/e2e/multi_vc_config_secret.go
@@ -157,7 +157,6 @@ var _ = ginkgo.Describe("[multivc-configsecret] MultiVc-ConfigSecret", func() {
 
 		if originalVC1PasswordChanged {
 			clientIndex := 0
-			vcAddress := strings.Split(vCenterIP, ",")[0] + ":" + sshdPort
 			username := strings.Split(vCenterUser, ",")[0]
 			originalPassword := strings.Split(vCenterPassword, ",")[0]
 			newPassword := e2eTestPassword
@@ -169,7 +168,6 @@ var _ = ginkgo.Describe("[multivc-configsecret] MultiVc-ConfigSecret", func() {
 
 		if originalVC3PasswordChanged {
 			clientIndex2 := 2
-			vcAddress3 := strings.Split(vCenterIP, ",")[2] + ":" + sshdPort
 			username3 := strings.Split(vCenterUser, ",")[2]
 			originalPassword3 := strings.Split(vCenterPassword, ",")[2]
 			newPassword3 := "Admin!23"
@@ -242,8 +240,6 @@ var _ = ginkgo.Describe("[multivc-configsecret] MultiVc-ConfigSecret", func() {
 		// read original vsphere config secret
 		vsphereCfg, err := readVsphereConfSecret(client, ctx, csiNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		vcAddress := strings.Split(vsphereCfg.Global.VCenterHostname, ",")[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		username := strings.Split(vsphereCfg.Global.User, ",")[0]
 		originalPassword := strings.Split(vsphereCfg.Global.Password, ",")[0]
@@ -734,7 +730,7 @@ var _ = ginkgo.Describe("[multivc-configsecret] MultiVc-ConfigSecret", func() {
 		scaleUpReplicaCount = 5
 		scaleDownReplicaCount = 2
 		var clientIndex2 int
-		var username3, newPassword3, originalPassword3, vcAddress3 string
+		var username3, newPassword3, originalPassword3 string
 
 		// read original vsphere config secret
 		vsphereCfg, err := readVsphereConfSecret(client, ctx, csiNamespace)
@@ -751,20 +747,18 @@ var _ = ginkgo.Describe("[multivc-configsecret] MultiVc-ConfigSecret", func() {
 		}()
 
 		// read VC1 credentials
-		vcAddress1 := strings.Split(vsphereCfg.Global.VCenterHostname, ",")[0] + ":" + sshdPort
 		username1 := strings.Split(vsphereCfg.Global.User, ",")[0]
 		originalPassword1 := strings.Split(vsphereCfg.Global.Password, ",")[0]
 		newPassword1 := "E2E-test-password!23"
 
 		ginkgo.By("Changing password on the vCenter VC1 host")
 		clientIndex0 := 0
-		err = invokeVCenterChangePassword(ctx, username1, originalPassword1, newPassword1, vcAddress1, clientIndex0)
+		err = invokeVCenterChangePassword(ctx, username1, originalPassword1, newPassword1, vcAddress, clientIndex0)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		originalVC1PasswordChanged = true
 
 		if multiVCSetupType == "multi-3vc-setup" {
 			// read VC3 credentials
-			vcAddress3 = strings.Split(vsphereCfg.Global.VCenterHostname, ",")[2] + ":" + sshdPort
 			username3 = strings.Split(vsphereCfg.Global.User, ",")[2]
 			originalPassword3 = strings.Split(vsphereCfg.Global.Password, ",")[2]
 			newPassword3 = "Admin!23"
@@ -794,7 +788,7 @@ var _ = ginkgo.Describe("[multivc-configsecret] MultiVc-ConfigSecret", func() {
 		defer func() {
 			if originalVC1PasswordChanged {
 				ginkgo.By("Reverting the password change")
-				err = invokeVCenterChangePassword(ctx, username1, newPassword1, originalPassword1, vcAddress1,
+				err = invokeVCenterChangePassword(ctx, username1, newPassword1, originalPassword1, vcAddress,
 					clientIndex0)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				originalVC1PasswordChanged = false
@@ -846,20 +840,18 @@ var _ = ginkgo.Describe("[multivc-configsecret] MultiVc-ConfigSecret", func() {
 		}()
 
 		ginkgo.By("Rebooting VC2")
-		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		vcAddress := vCenterHostname[1] + ":" + sshdPort
-		framework.Logf("vcAddress - %s ", vcAddress)
-		err = invokeVCenterReboot(ctx, vcAddress)
+		framework.Logf("vcAddress - %s ", vcAddress2)
+		err = invokeVCenterReboot(ctx, vcAddress2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(vCenterHostname[1])
+		err = waitForHostToBeUp(vcAddress2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 
 		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
-		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
+		checkVcenterServicesRunning(ctx, vcAddress2, essentialServices)
 
 		ginkgo.By("Reverting the password change on VC1")
-		err = invokeVCenterChangePassword(ctx, username1, newPassword1, originalPassword1, vcAddress1,
+		err = invokeVCenterChangePassword(ctx, username1, newPassword1, originalPassword1, vcAddress,
 			clientIndex0)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		originalVC1PasswordChanged = false
@@ -918,7 +910,6 @@ var _ = ginkgo.Describe("[multivc-configsecret] MultiVc-ConfigSecret", func() {
 		// read original vsphere config secret
 		vsphereCfg, err := readVsphereConfSecret(client, ctx, csiNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		vcAddress := strings.Split(vsphereCfg.Global.VCenterHostname, ",")[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		username := strings.Split(vsphereCfg.Global.User, ",")[0]
 		originalPassword := strings.Split(vsphereCfg.Global.Password, ",")[0]

--- a/tests/e2e/multi_vc_preferential_topology.go
+++ b/tests/e2e/multi_vc_preferential_topology.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -454,12 +453,10 @@ var _ = ginkgo.Describe("[multivc-preferential] MultiVc-Preferential", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Rebooting VC")
-		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		vcAddress := vCenterHostname[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		err = invokeVCenterReboot(ctx, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(vCenterHostname[0])
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 

--- a/tests/e2e/no_hci_mesh_rwx_multivc_topology.go
+++ b/tests/e2e/no_hci_mesh_rwx_multivc_topology.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -185,15 +184,11 @@ var _ = ginkgo.Describe("[rwx-nohci-multivc-positive] RWX-Topology-NoHciMesh-Mul
 		}
 
 		if isVsanHealthServiceStopped {
-			vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-			vcAddress := vCenterHostname[0] + ":" + sshdPort
 			framework.Logf("Bringing vsanhealth up before terminating the test")
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
 
 		if isSPSServiceStopped {
-			vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-			vcAddress := vCenterHostname[0] + ":" + sshdPort
 			framework.Logf("Bringing sps up before terminating the test")
 			startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)
 			isSPSServiceStopped = false
@@ -207,8 +202,6 @@ var _ = ginkgo.Describe("[rwx-nohci-multivc-positive] RWX-Topology-NoHciMesh-Mul
 
 		// restarting pending and stopped services after vc reboot if any
 		if isVcRebooted {
-			vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-			vcAddress := vCenterHostname[0] + ":" + sshdPort
 			err := checkVcServicesHealthPostReboot(ctx, vcAddress, pollTimeout)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 				"Setup is not in healthy state, Got timed-out waiting for required VC services to be up and running")
@@ -993,13 +986,11 @@ var _ = ginkgo.Describe("[rwx-nohci-multivc-positive] RWX-Topology-NoHciMesh-Mul
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Rebooting VC1")
-		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		vcAddress := vCenterHostname[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		err = invokeVCenterReboot(ctx, vcAddress)
 		isVcRebooted = true
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(vCenterHostname[0])
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 
@@ -1112,8 +1103,6 @@ var _ = ginkgo.Describe("[rwx-nohci-multivc-positive] RWX-Topology-NoHciMesh-Mul
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Bring down Vsan-health service on VC1")
-		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		vcAddress := vCenterHostname[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1296,8 +1285,6 @@ var _ = ginkgo.Describe("[rwx-nohci-multivc-positive] RWX-Topology-NoHciMesh-Mul
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Bring down SPS service")
-		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		vcAddress := vCenterHostname[0] + ":" + sshdPort
 		framework.Logf("vcAddress - %s ", vcAddress)
 		err = invokeVCenterServiceControl(ctx, stopOperation, spsServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -75,7 +75,6 @@ var _ = ginkgo.Describe("[preferential-positive] Preferential-Topology-Positive"
 		allowedTopologyForRack3        []v1.TopologySelectorLabelRequirement
 		err                            error
 		isSPSServiceStopped            bool
-		vcAddress                      string
 		sshClientConfig                *ssh.ClientConfig
 		nimbusGeneratedK8sVmPwd        string
 		clientIndex                    int
@@ -101,7 +100,7 @@ var _ = ginkgo.Describe("[preferential-positive] Preferential-Topology-Positive"
 		bindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 		csiNamespace = GetAndExpectStringEnvVar(envCSINamespace)
 		isSPSServiceStopped = false
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+
 		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
 
 		sshClientConfig = &ssh.ClientConfig{

--- a/tests/e2e/preferential_topology_utils.go
+++ b/tests/e2e/preferential_topology_utils.go
@@ -44,7 +44,7 @@ func govcLoginCmd() string {
 	loginCmd := "export GOVC_INSECURE=1;"
 	loginCmd += fmt.Sprintf("export GOVC_URL='https://%s:%s@%s:%s';",
 		e2eVSphere.Config.Global.User, e2eVSphere.Config.Global.Password,
-		e2eVSphere.Config.Global.VCenterHostname, e2eVSphere.Config.Global.VCenterPort)
+		e2eVSphere.Config.Global.VCenterHostname, defaultVcAdminPortNum)
 	return loginCmd
 }
 

--- a/tests/e2e/snapshot_vmservice_vm.go
+++ b/tests/e2e/snapshot_vmservice_vm.go
@@ -67,7 +67,6 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 		cnsopC                     ctlrclient.Client
 		isVsanHealthServiceStopped bool
 		isSPSserviceStopped        bool
-		vcAddress                  string
 		restConfig                 *restclient.Config
 		snapc                      *snapclient.Clientset
 		pandoraSyncWaitTime        int
@@ -98,8 +97,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 			storagePolicyName = GetAndExpectStringEnvVar(envZonalStoragePolicyName)
 		}
 
-		// fetching vc ip and creating creating vc session
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		// creating vc session
 		vcRestSessionId = createVcSession4RestApis(ctx)
 
 		// reading storage class name for wcp setup "wcpglobal_storage_profile"

--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -103,6 +103,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 		if err == nil && service != nil {
 			deleteService(namespace, client, service)
 		}
+
 		if stretchedSVC {
 			zonalPolicy = GetAndExpectStringEnvVar(envZonalStoragePolicyName)
 			labels_ns = map[string]string{}
@@ -131,7 +132,6 @@ var _ = ginkgo.Describe("statefulset", func() {
 		}
 
 		if supervisorCluster || stretchedSVC {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			//if isQuotaValidationSupported is true then quotaValidation is considered in tests
 			vcVersion = getVCversion(ctx, vcAddress)
 			isQuotaValidationSupported = isVersionGreaterOrEqual(vcVersion, quotaSupportedVCVersion)

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -46,6 +46,7 @@ func init() {
 	framework.AfterReadingAllFlags(&framework.TestContext)
 	clusterFlavor := cnstypes.CnsClusterFlavor(os.Getenv(envClusterFlavor))
 	setClusterFlavor(clusterFlavor)
+	setSShdPort()
 
 	if os.Getenv(busyBoxImageEnvVar) != "" {
 		busyBoxImageOnGcr = os.Getenv(busyBoxImageEnvVar)

--- a/tests/e2e/tkgs_ha.go
+++ b/tests/e2e/tkgs_ha.go
@@ -70,7 +70,6 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		pandoraSyncWaitTime        int
 		labels_ns                  map[string]string
 		isVcRebooted               bool
-		vcAddress                  string
 		isQuotaValidationSupported bool
 	)
 	ginkgo.BeforeEach(func() {
@@ -87,7 +86,6 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		labels_ns = map[string]string{}
 		labels_ns[admissionapi.EnforceLevelLabel] = string(admissionapi.LevelPrivileged)
 		labels_ns["e2e-framework"] = f.BaseName
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 
 		if zonalPolicy == "" {
 			ginkgo.Fail(envZonalStoragePolicyName + " env variable not set")
@@ -144,7 +142,6 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		}
 
 		if supervisorCluster || stretchedSVC {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			//if isQuotaValidationSupported is true then quotaValidation is considered in tests
 			vcVersion = getVCversion(ctx, vcAddress)
 			isQuotaValidationSupported = isVersionGreaterOrEqual(vcVersion, quotaSupportedVCVersion)
@@ -3226,7 +3223,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		err = invokeVCenterReboot(ctx, vcAddress)
 		isVcRebooted = true
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName, wcpServiceName}

--- a/tests/e2e/tkgs_ha_utils.go
+++ b/tests/e2e/tkgs_ha_utils.go
@@ -138,6 +138,7 @@ func verifyVolumeProvisioningWithServiceDown(serviceName string, namespace strin
 	f *framework.Framework) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	var err error
 
 	ginkgo.By("CNS_TEST: Running for GC setup")
 	nodeList, err := fnodes.GetReadySchedulableNodes(ctx, client)
@@ -147,7 +148,6 @@ func verifyVolumeProvisioningWithServiceDown(serviceName string, namespace strin
 	}
 
 	ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-	vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 	err = invokeVCenterServiceControl(ctx, stopOperation, serviceName, vcAddress)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	isServiceStopped = true
@@ -708,9 +708,14 @@ func getClusterNameFromZone(ctx context.Context, availabilityZone string) string
 	cmd := fmt.Sprintf("dcli +username %s +password %s +skip +show com vmware "+
 		"vcenter consumptiondomains zones cluster associations get --zone "+
 		"%s", adminUser, nimbusGeneratedVcPwd, availabilityZone)
-	vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-	framework.Logf("Invoking command %v on vCenter host %v", cmd, vcAddress)
-	result, err := fssh.SSH(ctx, cmd, vcAddress, framework.TestContext.Provider)
+
+	// Read hosts sshd port number
+	ip, portNum, err := getPortNumAndIP(vcAddress)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	addr := ip + ":" + portNum
+
+	framework.Logf("Invoking command %v on vCenter host %v", cmd, addr)
+	result, err := fssh.SSH(ctx, cmd, addr, framework.TestContext.Provider)
 	framework.Logf("result: %v", result)
 	clusterId := strings.Split(result.Stdout, "- ")[1]
 	clusterID := strings.TrimSpace(clusterId)

--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -64,7 +64,6 @@ var _ = ginkgo.Describe("[topology-multireplica] Topology-MultiReplica",
 			isSPSServiceStopped        bool
 			isVsanHealthServiceStopped bool
 			sshClientConfig            *ssh.ClientConfig
-			vcAddress                  string
 			container_name             string
 			sts_count                  int
 			statefulSetReplicaCount    int32
@@ -126,7 +125,7 @@ var _ = ginkgo.Describe("[topology-multireplica] Topology-MultiReplica",
 				},
 				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 			}
-			vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+
 			if os.Getenv(envPandoraSyncWaitTime) != "" {
 				pandoraSyncWaitTime, err = strconv.Atoi(os.Getenv(envPandoraSyncWaitTime))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -167,7 +166,6 @@ var _ = ginkgo.Describe("[topology-multireplica] Topology-MultiReplica",
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				c = remoteC
 			}
-
 		})
 
 		ginkgo.AfterEach(func() {
@@ -1754,7 +1752,6 @@ var _ = ginkgo.Describe("[topology-multireplica] Topology-MultiReplica",
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintln("Changing password on the vCenter host"))
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			username := vsphereCfg.Global.User
 			newPassword := e2eTestPassword
 			err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, newPassword, vcAddress,

--- a/tests/e2e/vc_reboot_volume_lifecycle.go
+++ b/tests/e2e/vc_reboot_volume_lifecycle.go
@@ -44,7 +44,6 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 		storagePolicyName string
 		scParameters      map[string]string
 		isVcRebooted      bool
-		vcAddress         string
 	)
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
@@ -58,7 +57,6 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
 
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		scParameters = make(map[string]string)
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 
@@ -197,7 +195,7 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 		err = invokeVCenterReboot(ctx, vcAddress)
 		isVcRebooted = true
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		var essentialServices []string

--- a/tests/e2e/vcp_to_csi_attach_detach.go
+++ b/tests/e2e/vcp_to_csi_attach_detach.go
@@ -125,8 +125,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		vcpPvcsPreMig = []*v1.PersistentVolumeClaim{}
 		vcpPvcsPostMig = []*v1.PersistentVolumeClaim{}
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-
 		if isVsanHealthServiceStopped {
 			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
@@ -705,7 +703,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata on pvc created before migration")
 		verifyCnsVolumeMetadataAndCnsVSphereVolumeMigrationCrdForPvcs(ctx, client, vcpPvcsPreMig)
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ginkgo.By("Stopping sps on the vCenter")
 		isSPSServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, spsServiceName, vcAddress)
@@ -790,7 +787,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ginkgo.By("Stopping sps on the vCenter")
 		isSPSServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, spsServiceName, vcAddress)
@@ -905,7 +901,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata on pvc created before migration")
 		verifyCnsVolumeMetadataAndCnsVSphereVolumeMigrationCrdForPvcs(ctx, client, vcpPvcsPreMig)
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ginkgo.By("Stopping vsan-health on the vCenter")
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
@@ -990,7 +985,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ginkgo.By("Stopping vsan-health on the vCenter")
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -108,8 +108,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		vcpPvcsPreMig = []*v1.PersistentVolumeClaim{}
 		vcpPvcsPostMig = []*v1.PersistentVolumeClaim{}
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-
 		if isVsanHealthServiceStopped {
 			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 			err = invokeVCenterServiceControl(ctx, "start", vsanhealthServiceName, vcAddress)
@@ -446,8 +444,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		gomega.Expect(found).To(gomega.BeTrue())
 		err = waitAndVerifyCnsVolumeMetadata(ctx, crd.Spec.VolumeID, pvc2, pv2, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 
 		ginkgo.By(fmt.Sprintln("Stopping sps on the vCenter host"))
 		isSPSserviceStopped = true

--- a/tests/e2e/vcp_to_csi_full_sync.go
+++ b/tests/e2e/vcp_to_csi_full_sync.go
@@ -118,8 +118,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration full sync tests", fu
 		vcpPvcsPreMig = []*v1.PersistentVolumeClaim{}
 		vcpPvcsPostMig = []*v1.PersistentVolumeClaim{}
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-
 		if isVsanHealthServiceStopped {
 			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
@@ -472,7 +470,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration full sync tests", fu
 		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata on PVC1")
 		verifyCnsVolumeMetadataAndCnsVSphereVolumeMigrationCrdForPvcs(ctx, client, vcpPvcsPreMig)
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
@@ -650,7 +647,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration full sync tests", fu
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		vmdks = []string{}
 
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ginkgo.By(fmt.Sprintln("Stopping sps on the vCenter host"))
 		isSPSServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, spsServiceName, vcAddress)

--- a/tests/e2e/vm_service_vsan_stretch_cluster.go
+++ b/tests/e2e/vm_service_vsan_stretch_cluster.go
@@ -64,7 +64,6 @@ var _ bool = ginkgo.Describe("[vsan-stretch-vmsvc] vm service with csi vol tests
 		cnsopC                     ctlrclient.Client
 		isVsanHealthServiceStopped bool
 		isSPSserviceStopped        bool
-		vcAddress                  string
 		nodeList                   *v1.NodeList
 	)
 
@@ -86,9 +85,7 @@ var _ bool = ginkgo.Describe("[vsan-stretch-vmsvc] vm service with csi vol tests
 		readVcEsxIpsViaTestbedInfoJson(GetAndExpectStringEnvVar(envTestbedInfoJsonPath))
 		initialiseFdsVar(ctx)
 
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		vcRestSessionId = createVcSession4RestApis(ctx)
-		//csiNs = GetAndExpectStringEnvVar(envCSINamespace)
 
 		storageClassName = strings.ReplaceAll(storagePolicyName, " ", "-") // since this is a wcp setup
 		storageClassName = strings.ToLower(storageClassName)

--- a/tests/e2e/vmservice_vm.go
+++ b/tests/e2e/vmservice_vm.go
@@ -66,7 +66,6 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		cnsopC                     ctlrclient.Client
 		isVsanHealthServiceStopped bool
 		isSPSserviceStopped        bool
-		vcAddress                  string
 		isQuotaValidationSupported bool
 		defaultDatastore           *object.Datastore
 	)
@@ -90,7 +89,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		bootstrap()
 		isVsanHealthServiceStopped = false
 		isSPSserviceStopped = false
-		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+
 		vcRestSessionId = createVcSession4RestApis(ctx)
 
 		storageClassName = strings.ReplaceAll(storagePolicyName, "_", "-") // since this is a wcp setup
@@ -130,7 +129,6 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		gomega.Expect(vmi).NotTo(gomega.BeEmpty())
 
 		if supervisorCluster || stretchedSVC {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			//if isQuotaValidationSupported is true then quotaValidation is considered in tests
 			vcVersion = getVCversion(ctx, vcAddress)
 			isQuotaValidationSupported = isVersionGreaterOrEqual(vcVersion, quotaSupportedVCVersion)

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -58,6 +58,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		isSPSServiceStopped        bool
 		csiNamespace               string
 	)
+
 	ginkgo.BeforeEach(func() {
 		bootstrap()
 		ctx, cancel := context.WithCancel(context.Background())
@@ -83,7 +84,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	ginkgo.AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		if supervisorCluster {
 			dumpSvcNsEventsOnTestFailure(client, namespace)
 		}
@@ -372,7 +372,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		isVsanHealthServiceStopped = true
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
@@ -539,7 +538,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -658,7 +656,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
 
 		ginkgo.By(fmt.Sprintln("Stopping sps on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isSPSServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, spsServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1426,7 +1423,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		ginkgo.By("Invoking password rotation")
 		ginkgo.By("Get svcClient and svNamespace")
 		svClient, _ := getSvcClientAndNamespace()
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		passwordRotated, err := performPasswordRotationOnSupervisor(svClient, ctx, csiNamespace, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(passwordRotated).To(gomega.BeTrue())
@@ -1856,7 +1852,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By("Bringing SV API server down")
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		framework.Logf("VC ip address: %v", vcAddress)
 
 		err = bringSvcK8sAPIServerDown(ctx, vcAddress)
@@ -1959,7 +1954,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2559,7 +2553,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
 		isVsanHealthServiceStopped = true
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -212,7 +212,6 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		if isVsanHealthServiceStopped {
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
@@ -4239,7 +4238,6 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 				pods = append(pods, pod)
 			}
 			framework.Logf("Stopping vsan-health on the vCenter host")
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = waitVCenterServiceToBeInState(ctx, vsanhealthServiceName, vcAddress, svcStoppedMessage)
@@ -4348,7 +4346,6 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			}
 
 			framework.Logf("Starting vsan-health on the vCenter host")
-			vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 			framework.Logf("Sleeping full-sync interval for vsan health service " +
@@ -4607,7 +4604,6 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 				pods = append(pods, pod)
 			}
 			framework.Logf("Stopping vsan-health on the vCenter host")
-			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = waitVCenterServiceToBeInState(ctx, vsanhealthServiceName, vcAddress, svcStoppedMessage)
@@ -4716,7 +4712,6 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			}
 
 			framework.Logf("Starting vsan-health on the vCenter host")
-			vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 			framework.Logf("Sleeping full-sync interval for vsan health service " +

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -226,9 +226,14 @@ func waitForHostToBeDown(ctx context.Context, ip string) error {
 	framework.Logf("checking host status of %s", ip)
 	gomega.Expect(ip).NotTo(gomega.BeNil())
 	gomega.Expect(ip).NotTo(gomega.BeEmpty())
+	// Read hosts sshd port number
+	ip, portNum, err := getPortNumAndIP(ip)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	addr := ip + ":" + portNum
+
 	waitErr := wait.PollUntilContextTimeout(ctx, poll*2, pollTimeoutShort*2, true,
 		func(ctx context.Context) (bool, error) {
-			_, err := net.DialTimeout("tcp", ip+":22", poll)
+			_, err := net.DialTimeout("tcp", addr, poll)
 			if err == nil {
 				framework.Logf("host is reachable")
 				return false, nil

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -72,6 +72,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		isSPSServiceStopped        bool
 		fsType                     string
 	)
+
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
 		namespace = getNamespaceToRunTests(f)
@@ -117,14 +118,11 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		} else {
 			fsType = ext4FSType
 		}
-
 	})
 
 	ginkgo.AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 
 		if isSPSServiceStopped {
 			framework.Logf("Bringing sps up before terminating the test")
@@ -703,7 +701,6 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 		ginkgo.By("Bring down Vsan-health service")
 		isVsanHealthServiceStopped = true
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -778,7 +775,6 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 		var originalSizeInMb, fsSize int64
 		var err error
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 
 		/*
 			Note: As per PR #2935677, even if cns_new_sync is enabled volume expansion
@@ -1588,7 +1584,6 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		defer cancel()
 		var fsSize int64
 		var err error
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 
 		volHandle, pvclaim, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
 			ctx, f, client, "", storagePolicyName, namespace, ext4FSType)
@@ -1757,7 +1752,6 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 		ginkgo.By("Bring down Vsan-health service")
 		isVsanHealthServiceStopped = true
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In a public network setup, the port numbers for vCenter, Master VMs, Worker VMs, and ESXi host remains consistent.

In contrast, a private network setup may have varying port numbers for each vSphere resource component.

This PR introduces logic to correctly read the port numbers regardless of the network type—public or private—ensuring that the existing functionality continues to operate seamlessly without any regressions.

**Testing done**:
Yes on isolated testbed
[testlogs.txt](https://github.com/user-attachments/files/19646579/testlogs.txt)

**Special notes for your reviewer**:
s031044@P2XQC4DXP0 vsphere-csi-driver % golangci-lint run --enable=lll
ps031044@P2XQC4DXP0 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.59.1'
golangci/golangci-lint info found version: 1.59.1 for v1.59.1/darwin/arm64
golangci/golangci-lint info installed /Users/ps031044/go/bin/golangci-lint
INFO golangci-lint has version 1.59.1 built with go1.22.3 from 1a55854a on 2024-06-09T18:08:33Z 
INFO [config_reader] Config search paths: [./ /Users/ps031044/private-public-port-read/vsphere-csi-driver /Users/ps031044/private-public-port-read /Users/ps031044 /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 8 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|imports|name|types_sizes|deps|exports_file|files) took 1.258542583s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 131.10475ms 
INFO [linters_context/goanalysis] analyzers took 41.930803426s with top 10 stages: SA9005: 491.143578ms, SA1024: 466.475418ms, printf: 465.935166ms, SA1020: 455.488586ms, SA5012: 450.360038ms, SA4008: 446.626258ms, SA9008: 440.731251ms, SA9002: 425.161837ms, testinggoroutine: 423.259997ms, SA6002: 421.239961ms 
INFO [runner/max_same_issues] 7630/7633 issues with text "undefined: ginkgo" were hidden, use --max-same-issues 

