### PR TITLE
Fix the regression introduced in #3234

### DIFF
--- a/pkg/csi/service/driver.go
+++ b/pkg/csi/service/driver.go
@@ -147,59 +147,52 @@ func (driver *vsphereCSIDriver) BeforeServe(ctx context.Context) error {
 		return err
 	}
 
-	// If the cluster flavor is not vanilla or if `CSIInternalGeneratedClusterID` FSS is not enabled,
-	// then initialize the controller service.
-	if clusterFlavor != cnstypes.CnsClusterFlavorVanilla ||
-		!commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIInternalGeneratedClusterID) {
-		if err = driver.cnscs.Init(cfg, Version); err != nil {
-			log.Errorf("failed to init controller. Error: %+v", err)
-			return err
+	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIInternalGeneratedClusterID) {
+		CSINamespace := common.GetCSINamespace()
+		if cfg.Global.ClusterID == "" {
+			var clusterID string
+			cmData, err := commonco.ContainerOrchestratorUtility.GetConfigMap(ctx,
+				cnsconfig.ClusterIDConfigMapName, CSINamespace)
+			if err == nil {
+				// If ConfigMap for cluster ID already exists, then instead of
+				// using newly generated clusterID value, we will use the
+				// clusterID value stored in the existing immutable ConfigMap.
+				clusterID = cmData["clusterID"]
+				log.Infof("clusterID is not provided in vSphere Config Secret, "+
+					"using the clusterID %s from existing ConfigMap", clusterID)
+			} else {
+				// In case of vanilla k8s deployments, if cluster ID is not provided in the
+				// vSphere config secret, then generate an unique cluster ID internally.
+				clusterID = getNewUUID()
+				// Create the immutable ConfigMap to store cluster ID, so that it will be
+				// persisted in etcd and it can't be updated by any user.
+				configMapData := map[string]string{"clusterID": clusterID}
+
+				err := commonco.ContainerOrchestratorUtility.CreateConfigMap(ctx,
+					cnsconfig.ClusterIDConfigMapName, CSINamespace, configMapData, true)
+				if err != nil {
+					return logger.LogNewErrorf(log, "Failed to create the immutable ConfigMap, Err: %v",
+						err)
+				}
+				log.Infof("clusterID is not provided in vSphere Config Secret, "+
+					"generated a new clusterID %s", clusterID)
+			}
+			cnsconfig.GeneratedVanillaClusterID = clusterID
+			cfg.Global.ClusterID = clusterID
+		} else {
+			// If cluster ID is provided by user in vSphere config secret and immutable
+			// ConfigMap to store cluster ID also exists then kill the controller.
+			// User needs to delete the cluster ID from vSphere config secret.
+			if _, err := commonco.ContainerOrchestratorUtility.GetConfigMap(ctx,
+				cnsconfig.ClusterIDConfigMapName, CSINamespace); err == nil {
+				return logger.LogNewErrorf(log, "Cluster ID is present in vSphere Config Secret "+
+					"as well as in %s ConfigMap. Please remove the cluster ID from vSphere Config "+
+					"Secret.", cnsconfig.ClusterIDConfigMapName)
+			}
 		}
-
-		return nil
 	}
-
-	// The following code is required only for vanilla k8s deployments with `CSIInternalGeneratedClusterID` FSS enabled.
-	CSINamespace := common.GetCSINamespace()
-	cmData, err := commonco.ContainerOrchestratorUtility.GetConfigMap(ctx, cnsconfig.ClusterIDConfigMapName, CSINamespace)
-	if cfg.Global.ClusterID == "" && err == nil {
-		// If ConfigMap for cluster ID already exists, then instead of
-		// using newly generated clusterID value, we will use the
-		// clusterID value stored in the existing immutable ConfigMap.
-		clusterID := cmData["clusterID"]
-		log.Infof("clusterID is not provided in vSphere Config Secret, "+
-			"using the clusterID %s from existing ConfigMap", clusterID)
-		cnsconfig.GeneratedVanillaClusterID = clusterID
-		cfg.Global.ClusterID = clusterID
-	}
-
-	if cfg.Global.ClusterID == "" && err != nil {
-		// In case of vanilla k8s deployments, if cluster ID is not provided in the
-		// vSphere config secret, then generate an unique cluster ID internally.
-		clusterID := getNewUUID()
-		// Create the immutable ConfigMap to store cluster ID, so that it will be
-		// persisted in etcd and it can't be updated by any user.
-		configMapData := map[string]string{"clusterID": clusterID}
-
-		err := commonco.ContainerOrchestratorUtility.CreateConfigMap(ctx,
-			cnsconfig.ClusterIDConfigMapName, CSINamespace, configMapData, true)
-		if err != nil {
-			return logger.LogNewErrorf(log, "Failed to create the immutable ConfigMap, Err: %v",
-				err)
-		}
-		log.Infof("clusterID is not provided in vSphere Config Secret, "+
-			"generated a new clusterID %s", clusterID)
-		cnsconfig.GeneratedVanillaClusterID = clusterID
-		cfg.Global.ClusterID = clusterID
-	}
-
-	if cfg.Global.ClusterID != "" && err == nil {
-		return logger.LogNewErrorf(log, "Cluster ID is present in vSphere Config Secret "+
-			"as well as in %s ConfigMap. Please remove the cluster ID from vSphere Config "+
-			"Secret.", cnsconfig.ClusterIDConfigMapName)
-	}
-
-	if err = driver.cnscs.Init(cfg, Version); err != nil {
+	if err := driver.cnscs.Init(cfg, Version); err != nil {
 		log.Errorf("failed to init controller. Error: %+v", err)
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of #3234, I refactored the BeforeServe method which introduced a regression in Vanilla deployments which is causing the CSI controller to stay stuck in CLBO -

```
root@k8s-control-157-1745853912:~# kubectl -n vmware-system-csi get pods
NAME                                      READY   STATUS             RESTARTS          AGE
vsphere-csi-controller-7bffffc495-24995   2/7     CrashLoopBackOff   2167 (82s ago)    38h
vsphere-csi-controller-7bffffc495-jg767   2/7     CrashLoopBackOff   178 (3m21s ago)   179m
vsphere-csi-controller-7bffffc495-kvzhm   2/7     CrashLoopBackOff   97 (3m47s ago)    86m
vsphere-csi-node-2h82g                    3/3     Running            10 (3h59m ago)    38h
vsphere-csi-node-9x2c5                    3/3     Running            13 (9h ago)       38h
vsphere-csi-node-b4jbd                    3/3     Running            7 (108m ago)      38h
vsphere-csi-node-d82x7                    3/3     Running            8 (29h ago)       38h
vsphere-csi-node-fmqrh                    3/3     Running            12 (13h ago)      38h
vsphere-csi-node-md486                    3/3     Running            11 (21h ago)      38h
vsphere-csi-node-sbmbt                    3/3     Running            1 (38h ago)       38h
vsphere-csi-node-vld5b                    3/3     Running            1 (38h ago)       38h
vsphere-csi-node-zcf62                    3/3     Running            11 (13h ago)      38h
vsphere-csi-node-zzdd8                    3/3     Running            17 (4h33m ago)    38h
```

The `vsphere-csi-controller` containers contain the following error -

```
2025-04-30T06:40:23.720Z	ERROR	service/driver.go:217	failed to run the driver. Err: +Cluster ID is present in vSphere Config Secret as well as in vsphere-csi-cluster-id ConfigMap. Please remove the cluster ID from vSphere Config Secret.	{"TraceId": "a558d9ac-e873-417c-a836-c15847c7f6a4"}
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service.(*vsphereCSIDriver).Run
	/build/pkg/csi/service/driver.go:217
main.main
	/build/cmd/vsphere-csi/main.go:96
runtime.main
	/usr/local/go/src/runtime/proc.go:271
```
The regression is due to the way `cfg.Global.ClusterID` is updated ([here](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/c853b84330a9758845238ea4bc7934c2a0f9a0d9/pkg/csi/service/driver.go#L173) and [here](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/c853b84330a9758845238ea4bc7934c2a0f9a0d9/pkg/csi/service/driver.go#L193)) and subsequently checked [here](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/c853b84330a9758845238ea4bc7934c2a0f9a0d9/pkg/csi/service/driver.go#L196).

This MR reverts the refactoring changes introduced.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes regression introduced in #3234 

**Testing done**:
Verified that the CSI controller pods have been stable after applying the fix.

```
root@k8s-control-157-1745853912:~# alias kcsi='kubectl -n vmware-system-csi'
root@k8s-control-157-1745853912:~# kcsi get pods
NAME                                      READY   STATUS    RESTARTS         AGE
vsphere-csi-controller-69569bf449-992b9   7/7     Running   1 (11m ago)      77m
vsphere-csi-controller-69569bf449-9bcck   7/7     Running   1 (16m ago)      77m
vsphere-csi-controller-69569bf449-qw6mw   7/7     Running   5 (44m ago)      77m
vsphere-csi-node-2h82g                    3/3     Running   10 (6h3m ago)    40h
vsphere-csi-node-9x2c5                    3/3     Running   13 (11h ago)     40h
vsphere-csi-node-b4jbd                    3/3     Running   10 (119m ago)    40h
vsphere-csi-node-d82x7                    3/3     Running   8 (31h ago)      40h
vsphere-csi-node-fmqrh                    3/3     Running   12 (15h ago)     40h
vsphere-csi-node-md486                    3/3     Running   11 (23h ago)     40h
vsphere-csi-node-sbmbt                    3/3     Running   1 (40h ago)      40h
vsphere-csi-node-vld5b                    3/3     Running   1 (40h ago)      40h
vsphere-csi-node-zcf62                    3/3     Running   11 (15h ago)     40h
vsphere-csi-node-zzdd8                    3/3     Running   17 (6h37m ago)   40h
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
