### PR TITLE
CSI sidecar bump up

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -240,7 +240,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -259,7 +259,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -330,7 +330,7 @@ spec:
             periodSeconds: 180
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -448,7 +448,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -531,7 +531,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -599,7 +599,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
           command:
             - "csi-node-driver-registrar.exe"
           args:
@@ -671,7 +671,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
           command:
             - "livenessprobe.exe"
           args:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PR bumps up the following sidecars to their latest versions:
csi-attacher - v4.8.1
csi-resizer - v1.13.2
csi-livenessprobe - v2.15.0
csi-node-registrar - v2.13.0

**Testing**:

Verified volume creation, pod creation
```
# kubectl get pvc
NAME              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
example-rwo-pvc   Bound    pvc-db68622f-bab7-41c8-af13-2149990664d1   1Gi        RWO            sc-mdwrk       <unset>                 4m7s
root@k8s-control-933-1747789014:/tmp# kubectl describe pod
Name:             example-block-pod
Namespace:        default
Priority:         0
Service Account:  default
Node:             k8s-node-717/10.192.70.177
Start Time:       Thu, 22 May 2025 17:52:21 +0000
Labels:           <none>
Annotations:      <none>
Status:           Pending
IP:               10.244.4.3
IPs:
  IP:  10.244.4.3
Containers:
  test-container:
    Container ID:  
    Image:         gcr.io/google_containers/busybox:1.24
    Image ID:      
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
      -c
      echo 'hello' > /mnt/volume1/index.html  && chmod o+rX /mnt /mnt/volume1/index.html && while true ; do sleep 2 ; done
    State:          Waiting
      Reason:       CreateContainerError
    Ready:          False
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /mnt/volume1 from test-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-j867j (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True 
  Initialized                 True 
  Ready                       False 
  ContainersReady             False 
  PodScheduled                True 
Volumes:
  test-volume:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  example-rwo-pvc
    ReadOnly:   false
  kube-api-access-j867j:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason                  Age                From                     Message
  ----     ------                  ----               ----                     -------
  Normal   Scheduled               91s                default-scheduler        Successfully assigned default/example-block-pod to k8s-node-717
  Normal   SuccessfulAttachVolume  87s                attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-db68622f-bab7-41c8-af13-2149990664d1"
  Normal   Pulling                 58s                kubelet                  Pulling image "gcr.io/google_containers/busybox:1.24"
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
CSI sidecar bump up
```
