### PR TITLE
vanilla test fix for k8s upgrade 1.33

### DIFF
--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -842,7 +842,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 		ginkgo.By("create a new pod pod2, using pvc1")
 		pod2, err := createPod(ctx, client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, execCommand)
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := fpod.DeletePodWithWait(ctx, client, pod2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/operationstorm.go
+++ b/tests/e2e/operationstorm.go
@@ -334,7 +334,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Vo
 		err = client.CoreV1().Namespaces().Delete(ctx, namespace, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		err = waitForNamespaceToGetDeleted(ctx, client, namespace, pollTimeout, k8sPodTerminationTimeOutLong)
+		err = waitForNamespaceToGetDeleted(ctx, client, namespace, healthStatusPollInterval, k8sPodTerminationTimeOutLong)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify the volumes are deleted from CNS")

--- a/tests/e2e/storagepolicy.go
+++ b/tests/e2e/storagepolicy.go
@@ -54,8 +54,7 @@ import (
 // 7. Delete pod and Wait for Volume Disk to be detached from the Node.
 // 8. Delete PVC, PV and Storage Class.
 
-var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
-	"Storage Policy Based Volume Provisioning", func() {
+var _ = ginkgo.Describe("Storage Policy Based Volume Provisioning", func() {
 
 	f := framework.NewDefaultFramework("e2e-spbm-policy")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
@@ -91,8 +90,9 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 		}
 	})
 
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify dynamic volume provisioning works "+
-		"when storage policy specified in the storageclass is compliant for shared datastores", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] [csi-supervisor] [csi-guest] Verify dynamic "+
+		"volume provisioning works when storage policy specified in the storageclass "+
+		"is compliant for shared datastores", func() {
 		storagePolicyNameForSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 		ginkgo.By(fmt.Sprintf("Invoking test for storage policy: %s", storagePolicyNameForSharedDatastores))
 		scParameters := make(map[string]string)
@@ -115,8 +115,9 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 			namespace, scParameters, storagePolicyNameForSharedDatastores)
 	})
 
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify dynamic volume provisioning fails "+
-		"when storage policy specified in the storageclass is compliant for non-shared datastores", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] [csi-supervisor] [csi-guest] Verify dynamic "+
+		"volume provisioning fails when storage policy specified in the storageclass is compliant "+
+		"for non-shared datastores", func() {
 		storagePolicyNameForNonSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForNonSharedDatastores)
 		ginkgo.By(fmt.Sprintf("Invoking test for storage policy: %s", storagePolicyNameForNonSharedDatastores))
 		scParameters := make(map[string]string)
@@ -163,8 +164,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 
 	})
 
-	ginkgo.It("Verify non-existing SPBM policy is not honored for dynamic volume provisioning "+
-		"using storageclass", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify non-existing SPBM policy is not honored "+
+		"for dynamic volume provisioning using storageclass", func() {
 		ginkgo.By(fmt.Sprintf("Invoking test for SPBM policy: %s", f.Namespace.Name))
 		scParameters := make(map[string]string)
 		scParameters[scParamStoragePolicyName] = f.Namespace.Name

--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
@@ -278,7 +279,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 
 		// Check Pod status after recreating Storage class with different binding mode
 		ginkgo.By("Verify Pod status after recreating Storage class with different binding mode")
-		pod_status := fpod.VerifyPodsRunning(ctx, client, namespace, pod.Name, nil, true, 0)
+		pod_status := fpod.VerifyPodsRunning(ctx, client, namespace, pod.Name,
+			labels.SelectorFromSet(map[string]string{"name": pod.Name}), true, 0)
 		if pod.Status.Phase == v1.PodRunning {
 			framework.Logf("Pod is in Running state after recreating Storage Class")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Vanilla test fix for k8s upgrade 1.33
Polling added for namespace deletion tests
Ginkgo Label fix for vanilla in storagepolicy tests

**Testing done**:
YES
https://gist.github.com/rajguptavm/e265772ba19976944516edddbb2f4b3b

@rpanduranga @sipriyaa Please review it.
