### PR TITLE
Add guest cluster details on pre-existing PVC/VolumeSnapshots in fullsync after GC upgrade

### DIFF
--- a/manifests/guestcluster/1.29/pvcsi.yaml
+++ b/manifests/guestcluster/1.29/pvcsi.yaml
@@ -547,6 +547,7 @@ data:
   "tkgs-ha": "true"
   "cnsmgr-suspend-create-volume": "true"
   "workload-domain-isolation": "false"
+  "sv-pvc-snapshot-protection-finalizer": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.30/pvcsi.yaml
+++ b/manifests/guestcluster/1.30/pvcsi.yaml
@@ -547,6 +547,7 @@ data:
   "tkgs-ha": "true"
   "cnsmgr-suspend-create-volume": "true"
   "workload-domain-isolation": "false"
+  "sv-pvc-snapshot-protection-finalizer": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.31/pvcsi.yaml
+++ b/manifests/guestcluster/1.31/pvcsi.yaml
@@ -686,6 +686,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
+  "sv-pvc-snapshot-protection-finalizer": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.32/pvcsi.yaml
+++ b/manifests/guestcluster/1.32/pvcsi.yaml
@@ -686,6 +686,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
+  "sv-pvc-snapshot-protection-finalizer": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.33/pvcsi.yaml
+++ b/manifests/guestcluster/1.33/pvcsi.yaml
@@ -667,6 +667,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
+  "sv-pvc-snapshot-protection-finalizer": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -512,6 +512,7 @@ data:
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
   "WCP_VMService_BYOK": "false"
+  "sv-pvc-snapshot-protection-finalizer": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -512,6 +512,7 @@ data:
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
   "WCP_VMService_BYOK": "false"
