### PR TITLE
Reading multi vc ips export variables at runtime

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -687,19 +687,13 @@ func setSShdPort() {
 	isPrivateNetwork := GetBoolEnvVarOrDefault("IS_PRIVATE_NETWORK", false)
 
 	if multivc {
-		vCenterHostnames := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
-		if len(vCenterHostnames) >= 3 {
-			vcAddress = vCenterHostnames[0]
-			vcAddress2 = vCenterHostnames[1]
-			vcAddress3 = vCenterHostnames[2]
-		}
+		vcAddress2 = GetAndExpectEnvVar(envVcIP2)
+		vcAddress3 = GetAndExpectEnvVar(envVcIP3)
 	}
 
 	if isPrivateNetwork {
 		if multivc {
-			vcAddress2 = GetorIgnoreStringEnvVar(envVcIP2)
 			vcIp2SshPortNum = GetorIgnoreStringEnvVar(envVc2SshdPortNum)
-			vcAddress3 = GetorIgnoreStringEnvVar(envVcIP3)
 			vcIp3SshPortNum = GetorIgnoreStringEnvVar(envVc3SshdPortNum)
 
 			safeInsertToMap(vcAddress2, vcIp2SshPortNum)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the code where instead of reading it from e2e conf, we need to read it through jenkins runtime export variables

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Reading VC Ips at runtime for multi-vc

**Testing done**:
Yes

[multivc-logs.txt.txt](https://github.com/user-attachments/files/19844910/multivc-logs.txt.txt)

