### PR TITLE
Enhance CNS Unregister Volume API to refer to K8s metadata instead of CNS metadata

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -351,6 +351,11 @@ func (c *FakeK8SOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string,
 	return "", false
 }
 
+// GetPVCNameFromCSIVolumeID retrieves the pvc name from volumeID.
+func (c *FakeK8SOrchestrator) GetPVCNameFromCSIVolumeID(volumeID string) (string, bool) {
+	return "", false
+}
+
 // InitializeCSINodes creates CSINode instances for each K8s node with the appropriate topology keys.
 func (c *FakeK8SOrchestrator) InitializeCSINodes(ctx context.Context) error {
 	return nil

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -93,6 +93,8 @@ type COCommonInterface interface {
 	// GetPVNameFromCSIVolumeID retrieves the pv name from the volumeID.
 	// This method will not return pv name in case of in-tree migrated volumes
 	GetPVNameFromCSIVolumeID(volumeID string) (string, bool)
+	// GetPVCNameFromCSIVolumeID returns PV claim name for the volume ID
+	GetPVCNameFromCSIVolumeID(volumeID string) (string, bool)
 	// InitializeCSINodes creates CSINode instances for each K8s node with the appropriate topology keys.
 	InitializeCSINodes(ctx context.Context) error
 	// StartZonesInformer starts a dynamic informer which listens on Zones CR in

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -107,10 +107,11 @@ func (m *volumeIDToPvcMap) remove(volumeHandle string) {
 }
 
 // Returns the namespaced pvc name corresponding to volumeHandle.
-func (m *volumeIDToPvcMap) get(volumeHandle string) string {
+func (m *volumeIDToPvcMap) get(volumeHandle string) (string, bool) {
 	m.RLock()
 	defer m.RUnlock()
-	return m.items[volumeHandle]
+	pvcname, found := m.items[volumeHandle]
+	return pvcname, found
 }
 
 // Map of the volumeName which refers to the PVName, to the list of node names in the cluster.
@@ -1791,4 +1792,9 @@ func (c *K8sOrchestrator) CreateConfigMap(ctx context.Context, name string, name
 // GetPVNameFromCSIVolumeID retrieves the pv name from volumeID using volumeIDToNameMap.
 func (c *K8sOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string, bool) {
 	return c.volumeIDToNameMap.get(volumeID)
+}
+
+// GetPVCNameFromCSIVolumeID retrieves the pvc name from volumeID using volumeIDToPvcMap.
+func (c *K8sOrchestrator) GetPVCNameFromCSIVolumeID(volumeID string) (string, bool) {
+	return c.volumeIDToPvcMap.get(volumeID)
 }

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_helper.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_helper.go
@@ -39,7 +39,7 @@ import (
 func (c *K8sOrchestrator) getPVCAnnotations(ctx context.Context, volumeID string) (map[string]string, error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("Getting annotations on pvc corresponding to volume: %s", volumeID)
-	if pvc := c.volumeIDToPvcMap.get(volumeID); pvc != "" {
+	if pvc, _ := c.volumeIDToPvcMap.get(volumeID); pvc != "" {
 		parts := strings.Split(pvc, "/")
 		pvcNamespace := parts[0]
 		pvcName := parts[1]
@@ -67,7 +67,7 @@ func (c *K8sOrchestrator) getPVCAnnotations(ctx context.Context, volumeID string
 func (c *K8sOrchestrator) updatePVCAnnotations(ctx context.Context,
 	volumeID string, annotations map[string]string) error {
 	log := logger.GetLogger(ctx)
-	if pvc := c.volumeIDToPvcMap.get(volumeID); pvc != "" {
+	if pvc, _ := c.volumeIDToPvcMap.get(volumeID); pvc != "" {
 		parts := strings.Split(pvc, "/")
 		pvcNamespace := parts[0]
 		pvcName := parts[1]

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
@@ -19,6 +19,7 @@ package cnsunregistervolume
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,7 +57,6 @@ import (
 
 const (
 	defaultMaxWorkerThreadsForUnregisterVolume = 40
-	metadata                                   = "VOLUME_METADATA"
 )
 
 var (
@@ -212,57 +212,23 @@ func (r *ReconcileCnsUnregisterVolume) Reconcile(ctx context.Context,
 	// 5. Invoke CNS DeleteVolume API with deleteDisk set to false.
 	// 6. Set the CnsUnregisterVolumeStatus.Unregistered to true.
 
-	// TODO - Add validations whether the volume is not in use in a TKC or by a VM service VM.
-
-	queryFilter := cnstypes.CnsQueryFilter{
-		VolumeIds: []cnstypes.CnsVolumeId{{Id: instance.Spec.VolumeID}},
-	}
-	querySelection := cnstypes.CnsQuerySelection{
-		Names: []string{
-			metadata,
-		},
-	}
-
-	queryResult, err := r.volumeManager.QueryVolumeAsync(ctx, queryFilter, &querySelection)
-	if err != nil {
-		msg := fmt.Sprintf("Unable to query volume %q . Error: %+v", instance.Spec.VolumeID, err)
-		log.Error(msg)
-		setInstanceError(ctx, r, instance, msg)
-		return reconcile.Result{RequeueAfter: timeout}, nil
-	}
-	if len(queryResult.Volumes) == 0 {
-		msg := fmt.Sprintf("Volume: %q not found while querying CNS. It may have already been unregistered.",
-			instance.Spec.VolumeID)
-		err = setInstanceSuccess(ctx, r, instance, msg)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to update CnsUnregistered instance with error: %+v", err)
-			log.Error(msg)
-			setInstanceError(ctx, r, instance, msg)
-			return reconcile.Result{RequeueAfter: timeout}, nil
-		}
-		backOffDurationMapMutex.Lock()
-		delete(backOffDuration, instance.Name)
-		backOffDurationMapMutex.Unlock()
-		log.Info(msg)
-		return reconcile.Result{}, nil
-	}
-
-	cnsVol := queryResult.Volumes[0]
-
 	var pvName, pvcName, pvcNamespace string
-	for _, entity := range cnsVol.Metadata.EntityMetadata {
-		if k8sEntityMetadata, ok := entity.(*cnstypes.CnsKubernetesEntityMetadata); ok {
-			entityType := k8sEntityMetadata.EntityType
-
-			if entityType == string(cnstypes.CnsKubernetesEntityTypePV) {
-				pvName = entity.(*cnstypes.CnsKubernetesEntityMetadata).EntityName
-			}
-
-			if entityType == string(cnstypes.CnsKubernetesEntityTypePVC) {
-				pvcName = entity.(*cnstypes.CnsKubernetesEntityMetadata).EntityName
-				pvcNamespace = entity.(*cnstypes.CnsKubernetesEntityMetadata).Namespace
-			}
+	pvName, pvfound := commonco.ContainerOrchestratorUtility.GetPVNameFromCSIVolumeID(instance.Spec.VolumeID)
+	if pvfound {
+		log.Infof("found PV: %q for the volumd Id: %q", pvName, instance.Spec.VolumeID)
+		pvcNamewithNamespace, pvcfound := commonco.ContainerOrchestratorUtility.
+			GetPVCNameFromCSIVolumeID(instance.Spec.VolumeID)
+		if pvcfound {
+			parts := strings.Split(pvcNamewithNamespace, "/")
+			pvcNamespace = parts[0]
+			pvcName = parts[1]
+			log.Infof("found PVC: %q in the namespace:%q for the volumd Id: %q", pvcName, pvcNamespace,
+				instance.Spec.VolumeID)
+		} else {
+			log.Infof("cound not find PVC for the volume Id: %q", instance.Spec.VolumeID)
 		}
+	} else {
+		log.Infof("cound not find PV for the volume Id: %q", instance.Spec.VolumeID)
 	}
 
 	k8sclient, err := k8s.NewClient(ctx)
@@ -272,8 +238,9 @@ func (r *ReconcileCnsUnregisterVolume) Reconcile(ctx context.Context,
 		setInstanceError(ctx, r, instance, "Failed to init K8S client for volume unregistration")
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
-
-	err = validateVolumeNotInUse(ctx, cnsVol, pvcName, pvcNamespace, k8sclient)
+	// TODO - Add validations whether the volume is not in use in a TKC
+	// validateVolumeNotInUse does not check if detached PVC/PV in TKC, having reference to supervisor PVC/PV
+	err = validateVolumeNotInUse(ctx, instance.Spec.VolumeID, pvcName, pvcNamespace, k8sclient)
 	if err != nil {
 		log.Error(err)
 		setInstanceError(ctx, r, instance, err.Error())
@@ -302,9 +269,6 @@ func (r *ReconcileCnsUnregisterVolume) Reconcile(ctx context.Context,
 			}
 			log.Infof("Updated ReclaimPolicy on PV %q to %q", pvName, v1.PersistentVolumeReclaimRetain)
 		}
-	} else {
-		log.Infof("CNS metadata for volume %s has missing pvName."+
-			"PV may have already been deleted. Continuing with other operations..", instance.Spec.VolumeID)
 	}
 
 	// Delete PVC.
@@ -323,9 +287,6 @@ func (r *ReconcileCnsUnregisterVolume) Reconcile(ctx context.Context,
 		} else {
 			log.Infof("Deleted PVC %q in namespace %q", pvcName, pvcNamespace)
 		}
-	} else {
-		log.Infof("CNS metadata for volume %s has missing pvcName or namespace."+
-			"PVC may have already been deleted. Continuing with other operations..", instance.Spec.VolumeID)
 	}
 
 	if pvName != "" {
@@ -378,7 +339,7 @@ func (r *ReconcileCnsUnregisterVolume) Reconcile(ctx context.Context,
 
 // validateVolumeNotInUse validates whether the volume to be unregistered is not in use by
 // either PodVM, TKG cluster or Volume service VM.
-func validateVolumeNotInUse(ctx context.Context, cnsVol cnstypes.CnsVolume, pvcName string,
+func validateVolumeNotInUse(ctx context.Context, volumeID string, pvcName string,
 	pvcNamespace string, k8sClient clientset.Interface) error {
 
 	log := logger.GetLogger(ctx)
@@ -395,30 +356,14 @@ func validateVolumeNotInUse(ctx context.Context, cnsVol cnstypes.CnsVolume, pvcN
 		for _, podVol := range pod.Spec.Volumes {
 			if podVol.PersistentVolumeClaim != nil &&
 				podVol.PersistentVolumeClaim.ClaimName == pvcName {
-				log.Debugf("Volume %s is in use by pod %s in namespace %s", cnsVol.VolumeId.Id,
+				log.Debugf("Volume %s is in use by pod %s in namespace %s", volumeID,
 					pod.Name, pvcNamespace)
 				return fmt.Errorf("cannot unregister the volume %s as it's in use by pod %s in namespace %s",
-					cnsVol.VolumeId.Id, pod.Name, pvcNamespace)
+					volumeID, pod.Name, pvcNamespace)
 			}
 		}
 	}
 
-	// Check if the Supervisor volume is not used in any TKGs cluster.
-	// For volumes created from TKGs Cluster, CNS metadata will have two entries for containerClusterArray.
-	// One for clusterFlavor: "WORKLOAD" & clusterDistribution "SupervisorCluster",
-	// another for clusterFlavor: "GUEST_CLUSTER" & clusterDistribution: "TKGService".
-	for _, containerCluster := range cnsVol.Metadata.ContainerClusterArray {
-		if containerCluster.ClusterFlavor == "GUEST_CLUSTER" {
-			log.Debugf("Volume %s is in use by guest cluster with CNS clusterId %s", cnsVol.VolumeId.Id,
-				containerCluster.ClusterId)
-			return fmt.Errorf("cannot unregister the volume %s as it's in use by guest cluster with CNS clusterId %s",
-				cnsVol.VolumeId.Id, containerCluster.ClusterId)
-		}
-	}
-
-	// Check if the Supervisor volume is not used by a volume service VM.
-	// If the volume is specified in the VirtualMachine's spec, then it intends
-	// to be attached to the VM. We will check for the presence of volume in VM's spec.
 	restClientConfig, err := k8s.GetKubeConfig(ctx)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to initialize rest clientconfig. Error: %+v", err)
@@ -440,17 +385,24 @@ func validateVolumeNotInUse(ctx context.Context, cnsVol cnstypes.CnsVolume, pvcN
 		return err
 	}
 
+	log.Debugf("Found %d VirtualMachines in namespace %s", len(vmList.Items), pvcNamespace)
 	for _, vmInstance := range vmList.Items {
+		log.Debugf("Checking if volume %s is in use by VirtualMachine %s in namespace %s",
+			volumeID, vmInstance.Name, pvcNamespace)
 		for _, vmVol := range vmInstance.Spec.Volumes {
 			if vmVol.PersistentVolumeClaim != nil &&
 				vmVol.PersistentVolumeClaim.ClaimName == pvcName {
-				log.Debugf("Volume %s is in use by VirtualMachine %s in namespace %s", cnsVol.VolumeId.Id,
+				// If the volume is specified in the VirtualMachine's spec, then it is
+				// either, in the process of being attached to the VM or is already attached.
+				// In either case, we cannot unregister the volume.
+				log.Debugf("Volume %s is in use by VirtualMachine %s in namespace %s", volumeID,
 					vmInstance.Name, pvcNamespace)
 				return fmt.Errorf("cannot unregister the volume %s as it's in use by VirtualMachine %s in namespace %s",
-					cnsVol.VolumeId.Id, vmInstance.Name, pvcNamespace)
+					volumeID, vmInstance.Name, pvcNamespace)
 			}
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Enhances CNS Unregister Volume functionality by removing the dependency on the less reliable `cns volume metadata` and using the kubernetes cluster as the source of truth.

**Testing done**:
<details><summary>Environment</summary>
<p>

- VMware vCenter Server
- Release: 9.1.0.0
- Version: 9.1.0.0
- Build: 85717360
- Type: vCenter Server with an embedded Platform Services Controller
- Supervisor - v1.30.10+vmware.1-fips-vsc9.0.0.0-24719998

</p>
</details> 
<details><summary>When volume is unused</summary>

```
{"level":"info","time":"2025-05-27T08:44:41.729993926Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"unregister-unused-vol\" from namespace \"default\". timeout \"1s\" seconds"}
{"level":"info","time":"2025-05-27T08:44:41.730211139Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-dc369d5e-1847-4852-837d-66dcd0c8e9b0\" for the volumd Id: \"f7766c13-e8a0-4f06-8a0f-04d571c82455\""}
{"level":"info","time":"2025-05-27T08:44:41.730384202Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"unused-pvc\" in the namespace:\"unused-vol\" for the volumd Id: \"f7766c13-e8a0-4f06-8a0f-04d571c82455\""}
{"level":"info","time":"2025-05-27T08:44:41.780792112Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:269","msg":"Updated ReclaimPolicy on PV \"pvc-dc369d5e-1847-4852-837d-66dcd0c8e9b0\" to \"Retain\""}
{"level":"info","time":"2025-05-27T08:44:41.834154967Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:287","msg":"Deleted PVC \"unused-pvc\" in namespace \"unused-vol\""}
{"level":"info","time":"2025-05-27T08:44:41.847664247Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:304","msg":"Deleted PV \"pvc-dc369d5e-1847-4852-837d-66dcd0c8e9b0\""}
{"level":"info","time":"2025-05-27T08:44:42.332753073Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:320","msg":"Deleted CNS volume \"f7766c13-e8a0-4f06-8a0f-04d571c82455\" with deleteDisk set to false"}
{"level":"info","time":"2025-05-27T08:44:42.344265955Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:335","msg":"Successfully unregistered the volume on namespace: default"}
```

**Result:** volume got unregistered successfully

</details> 
<details><summary>When volume is in use by a pod</summary>
<p>

```
{"level":"info","time":"2025-05-27T08:53:38.733115608Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"unregister-vol-used-by-pod\" from namespace \"default\". timeout \"32s\" seconds"}
{"level":"info","time":"2025-05-27T08:53:38.733205067Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-683be09c-11c7-4ca2-acae-a5a322a6f2c7\" for the volumd Id: \"9c17e37b-0598-4cb3-a087-58af7a5e7ea5\""}
{"level":"info","time":"2025-05-27T08:53:38.733222435Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"vol-used-by-pod\" in the namespace:\"pod\" for the volumd Id: \"9c17e37b-0598-4cb3-a087-58af7a5e7ea5\""}
{"level":"error","time":"2025-05-27T08:53:38.74408916Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:244","msg":"cannot unregister the volume 9c17e37b-0598-4cb3-a087-58af7a5e7ea5 as it's in use by pod pod in namespace pod","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:244\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
{"level":"info","time":"2025-05-27T08:54:10.754676608Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"unregister-vol-used-by-pod\" from namespace \"default\". timeout \"1m4s\" seconds"}
{"level":"info","time":"2025-05-27T08:54:10.754810877Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-683be09c-11c7-4ca2-acae-a5a322a6f2c7\" for the volumd Id: \"9c17e37b-0598-4cb3-a087-58af7a5e7ea5\""}
{"level":"info","time":"2025-05-27T08:54:10.754845035Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"vol-used-by-pod\" in the namespace:\"pod\" for the volumd Id: \"9c17e37b-0598-4cb3-a087-58af7a5e7ea5\""}
{"level":"error","time":"2025-05-27T08:54:10.764394367Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:244","msg":"cannot unregister the volume 9c17e37b-0598-4cb3-a087-58af7a5e7ea5 as it's in use by pod pod in namespace pod","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:244\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
```

**Result:** unregistration failed successfully
</p>
</details> 
<details><summary>When volume is in use by a VM</summary>
<p>

```
{"level":"info","time":"2025-05-27T08:23:11.240141831Z","caller":"manager/init.go:190","msg":"Creating \"cnsunregistervolumes\" CRD","TraceId":"56bc153d-40dc-4898-b8e4-98e8d5514d7d"}
{"level":"info","time":"2025-05-27T08:23:11.270648747Z","caller":"kubernetes/kubernetes.go:515","msg":"\"cnsunregistervolumes.cns.vmware.com\" CRD created successfully","TraceId":"56bc153d-40dc-4898-b8e4-98e8d5514d7d"}
{"level":"info","time":"2025-05-27T08:23:16.290268958Z","caller":"manager/init.go:197","msg":"\"cnsunregistervolumes\" CRD is created successfully","TraceId":"239dc0d3-bea9-4266-937f-05c89206c23b"}
{"level":"info","time":"2025-05-27T08:23:16.416484069Z","caller":"controller/controller.go:175","msg":"Starting EventSource","TraceId":"56bc153d-40dc-4898-b8e4-98e8d5514d7d","controller":"cnsunregistervolume-controller","source":"kind source: *v1alpha1.CnsUnregisterVolume"}
{"level":"info","time":"2025-05-27T08:23:16.416705284Z","caller":"controller/controller.go:183","msg":"Starting Controller","TraceId":"56bc153d-40dc-4898-b8e4-98e8d5514d7d","controller":"cnsunregistervolume-controller"}
{"level":"info","time":"2025-05-27T08:23:16.526642827Z","caller":"controller/controller.go:217","msg":"Starting workers","TraceId":"56bc153d-40dc-4898-b8e4-98e8d5514d7d","controller":"cnsunregistervolume-controller","worker count":40}
{"level":"info","time":"2025-05-27T08:25:07.011441681Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"unregister-vol-used-by-vm-svc-vm\" from namespace \"default\". timeout \"1s\" seconds"}
{"level":"info","time":"2025-05-27T08:25:07.01222132Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-98224a00-c39e-4a37-8ccb-26858d5952ac\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"info","time":"2025-05-27T08:25:07.012504569Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"vol-used-by-vm-svc-vm\" in the namespace:\"vm-svc-vm\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"error","time":"2025-05-27T08:25:07.052735355Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:244","msg":"cannot unregister the volume bbeff293-afa3-46cc-ae48-a6a01701d317 as it's in use by VirtualMachine vm in namespace vm-svc-vm","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:244\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
{"level":"info","time":"2025-05-27T08:25:07.068109961Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"unregister-vol-used-by-vm-svc-vm\" from namespace \"default\". timeout \"2s\" seconds"}
{"level":"info","time":"2025-05-27T08:25:07.068162352Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-98224a00-c39e-4a37-8ccb-26858d5952ac\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"info","time":"2025-05-27T08:25:07.068177436Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"vol-used-by-vm-svc-vm\" in the namespace:\"vm-svc-vm\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"error","time":"2025-05-27T08:25:07.103688872Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:244","msg":"cannot unregister the volume bbeff293-afa3-46cc-ae48-a6a01701d317 as it's in use by VirtualMachine vm in namespace vm-svc-vm","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:244\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
{"level":"info","time":"2025-05-27T08:25:08.068014605Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"unregister-vol-used-by-vm-svc-vm\" from namespace \"default\". timeout \"4s\" seconds"}
{"level":"info","time":"2025-05-27T08:25:08.068090953Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-98224a00-c39e-4a37-8ccb-26858d5952ac\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"info","time":"2025-05-27T08:25:08.06810906Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"vol-used-by-vm-svc-vm\" in the namespace:\"vm-svc-vm\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"error","time":"2025-05-27T08:25:08.095787498Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:244","msg":"cannot unregister the volume bbeff293-afa3-46cc-ae48-a6a01701d317 as it's in use by VirtualMachine vm in namespace vm-svc-vm","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:244\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
{"level":"info","time":"2025-05-27T08:25:12.107919091Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"unregister-vol-used-by-vm-svc-vm\" from namespace \"default\". timeout \"8s\" seconds"}
{"level":"info","time":"2025-05-27T08:25:12.10798796Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-98224a00-c39e-4a37-8ccb-26858d5952ac\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"info","time":"2025-05-27T08:25:12.108001074Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"vol-used-by-vm-svc-vm\" in the namespace:\"vm-svc-vm\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"error","time":"2025-05-27T08:25:12.138648937Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:244","msg":"cannot unregister the volume bbeff293-afa3-46cc-ae48-a6a01701d317 as it's in use by VirtualMachine vm in namespace vm-svc-vm","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:244\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
{"level":"info","time":"2025-05-27T08:25:20.156342608Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"unregister-vol-used-by-vm-svc-vm\" from namespace \"default\". timeout \"16s\" seconds"}
{"level":"info","time":"2025-05-27T08:25:20.156531749Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-98224a00-c39e-4a37-8ccb-26858d5952ac\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"info","time":"2025-05-27T08:25:20.156544495Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"vol-used-by-vm-svc-vm\" in the namespace:\"vm-svc-vm\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"error","time":"2025-05-27T08:25:20.199193522Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:244","msg":"cannot unregister the volume bbeff293-afa3-46cc-ae48-a6a01701d317 as it's in use by VirtualMachine vm in namespace vm-svc-vm","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:244\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
{"level":"info","time":"2025-05-27T08:25:36.212811381Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"unregister-vol-used-by-vm-svc-vm\" from namespace \"default\". timeout \"32s\" seconds"}
{"level":"info","time":"2025-05-27T08:25:36.212885555Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-98224a00-c39e-4a37-8ccb-26858d5952ac\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"info","time":"2025-05-27T08:25:36.212899273Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"vol-used-by-vm-svc-vm\" in the namespace:\"vm-svc-vm\" for the volumd Id: \"bbeff293-afa3-46cc-ae48-a6a01701d317\""}
{"level":"error","time":"2025-05-27T08:25:36.249968556Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:244","msg":"cannot unregister the volume bbeff293-afa3-46cc-ae48-a6a01701d317 as it's in use by VirtualMachine vm in namespace vm-svc-vm","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:244\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
```

**Result:** unregistration failed successfully
</p>
</details> 
<details><summary>When a volume is created from TKC but not used by a pod</summary>
<p>

```
{"level":"info","time":"2025-05-27T09:30:50.479224951Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:204","msg":"Reconciling CnsUnregisterVolume instance \"vol-used-by-tkc\" from namespace \"default\". timeout \"1s\" seconds"}
{"level":"info","time":"2025-05-27T09:30:50.482062429Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:217","msg":"found PV: \"pvc-3db4ac70-bf5e-4a19-9a60-78f580accf09\" for the volumd Id: \"db05cb2f-b53a-4317-b79b-8621cd4d9cea\""}
{"level":"info","time":"2025-05-27T09:30:50.482079062Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:224","msg":"found PVC: \"d68819ea-df5a-4f62-a1dd-6c49b0dcb14f-e5b83788-6d37-4742-a5da-92e9dbd7faf6\" in the namespace:\"guest-cluster\" for the volumd Id: \"db05cb2f-b53a-4317-b79b-8621cd4d9cea\""}
{"level":"info","time":"2025-05-27T09:30:50.598124071Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:269","msg":"Updated ReclaimPolicy on PV \"pvc-3db4ac70-bf5e-4a19-9a60-78f580accf09\" to \"Retain\""}
{"level":"info","time":"2025-05-27T09:30:50.664432341Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:287","msg":"Deleted PVC \"d68819ea-df5a-4f62-a1dd-6c49b0dcb14f-e5b83788-6d37-4742-a5da-92e9dbd7faf6\" in namespace \"guest-cluster\""}
{"level":"info","time":"2025-05-27T09:30:50.696156895Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:304","msg":"Deleted PV \"pvc-3db4ac70-bf5e-4a19-9a60-78f580accf09\""}
{"level":"info","time":"2025-05-27T09:30:51.232430534Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:320","msg":"Deleted CNS volume \"db05cb2f-b53a-4317-b79b-8621cd4d9cea\" with deleteDisk set to false"}
{"level":"info","time":"2025-05-27T09:30:51.249122137Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:335","msg":"Successfully unregistered the volume on namespace: default"}
```

**Result:**  volume got unregistered successfully
</p>
</details> 
<details><summary>When volume is created from TKC and is in use by a TKC pod</summary>
<p>

```
{"level":"info","time":"2025-05-29T08:33:41.895093225Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:205","msg":"Reconciling CnsUnregisterVolume instance \"vol-used-by-tkc-pod\" from namespace \"default\". timeout \"32s\" seconds"}
{"level":"info","time":"2025-05-29T08:33:41.895170935Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:218","msg":"found PV: \"pvc-4a020fc3-3e33-45b9-a4c4-dc5098b78d2b\" for the volumd Id: \"f56c1651-9f6a-48c7-a93b-edac381e49a1\""}
{"level":"info","time":"2025-05-29T08:33:41.895184404Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:225","msg":"found PVC: \"d68819ea-df5a-4f62-a1dd-6c49b0dcb14f-d22b1ae1-3b90-4c36-8d7a-0e1b958c6bae\" in the namespace:\"guest-cluster\" for the volumd Id: \"f56c1651-9f6a-48c7-a93b-edac381e49a1\""}
{"level":"error","time":"2025-05-29T08:33:41.929406698Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:245","msg":"cannot unregister the volume f56c1651-9f6a-48c7-a93b-edac381e49a1 as it's in use by VirtualMachine tkg-np-2-hx25j-5kcks-lrrml in namespace guest-cluster","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:245\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
```
**Result:** unregistration failed successfully
</p>
</details> 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enhance CNS Unregister Volume API to refer to K8s metadata instead of CNS metadata
```
