### PR TITLE
Upgrade to vm-operator v1alpha3 api for pvCSI

### DIFF
--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -161,12 +161,12 @@ func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.Cont
 			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to get config with error: %+v", err)
 		}
-		vmOperatorClient, err := k8s.NewClientForGroup(ctx, cfg, vmoperatorv1alpha1.GroupName)
+		vmOperatorClient, err := k8s.NewClientForGroup(ctx, cfg, vmoperatorv1alpha3.GroupName)
 		if err != nil {
 			return logger.LogNewErrorCodef(log, codes.Internal,
-				"failed to get client for group %s with error: %+v", vmoperatorv1alpha1.GroupName, err)
+				"failed to get client for group %s with error: %+v", vmoperatorv1alpha3.GroupName, err)
 		}
-		vmList := &vmoperatorv1alpha1.VirtualMachineList{}
+		vmList := &vmoperatorv1alpha3.VirtualMachineList{}
 		err = vmOperatorClient.List(ctx, vmList)
 		if err != nil {
 			return logger.LogNewErrorCodef(log, codes.Internal,

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -31,7 +31,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -687,9 +687,11 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 		// volume in the spec and patching virtualMachine instance.
 		vmvolumes := vmoperatortypes.VirtualMachineVolume{
 			Name: req.VolumeId,
-			PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-				PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: req.VolumeId,
+			VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: req.VolumeId,
+					},
 				},
 			},
 		}
@@ -710,11 +712,11 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 	}
 
 	for _, volume := range virtualMachine.Status.Volumes {
-		if volume.Name == req.VolumeId && volume.Attached && volume.DiskUuid != "" {
-			diskUUID = volume.DiskUuid
+		if volume.Name == req.VolumeId && volume.Attached && volume.DiskUUID != "" {
+			diskUUID = volume.DiskUUID
 			isVolumeAttached = true
 			log.Infof("Volume %q is already attached in the virtualMachine.Spec.Volumes. Disk UUID: %q",
-				volume.Name, volume.DiskUuid)
+				volume.Name, volume.DiskUUID)
 			break
 		}
 	}
@@ -752,10 +754,10 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 				virtualMachine.Name, req.VolumeId)
 			for _, volume := range vm.Status.Volumes {
 				if volume.Name == req.VolumeId {
-					if volume.Attached && volume.DiskUuid != "" && volume.Error == "" {
-						diskUUID = volume.DiskUuid
+					if volume.Attached && volume.DiskUUID != "" && volume.Error == "" {
+						diskUUID = volume.DiskUUID
 						log.Infof("observed disk UUID %q is set for the volume %q on virtualmachine %q",
-							volume.DiskUuid, volume.Name, vm.Name)
+							volume.DiskUUID, volume.Name, vm.Name)
 					} else {
 						if volume.Error != "" {
 							msg := fmt.Sprintf("observed Error: %q is set on the volume %q on virtualmachine %q",

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -545,9 +545,11 @@ func TestVirtualMachineVolumePatchWithOptimisticMerge(t *testing.T) {
 				Volumes: []vmoperatortypes.VirtualMachineVolume{
 					{
 						Name: "my-vol-1",
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "my-pvc-1",
+						VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "my-pvc-1",
+								},
 							},
 						},
 					},
@@ -575,9 +577,11 @@ func TestVirtualMachineVolumePatchWithOptimisticMerge(t *testing.T) {
 		vm1.Spec.Volumes,
 		vmoperatortypes.VirtualMachineVolume{
 			Name: "my-vol-2",
-			PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-				PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
-					ClaimName: "my-pvc-2",
+			VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "my-pvc-2",
+					},
 				},
 			},
 		})
@@ -608,9 +612,11 @@ func TestVirtualMachineVolumePatchWithOptimisticMerge(t *testing.T) {
 	vm2.Spec.Volumes = []vmoperatortypes.VirtualMachineVolume{
 		{
 			Name: "my-vol-2",
-			PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-				PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
-					ClaimName: "my-pvc-2",
+			VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "my-pvc-2",
+					},
 				},
 			},
 		},

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"time"
 
-	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -218,8 +218,8 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 			log.Errorf("failed to add to scheme for %s with err: %+v", ccV1beta1.GroupVersion.Group, err)
 			return nil, err
 		}
-	case vmoperatorv1alpha1.GroupName:
-		err = vmoperatorv1alpha1.AddToScheme(scheme)
+	case vmoperatorv1alpha3.GroupName:
+		err = vmoperatorv1alpha3.AddToScheme(scheme)
 		if err != nil {
 			log.Errorf("failed to add to scheme with err: %+v", err)
 			return nil, err
@@ -307,14 +307,14 @@ func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config,
 	log := logger.GetLogger(ctx)
 
 	scheme := runtime.NewScheme()
-	err = vmoperatorv1alpha1.AddToScheme(scheme)
+	err = vmoperatorv1alpha3.AddToScheme(scheme)
 	if err != nil {
 		log.Errorf("failed to add to scheme with err: %+v", err)
 	}
 
 	gvk := schema.GroupVersionKind{
-		Group:   vmoperatorv1alpha1.GroupVersion.Group,
-		Version: vmoperatorv1alpha1.GroupVersion.Version,
+		Group:   vmoperatorv1alpha3.GroupVersion.Group,
+		Version: vmoperatorv1alpha3.GroupVersion.Version,
 		Kind:    virtualMachineKind,
 	}
 

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/util.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"strconv"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR intent to upgrade vm-operator api version to v1alpha3
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing performed 
scenario 1: Supervisor is latest and TRr is not upto date:
 
[v1alpha3_guest_old_supervisor_latest.log](https://github.com/user-attachments/files/19734341/v1alpha3_guest_old_supervisor_latest.log)
[
[RWX_v1alpah3_guest_old_supervisor_updated.log](https://github.com/user-attachments/files/19734346/RWX_v1alpah3_guest_old_supervisor_updated.log)
](url)

Scenario 2:
Supervisor and TKr both are upto date:
 
[v1alpha3_supervisor_guest_latest.log](https://github.com/user-attachments/files/19734343/v1alpha3_supervisor_guest_latest.log)

[RWX_v1alpah3_supervisor_guest_updated.log](https://github.com/user-attachments/files/19734348/RWX_v1alpah3_supervisor_guest_updated.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrade to vm-operator v1alpha3 api for pvCSI
```
