### PR TITLE
Changes for supporting file volumes with VM service VMs

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -160,6 +160,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "update", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfileaccessconfigs"]
+    verbs: ["get", "list", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -162,7 +162,7 @@ rules:
     verbs: ["get", "list", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfileaccessconfigs"]
-    verbs: ["get", "list", "create"]
+    verbs: ["get", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -528,6 +528,7 @@ data:
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
   "WCP_VMService_BYOK": "false"
+  "file-volume-with-vm-service" : "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states
@@ -615,6 +616,10 @@ webhooks:
         operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
+      - apiGroups:   ["cns.vmware.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE"]
+        resources:   ["cnsfileaccessconfigs"]
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail
@@ -629,6 +634,9 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfileaccessconfigs"]
     verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -163,6 +163,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "update", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfileaccessconfigs"]
+    verbs: ["get", "list", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -165,7 +165,7 @@ rules:
     verbs: ["get", "list", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfileaccessconfigs"]
-    verbs: ["get", "list", "create"]
+    verbs: ["get", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -536,6 +536,7 @@ data:
   "workload-domain-isolation": "false"
   "WCP_VMService_BYOK": "false"
   "sv-pvc-snapshot-protection-finalizer": "false"
+  "file-volume-with-vm-service" : "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states
@@ -628,6 +629,10 @@ webhooks:
         operations:  ["CREATE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
+      - apiGroups:   ["cns.vmware.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE"]
+        resources:   ["cnsfileaccessconfigs"]
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail
@@ -674,6 +679,9 @@ rules:
   - apiGroups: ["encryption.vmware.com"]
     resources: ["encryptionclasses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfileaccessconfigs"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -163,6 +163,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "update", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfileaccessconfigs"]
+    verbs: ["get", "list", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -165,7 +165,7 @@ rules:
     verbs: ["get", "list", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfileaccessconfigs"]
-    verbs: ["get", "list", "create"]
+    verbs: ["get", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -536,6 +536,7 @@ data:
   "workload-domain-isolation": "false"
   "WCP_VMService_BYOK": "false"
   "sv-pvc-snapshot-protection-finalizer": "false"
+  "file-volume-with-vm-service" : "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states
@@ -628,6 +629,15 @@ webhooks:
         operations:  ["CREATE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
+        scope:  "Namespaced"
+      - apiVersions: ["v1"]
+        operations:  ["CREATE"]
+        resources:   ["volumesnapshots"]
+        scope:       "Namespaced"
+      - apiGroups:   ["cns.vmware.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE"]
+        resources:   ["cnsfileaccessconfigs"]
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail
@@ -674,6 +684,9 @@ rules:
   - apiGroups: ["encryption.vmware.com"]
     resources: ["encryptionclasses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfileaccessconfigs"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -39,7 +39,8 @@ const (
 	// DefaultQuerySnapshotLimit constant is already present in pkg/csi/service/common/constants.go
 	// However, using that constant creates an import cycle.
 	// TODO: Refactor to move all the constants into a top level directory.
-	DefaultQuerySnapshotLimit = int64(128)
+	DefaultQuerySnapshotLimit  = int64(128)
+	vmOperatorApiVersionPrefix = "vmoperator.vmware.com"
 )
 
 // QueryVolumeUtil helps to invoke query volume API based on the feature
@@ -274,8 +275,9 @@ func QueryAllVolumesForCluster(ctx context.Context, m cnsvolume.Manager, cluster
 }
 
 func GetVirtualMachineAllApiVersions(ctx context.Context, vmKey types.NamespacedName,
-	vmOperatorClient client.Client) (*vmoperatorv1alpha4.VirtualMachine, error) {
+	vmOperatorClient client.Client) (*vmoperatorv1alpha4.VirtualMachine, string, error) {
 	log := logger.GetLogger(ctx)
+	apiVersion := vmOperatorApiVersionPrefix + "/v1alpha4"
 	vmV1alpha1 := &vmoperatorv1alpha1.VirtualMachine{}
 	vmV1alpha2 := &vmoperatorv1alpha2.VirtualMachine{}
 	vmV1alpha3 := &vmoperatorv1alpha3.VirtualMachine{}
@@ -298,39 +300,42 @@ func GetVirtualMachineAllApiVersions(ctx context.Context, vmKey types.Namespaced
 				} else if err == nil {
 					log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha1 VirtualMachine "+
 						"to v1alpha4 VirtualMachine, name %s", vmV1alpha1.Name)
+					apiVersion = vmOperatorApiVersionPrefix + "/v1alpha1"
 					err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachine_To_v1alpha4_VirtualMachine(
 						vmV1alpha1, vmV1alpha4, nil)
 					if err != nil {
-						return nil, err
+						return nil, apiVersion, err
 					}
 				}
 			} else if err == nil {
 				log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha2 VirtualMachine "+
 					"to v1alpha4 VirtualMachine, name %s", vmV1alpha2.Name)
+				apiVersion = vmOperatorApiVersionPrefix + "/v1alpha2"
 				err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachine_To_v1alpha4_VirtualMachine(
 					vmV1alpha2, vmV1alpha4, nil)
 				if err != nil {
-					return nil, err
+					return nil, apiVersion, err
 				}
 			}
 		} else if err == nil {
 			log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha3 VirtualMachine "+
 				"to v1alpha4 VirtualMachine, name %s", vmV1alpha3.Name)
+			apiVersion = vmOperatorApiVersionPrefix + "/v1alpha3"
 			err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachine_To_v1alpha4_VirtualMachine(
 				vmV1alpha3, vmV1alpha4, nil)
 			if err != nil {
-				return nil, err
+				return nil, apiVersion, err
 			}
 		}
 	}
 	if err != nil {
 		log.Errorf("GetVirtualMachineAllApiVersions: failed to get VirtualMachine "+
 			"with name %s and namespace %s, error %v", vmKey.Name, vmKey.Namespace, err)
-		return nil, err
+		return nil, apiVersion, err
 	}
 	log.Infof("successfully fetched the virtual machines with name %s and namespace %s",
 		vmKey.Name, vmKey.Namespace)
-	return vmV1alpha4, nil
+	return vmV1alpha4, apiVersion, nil
 }
 func isKindNotFound(errMsg string) bool {
 	return strings.Contains(errMsg, "no matches for kind") || strings.Contains(errMsg, "no kind is registered")

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -436,6 +436,8 @@ const (
 	// SVPVCSnapshotProtectionFinalizer is FSS that controls add/remove
 	// CNS finalizer on supervisor PVC/Snapshots from PVCSI
 	SVPVCSnapshotProtectionFinalizer = "sv-pvc-snapshot-protection-finalizer"
+	// FileVolumesWithVmService is an FSS to support file volumes with VM service VMs.
+	FileVolumesWithVmService = "file-volume-with-vm-service"
 )
 
 var WCPFeatureStates = map[string]struct{}{

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -674,7 +674,7 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 	timeoutSeconds := int64(getAttacherTimeoutInMin(ctx) * 60)
 	timeout := time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
 	for {
-		virtualMachine, err = utils.GetVirtualMachineAllApiVersions(
+		virtualMachine, _, err = utils.GetVirtualMachineAllApiVersions(
 			ctx, vmKey, c.vmOperatorClient)
 		if err != nil {
 			msg := fmt.Sprintf("failed to get VirtualMachines for the node: %q. Error: %+v", req.NodeId, err)
@@ -1054,7 +1054,7 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 	timeoutSeconds := int64(getAttacherTimeoutInMin(ctx) * 60)
 	timeout := time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
 	for {
-		virtualMachine, err = utils.GetVirtualMachineAllApiVersions(
+		virtualMachine, _, err = utils.GetVirtualMachineAllApiVersions(
 			ctx, vmKey, c.vmOperatorClient)
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -61,6 +61,7 @@ var (
 	featureGateVolumeHealthEnabled            bool
 	featureGateTopologyAwareFileVolumeEnabled bool
 	featureGateByokEnabled                    bool
+	featureFileVolumesWithVmServiceEnabled    bool
 )
 
 // watchConfigChange watches on the webhook configuration directory for changes
@@ -165,6 +166,8 @@ func StartWebhookServer(ctx context.Context) error {
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		featureGateTopologyAwareFileVolumeEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.TopologyAwareFileVolume)
+		featureFileVolumesWithVmServiceEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
+			common.FileVolumesWithVmService)
 
 		if featureGateCsiMigrationEnabled || featureGateBlockVolumeSnapshotEnabled {
 			certs, err := tls.LoadX509KeyPair(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile)

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -163,6 +163,12 @@ func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request
 			admissionResp := validatePVC(ctx, &req.AdmissionRequest)
 			resp.AdmissionResponse = *admissionResp.DeepCopy()
 		}
+	} else if req.Kind.Kind == "CnsFileAccessConfig" {
+		if featureFileVolumesWithVmServiceEnabled {
+			admissionResp := validateCnsFileAccessConfig(ctx, h.clientConfig, &req.AdmissionRequest)
+			resp.AdmissionResponse = *admissionResp.DeepCopy()
+
+		}
 	}
 	return
 }

--- a/pkg/syncer/admissionhandler/validate_cnffileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnffileaccessconfig.go
@@ -1,0 +1,100 @@
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+
+	"k8s.io/client-go/rest"
+	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+)
+
+// validateCnsFileAccessConfig validates if a CnsFileAccessConfig CR with the same VM and PVC already exists.
+// If it already exists, do not allow creation of another CR.
+func validateCnsFileAccessConfig(ctx context.Context, clientConfig *rest.Config,
+	req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	log := logger.GetLogger(ctx)
+
+	cnsFileAccessConfig := cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
+	log.Debugf("JSON req.Object.Raw: %v", string(req.Object.Raw))
+	if err := json.Unmarshal(req.Object.Raw, &cnsFileAccessConfig); err != nil {
+		log.Errorf("error deserializing CnsFileAccessConfig: %v. skipping validation.", err)
+		// return AdmissionResponse result
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: fmt.Sprintf("Failed to serialize CnsFileAccessConfig: %v", err),
+			},
+		}
+	}
+
+	vm := cnsFileAccessConfig.Spec.VMName
+	pvc := cnsFileAccessConfig.Spec.PvcName
+	namespace := cnsFileAccessConfig.Namespace
+	existingCnsFileAccessConfigName, err := cnsFileAccessConfigAlreadyExists(ctx,
+		clientConfig, namespace, vm, pvc)
+	if err != nil {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: fmt.Sprintf("Failed to verify if CnsFileAccessConfig already exists: %v", err),
+			},
+		}
+	}
+
+	// If CR already exists, do not allow this request
+	if existingCnsFileAccessConfigName != "" {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: fmt.Sprintf("CnsFileAccessConfig %s already exists for VM %s and PVC %s",
+					existingCnsFileAccessConfigName, vm, pvc),
+			},
+		}
+	}
+
+	// Existing CR not found. Allow this request.
+	return &admissionv1.AdmissionResponse{
+		Allowed: true,
+	}
+
+}
+
+// cnsFileAccessConfigAlreadyExists lists all CnsFileAccessConfig CRs in the given namespace
+// and verifies if any of them has the same VM name and PVC name.
+// It returns the name of the CR with the same VM and PVC.
+func cnsFileAccessConfigAlreadyExists(ctx context.Context, clientConfig *rest.Config, namespace string,
+	vm string, pvc string) (string, error) {
+	log := logger.GetLogger(ctx)
+
+	cnsOperatorClient, err := k8s.NewClientForGroup(ctx, clientConfig, cnsoperatorv1alpha1.GroupName)
+	if err != nil {
+		log.Errorf("failed to create CnsOperator client. Err: %+v", err)
+		return "", err
+	}
+
+	// Get the list of all CnsFileAccessConfig CRs in the given namespace.
+	cnsFileAccessConfigList := &cnsfileaccessconfigv1alpha1.CnsFileAccessConfigList{}
+	err = cnsOperatorClient.List(ctx, cnsFileAccessConfigList, &client.ListOptions{Namespace: namespace})
+	if err != nil {
+		log.Errorf("failed to list CnsFileAccessConfigList CRs from %s namesapace. Error: %+v",
+			namespace, err)
+		return "", err
+	}
+
+	for _, cnsFileAccessConfig := range cnsFileAccessConfigList.Items {
+		if cnsFileAccessConfig.Spec.VMName == vm {
+			if cnsFileAccessConfig.Spec.PvcName == pvc {
+				return cnsFileAccessConfig.Name, nil
+			}
+		}
+	}
+	return "", nil
+}

--- a/pkg/syncer/admissionhandler/validatepv.go
+++ b/pkg/syncer/admissionhandler/validatepv.go
@@ -40,7 +40,7 @@ func validatePv(ctx context.Context, req *admissionv1.AdmissionRequest) *admissi
 			log.Errorf("error deserializing PV: %v. skipping validation.", err)
 			allowed = false
 			result = &metav1.Status{
-				Message: fmt.Sprintf("Failed to serialize PV: %+V", err),
+				Message: fmt.Sprintf("Failed to serialize PV: %+v", err),
 			}
 			break
 		}

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -240,7 +240,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 	backOffDurationMapMutex.Unlock()
 
 	// Get the virtualmachine instance
-	vm, err := getVirtualMachine(ctx, r.vmOperatorClient, instance.Spec.VMName, instance.Namespace)
+	vm, apiVersion, err := getVirtualMachine(ctx, r.vmOperatorClient, instance.Spec.VMName, instance.Namespace)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to get virtualmachine instance for the VM with name: %q. Error: %+v",
 			instance.Spec.VMName, err)
@@ -370,7 +370,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 	}
 	if !vmOwnerRefExists {
 		// Set ownerRef on CnsFileAccessConfig instance (in-memory) to VM instance.
-		setInstanceOwnerRef(instance, instance.Spec.VMName, vm.UID)
+		setInstanceOwnerRef(instance, instance.Spec.VMName, vm.UID, apiVersion)
 		err = updateCnsFileAccessConfig(ctx, r.client, instance)
 		if err != nil {
 			msg := fmt.Sprintf("failed to update CnsFileAccessConfig instance: %q on namespace: %q. Error: %+v",

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/util.go
@@ -36,32 +36,32 @@ import (
 // getVirtualMachine gets the virtual machine instance with a name on a SV
 // namespace.
 func getVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
-	vmName string, namespace string) (*vmoperatorv1alpha4.VirtualMachine, error) {
+	vmName string, namespace string) (*vmoperatorv1alpha4.VirtualMachine, string, error) {
 	log := logger.GetLogger(ctx)
 	vmKey := apitypes.NamespacedName{
 		Namespace: namespace,
 		Name:      vmName,
 	}
-	virtualMachine, err := utils.GetVirtualMachineAllApiVersions(ctx,
+	virtualMachine, apiVersion, err := utils.GetVirtualMachineAllApiVersions(ctx,
 		vmKey, vmOperatorClient)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to get virtualmachine instance for the VM with name: %q. Error: %+v", vmName, err)
 		log.Error(msg)
-		return nil, err
+		return nil, apiVersion, err
 	}
-	return virtualMachine, nil
+	return virtualMachine, apiVersion, nil
 }
 
 // setInstanceOwnerRef sets ownerRef on CnsFileAccessConfig instance to VM
 // instance.
 func setInstanceOwnerRef(instance *cnsfileaccessconfigv1alpha1.CnsFileAccessConfig, vmName string,
-	vmUID apitypes.UID) {
+	vmUID apitypes.UID, apiVersion string) {
 	bController := true
 	bOwnerDeletion := true
 	kind := reflect.TypeOf(vmoperatorv1alpha4.VirtualMachine{}).Name()
 	instance.OwnerReferences = []metav1.OwnerReference{
 		{
-			APIVersion:         "v1",
+			APIVersion:         apiVersion,
 			Controller:         &bController,
 			BlockOwnerDeletion: &bOwnerDeletion,
 			Kind:               kind,

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -428,7 +428,7 @@ func getNodeTopologyInfoForGuest(ctx context.Context, instance *csinodetopologyv
 		Name:      instance.Name, // use the nodeName as the VM key
 	}
 	log.Info("fetching virtual machines with all versions")
-	virtualMachine, err := utils.GetVirtualMachineAllApiVersions(
+	virtualMachine, _, err := utils.GetVirtualMachineAllApiVersions(
 		ctx, vmKey, vmOperatorClient)
 	if err != nil {
 		return nil, logger.LogNewErrorf(log,

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -100,7 +100,7 @@ func GetTKGVMIP(ctx context.Context, vmOperatorClient client.Client, dc dynamic.
 		Namespace: vmNamespace,
 		Name:      vmName,
 	}
-	virtualMachineInstance, err := utils.GetVirtualMachineAllApiVersions(ctx,
+	virtualMachineInstance, _, err := utils.GetVirtualMachineAllApiVersions(ctx,
 		vmKey, vmOperatorClient)
 	if err != nil {
 		log.Errorf("failed to get virtualmachine %s/%s with error: %v", vmNamespace, vmName, err)


### PR DESCRIPTION
Allow devops user to create CnsFileAccessConfig CRs for a VM service VM.
Also fixed a bug where incorrect API version was being set in ownereference of the CnsFileAccessConfig CR because of which these CRs were not getting cleaned up on VM deletion.

**Testing done**:
Manually added RBAC roles on clusterrole and logged in as devops user and did the following:

VM yaml:

```
apiVersion: vmoperator.vmware.com/v1alpha3
kind: VirtualMachine
metadata:
  name: vm-1
  namespace: test
spec:
 imageName: vmi-fc797a86088049b97
 className: best-effort-small
 powerState: PoweredOn
 storageClass: vsan-default-storage-policy
```

PVC yaml:
```
root@lvn-dvm-10-162-72-96:~# cat pvc.yaml 
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: rwm-pvc
spec:
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 100Mi
  storageClassName: vsan-default-storage-policy
```


Cns File AccessConfig YAML:
```
root@lvn-dvm-10-162-72-96:~# cat cnsfileaccess.yaml 
apiVersion: cns.vmware.com/v1alpha1
kind: CnsFileAccessConfig
metadata:
  name: rwm-vm-1
  namespace: test
spec:
  pvcName: rwm-pvc
  vmName: vm-1
```


Describe:

root@lvn-dvm-10-162-72-96:~# kubectl describe cnsfileaccessconfig
```
Name:         rwm-vm-1
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2025-06-02T07:49:47Z
  Finalizers:
    cns.vmware.com
  Generation:  5
  Owner References:
    API Version:           vmoperator.vmware.com/v1alpha4
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  VirtualMachine
    Name:                  vm-1
    UID:                   33fc9bae-20f8-4685-812b-28b051bf6b89
  Resource Version:        803682
  UID:                     f5b5db6c-f035-49ed-9ba0-843710a90127
Spec:
  Pvc Name:  rwm-pvc
  Vm Name:   vm-1
Status:
  Access Points:
    NFSv3:    host10.cibgst.com:/52511a8a-4b88-ff49-6f20-4916afd387c1
    NFSv4.1:  host10.cibgst.com:/vsanfs/52511a8a-4b88-ff49-6f20-4916afd387c1
  Done:       true
Events:
  Type     Reason                        Age                    From            Message
  ----     ------                        ----                   ----            -------
  Normal   CnsFileAccessConfigSucceeded  42s                    cns.vmware.com  Successfully configured access points of VM: "vm-1" on the volume: "rwm-pvc"
```

1. Verified that the correct apiVersion gets populated on the CnsFileAccessConfig CR's ownerReference. - it is always v1alpha1.
2. Verified that on deleting the VM, CnsFileAccessConfig CR also gets deleted on its own.
3. Created 2 VMs having their own CnsFileAccessConfig CRs with the same volumes. Deleted one of the VMs and verified that CnsFileAccessConfig CR of only the deleted VM gets deleted while the other continues to exist.
4. Verified that creation of a CnsFileAccessConfig CR with same VM and PVC gets denied.
```
root@lvn-dvm-10-162-104-240:~# kubectl apply -f cnsfile.yaml 
Error from server: error when creating "cnsfile.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: CnsFileAccessConfig rwm-vm-1 already exists for VM vm-1 and PVC rwm-pvc

```
5. Created CnsFileAccessConfig CR with same VM, different PVC. It got created.
6. Verified that devops user is not able to edit.
```
error: cnsfileaccessconfigs.cns.vmware.com "rwm-vm-1" could not be patched: cnsfileaccessconfigs.cns.vmware.com "rwm-vm-1" is forbidden: User "sso:saloni@vsphere.local" cannot patch resource "cnsfileaccessconfigs" in API group "cns.vmware.com" in the namespace "test"
You can run `kubectl replace -f /tmp/kubectl-edit-1461090230.yaml` to try this update again.

```
7. Verified that devops user is able to delete the CRs.

