### PR TITLE
Add backward compatibility for vm-operator api version v1alpha1

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -20,9 +20,15 @@ import (
 	"context"
 	"math"
 	"strconv"
+	"strings"
 
+	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatorv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"google.golang.org/grpc/codes"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -264,4 +270,224 @@ func QueryAllVolumesForCluster(ctx context.Context, m cnsvolume.Manager, cluster
 			"QueryAllVolume failed with err=%+v", err.Error())
 	}
 	return queryAllResult, nil
+}
+
+func GetVirtualMachineAllApiVersions(ctx context.Context, vmKey types.NamespacedName,
+	vmOperatorClient client.Client) (*vmoperatorv1alpha3.VirtualMachine, error) {
+	log := logger.GetLogger(ctx)
+	vmV1alpha1 := &vmoperatorv1alpha1.VirtualMachine{}
+	vmV1alpha2 := &vmoperatorv1alpha2.VirtualMachine{}
+	vmV1alpha3 := &vmoperatorv1alpha3.VirtualMachine{}
+	var err error
+	log.Infof("get machine with vm-operator api version v1alpha3 name: %s, namespace: %s",
+		vmKey.Name, vmKey.Namespace)
+	err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha3)
+	if err != nil && isKindNotFound(err.Error()) {
+		log.Warnf("failed to get VirtualMachines. %s", err.Error())
+		err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha2)
+		if err != nil && isKindNotFound(err.Error()) {
+			log.Warnf("failed to get VirtualMachines. %s", err.Error())
+			err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha1)
+			if err != nil && isKindNotFound(err.Error()) {
+				log.Warnf("failed to get VirtualMachines. %s", err.Error())
+			} else if err == nil {
+				log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha1 VirtualMachine "+
+					"to v1alpha3 VirtualMachine, name %s", vmV1alpha1.Name)
+				err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachine_To_v1alpha3_VirtualMachine(
+					vmV1alpha1, vmV1alpha3, nil)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else if err == nil {
+			log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha2 VirtualMachine "+
+				"to v1alpha3 VirtualMachine, name %s", vmV1alpha2.Name)
+			err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachine_To_v1alpha3_VirtualMachine(
+				vmV1alpha2, vmV1alpha3, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err != nil {
+		log.Errorf("GetVirtualMachineAllApiVersions: failed to get VirtualMachine "+
+			"with name %s and namespace %s, error %v", vmKey.Name, vmKey.Namespace, err)
+		return nil, err
+	}
+	log.Infof("successfully fetched the virtual machines with name %s and namespace %s",
+		vmKey.Name, vmKey.Namespace)
+	return vmV1alpha3, nil
+}
+func isKindNotFound(errMsg string) bool {
+	return strings.Contains(errMsg, "no matches for kind")
+}
+func GetVirtualMachineListAllApiVersions(ctx context.Context, namespace string,
+	vmOperatorClient client.Client) (*vmoperatorv1alpha3.VirtualMachineList, error) {
+	log := logger.GetLogger(ctx)
+	vmListV1alpha1 := &vmoperatorv1alpha1.VirtualMachineList{}
+	vmListV1alpha2 := &vmoperatorv1alpha2.VirtualMachineList{}
+	vmListV1alpha3 := &vmoperatorv1alpha3.VirtualMachineList{}
+	var err error
+	if namespace != "" {
+		// get list of virtualmachine for specific namespace
+		log.Infof("list virtualmachines for namespace %s", namespace)
+		err = vmOperatorClient.List(ctx, vmListV1alpha3, client.InNamespace(namespace))
+		if err != nil && isKindNotFound(err.Error()) {
+			err := vmOperatorClient.List(ctx, vmListV1alpha2, client.InNamespace(namespace))
+			if err != nil && isKindNotFound(err.Error()) {
+				err := vmOperatorClient.List(ctx, vmListV1alpha1, client.InNamespace(namespace))
+				if err != nil {
+					return nil, err
+				} else {
+					log.Info("converting v1alpha1 VirtualMachineList to v1alpha3 VirtualMachineList")
+					err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachineList_To_v1alpha3_VirtualMachineList(
+						vmListV1alpha1, vmListV1alpha3, nil)
+					if err != nil {
+						return nil, err
+					}
+				}
+			} else if err == nil {
+				log.Info("converting v1alpha2 VirtualMachineList to v1alpha3 VirtualMachineList")
+				err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachineList_To_v1alpha3_VirtualMachineList(
+					vmListV1alpha2, vmListV1alpha3, nil)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	} else {
+		// get list of virtualmachine without providing namespace (all)
+		log.Info("list all virtualmachines")
+		err = vmOperatorClient.List(ctx, vmListV1alpha3)
+		if err != nil && isKindNotFound(err.Error()) {
+			err := vmOperatorClient.List(ctx, vmListV1alpha2)
+			if err != nil && isKindNotFound(err.Error()) {
+				err := vmOperatorClient.List(ctx, vmListV1alpha1)
+				if err != nil {
+					return nil, err
+				} else {
+					log.Info("converting v1alpha1 VirtualMachineList to v1alpha3 VirtualMachineList")
+					err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachineList_To_v1alpha3_VirtualMachineList(
+						vmListV1alpha1, vmListV1alpha3, nil)
+					if err != nil {
+						return nil, err
+					}
+				}
+			} else if err == nil {
+				log.Info("converting v1alpha2 VirtualMachineList to v1alpha3 VirtualMachineList")
+				err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachineList_To_v1alpha3_VirtualMachineList(
+					vmListV1alpha2, vmListV1alpha3, nil)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("successfully fetched the virtual machines for namespace %s", namespace)
+	return vmListV1alpha3, nil
+}
+
+func PatchVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
+	vmV1alpha3, old_vmV1alpha3 *vmoperatorv1alpha3.VirtualMachine) error {
+	log := logger.GetLogger(ctx)
+	vmV1alpha1, old_vmV1alpha1 := &vmoperatorv1alpha1.VirtualMachine{}, &vmoperatorv1alpha1.VirtualMachine{}
+	vmV1alpha2, old_vmV1alpha2 := &vmoperatorv1alpha2.VirtualMachine{}, &vmoperatorv1alpha2.VirtualMachine{}
+	vmPatch3 := client.MergeFromWithOptions(
+		old_vmV1alpha3.DeepCopy(),
+		client.MergeFromWithOptimisticLock{})
+	log.Infof("PatchVirtualMachine: patch virtualmachine name: %s", vmV1alpha3.Name)
+	// try patch virtualmachine with api version v1alpha3
+	err := vmOperatorClient.Patch(ctx, vmV1alpha3, vmPatch3)
+	if err != nil && isKindNotFound(err.Error()) {
+		log.Infof("PatchVirtualMachine: converting v1alpha3 VirtualMachine to "+
+			"v1alpha2 VirtualMachine, name: %s", vmV1alpha3.Name)
+		err = vmoperatorv1alpha2.Convert_v1alpha3_VirtualMachine_To_v1alpha2_VirtualMachine(
+			vmV1alpha3, vmV1alpha2, nil)
+		if err != nil {
+			return err
+		}
+		err = vmoperatorv1alpha2.Convert_v1alpha3_VirtualMachine_To_v1alpha2_VirtualMachine(
+			old_vmV1alpha3, old_vmV1alpha2, nil)
+		if err != nil {
+			return err
+		}
+		vmPatch2 := client.MergeFromWithOptions(
+			old_vmV1alpha2.DeepCopy(),
+			client.MergeFromWithOptimisticLock{})
+		// try patch virtualmachine with api version v1alpha2
+		err := vmOperatorClient.Patch(ctx, vmV1alpha2, vmPatch2)
+		if err != nil && isKindNotFound(err.Error()) {
+			log.Infof("PatchVirtualMachine: converting v1alpha3 VirtualMachine to "+
+				"v1alpha1 VirtualMachine, name: %s", vmV1alpha3.Name)
+			err = vmoperatorv1alpha1.Convert_v1alpha3_VirtualMachine_To_v1alpha1_VirtualMachine(
+				vmV1alpha3, vmV1alpha1, nil)
+			if err != nil {
+				return err
+			}
+			err = vmoperatorv1alpha1.Convert_v1alpha3_VirtualMachine_To_v1alpha1_VirtualMachine(
+				old_vmV1alpha3, old_vmV1alpha1, nil)
+			if err != nil {
+				return err
+			}
+			vmPatch1 := client.MergeFromWithOptions(
+				old_vmV1alpha1.DeepCopy(),
+				client.MergeFromWithOptimisticLock{})
+			// try patch virtualmachine with api version v1alpha1
+			err := vmOperatorClient.Patch(ctx, vmV1alpha1, vmPatch1)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if err != nil {
+		log.Errorf("PatchVirtualMachine: error while patching virtualmachine name: %s, err %v",
+			vmV1alpha3.Name, err)
+		return err
+	}
+	log.Infof("PatchVirtualMachine: successfully patched the virtualmachine, name: %s", vmV1alpha3.Name)
+	return nil
+}
+
+func UpdateVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
+	vmV1alpha3 *vmoperatorv1alpha3.VirtualMachine) error {
+	vmV1alpha1 := &vmoperatorv1alpha1.VirtualMachine{}
+	vmV1alpha2 := &vmoperatorv1alpha2.VirtualMachine{}
+	log := logger.GetLogger(ctx)
+	log.Infof("UpdateVirtualMachine: update virtualmachine name: %s", vmV1alpha3.Name)
+	// try update virtualmachine with api version v1alpha3
+	err := vmOperatorClient.Update(ctx, vmV1alpha3)
+	if err != nil && isKindNotFound(err.Error()) {
+		log.Infof("UpdateVirtualMachine: converting v1alpha3 VirtualMachine to "+
+			"v1alpha2 VirtualMachine, name: %s", vmV1alpha3.Name)
+		err = vmoperatorv1alpha2.Convert_v1alpha3_VirtualMachine_To_v1alpha2_VirtualMachine(
+			vmV1alpha3, vmV1alpha2, nil)
+		if err != nil {
+			return err
+		}
+		// try update virtualmachine with api version v1alpha2
+		err := vmOperatorClient.Update(ctx, vmV1alpha2)
+		if err != nil && isKindNotFound(err.Error()) {
+			log.Infof("UpdateVirtualMachine: converting v1alpha3 VirtualMachine to "+
+				"v1alpha1 VirtualMachine, name: %s", vmV1alpha3.Name)
+			err = vmoperatorv1alpha1.Convert_v1alpha3_VirtualMachine_To_v1alpha1_VirtualMachine(
+				vmV1alpha3, vmV1alpha1, nil)
+			if err != nil {
+				return err
+			}
+			// try update virtualmachine with api version v1alpha1
+			err := vmOperatorClient.Update(ctx, vmV1alpha1)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if err != nil {
+		log.Errorf("UpdateVirtualMachine: error while updating virtualmachine name: %s, err %v", vmV1alpha3.Name, err)
+		return err
+	}
+	log.Infof("UpdateVirtualMachine: successfully updated the virtualmachine, name: %s", vmV1alpha3.Name)
+	return nil
 }

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -42,6 +42,7 @@ import (
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -166,8 +167,7 @@ func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.Cont
 			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to get client for group %s with error: %+v", vmoperatorv1alpha3.GroupName, err)
 		}
-		vmList := &vmoperatorv1alpha3.VirtualMachineList{}
-		err = vmOperatorClient.List(ctx, vmList)
+		vmList, err := utils.GetVirtualMachineListAllApiVersions(ctx, "", vmOperatorClient)
 		if err != nil {
 			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to list virtualmachines with error: %+v", err)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"time"
 
+	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	vmoperatorv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -219,6 +221,19 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 			return nil, err
 		}
 	case vmoperatorv1alpha3.GroupName:
+		log.Info("adding scheme for vm-operator version v1alpha1")
+		err = vmoperatorv1alpha1.AddToScheme(scheme)
+		if err != nil {
+			log.Errorf("failed to add to scheme with err: %+v", err)
+			return nil, err
+		}
+		log.Info("adding scheme for vm-operator version v1alpha2")
+		err = vmoperatorv1alpha2.AddToScheme(scheme)
+		if err != nil {
+			log.Errorf("failed to add to scheme with err: %+v", err)
+			return nil, err
+		}
+		log.Info("adding scheme for vm-operator version v1alpha3")
 		err = vmoperatorv1alpha3.AddToScheme(scheme)
 		if err != nil {
 			log.Errorf("failed to add to scheme with err: %+v", err)
@@ -307,14 +322,23 @@ func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config,
 	log := logger.GetLogger(ctx)
 
 	scheme := runtime.NewScheme()
+	log.Info("adding scheme for vm-operator versions v1alpha1, v1alpha2, v1alpha3")
 	err = vmoperatorv1alpha3.AddToScheme(scheme)
+	if err != nil {
+		log.Errorf("failed to add to scheme with err: %+v", err)
+	}
+	err = vmoperatorv1alpha2.AddToScheme(scheme)
+	if err != nil {
+		log.Errorf("failed to add to scheme with err: %+v", err)
+	}
+	err = vmoperatorv1alpha1.AddToScheme(scheme)
 	if err != nil {
 		log.Errorf("failed to add to scheme with err: %+v", err)
 	}
 
 	gvk := schema.GroupVersionKind{
-		Group:   vmoperatorv1alpha3.GroupVersion.Group,
-		Version: vmoperatorv1alpha3.GroupVersion.Version,
+		Group:   vmoperatorv1alpha1.GroupVersion.Group,
+		Version: vmoperatorv1alpha1.GroupVersion.Version,
 		Kind:    virtualMachineKind,
 	}
 

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
-
 	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -128,7 +127,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
-	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatortypes.GroupName)
+	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatorv1alpha3.GroupName)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to initialize vmOperatorClient. Error: %+v", err)
 		log.Error(msg)
@@ -362,7 +361,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 	vmOwnerRefExists := false
 	if len(instance.OwnerReferences) != 0 {
 		for _, ownerRef := range instance.OwnerReferences {
-			if ownerRef.Kind == reflect.TypeOf(vmoperatortypes.VirtualMachine{}).Name() &&
+			if ownerRef.Kind == reflect.TypeOf(vmoperatorv1alpha3.VirtualMachine{}).Name() &&
 				ownerRef.Name == instance.Spec.VMName && ownerRef.UID == vm.UID {
 				vmOwnerRefExists = true
 				break
@@ -503,7 +502,7 @@ func (r *ReconcileCnsFileAccessConfig) removePermissionsForFileVolume(ctx contex
 // permissions by setting the parameter removePermission to true or false
 // respectively. Returns error if any operation fails.
 func (r *ReconcileCnsFileAccessConfig) configureNetPermissionsForFileVolume(ctx context.Context,
-	volumeID string, vm *vmoperatortypes.VirtualMachine, instance *cnsfileaccessconfigv1alpha1.CnsFileAccessConfig,
+	volumeID string, vm *vmoperatorv1alpha3.VirtualMachine, instance *cnsfileaccessconfigv1alpha1.CnsFileAccessConfig,
 	removePermission bool) error {
 	log := logger.GetLogger(ctx)
 	tkgVMIP, err := r.getVMExternalIP(ctx, vm)
@@ -595,7 +594,7 @@ func (r *ReconcileCnsFileAccessConfig) configureVolumeACLs(ctx context.Context,
 
 // getVMExternalIP helps to fetch the external facing IP for a given TKG VM.
 func (r *ReconcileCnsFileAccessConfig) getVMExternalIP(ctx context.Context,
-	vm *vmoperatortypes.VirtualMachine) (string, error) {
+	vm *vmoperatorv1alpha3.VirtualMachine) (string, error) {
 	log := logger.GetLogger(ctx)
 	networkProvider, err := cnsoperatorutil.GetNetworkProvider(ctx)
 	if err != nil {

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/util.go
@@ -23,26 +23,28 @@ import (
 	"reflect"
 	"strconv"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
 // getVirtualMachine gets the virtual machine instance with a name on a SV
 // namespace.
 func getVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
-	vmName string, namespace string) (*vmoperatortypes.VirtualMachine, error) {
+	vmName string, namespace string) (*vmoperatorv1alpha3.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
-	virtualMachine := &vmoperatortypes.VirtualMachine{}
 	vmKey := apitypes.NamespacedName{
 		Namespace: namespace,
 		Name:      vmName,
 	}
-	if err := vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
+	virtualMachine, err := utils.GetVirtualMachineAllApiVersions(ctx,
+		vmKey, vmOperatorClient)
+	if err != nil {
 		msg := fmt.Sprintf("Failed to get virtualmachine instance for the VM with name: %q. Error: %+v", vmName, err)
 		log.Error(msg)
 		return nil, err
@@ -56,7 +58,7 @@ func setInstanceOwnerRef(instance *cnsfileaccessconfigv1alpha1.CnsFileAccessConf
 	vmUID apitypes.UID) {
 	bController := true
 	bOwnerDeletion := true
-	kind := reflect.TypeOf(vmoperatortypes.VirtualMachine{}).Name()
+	kind := reflect.TypeOf(vmoperatorv1alpha3.VirtualMachine{}).Name()
 	instance.OwnerReferences = []metav1.OwnerReference{
 		{
 			APIVersion:         "v1",

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -42,8 +42,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
@@ -107,7 +107,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
-	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatortypes.GroupName)
+	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatorv1alpha3.GroupName)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to initialize vmOperatorClient. Error: %+v", err)
 		log.Error(msg)
@@ -770,10 +770,9 @@ func updateSVPVC(ctx context.Context, client client.Client,
 // isVmCrPresent checks whether VM CR is present in SV namespace
 // with given vmuuid and returns the VirtualMachine CR object if it is found
 func isVmCrPresent(ctx context.Context, vmOperatorClient client.Client,
-	vmuuid string, namespace string) (*vmoperatortypes.VirtualMachine, error) {
+	vmuuid string, namespace string) (*vmoperatorv1alpha3.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
-	vmList := &vmoperatortypes.VirtualMachineList{}
-	err := vmOperatorClient.List(ctx, vmList, client.InNamespace(namespace))
+	vmList, err := utils.GetVirtualMachineListAllApiVersions(ctx, namespace, vmOperatorClient)
 	if err != nil {
 		msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
 		log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,6 +46,7 @@ import (
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	commonconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -425,15 +426,14 @@ func validateVolumeNotInUse(ctx context.Context, cnsVol cnstypes.CnsVolume, pvcN
 		return err
 	}
 
-	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatortypes.GroupName)
+	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatorv1alpha3.GroupName)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to initialize vmOperatorClient. Error: %+v", err)
 		log.Error(msg)
 		return err
 	}
 
-	vmList := &vmoperatortypes.VirtualMachineList{}
-	err = vmOperatorClient.List(ctx, vmList, client.InNamespace(pvcNamespace))
+	vmList, err := utils.GetVirtualMachineListAllApiVersions(ctx, pvcNamespace, vmOperatorClient)
 	if err != nil {
 		msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
 		log.Error(msg)
@@ -451,7 +451,6 @@ func validateVolumeNotInUse(ctx context.Context, cnsVol cnstypes.CnsVolume, pvcN
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
+	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,6 +45,7 @@ import (
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -96,7 +97,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		log.Infof("The %s FSS is enabled in %s", common.TKGsHA, cnstypes.CnsClusterFlavorGuest)
 		restClientConfigForSupervisor :=
 			k8s.GetRestClientConfigForSupervisor(ctx, configInfo.Cfg.GC.Endpoint, configInfo.Cfg.GC.Port)
-		vmOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfigForSupervisor, vmoperatortypes.GroupName)
+		vmOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfigForSupervisor, vmoperatorv1alpha3.GroupName)
 		if err != nil {
 			log.Errorf("failed to create vmOperatorClient. Error: %+v", err)
 			return err
@@ -422,19 +423,17 @@ func (r *ReconcileCSINodeTopology) reconcileForGuest(ctx context.Context, reques
 func getNodeTopologyInfoForGuest(ctx context.Context, instance *csinodetopologyv1alpha1.CSINodeTopology,
 	vmOperatorClient client.Client, supervisorNamespace string) ([]csinodetopologyv1alpha1.TopologyLabel, error) {
 	log := logger.GetLogger(ctx)
-
-	virtualMachine := &vmoperatortypes.VirtualMachine{}
 	vmKey := types.NamespacedName{
 		Namespace: supervisorNamespace,
 		Name:      instance.Name, // use the nodeName as the VM key
 	}
-
-	var err error
-	if err = vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
+	log.Info("fetching virtual machines with all versions")
+	virtualMachine, err := utils.GetVirtualMachineAllApiVersions(
+		ctx, vmKey, vmOperatorClient)
+	if err != nil {
 		return nil, logger.LogNewErrorf(log,
 			"failed to get VirtualMachines for the node: %q. Error: %+v", instance.Name, err)
 	}
-
 	var topologyLabels []csinodetopologyv1alpha1.TopologyLabel
 	if virtualMachine.Status.Zone != "" {
 		topologyLabels = make([]csinodetopologyv1alpha1.TopologyLabel, 0)

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,6 +28,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -96,12 +96,12 @@ func GetTKGVMIP(ctx context.Context, vmOperatorClient client.Client, dc dynamic.
 	vmNamespace, vmName string, network_provider_type string) (string, error) {
 	log := logger.GetLogger(ctx)
 	log.Infof("Determining external IP Address of VM: %s/%s", vmNamespace, vmName)
-	virtualMachineInstance := &vmoperatortypes.VirtualMachine{}
 	vmKey := apitypes.NamespacedName{
 		Namespace: vmNamespace,
 		Name:      vmName,
 	}
-	err := vmOperatorClient.Get(ctx, vmKey, virtualMachineInstance)
+	virtualMachineInstance, err := utils.GetVirtualMachineAllApiVersions(ctx,
+		vmKey, vmOperatorClient)
 	if err != nil {
 		log.Errorf("failed to get virtualmachine %s/%s with error: %v", vmNamespace, vmName, err)
 		return "", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add backward compatibility for vm-operator api version v1alpha1 / v1alpha2

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
 
TRK Setup with virtual machines created with v1alpha1/v1alpah2 api version:
[vm-v1alpha1-manual-testing.log](https://github.com/user-attachments/files/19930996/vm-v1alpha1-manual-testing.log)
[vm-v1alpha1-vsphere-csi-node.log](https://github.com/user-attachments/files/19930994/vm-v1alpha1-vsphere-csi-node.log)
[vm-v1alpha1-vsphere-syncer.log](https://github.com/user-attachments/files/19930995/vm-v1alpha1-vsphere-syncer.log)
[vm-v1alpha1-vshere-csi-controller.log](https://github.com/user-attachments/files/19930997/vm-v1alpha1-vshere-csi-controller.log)


nsxt:
with virtual machines created with v1alpha3/v1alpah4 api version:
[nsxt_vm_v1alpha3_manual_testing.log](https://github.com/user-attachments/files/19931922/nsxt_vm_v1alpha3_manual_testing.log)
[nsxt_vm_v1alpha3_vsphere-syncer.log](https://github.com/user-attachments/files/19931923/nsxt_vm_v1alpha3_vsphere-syncer.log)
[nsxt_vm_v1alpha3_vsphere-csi-node.log](https://github.com/user-attachments/files/19931924/nsxt_vm_v1alpha3_vsphere-csi-node.log)
[nsxt_vm_v1alpha3_vsphere-csi-controller.log](https://github.com/user-attachments/files/19931925/nsxt_vm_v1alpha3_vsphere-csi-controller.log)


vds:
[vds_vm_v1alpha3_manual_testing.log](https://github.com/user-attachments/files/19936636/vds_vm_v1alpha3_manual_testing.log)
[vds_vm_v1alpha3_vsphere-csi-controller.log](https://github.com/user-attachments/files/19936637/vds_vm_v1alpha3_vsphere-csi-controller.log)
[vds_vm_v1alpha3_vsphere-csi-node.log](https://github.com/user-attachments/files/19936638/vds_vm_v1alpha3_vsphere-csi-node.log)
[vds_vm_v1alpha3_vsphere-syncer.log](https://github.com/user-attachments/files/19936641/vds_vm_v1alpha3_vsphere-syncer.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add backward compatibility for vm-operator api version v1alpha1
```
