### PR TITLE
fullsync fix: Fix Syncer panics due to incorrect PVC configuration

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1460,7 +1460,7 @@ func fetchPVs(ctx context.Context, metadataSyncer *metadataSyncInformer) (map[st
 
 	volumeMap := make(map[string]*v1.PersistentVolume)
 	for _, pv := range pvList {
-		if pv.Status.Phase != v1.VolumePending {
+		if pv.Spec.ClaimRef != nil && pv.Status.Phase != v1.VolumePending {
 			volumeMap[pv.Spec.ClaimRef.Name] = pv
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix Syncer panics with NPE due to nil claimreference for PVC 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing Performed
[full-sync-nil-claimref-manual-testing.log](https://github.com/user-attachments/files/20184692/full-sync-nil-claimref-manual-testing.log)
[fullsync-nil-claimref-vsphere-syncer.log](https://github.com/user-attachments/files/20184698/fullsync-nil-claimref-vsphere-syncer.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix Syncer panics due to incorrect PVC configuration
```