+  "sv-pvc-snapshot-protection-finalizer": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -433,6 +433,9 @@ const (
 	VPCCapabilitySupervisor = "VPC_Supported"
 	// WCP_VMService_BYOK_FSS enables Bring Your Own Key (BYOK) capabilities.
 	WCP_VMService_BYOK = "WCP_VMService_BYOK"
+	// SVPVCSnapshotProtectionFinalizer is FSS that controls add/remove
+	// CNS finalizer on supervisor PVC/Snapshots from PVCSI
+	SVPVCSnapshotProtectionFinalizer = "sv-pvc-snapshot-protection-finalizer"
 )
 
 var WCPFeatureStates = map[string]struct{}{

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
-	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
 
 const (
@@ -214,14 +213,14 @@ func getAccessMode(accessMode csi.VolumeCapability_AccessMode_Mode) v1.Persisten
 // getPersistentVolumeClaimSpecWithStorageClass return the PersistentVolumeClaim spec with specified storage class
 func getPersistentVolumeClaimSpecWithStorageClass(pvcName string, namespace string, diskSize string,
 	storageClassName string, pvcAccessMode v1.PersistentVolumeAccessMode, annotations map[string]string,
-	labels map[string]string, volumeSnapshotName string) *v1.PersistentVolumeClaim {
+	labels map[string]string, finalizers []string, volumeSnapshotName string) *v1.PersistentVolumeClaim {
 	claim := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pvcName,
 			Namespace:   namespace,
 			Annotations: annotations,
 			Labels:      labels,
-			Finalizers:  []string{cnsoperatortypes.CNSPvcFinalizer},
+			Finalizers:  finalizers,
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{
@@ -250,14 +249,14 @@ func getPersistentVolumeClaimSpecWithStorageClass(pvcName string, namespace stri
 
 func constructVolumeSnapshotWithVolumeSnapshotClass(volumeSnapshotName string, namespace string,
 	volumeSnapshotClassName string, pvcName string, annotation map[string]string,
-	labels map[string]string) *snap.VolumeSnapshot {
+	labels map[string]string, finalizers []string) *snap.VolumeSnapshot {
 	volumeSnapshot := &snap.VolumeSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        volumeSnapshotName,
 			Namespace:   namespace,
 			Labels:      labels,
 			Annotations: annotation,
-			Finalizers:  []string{cnsoperatortypes.CNSSnapshotFinalizer},
+			Finalizers:  finalizers,
 		},
 		Spec: snap.VolumeSnapshotSpec{
 			Source: snap.VolumeSnapshotSource{

--- a/pkg/syncer/cnsoperator/types/types.go
+++ b/pkg/syncer/cnsoperator/types/types.go
@@ -24,6 +24,11 @@ const (
 	// to avoid Detach-Delete race which in-turn avoids ResourceInUse errors
 	CNSPvcFinalizer = "cns.vmware.com/pvc-protection"
 
+	// CNSVolumeFinalizer is the finalizer on Supervisor PVC created from Guest cluster
+	// and associated with Guest cluster PVC,
+	// This finalizer is added to avoid deletion of such PVCs directly from Supervisor.
+	CNSVolumeFinalizer = "cns.vmware.com/pvc-delete-protection"
+
 	// CNSSnapshotFinalizer is the finalizer on Supervisor VolumeSnapshot created from Guest cluster
 	// and associated with Guest cluster VolumeSnapshot,
 	// This finalizer is added to avoid deletion of such VolumeSnapshots directly from Supervisor.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds upgrade changes on top of original changes merged via https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3238/files.
In case of GC upgrade, if there are any pre-existing PVC/Volumesnapshots present in guest cluster, along with associated PVCs/Snapshots in supervisor cluster, this code adds finalizers on these supervisor pvc/snapshots as a part of GC full sync, to add delete protection for pre-existing objects in upgrade cases.
Kept entire code under FSS in guest cluster and Supervisor cluster to enable/disable the behaviour as required.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
New testing done with FSS change 
[CODB-prevent-deletion-with-fss.log](https://github.com/user-attachments/files/19788788/CODB-prevent-deletion-with-fss.log)


Tested create/delete of PVC/snapshot manually on guest cluster without and with changes (to emulate upgrade case)

```

root@420608814f437a4e898b0e09558701a2 [ ~ ]# export KUBECONFIG=         <<< Supervisor cluster
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get vs -A
No resources found
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get pvc -A -o yaml
apiVersion: v1
items: []
kind: List
metadata:
  resourceVersion: ""
root@420608814f437a4e898b0e09558701a2 [ ~ ]#

root@420608814f437a4e898b0e09558701a2 [ ~ ]# export KUBECONFIG=gc1_kubeconfig.yaml <<< guest cluster before upgrade/without these changes

root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get vs -A
No resources found
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get pvc -A -o yaml
apiVersion: v1
items: []
kind: List
metadata:
  resourceVersion: ""
root@420608814f437a4e898b0e09558701a2 [ ~ ]#

root@420608814f437a4e898b0e09558701a2 [ ~ ]# export KUBECONFIG=gc1_kubeconfig.yaml
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k create -f pvc.yaml             << create PVC in guest cluster with old code
persistentvolumeclaim/example-raw-block-pvc-2 created
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get pvc -A
NAMESPACE   NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
default     example-raw-block-pvc-2   Bound    pvc-eb720057-dd49-4609-80e3-e3bae9539b2c   1Gi        RWO            wcpglobal-storage-profile   <unset>                 14s
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k create -f vs.yaml             << create snapshot in guest cluster with old code
volumesnapshot.snapshot.storage.k8s.io/example-raw-block-snapshot-3 created
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get vs -A
NAMESPACE   NAME                           READYTOUSE   SOURCEPVC                 SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
default     example-raw-block-snapshot-3   true         example-raw-block-pvc-2                           1Gi           volumesnapshotclass-delete   snapcontent-1aa8568b-0792-41dd-b301-8be431324656   1s             8s
root@420608814f437a4e898b0e09558701a2 [ ~ ]#


root@420608814f437a4e898b0e09558701a2 [ ~ ]# export KUBECONFIG=
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get pvc -A
NAMESPACE   NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-ns     c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a-eb720057-dd49-4609-80e3-e3bae9539b2c   Bound    pvc-54d9ed35-bb73-4a86-a6ac-01e5a848c1b5   1Gi        RWO            wcpglobal-storage-profile   <unset>                 71s
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get vs -A
NAMESPACE   NAME                                                                        READYTOUSE   SOURCEPVC                                                                   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
test-ns     c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a-1aa8568b-0792-41dd-b301-8be431324656   true         c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a-eb720057-dd49-4609-80e3-e3bae9539b2c                           1Gi           volumesnapshotclass-delete   snapcontent-3d2aa120-e191-4bd3-890d-52dc58e2c1c6   48s            57s
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get pvc -A -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"domain-c54"}]'
      csi.vsphere.volume-requested-topology: '[{"topology.kubernetes.io/zone":"domain-c54"}]'
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Fri Apr  4 06:53:36 UTC
        2025
    creationTimestamp: "2025-04-04T06:53:20Z"
    finalizers:
    - kubernetes.io/pvc-protection               <<<<<<<< NO CNS finalizer present on supervisor PVC
    labels:
      my-cluster/TKGService: c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a
    name: c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a-eb720057-dd49-4609-80e3-e3bae9539b2c
    namespace: test-ns
    resourceVersion: "14049869"
    uid: 54d9ed35-bb73-4a86-a6ac-01e5a848c1b5
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: wcpglobal-storage-profile
    volumeMode: Filesystem
    volumeName: pvc-54d9ed35-bb73-4a86-a6ac-01e5a848c1b5
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
root@420608814f437a4e898b0e09558701a2 [ ~ ]#

root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get vs -A -o yaml
apiVersion: v1
items:
- apiVersion: snapshot.storage.k8s.io/v1
  kind: VolumeSnapshot
  metadata:
    annotations:
      csi.vsphere.guest-initiated-csi-snapshot: "true"
      csi.vsphere.volume/snapshot: 21b77e60-17bf-4d38-b664-f4ad1758ac13+d75abd17-8e80-490e-88b1-12bbb126203c
    creationTimestamp: "2025-04-04T06:53:38Z"
    finalizers:
    - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection   <<<<<<<< NO CNS finalizer present on supervisor snapshot
    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
    generation: 1
    name: c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a-1aa8568b-0792-41dd-b301-8be431324656
    namespace: test-ns
    resourceVersion: "14049865"
    uid: 3d2aa120-e191-4bd3-890d-52dc58e2c1c6
  spec:
    source:
      persistentVolumeClaimName: c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a-eb720057-dd49-4609-80e3-e3bae9539b2c
    volumeSnapshotClassName: volumesnapshotclass-delete
  status:
    boundVolumeSnapshotContentName: snapcontent-3d2aa120-e191-4bd3-890d-52dc58e2c1c6
    creationTime: "2025-04-04T06:53:47Z"
    readyToUse: true
    restoreSize: 1Gi
kind: List
metadata:
  resourceVersion: ""
root@420608814f437a4e898b0e09558701a2 [ ~ ]#

root@420608814f437a4e898b0e09558701a2 [ ~ ]# export KUBECONFIG=gc1_kubeconfig.yaml
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k edit deploy -n vmware-system-csi    <<< update CSI to new code like upgrade case
deployment.apps/vsphere-csi-controller edited
root@420608814f437a4e898b0e09558701a2 [ ~ ]#

root@420608814f437a4e898b0e09558701a2 [ ~ ]# export KUBECONFIG=
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get pvc -A -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"domain-c54"}]'
      csi.vsphere.volume-requested-topology: '[{"topology.kubernetes.io/zone":"domain-c54"}]'
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Fri Apr  4 06:53:36 UTC
        2025
    creationTimestamp: "2025-04-04T06:53:20Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection     <<<<<<<<<<<<<<<<<<< CNS finalizer added to PVC by guest cluster full sync
    labels:
      my-cluster/TKGService: c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a
    name: c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a-eb720057-dd49-4609-80e3-e3bae9539b2c
    namespace: test-ns
    resourceVersion: "14053150"
    uid: 54d9ed35-bb73-4a86-a6ac-01e5a848c1b5
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: wcpglobal-storage-profile
    volumeMode: Filesystem
    volumeName: pvc-54d9ed35-bb73-4a86-a6ac-01e5a848c1b5
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
root@420608814f437a4e898b0e09558701a2 [ ~ ]#

root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get vs -A -o yaml
apiVersion: v1
items:
- apiVersion: snapshot.storage.k8s.io/v1
  kind: VolumeSnapshot
  metadata:
    annotations:
      csi.vsphere.guest-initiated-csi-snapshot: "true"
      csi.vsphere.volume/snapshot: 21b77e60-17bf-4d38-b664-f4ad1758ac13+d75abd17-8e80-490e-88b1-12bbb126203c
    creationTimestamp: "2025-04-04T06:53:38Z"
    finalizers:
    - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
    - cns.vmware.com/volumesnapshot-protection             <<<<<<<<<<< CNS finalizer added by guest cluster full sync
    generation: 1
    labels:
      my-cluster/TKGService: c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a
    name: c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a-1aa8568b-0792-41dd-b301-8be431324656
    namespace: test-ns
    resourceVersion: "14058814"
    uid: 3d2aa120-e191-4bd3-890d-52dc58e2c1c6
  spec:
    source:
      persistentVolumeClaimName: c8ec50e8-e3e4-4ae4-b325-1bbf22ad450a-eb720057-dd49-4609-80e3-e3bae9539b2c
    volumeSnapshotClassName: volumesnapshotclass-delete
  status:
    boundVolumeSnapshotContentName: snapcontent-3d2aa120-e191-4bd3-890d-52dc58e2c1c6
    creationTime: "2025-04-04T06:53:47Z"
    readyToUse: true
    restoreSize: 1Gi
kind: List
metadata:
  resourceVersion: ""
root@420608814f437a4e898b0e09558701a2 [ ~ ]#

root@420608814f437a4e898b0e09558701a2 [ ~ ]# export KUBECONFIG=gc1_kubeconfig.yaml
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k delete -f vs.yaml               << try to delete snapshot and pvc
volumesnapshot.snapshot.storage.k8s.io "example-raw-block-snapshot-3" deleted
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get vs -A
No resources found
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
(reverse-i-search)`get': k ^Ct vs -A
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k delete pvc --all
persistentvolumeclaim "example-raw-block-pvc-2" deleted
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get pvc -A
No resources found
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# export KUBECONFIG=
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get vs -A                 <<< snap and PVC deleted successfully
No resources found
root@420608814f437a4e898b0e09558701a2 [ ~ ]# k get pvc -A
No resources found
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
root@420608814f437a4e898b0e09558701a2 [ ~ ]#
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add guest cluster details on pre-existing PVC/VolumeSnapshots in fullsync after GC upgrade
```
