### PR TITLE
Workload domain isolation automation code for VM Service VM

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -477,6 +477,8 @@ var (
 	envZonal3StoragePolicyName            = "ZONAL3_STORAGE_POLICY_IMM"
 	topologyDomainIsolation               = "Workload_Management_Isolation"
 	envIsolationSharedStoragePolicyName   = "WORKLOAD_ISOLATION_SHARED_STORAGE_POLICY"
+	envSharedZone2Zone4StoragePolicyName  = "SHARED_ZONE2_ZONE4_STORAGE_POLICY_IMM"
+	envSharedZone2Zone4DatastoreUrl       = "SHARED_ZONE2_ZONE4_DATASTORE_URL"
 )
 
 // GetAndExpectEnvVar returns the value of an environment variable or fails the regression if it's not set.

--- a/tests/e2e/mgmt_wrkld_domain_isolation_vmservice.go
+++ b/tests/e2e/mgmt_wrkld_domain_isolation_vmservice.go
@@ -259,4 +259,100 @@ var _ bool = ginkgo.Describe("[domain-isolation-vmsvc] Domain-Isolation-VmServic
 		err = verifyVmServiceVmAnnotationAffinity(vm, allowedTopologiesMap, nodeList)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
+	/*
+		Testcase-2
+		Brief:
+		Static volume attached to Vm Service VM
+		Multizones -> zone-2 and zone-4 tagged to WCP namespace
+		storage policy compatible only with zone-2 and zone-4
+		Immediate Binding mode
+
+		Steps:
+		1. Create a WCP namespace tagged to workload domain zone-2 and zone-4 with a shared storage policy
+		(compatible only with zone-2 and zone-4 workload domain) and assign it to the namespace.
+		2. Create FCD using the above policy.
+		3. Create a static PV and PVC using cns register volume API
+		4. Wait for static PV and PVC to reach the Bound state.
+		5. Verify PVC annotation.
+		6. Verify PV affinity. It should show zone-2 and zone-4 topology affinity details.
+		7. Create a VMservice VM using the static volume created in step #3.
+		8. Wait for VM to get an IP and to be in a power-on state.
+		9. Once the VM is up, verify that the volume is accessible inside the VM.
+		10. Write some IO to the CSI volumes and read it back from them and verify the data integrity
+		11. Verify VM node annotation.
+		12. Perform cleanup: Delete VM, PVC and Namespace.
+	*/
+
+	ginkgo.It("Static volume attachment to vm using shared policy", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var secretName string
+		var vm *vmopv1.VirtualMachine
+		var vmlbsvc *vmopv1.VirtualMachineService
+
+		// reading shared storage policy of zone-2 and zone-4 workload domain and its datastore url
+		storagePolicyNameZone24 := GetAndExpectStringEnvVar(envSharedZone2Zone4StoragePolicyName)
+		storageProfileIdZone24 := e2eVSphere.GetSpbmPolicyID(storagePolicyNameZone24)
+		storageDatastoreUrlZone24 := GetAndExpectStringEnvVar(envSharedZone2Zone4DatastoreUrl)
+
+		ginkgo.By("Create a WCP namespace and tag zone-2 and zone-4 to it")
+		zone4 := allowedTopologies[0].Values[3]
+		allowedTopologies[0].Values = []string{zone2, zone4}
+		allowedTopologiesMap := convertToTopologyMap(allowedTopologies)
+		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId,
+			[]string{storageProfileIdZone24}, getSvcId(vcRestSessionId),
+			[]string{zone2, zone4}, vmClass, contentLibId)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
+		defer func() {
+			delTestWcpNs(vcRestSessionId, namespace)
+			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
+		}()
+
+		ginkgo.By("Read shared storage policy which is tagged to wcp namespace")
+		storageclass, err := client.StorageV1().StorageClasses().Get(ctx, storagePolicyNameZone24, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Create static volume")
+		fcdID, defaultDatastore, staticPvc, staticPv, err := createStaticVolumeOnSvc(ctx, client,
+			namespace, storageDatastoreUrlZone24, storagePolicyNameZone24)
+		defer func() {
+			ginkgo.By("Deleting loadbalancing service, VM and its bootstrap data")
+			err = deleteVmServiceVmWithItsConfig(ctx, client, vmopC,
+				vmlbsvc, namespace, vm, secretName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete FCD")
+			err := e2eVSphere.deleteFCD(ctx, fcdID, defaultDatastore.Reference())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete PVC")
+			err = fpv.DeletePersistentVolumeClaim(ctx, client, staticPvc.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(staticPv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Refresh PVC state")
+		staticPvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, staticPvc.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify volume affinity annotation state")
+		err = verifyVolumeAnnotationAffinity(staticPvc, staticPv, allowedTopologiesMap, topologyCategories)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Create vm service vm")
+		secretName, vm, vmlbsvc, err = createVmServiceVm(ctx, client, vmopC, cnsopC, namespace,
+			[]*v1.PersistentVolumeClaim{staticPvc}, vmClass, storageclass.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify vm affinity annotation state")
+		err = verifyVmServiceVmAnnotationAffinity(vm, allowedTopologiesMap, nodeList)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
 })

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -7618,3 +7618,108 @@ func getPortNumAndIP(ip string) (string, string, error) {
 
 	return ip, port, nil
 }
+
+/*
+createStaticVolumeOnSvc utility function to create a static volume on a service, register it with CNS,
+and verify the PV/PVC setup
+*/
+func createStaticVolumeOnSvc(ctx context.Context, client clientset.Interface, namespace string, datastoreUrl string,
+	storagePolicyName string) (string, *object.Datastore, *v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
+	var datacenters []string
+	var defaultDatacenter *object.Datacenter
+	var pandoraSyncWaitTime int
+	var defaultDatastore *object.Datastore
+	curtime := time.Now().Unix()
+	curtimestring := strconv.FormatInt(curtime, 10)
+	pvcName := "cns-pvc-" + curtimestring
+
+	// Get Kubernetes client configuration
+	restConfig := getRestConfigClient()
+
+	// Find and load datacenters
+	finder := find.NewFinder(e2eVSphere.Client.Client, false)
+	cfg, err := getConfig()
+	if err != nil {
+		return "", nil, nil, nil, fmt.Errorf("failed to get config: %v", err)
+	}
+
+	dcList := strings.Split(cfg.Global.Datacenters, ",")
+	for _, dc := range dcList {
+		dcName := strings.TrimSpace(dc)
+		if dcName != "" {
+			datacenters = append(datacenters, dcName)
+		}
+	}
+
+	// Loop through datacenters to find the right one
+	for _, dc := range datacenters {
+		defaultDatacenter, err = finder.Datacenter(ctx, dc)
+		if err != nil {
+			return "", nil, nil, nil, fmt.Errorf("failed to get datacenter '%s': %v", dc, err)
+		}
+		finder.SetDatacenter(defaultDatacenter)
+		defaultDatastore, err = getDatastoreByURL(ctx, datastoreUrl, defaultDatacenter)
+		if err != nil {
+			return "", nil, nil, nil, fmt.Errorf("failed to get datastore from "+
+				"URL '%s' in datacenter '%s': %v", datastoreUrl, dc, err)
+		}
+	}
+
+	// Get Storage Profile ID
+	profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+
+	// Create FCD (CNS Volume)
+	fcdID, err := e2eVSphere.createFCDwithValidProfileID(ctx,
+		"staticfcd"+curtimestring, profileID, diskSizeInMb, defaultDatastore.Reference())
+	if err != nil {
+		return "", defaultDatastore, nil, nil, fmt.Errorf("failed to create FCD with profile ID '%s': %v", profileID, err)
+	}
+
+	// Sync time for Pandora (if set in environment variable)
+	if os.Getenv(envPandoraSyncWaitTime) != "" {
+		pandoraSyncWaitTime, err = strconv.Atoi(os.Getenv(envPandoraSyncWaitTime))
+		if err != nil {
+			return fcdID, defaultDatastore, nil, nil, fmt.Errorf("invalid Pandora sync "+
+				"wait time '%s': %v", os.Getenv(envPandoraSyncWaitTime), err)
+		}
+	} else {
+		pandoraSyncWaitTime = defaultPandoraSyncWaitTime
+	}
+
+	// Sleep to allow FCD to sync with Pandora
+	ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow newly created "+
+		"FCD:%s to sync with Pandora", pandoraSyncWaitTime, fcdID))
+	time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
+
+	// Register volume with CNS
+	cnsRegisterVolume := getCNSRegisterVolumeSpec(ctx, namespace, fcdID, "", pvcName, v1.ReadWriteOnce)
+	err = createCNSRegisterVolume(ctx, restConfig, cnsRegisterVolume)
+	if err != nil {
+		return fcdID, defaultDatastore, nil, nil,
+			fmt.Errorf("failed to create CNS register volume for FCD '%s': %v", fcdID, err)
+	}
+
+	// Wait for CNS volume creation to complete
+	framework.ExpectNoError(waitForCNSRegisterVolumeToGetCreated(ctx, restConfig,
+		namespace, cnsRegisterVolume, poll, supervisorClusterOperationsTimeout))
+	cnsRegisterVolumeName := cnsRegisterVolume.GetName()
+	framework.Logf("CNS register volume name: %s", cnsRegisterVolumeName)
+
+	// Retrieve and verify PV and PVC
+	ginkgo.By("Verifying created PV, PVC, and checking bidirectional reference")
+	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		return fcdID, defaultDatastore, nil, nil,
+			fmt.Errorf("failed to get PVC '%s' from namespace '%s': %v", pvcName, namespace, err)
+	}
+
+	pv := getPvFromClaim(client, namespace, pvcName)
+	if pv == nil {
+		return fcdID, defaultDatastore, pvc, nil,
+			fmt.Errorf("failed to retrieve PV for PVC '%s' in namespace '%s'", pvcName, namespace)
+	}
+
+	verifyBidirectionalReferenceOfPVandPVC(ctx, client, pvc, pv, fcdID)
+
+	return fcdID, defaultDatastore, pvc, pv, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR holds the usecase for creating VM Service VM in an domain isolated testbed and includes set of helper methods to verify vm service creation in a domain isolated environment.

**Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #**
Usecase and required helper utils

Testing done:
Yes
[isolation-tc2.txt](https://github.com/user-attachments/files/19832511/isolation-tc2.txt)


**Special notes for your reviewer:**

ps031044@P2XQC4DXP0 vsphere-csi-driver % golangci-lint run --enable=lll 
ps031044@P2XQC4DXP0 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.59.1'
golangci/golangci-lint info found version: 1.59.1 for v1.59.1/darwin/arm64
golangci/golangci-lint info installed /Users/ps031044/go/bin/golangci-lint
INFO golangci-lint has version 1.59.1 built with go1.22.3 from 1a55854a on 2024-06-09T18:08:33Z 
INFO [config_reader] Config search paths: [./ /Users/ps031044/isolation-vmservicepart2/vsphere-csi-driver /Users/ps031044/isolation-vmservicepart2 /Users/ps031044 /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 8 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck unused] 
