### PR TITLE
Test code fixes for pvc creation timeout and vm service ns creation

### DIFF
--- a/tests/e2e/binding_modes_with_topology.go
+++ b/tests/e2e/binding_modes_with_topology.go
@@ -113,7 +113,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By("Expect claim to be in Bound state and provisioning volume passes")
 		err = fpv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
 
 		pv = getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -481,6 +481,21 @@ var (
 	envSharedZone2Zone4DatastoreUrl       = "SHARED_ZONE2_ZONE4_DATASTORE_URL"
 )
 
+// storage policy usages for storage quota validation
+var usageSuffixes = []string{
+	"-pvc-usage",
+	"-latebinding-pvc-usage",
+	"-snapshot-usage",
+	"-latebinding-snapshot-usage",
+	"-vm-usage",
+	"-latebinding-vm-usage",
+}
+
+const (
+	storagePolicyUsagePollInterval = 10 * time.Second
+	storagePolicyUsagePollTimeout  = 1 * time.Minute
+)
+
 // GetAndExpectEnvVar returns the value of an environment variable or fails the regression if it's not set.
 func GetAndExpectEnvVar(varName string) string {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/provision_with_multiple_zones.go
+++ b/tests/e2e/provision_with_multiple_zones.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -115,7 +114,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		}()
 		ginkgo.By("Expect claim to pass provisioning volume")
 		err = fpv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
 
 		ginkgo.By("Verify if volume is provisioned in specified zone and region")

--- a/tests/e2e/snapshot_vmservice_vm.go
+++ b/tests/e2e/snapshot_vmservice_vm.go
@@ -128,6 +128,11 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 		namespace = createTestWcpNs(
 			vcRestSessionId, storageProfileId, vmClass, contentLibId, getSvcId(vcRestSessionId))
 
+		framework.Logf("Verifying storage policies usage for each storage class")
+		restConfig = getRestConfigClient()
+		err = ListStoragePolicyUsages(ctx, client, restConfig, namespace, []string{storageClassName})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		// creating vm schema
 		vmopScheme := runtime.NewScheme()
 		gomega.Expect(vmopv1.AddToScheme(vmopScheme)).Should(gomega.Succeed())
@@ -150,10 +155,6 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 		restConfig = getRestConfigClient()
 		snapc, err = snapclient.NewForConfig(restConfig)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		ginkgo.By("Sleeping for a minute for storage policy to get " +
-			"refresh and added to namespace")
-		setStoragePolicyQuota(ctx, restConfig, storageClassName, namespace, rqLimit)
 
 		// reading full sync wait time
 		if os.Getenv(envPandoraSyncWaitTime) != "" {

--- a/tests/e2e/svmotion_volumes.go
+++ b/tests/e2e/svmotion_volumes.go
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 
 		ginkgo.By("Expect claim to provision volume successfully")
 		err = fpv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)

--- a/tests/e2e/volume_provisioning_with_topology.go
+++ b/tests/e2e/volume_provisioning_with_topology.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -103,7 +102,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 
 		ginkgo.By("Expect claim to pass provisioning volume")
 		err = fpv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
 
 		ginkgo.By("Verify if volume is provisioned in specified zone and region")

--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -104,7 +104,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 		}()
 		ginkgo.By("Expect claim to pass provisioning volume as shared datastore")
 		err = fpv.WaitForPersistentVolumeClaimPhase(ctx,
-			v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+			v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Failed to provision volume on shared datastore with err: %v", err))
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
In this PR, the PVC creation timeout is set to 1 minute, but it has not been updated to the default 5-minute wait time. Additionally, while the namespace creation for the VM service VM is successful, there is a delay when adding the storage policy, tags, and zone. To address this, a polling mechanism has been added before creating the PVC in the namespace.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Test code fixes for pvc creation timeout and vm service ns creation

**Testing done**:
Yes
[testlogs.txt](https://github.com/user-attachments/files/19888435/testlogs.txt)

**Special notes for your reviewer**:
ps031044@P2XQC4DXP0 vsphere-csi-driver % golangci-lint run --enable=lll 
ps031044@P2XQC4DXP0 vsphere-csi-driver % 

