### PR TITLE
Cherry pick: Update pvc lable in case tanzukubernetescluster-uid is changed (#3271)

### DIFF
--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -431,7 +431,7 @@ func setGuestClusterDetailsOnSupervisorPVC(ctx context.Context, metadataSyncer *
 			// Add label to Supervisor PVC that contains guest cluster details, if not present already.
 			key := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
 				metadataSyncer.configInfo.Cfg.GC.ClusterDistribution)
-			if _, ok := svPVC.Labels[key]; !ok {
+			if val, ok := svPVC.Labels[key]; !ok || val != metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID {
 				if svPVC.Labels == nil {
 					svPVC.Labels = make(map[string]string)
 				}
@@ -523,7 +523,7 @@ func setGuestClusterDetailsOnSupervisorSnapshot(ctx context.Context, metadataSyn
 			tkcLabelPresent := true
 			key := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
 				metadataSyncer.configInfo.Cfg.GC.ClusterDistribution)
-			if _, ok := svVS.Labels[key]; !ok {
+			if val, ok := svVS.Labels[key]; !ok || val != metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID {
 				if svVS.Labels == nil {
 					svVS.Labels = make(map[string]string)
 				}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry pick 61ae9779e4267a96aa0ff245d50aca098746df15

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
NA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
cherrypick to release-3.5
```
