### PR TITLE
Fix panic on DeletedFinalStateUnknown

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2028,8 +2028,20 @@ func topoCRUpdated(oldObj interface{}, newObj interface{}) {
 func topoCRDeleted(obj interface{}) {
 	ctx, log := logger.GetNewContextWithLogger()
 	// Verify object received.
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		if unknown.Obj == nil {
+			log.Errorf("topoCRDeleted: received empty DeletedFinalStateUnknown object, ignoring")
+			return
+		}
+		obj = unknown.Obj
+	}
+	unstruct, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		log.Errorf("topoCRDeleted: received non-unstructured object %T, ignoring", obj)
+		return
+	}
 	var nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, &nodeTopoObj)
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstruct.Object, &nodeTopoObj)
 	if err != nil {
 		log.Errorf("topoCRDeleted: failed to cast object %+v to %s type. Error: %+v",
 			obj, csinodetopology.CRDSingular, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Properly handle `DeletedFinalStateUnknown` when watching Nodes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3261

**Testing done**:
Manually, the CSI driver no longer panics when an API server node is removed.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed panic when an API server machine is removed.
```
