### PR TITLE
Workload domain isolation automation code for  VM Service VM

### DIFF
--- a/tests/e2e/mgmt_wrkld_domain_isolation.go
+++ b/tests/e2e/mgmt_wrkld_domain_isolation.go
@@ -197,9 +197,9 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 		// here fetching zone:zone-2 from topologyAffinityDetails
 		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId,
 			[]string{storageProfileId}, getSvcId(vcRestSessionId),
-			[]string{zone2})
+			[]string{zone2}, "", "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(statuscode).To(gomega.Equal(204))
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
 		defer func() {
 			delTestWcpNs(vcRestSessionId, namespace)
 			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
@@ -275,9 +275,9 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 
 		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId, []string{storageProfileId},
 			getSvcId(vcRestSessionId),
-			[]string{zone1})
+			[]string{zone1}, "", "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(statuscode).To(gomega.Equal(204))
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
 		defer func() {
 			delTestWcpNs(vcRestSessionId, namespace)
 			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
@@ -352,9 +352,9 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 			topValEndIndex)
 		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId,
 			[]string{storageProfileId}, getSvcId(vcRestSessionId),
-			[]string{zone2})
+			[]string{zone2}, "", "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(statuscode).To(gomega.Equal(204))
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
 		defer func() {
 			delTestWcpNs(vcRestSessionId, namespace)
 			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
@@ -444,9 +444,9 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 		ginkgo.By("Create a WCP namespace and tag it to zone-2 and zone-3 wrkld " +
 			"domains using storage policy compatible to all zones")
 		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId, []string{storageProfileId},
-			getSvcId(vcRestSessionId), []string{zone2, zone3})
+			getSvcId(vcRestSessionId), []string{zone2, zone3}, "", "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(statuscode).To(gomega.Equal(204))
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
 		defer func() {
 			delTestWcpNs(vcRestSessionId, namespace)
 			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
@@ -618,9 +618,9 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 		// here fetching zone:zone-3 from topologyAffinityDetails
 		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId,
 			[]string{sharedStorageProfileId}, getSvcId(vcRestSessionId),
-			[]string{zone3})
+			[]string{zone3}, "", "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(statuscode).To(gomega.Equal(204))
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
 		defer func() {
 			delTestWcpNs(vcRestSessionId, namespace)
 			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
@@ -690,9 +690,9 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 		ginkgo.By("Create a WCP namespace tagged to zone-1 & zone-2")
 		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId,
 			[]string{sharedStorageProfileId}, getSvcId(vcRestSessionId),
-			[]string{zone1, zone2})
+			[]string{zone1, zone2}, "", "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(statuscode).To(gomega.Equal(204))
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
 		defer func() {
 			delTestWcpNs(vcRestSessionId, namespace)
 			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
@@ -807,9 +807,9 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(
 			vcRestSessionId,
 			[]string{storageProfileIdZone1, storageProfileIdZone3},
-			getSvcId(vcRestSessionId), []string{zone3})
+			getSvcId(vcRestSessionId), []string{zone3}, "", "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(statuscode).To(gomega.Equal(204))
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
 		defer func() {
 			delTestWcpNs(vcRestSessionId, namespace)
 			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())

--- a/tests/e2e/mgmt_wrkld_domain_isolation_vmservice.go
+++ b/tests/e2e/mgmt_wrkld_domain_isolation_vmservice.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	ctlrclient "sigs.k8s.io/controller-runtime/pkg/client"
+	cnsop "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+var _ bool = ginkgo.Describe("[domain-isolation-vmsvc] Domain-Isolation-VmServiceVm", func() {
+
+	f := framework.NewDefaultFramework("vmsvc")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	f.SkipNamespaceCreation = true // tests will create their own namespaces
+	var (
+		client                  clientset.Interface
+		namespace               string
+		vcRestSessionId         string
+		allowedTopologies       []v1.TopologySelectorLabelRequirement
+		topkeyStartIndex        int
+		topologyCategories      []string
+		labelsMap               map[string]string
+		labels_ns               map[string]string
+		err                     error
+		zone2                   string
+		statuscode              int
+		vmClass                 string
+		contentLibId            string
+		datastoreURL            string
+		vmopC                   ctlrclient.Client
+		cnsopC                  ctlrclient.Client
+		nodeList                *v1.NodeList
+		topologyAffinityDetails map[string][]string
+		storagePolicyNameZone2  string
+		storageProfileIdZone2   string
+	)
+
+	ginkgo.BeforeEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// making vc connection
+		client = f.ClientSet
+		bootstrap()
+
+		// reading vc session id
+		if vcRestSessionId == "" {
+			vcRestSessionId = createVcSession4RestApis(ctx)
+		}
+
+		// fetching nodes list
+		nodeList, err = fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		// reading topology map for management and workload domain
+		topologyMap := GetAndExpectStringEnvVar(envTopologyMap)
+		allowedTopologies = createAllowedTopolgies(topologyMap)
+
+		// Set namespace labels to allow privileged pod creation
+		labels_ns = map[string]string{}
+		labels_ns[admissionapi.EnforceLevelLabel] = string(admissionapi.LevelPrivileged)
+		labels_ns["e2e-framework"] = f.BaseName
+
+		//setting labels map on pvc
+		labelsMap = make(map[string]string)
+		labelsMap["app"] = "test"
+
+		//fetching zones
+		topologyAffinityDetails, topologyCategories = createTopologyMapLevel5(topologyMap)
+		zone2 = topologyAffinityDetails[topologyCategories[0]][1]
+
+		// get or set vm class required for VM creation
+		vmClass = os.Getenv(envVMClass)
+		if vmClass == "" {
+			vmClass = vmClassBestEffortSmall
+		}
+
+		// fetch shared vsphere datatsore url
+		datastoreURL = GetAndExpectStringEnvVar(envSharedDatastoreURL)
+		dsRef := getDsMoRefFromURL(ctx, datastoreURL)
+		framework.Logf("dsmoId: %v", dsRef.Value)
+
+		// reading zonal storage policy of zone-2 workload domain
+		storagePolicyNameZone2 = GetAndExpectStringEnvVar(envZonal2StoragePolicyName)
+		storageProfileIdZone2 = e2eVSphere.GetSpbmPolicyID(storagePolicyNameZone2)
+
+		// read or create content library if it is empty
+		if contentLibId == "" {
+			contentLibId, err = createAndOrGetContentlibId4Url(vcRestSessionId, GetAndExpectStringEnvVar(envContentLibraryUrl),
+				dsRef.Value)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		/* Sets up a Kubernetes client with a custom scheme, adds the vmopv1 API types to the scheme,
+		and ensures that the client is properly initialized without errors */
+		vmopScheme := runtime.NewScheme()
+		gomega.Expect(vmopv1.AddToScheme(vmopScheme)).Should(gomega.Succeed())
+		vmopC, err = ctlrclient.New(f.ClientConfig(), ctlrclient.Options{Scheme: vmopScheme})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		cnsOpScheme := runtime.NewScheme()
+		gomega.Expect(cnsop.AddToScheme(cnsOpScheme)).Should(gomega.Succeed())
+		cnsopC, err = ctlrclient.New(f.ClientConfig(), ctlrclient.Options{Scheme: cnsOpScheme})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		framework.Logf("Collecting supervisor PVC events before performing PV/PVC cleanup")
+		dumpSvcNsEventsOnTestFailure(client, namespace)
+		eventList, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, item := range eventList.Items {
+			framework.Logf(item.Message)
+		}
+	})
+
+	/*
+		Testcase-1
+		Brief:
+		Dynamic volume attached to Vm Service VM
+		Singlezone -> zone-2 tagged to WCP namespace
+		zonal storage policy compatible only with zone-2
+		Immediate Binding mode
+
+		Steps:
+		1. Create a WCP namespace tagged to workload domain zone-2 with a zonal storage policy
+		(compatible only with zone-2 workload domain) and assign it to the namespace.
+		2. Create a PVC using the above policy. (Policy created using Immediate Binding mode)
+		3. Wait for PVC to come to Bound State.
+		4. Verify PVC annotation.
+		5. Verify PV affinity. It should show zone-2 topology affinity details.
+		6. Create a VMservice VM using PVC created in step #2.
+		7. Wait for VM to get an IP and to be in a power-on state.
+		8. Once the VM is up, verify that the volume is accessible inside the VM.
+		9. Write some IO to the CSI volumes read it back from them and verify the data integrity
+		10. Verify VM node annotation.
+		11. Perform cleanup: Delete VM, PVC and Namespace.
+	*/
+
+	ginkgo.It("Volume attachment to vm using zonal policy", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var secretName string
+		var vm *vmopv1.VirtualMachine
+		var vmlbsvc *vmopv1.VirtualMachineService
+
+		/*
+			EX - zone -> zone-1, zone-2, zone-3, zone-4
+			so topValStartIndex=1 and topValEndIndex=2 will fetch the 1st index value from topology map string
+		*/
+		topValStartIndex := 1
+		topValEndIndex := 2
+
+		ginkgo.By("Create a WCP namespace and tag zone-2 to it")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+		allowedTopologiesMap := convertToTopologyMap(allowedTopologies)
+
+		// creating namespace with zonal2 storage policy
+		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId,
+			[]string{storageProfileIdZone2}, getSvcId(vcRestSessionId),
+			[]string{zone2}, vmClass, contentLibId)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
+		defer func() {
+			delTestWcpNs(vcRestSessionId, namespace)
+			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
+		}()
+
+		ginkgo.By("Read zonal-2 storage policy which is tagged to wcp namespace")
+		storageclass, err := client.StorageV1().StorageClasses().Get(ctx, storagePolicyNameZone2, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow namespace to get created and "+
+			"storage policy and zonal tag to get added to it",
+			oneMinuteWaitTimeInSeconds))
+		time.Sleep(time.Duration(oneMinuteWaitTimeInSeconds) * time.Second)
+
+		ginkgo.By("Create a PVC using zonal-2 storage policy")
+		pvc, err := createPVC(ctx, client, namespace, labelsMap, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Wait for PVC to be in bound state")
+		pvs, err := fpv.WaitForPVClaimBoundPhase(ctx, client, []*v1.PersistentVolumeClaim{pvc}, pollTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pv := pvs[0]
+		volHandle := pv.Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		defer func() {
+			ginkgo.By("Deleting loadbalancing service, VM and its bootstrap data")
+			err = deleteVmServiceVmWithItsConfig(ctx, client, vmopC,
+				vmlbsvc, namespace, vm, secretName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete PVC")
+			err = fpv.DeletePersistentVolumeClaim(ctx, client, pvc.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Waiting for CNS volumes to be deleted")
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Refresh PVC state")
+		pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify volume affinity annotation state")
+		err = verifyVolumeAnnotationAffinity(pvc, pv, allowedTopologiesMap, topologyCategories)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Create vm service vm")
+		secretName, vm, vmlbsvc, err = createVmServiceVm(ctx, client, vmopC, cnsopC, namespace,
+			[]*v1.PersistentVolumeClaim{pvc}, vmClass, storageclass.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify vm affinity annotation state")
+		err = verifyVmServiceVmAnnotationAffinity(vm, allowedTopologiesMap, nodeList)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -4979,7 +4979,7 @@ func verifyVolumeTopologyForLevel5(pv *v1.PersistentVolume, allowedTopologiesMap
 				if topologyFeature == topologyTkgHaName ||
 					topologyFeature == podVMOnStretchedSupervisor ||
 					topologyFeature == topologyDomainIsolation {
-					return false, fmt.Errorf("pv node affinity key: %v does not does not exist in the"+
+					return false, fmt.Errorf("pv node affinity key: %v does not does not exist in the "+
 						"allowed topologies map: %v", topology.Key, allowedTopologiesMap)
 				} else {
 					return false, fmt.Errorf("PV node affinity details does not exist in the allowed " +

--- a/tests/e2e/vmservice_utils.go
+++ b/tests/e2e/vmservice_utils.go
@@ -60,6 +60,8 @@ type subscribedContentLibBasic struct {
 	url     string
 }
 
+const vmServiceVmLabelKey = "topology.kubernetes.io/zone"
+
 // createTestWcpNs create a wcp namespace with given storage policy, vm class and content lib via REST API
 func createTestWcpNs(
 	vcRestSessionId string, storagePolicyId string, vmClass string, contentLibId string,
@@ -1244,4 +1246,155 @@ func createVMServiceandWaitForVMtoGetIP(ctx context.Context, vmopC ctlrclient.Cl
 			}
 		}
 	}
+}
+
+/*
+This utility creates a VirtualMachine with specified PVCs, waits for the VM to be provisioned,
+verifies PVC attachment, and ensures data integrity by verifying the accessibility of the disks
+and verifying the attached volumes.
+*/
+func createVmServiceVm(ctx context.Context, client clientset.Interface, vmopC ctlrclient.Client,
+	cnsopC ctlrclient.Client, namespace string,
+	pvclaims []*v1.PersistentVolumeClaim, vmClass string,
+	storageClassName string) (string, *vmopv1.VirtualMachine, *vmopv1.VirtualMachineService, error) {
+
+	/*Fetch the VM image name from the environment variable. This image is used for
+	creating the VirtualMachineInstance */
+	vmImageName := GetAndExpectStringEnvVar(envVmsvcVmImageName)
+	framework.Logf("Waiting for virtual machine image list to be "+
+		"available in namespace '%s' for image '%s'", namespace, vmImageName)
+	vmi := waitNGetVmiForImageName(ctx, vmopC, vmImageName)
+
+	/* Create a bootstrap secret for the VirtualMachineService VM. This secret contains
+	credentials or configuration data needed by the VM. */
+	secretName := createBootstrapSecretForVmsvcVms(ctx, client, namespace)
+
+	var vm *vmopv1.VirtualMachine
+	//Create the Virtual Machine with PVC
+	if len(pvclaims) == 1 {
+		vm = createVmServiceVmWithPvcs(ctx, vmopC, namespace, vmClass,
+			[]*v1.PersistentVolumeClaim{pvclaims[0]}, vmi, storageClassName, secretName)
+	} else {
+		vm = createVmServiceVmWithPvcs(ctx, vmopC, namespace, vmClass,
+			pvclaims, vmi, storageClassName, secretName)
+	}
+
+	// Create a service (load balancer) for the VM.
+	vmlbsvc := createService4Vm(ctx, vmopC, namespace, vm.Name)
+
+	// Wait for the VM to get an IP address.
+	vmIp, err := waitNgetVmsvcVmIp(ctx, vmopC, namespace, vm.Name)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to get VM IP: %w", err)
+	}
+
+	// Verify that the PVCs are attached to the VirtualMachine.
+	if len(pvclaims) == 1 {
+		err = waitNverifyPvcsAreAttachedToVmsvcVm(ctx, vmopC, cnsopC, vm, []*v1.PersistentVolumeClaim{pvclaims[0]})
+	} else {
+		err = waitNverifyPvcsAreAttachedToVmsvcVm(ctx, vmopC, cnsopC, vm, pvclaims)
+	}
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("PVCs not attached to VM: %w", err)
+	}
+
+	// After the VM has been created and the PVCs are attached, fetch the current state of the VM.
+	vm, err = getVmsvcVM(ctx, vmopC, vm.Namespace, vm.Name)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to get VM info: %w", err)
+	}
+
+	/* Verify that the attached volumes are accessible and validate data integrity. The function iterates through each
+	volume of the VM, verifies that the PVC is accessible, and checks the data integrity on each attached disk */
+	for i, vol := range vm.Status.Volumes {
+		volFolder := formatNVerifyPvcIsAccessible(vol.DiskUuid, i+1, vmIp)
+		verifyDataIntegrityOnVmDisk(vmIp, volFolder)
+	}
+
+	return secretName, vm, vmlbsvc, nil
+}
+
+/*
+This utility deletes a VirtualMachine, its associated load balancing service, and
+the VM's bootstrap secret, ensuring a clean removal of all related resources.
+*/
+func deleteVmServiceVmWithItsConfig(ctx context.Context, client clientset.Interface, vmopC ctlrclient.Client,
+	vmlbsvc *vmopv1.VirtualMachineService, namespace string, vm *vmopv1.VirtualMachine, secretName string) error {
+
+	// Delete the load balancing service associated with the VM.
+	if err := vmopC.Delete(ctx, &vmopv1.VirtualMachineService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmlbsvc.Name, // Name of the VirtualMachineService to delete.
+			Namespace: namespace,    // Namespace where the service exists.
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to delete VirtualMachineService %q: %w", vmlbsvc.Name, err)
+	}
+
+	// Delete the Virtual Machine itself.
+	if err := vmopC.Delete(ctx, &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vm.Name,   // Name of the VirtualMachine to delete.
+			Namespace: namespace, // Namespace where the VirtualMachine exists.
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to delete VirtualMachine %q: %w", vm.Name, err)
+	}
+
+	//Delete the bootstrap secret for the VM.
+	if err := client.CoreV1().Secrets(namespace).Delete(ctx, secretName, *metav1.NewDeleteOptions(0)); err != nil {
+		return fmt.Errorf("failed to delete secret %q: %w", secretName, err)
+	}
+	return nil
+}
+
+/*
+verifyAllowedTopologyLabelsForVmServiceVM checks if the VM has a
+topology.kubernetes.io/zone label, verifies if its value is in the allowed zones
+*/
+func verifyAllowedTopologyLabelsForVmServiceVM(vm *vmopv1.VirtualMachine, allowedTopologies map[string][]string) error {
+	label := vm.Labels
+
+	// Check if the topologyKey label exists on the VM
+	zone, labelExists := label[vmServiceVmLabelKey]
+	if !labelExists {
+		return fmt.Errorf("couldn't find label '%s' on svc pvc: %s", vmServiceVmLabelKey, vm.Name)
+	}
+
+	// Check if allowed zones for the key exist in allowedTopologies
+	allowedZones, keyExists := allowedTopologies[vmServiceVmLabelKey]
+	if !keyExists {
+		return fmt.Errorf("couldn't find allowed topologies for key: %s", vmServiceVmLabelKey)
+	}
+
+	// Verify if the VM's zone is in the list of allowed zones
+	if !containsItem(allowedZones, zone) {
+		return fmt.Errorf("zone %q not found in allowed accessible "+
+			"topologies: %v for svc pvc: %s", zone, allowedZones, vm.Name)
+	}
+
+	return nil
+}
+
+/*
+Verifies if the virtual machine is running on a node that matches the
+allowed topologies
+*/
+func verifyVmServiceVMNodeLocation(vm *vmopv1.VirtualMachine, nodeList *v1.NodeList,
+	allowedTopologiesMap map[string][]string) (bool, error) {
+	ip := strings.Replace(vm.Status.Host, ".", "-", -1)
+	for _, node := range nodeList.Items {
+		nodeName := strings.Replace(node.Name, ".", "-", -1)
+		if strings.Contains(nodeName, ip) {
+			for labelKey, labelValue := range node.Labels {
+				if topologyValue, ok := allowedTopologiesMap[labelKey]; ok {
+					if !contains(topologyValue, labelValue) {
+						return false, fmt.Errorf("VM: %s is not running on node located in %s", vm.Name, labelValue)
+					}
+				}
+			}
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("VM: %s is not running on any node with matching IP", vm.Name)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR holds the usecase for creating VM Service VM in an domain isolated testbed and includes set of helper methods to verify vm service creation in a domain isolated environment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Holds usecase and required helper utils

**Testing done**:
Yes

[testlogs.txt.txt](https://github.com/user-attachments/files/19788976/testlogs.txt.txt)
[isolation-logs.txt](https://github.com/user-attachments/files/19788978/isolation-logs.txt)

**Special notes for your reviewer**:

ps031044@P2XQC4DXP0 vsphere-csi-driver % golangci-lint run --enable=lll
ps031044@P2XQC4DXP0 vsphere-csi-driver % make golangci-lint 
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.59.1'
golangci/golangci-lint info found version: 1.59.1 for v1.59.1/darwin/arm64
golangci/golangci-lint info installed /Users/ps031044/go/bin/golangci-lint
INFO golangci-lint has version 1.59.1 built with go1.22.3 from 1a55854a on 2024-06-09T18:08:33Z 
INFO [config_reader] Config search paths: [./ /Users/ps031044/isolation-vmservice/vsphere-csi-driver /Users/ps031044/isolation-vmservice /Users/ps031044 /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 8 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck unused] 
INFO [loader] Go packages loading at mode 575 (deps|files|imports|name|types_sizes|compiled_files|exports_file) took 43.460578584s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 127.45825ms 
INFO [linters_context/goanalysis] analyzers took 41.042808241s with top 10 stages: printf: 526.43046ms, SA1023: 456.799669ms, ctrlflow: 440.131749ms, SA4015: 423.640334ms, SA4016: 389.592712ms, S1010: 378.995254ms, SA1003: 370.65659ms, SA4028: 370.455662ms, SA5008: 362.713084ms, SA5012: 362.554876ms 
