### PR TITLE
Fixed reading vCenter IP address for topology preferential setup in an isolated nimbus testbed env

### DIFF
--- a/tests/e2e/preferential_topology_utils.go
+++ b/tests/e2e/preferential_topology_utils.go
@@ -44,7 +44,7 @@ func govcLoginCmd() string {
 	loginCmd := "export GOVC_INSECURE=1;"
 	loginCmd += fmt.Sprintf("export GOVC_URL='https://%s:%s@%s:%s';",
 		e2eVSphere.Config.Global.User, e2eVSphere.Config.Global.Password,
-		e2eVSphere.Config.Global.VCenterHostname, defaultVcAdminPortNum)
+		vcAddress, defaultVcAdminPortNum)
 	return loginCmd
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed reading vCenter address for running govc command in topology usecases for isolated testbed environment for topology preferential setup.

**Testing done**:
Yes
[testlogs.txt](https://github.com/user-attachments/files/20515421/testlogs.txt)


**Special notes for your reviewer**:
ps031044@P2XQC4DXP0 vsphere-csi-driver % golangci-lint run --enable=lll
ps031044@P2XQC4DXP0 vsphere-csi-driver % 

