### PR TITLE
set securityContext for all containers in cns-csi controller pod

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -296,6 +296,10 @@ spec:
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
               value: vmware-system-appplatform-operator-system
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -320,6 +324,10 @@ spec:
             - name: KUBERNETES_SERVICE_PORT
               value: "6443"
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -389,8 +397,8 @@ spec:
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -403,6 +411,10 @@ spec:
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.14.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -444,8 +456,8 @@ spec:
               protocol: TCP
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -466,6 +478,10 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -724,8 +740,8 @@ spec:
                   fieldPath: metadata.namespace
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -299,6 +299,10 @@ spec:
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
               value: vmware-system-appplatform-operator-system
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -323,6 +327,10 @@ spec:
             - name: KUBERNETES_SERVICE_PORT
               value: "6443"
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -346,6 +354,10 @@ spec:
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -392,8 +404,8 @@ spec:
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -406,6 +418,10 @@ spec:
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.14.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -447,8 +463,8 @@ spec:
               protocol: TCP
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -469,6 +485,10 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -764,8 +784,8 @@ spec:
                   fieldPath: metadata.namespace
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -299,6 +299,10 @@ spec:
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
               value: vmware-system-appplatform-operator-system
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -323,6 +327,10 @@ spec:
             - name: KUBERNETES_SERVICE_PORT
               value: "6443"
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -346,6 +354,10 @@ spec:
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -392,8 +404,8 @@ spec:
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -406,6 +418,10 @@ spec:
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.14.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -447,8 +463,8 @@ spec:
               protocol: TCP
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -469,6 +485,10 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -764,8 +784,8 @@ spec:
                   fieldPath: metadata.namespace
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65533
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is adding securityContext to all containers of CNS-CSI controller.
Only CSI controller and Syncer container was having securityContext with runAsNonRoot. We need need to make sure all containers in the Pod has securityContext with runAsNonRoot.


**Testing done**:
Verified Creating PVC/PV to confirm sidecar container can communicate with CSI controller container using CSI socket created using user:group nobody: nogroup


```
nobody [ /csi ]$ ls -la
total 8
drwxrwxrwx 2 root   root    4096 May 16 22:29 .
drwxr-xr-x 1 root   root    4096 May 16 22:29 ..
srwxr-xr-x 1 nobody nogroup    0 May 16 22:29 csi.sock
nobody [ /csi ]$ 
```


Verified updating vSphere config secret to confirm CSI controller and CSI syncer is able to observe change and is properly reloading configurations.

```
{"level":"info","time":"2025-05-16T23:23:02.544631452Z","caller":"manager/init.go:409","msg":"Reloading Configuration","TraceId":"898b382f-981c-4adb-8885-335d2e861b29"}
{"level":"info","time":"2025-05-16T23:23:02.54640442Z","caller":"syncer/metadatasyncer.go:2114","msg":"Reloading Configuration","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.547163225Z","caller":"manager/init.go:445","msg":"Reloaded the value for CnsRegisterVolumesCleanupIntervalInMin to 720","TraceId":"898b382f-981c-4adb-8885-335d2e861b29"}
{"level":"info","time":"2025-05-16T23:23:02.547227558Z","caller":"manager/init.go:414","msg":"Successfully reloaded configuration from: \"/etc/vmware/wcp/vsphere-cloud-provider.conf\"","TraceId":"898b382f-981c-4adb-8885-335d2e861b29"}
{"level":"info","time":"2025-05-16T23:23:02.550750803Z","caller":"volume/manager.go:365","msg":"Re-initializing defaultManager.virtualCenter","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.550998078Z","caller":"volume/listview.go:147","msg":"attempting to acquire lock before updating vc object","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.551312466Z","caller":"volume/listview.go:150","msg":"acquired lock before updating vc object","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.552524016Z","caller":"volume/listview.go:152","msg":"updated VirtualCenter object reference in ListView","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.552558473Z","caller":"volume/manager.go:368","msg":"Done resetting volume.defaultManager","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.552567116Z","caller":"volume/manager.go:252","msg":"Retrieving existing defaultManager...","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.558765995Z","caller":"storagepool/service.go:192","msg":"Resetting VC connection in StoragePool service","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.558930738Z","caller":"storagepool/service.go:221","msg":"Successfully reset VC connection in StoragePool service","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.558952619Z","caller":"syncer/metadatasyncer.go:2281","msg":"updated metadataSyncer.configInfo","TraceId":"b8842591-0725-47e8-8edd-92dfcadddff7"}
{"level":"info","time":"2025-05-16T23:23:02.558973444Z","caller":"syncer/metadatasyncer.go:591","msg":"Successfully reloaded configuration from: \"/etc/vmware/wcp/vsphere-cloud-provider.conf\"","TraceId":"aa3128c6-e79d-4b7a-bc3f-bac2dd81b21a"}
```





**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set securityContext for all containers in cns-csi controller pod
```
