### PR TITLE
Refactor CNS Register Volume workflow for better readability

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -369,30 +369,21 @@ func isPVCBound(ctx context.Context, client clientset.Interface, claim *v1.Persi
 // value.
 func getMaxWorkerThreadsToReconcileCnsRegisterVolume(ctx context.Context) int {
 	log := logger.GetLogger(ctx)
-	workerThreads := defaultMaxWorkerThreadsForRegisterVolume
-	if v := os.Getenv("WORKER_THREADS_REGISTER_VOLUME"); v != "" {
-		if value, err := strconv.Atoi(v); err == nil {
-			if value <= 0 {
-				log.Warnf("Maximum number of worker threads to run set in env variable "+
-					"WORKER_THREADS_REGISTER_VOLUME %s is less than 1, will use the default value %d",
-					v, defaultMaxWorkerThreadsForRegisterVolume)
-			} else if value > defaultMaxWorkerThreadsForRegisterVolume {
-				log.Warnf("Maximum number of worker threads to run set in env variable "+
-					"WORKER_THREADS_REGISTER_VOLUME %s is greater than %d, will use the default value %d",
-					v, defaultMaxWorkerThreadsForRegisterVolume, defaultMaxWorkerThreadsForRegisterVolume)
-			} else {
-				workerThreads = value
-				log.Debugf("Maximum number of worker threads to run to reconcile CnsRegisterVolume instances is set to %d",
-					workerThreads)
-			}
-		} else {
-			log.Warnf("Maximum number of worker threads to run set in env variable "+
-				"WORKER_THREADS_REGISTER_VOLUME %s is invalid, will use the default value %d",
-				v, defaultMaxWorkerThreadsForRegisterVolume)
-		}
-	} else {
-		log.Debugf("WORKER_THREADS_REGISTER_VOLUME is not set. Picking the default value %d",
-			defaultMaxWorkerThreadsForRegisterVolume)
+	v := os.Getenv("WORKER_THREADS_REGISTER_VOLUME")
+
+	if v == "" {
+		log.Debugf("WORKER_THREADS_REGISTER_VOLUME is not set. "+
+			"Using default value: %d", defaultMaxWorkerThreadsForRegisterVolume)
+		return defaultMaxWorkerThreadsForRegisterVolume
 	}
-	return workerThreads
+
+	value, err := strconv.Atoi(v)
+	if err != nil || value < 1 || value > defaultMaxWorkerThreadsForRegisterVolume {
+		log.Warnf("Invalid WORKER_THREADS_REGISTER_VOLUME value: %s. "+
+			"Using default value: %d", v, defaultMaxWorkerThreadsForRegisterVolume)
+		return defaultMaxWorkerThreadsForRegisterVolume
+	}
+
+	log.Debugf("Maximum worker threads for CnsRegisterVolume set to: %d", value)
+	return value
 }


### PR DESCRIPTION
Refactored the parameter names of `recordEvent`
Simplified the logic of `isBlockVolumeRegisterRequest` Refactored `validateCnsRegisterVolumeSpec`
Added handling for the scenario when volume ID and Disk URL Path are missing in `validateCnsRegisterVolumeSpec` Simplified the logic of `Add`
Updated `Reconcile` to avoid requeing the instance if it is not block volume register request Simplified the logic of `getMaxWorkerThreadsToReconcileCnsRegisterVolume`

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
