### PR TITLE
Cherry-pick PR: fix the winodws volume mountpath validation (#3312)

### DIFF
--- a/pkg/csi/service/osutils/windows_os_utils.go
+++ b/pkg/csi/service/osutils/windows_os_utils.go
@@ -105,8 +105,7 @@ func (osUtils *OsUtils) NodeStageBlockVolume(
 		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to get Disk Number, err: %v", err)
 	}
-	log.Infof("nodeStageBlockVolume diskNumber %s, diskId %s,stagingTargetPath %s ", diskNumber, diskID, stagingTargetPath)
-
+	log.Infof("nodeStageBlockVolume diskNumber %s, diskId %s,stagingTargetPath %s", diskNumber, diskID, stagingTargetPath)
 	mounted, err := osUtils.haveMountPoint(ctx, stagingTargetPath)
 	if err != nil {
 		return nil, err
@@ -138,6 +137,7 @@ func (osUtils *OsUtils) haveMountPoint(ctx context.Context, target string) (bool
 		return false, logger.LogNewErrorCodef(log, codes.Internal,
 			"Could not determine if staging path is already mounted, err: %v", err)
 	}
+	log.Infof("haveMountPoint returned mount status %v", notMounted)
 	if notMounted {
 		return false, nil
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The PR cherry picks recent fix related to winodws volume mountpath validation. Refer (#3312) for more details


**Testing done**:
Available on PR (#3312)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick PR: fix the winodws volume mountpath validation
```
