### PR TITLE
Add client authentication for vSphere CSI webhook server for security reasons

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -73,6 +73,8 @@ var (
 	printVersion  = flag.Bool("version", false, "Print syncer version and exit")
 	operationMode = flag.String("operation-mode", operationModeMetaDataSync,
 		"specify operation mode METADATA_SYNC or WEBHOOK_SERVER")
+	enableWebhookClientCertVerification = flag.Bool("webhook-client-cert-verification", false,
+		"Enable client cert authenticate of apiserver to CSI webhook")
 
 	supervisorFSSName = flag.String("supervisor-fss-name", "",
 		"Name of the feature state switch configmap in supervisor cluster")
@@ -128,7 +130,8 @@ func main() {
 
 	if *operationMode == operationModeWebHookServer {
 		log.Infof("Starting container with operation mode: %v", operationModeWebHookServer)
-		if webHookStartError := admissionhandler.StartWebhookServer(ctx); webHookStartError != nil {
+		if webHookStartError := admissionhandler.StartWebhookServer(ctx,
+			*enableWebhookClientCertVerification); webHookStartError != nil {
 			log.Fatalf("failed to start webhook server. err: %v", webHookStartError)
 		}
 	} else if *operationMode == operationModeMetaDataSync {

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -426,6 +426,7 @@ spec:
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
+            - "--webhook-client-cert-verification"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
@@ -464,6 +465,9 @@ spec:
               readOnly: true
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
+            - mountPath: /tmp/k8s-webhook-server/serving-certs/client-ca
+              name: client-ca
+              readOnly: true
         - name: csi-snapshotter
           image: localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
           args:
@@ -495,6 +499,13 @@ spec:
           hostPath:
             path: /etc/vmware/wcp/tls/
             type: Directory
+        - name: client-ca
+          configMap:
+            name: kube-root-ca.crt
+            defaultMode: 420
+            items:
+            - key: "ca.crt"
+              path: "ca.crt"
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -433,6 +433,7 @@ spec:
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
+            - "--webhook-client-cert-verification"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
@@ -471,6 +472,9 @@ spec:
               readOnly: true
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
+            - mountPath: /tmp/k8s-webhook-server/serving-certs/client-ca
+              name: client-ca
+              readOnly: true
         - name: csi-snapshotter
           image: localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
           args:
@@ -502,6 +506,13 @@ spec:
           hostPath:
             path: /etc/vmware/wcp/tls/
             type: Directory
+        - name: client-ca
+          configMap:
+            name: kube-root-ca.crt
+            defaultMode: 420
+            items:
+            - key: "ca.crt"
+              path: "ca.crt"
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -433,6 +433,7 @@ spec:
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
+            - "--webhook-client-cert-verification"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
@@ -471,6 +472,9 @@ spec:
               readOnly: true
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
+            - mountPath: /tmp/k8s-webhook-server/serving-certs/client-ca
+              name: client-ca
+              readOnly: true
         - name: csi-snapshotter
           image: localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
           args:
@@ -502,6 +506,13 @@ spec:
           hostPath:
             path: /etc/vmware/wcp/tls/
             type: Directory
+        - name: client-ca
+          configMap:
+            name: kube-root-ca.crt
+            defaultMode: 420
+            items:
+            - key: "ca.crt"
+              path: "ca.crt"
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -65,7 +65,7 @@ var (
 
 // watchConfigChange watches on the webhook configuration directory for changes
 // like cert, key etc. This is required for certificate rotation.
-func watchConfigChange() {
+func watchConfigChange(enableWebhookClientCertVerification bool) {
 	ctx, log := logger.GetNewContextWithLogger()
 	cfg, err := getWebHookConfig(ctx)
 	if err != nil {
@@ -90,7 +90,7 @@ func watchConfigChange() {
 					log.Infof("Restarting webhook server with new config")
 					errChan := make(chan error)
 					go func() {
-						err := restartWebhookServer(ctx)
+						err := restartWebhookServer(ctx, enableWebhookClientCertVerification)
 						if err != nil {
 							errChan <- err
 							return
@@ -121,7 +121,7 @@ func watchConfigChange() {
 }
 
 // StartWebhookServer starts the webhook server.
-func StartWebhookServer(ctx context.Context) error {
+func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification bool) error {
 	log := logger.GetLogger(ctx)
 	cr_log.SetLogger(zapr.NewLogger(log.Desugar()))
 
@@ -146,7 +146,7 @@ func StartWebhookServer(ctx context.Context) error {
 		featureGateVolumeHealthEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.VolumeHealth)
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		featureGateByokEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.WCP_VMService_BYOK)
-		if err := startCNSCSIWebhookManager(ctx); err != nil {
+		if err := startCNSCSIWebhookManager(ctx, enableWebhookClientCertVerification); err != nil {
 			return fmt.Errorf("unable to run the webhook manager: %w", err)
 		}
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
@@ -206,7 +206,7 @@ func StartWebhookServer(ctx context.Context) error {
 				}
 			}()
 			log.Info("Webhook server started")
-			watchConfigChange()
+			watchConfigChange(enableWebhookClientCertVerification)
 			<-stopCh
 			return nil
 		}
@@ -216,7 +216,7 @@ func StartWebhookServer(ctx context.Context) error {
 
 // restartWebhookServer stops the webhook server and start webhook using
 // updated config.
-func restartWebhookServer(ctx context.Context) error {
+func restartWebhookServer(ctx context.Context, enableWebhookClientCertVerification bool) error {
 	log := logger.GetLogger(ctx)
 	cfg, err := getWebHookConfig(ctx)
 	if err != nil {
@@ -230,7 +230,7 @@ func restartWebhookServer(ctx context.Context) error {
 		return err
 	}
 	log.Info("Restarting webhook server...")
-	return StartWebhookServer(ctx)
+	return StartWebhookServer(ctx, enableWebhookClientCertVerification)
 }
 
 // validationHandler is the handler for webhook http multiplexer to help

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -3,6 +3,7 @@ package admissionhandler
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -31,6 +32,13 @@ const (
 	DefaultWebhookMetricsBindAddress = "0"
 )
 
+var (
+	// This client is generated in the kubeadm bootstrap stages
+	// using the kubernetes CA
+	webhookClientCAFile        = "client-ca/ca.crt"
+	webhookClientCertificateCN = "apiserver-webhook-client"
+)
+
 func getWebhookPort() int {
 	portStr, ok := os.LookupEnv("CNSCSI_WEBHOOK_SERVICE_CONTAINER_PORT")
 	if !ok {
@@ -55,28 +63,39 @@ func getMetricsBindAddress() string {
 }
 
 // startCNSCSIWebhookManager starts the webhook server in supervisor cluster
-func startCNSCSIWebhookManager(ctx context.Context) error {
+func startCNSCSIWebhookManager(ctx context.Context, enableWebhookClientCertVerification bool) error {
 	log := logger.GetLogger(ctx)
 
+	var clientCAName string
 	webhookPort := getWebhookPort()
 	metricsBindAddress := getMetricsBindAddress()
 	log.Infof("setting up webhook manager with webhookPort %v and metricsBindAddress %v",
 		webhookPort, metricsBindAddress)
 
+	tlsConfigOpts := []func(*tls.Config){
+		func(t *tls.Config) {
+			// CipherSuites allows us to specify TLS 1.2 cipher suites that have been recommended by the Security team
+			t.CipherSuites = []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}
+			t.MinVersion = tls.VersionTLS12
+		},
+	}
+	// This client CA is used to verify the client connections being made to the webhook server and
+	// authenticate whether a valid cert is used to contact the server.
+	// Ref: https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/webhook/server.go#L220-L235
+	if enableWebhookClientCertVerification {
+		// set the copied file as the client CA
+		clientCAName = webhookClientCAFile
+		tlsConfigOpts = append(tlsConfigOpts, setVerifyPeerCertificate)
+	}
 	mgrOpts := manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: metricsBindAddress,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: webhookPort,
-			TLSOpts: []func(*tls.Config){
-				func(t *tls.Config) {
-					// CipherSuites allows us to specify TLS 1.2 cipher suites that have been recommended by the Security team
-					t.CipherSuites = []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-						tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}
-					t.MinVersion = tls.VersionTLS12
-				},
-			},
+			Port:         webhookPort,
+			TLSOpts:      tlsConfigOpts,
+			ClientCAName: clientCAName,
 		})}
 
 	if featureGateByokEnabled {
@@ -215,4 +234,19 @@ func (h *CSISupervisorMutationWebhook) mutateNewPVC(ctx context.Context, req adm
 	}
 
 	return admission.PatchResponseFromRaw(req.Object.Raw, newRawPVC)
+}
+
+// setVerifyPeerCertificate func sets VerifyPeerCertificate function to be used to
+// verify webhook client i.e. APIserver certificate during connection to CSI webhook server
+func setVerifyPeerCertificate(cfg *tls.Config) {
+	cfg.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		if len(verifiedChains) == 0 || len(verifiedChains[0]) == 0 {
+			return fmt.Errorf("no verified chains")
+		}
+		cert := verifiedChains[0][0]
+		if cert.Subject.CommonName != webhookClientCertificateCN {
+			return fmt.Errorf("unauthorized client CN: %s", cert.Subject.CommonName)
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This MR adds a flag to accept a client CA file for the webhook server. This client CA is used to verify the client connections being made to the webhook server and authenticate whether a valid cert is used to contact the server.

Ref: https://github.com/kubernetes-sigs/controller-runtime/blob/6ad5c1dd4418489606d19dfb87bf38905b440561/pkg/webhook/server.go#L220-L235

This also adds the tls option to verify the client certificate CN name to make sure no other client can be used to hit the webhooks.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manually tested the connection to webhook that failed if no certificate provided, however webhook validation for CSI operation went through fine.

```
root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]# k get service -n vmware-system-csi -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: Service
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"labels":{"app":"vsphere-csi-webhook"},"name":"vmware-system-csi-webhook-service","namespace":"vmware-system-csi"},"spec":{"ports":[{"port":443,"targetPort":9883}],"selector":{"app":"vsphere-csi-webhook"}}}
    creationTimestamp: "2025-06-04T06:27:28Z"
    labels:
      app: vsphere-csi-webhook
    name: vmware-system-csi-webhook-service
    namespace: vmware-system-csi
    resourceVersion: "1750"
    uid: 539753f3-ed69-45b0-abbd-f5a1b497298c
  spec:
    clusterIP: 172.24.29.131
    clusterIPs:
    - 172.24.29.131
    internalTrafficPolicy: Cluster
    ipFamilies:
    - IPv4
    ipFamilyPolicy: SingleStack
    ports:
    - port: 443
      protocol: TCP
      targetPort: 9883
    selector:
      app: vsphere-csi-webhook
    sessionAffinity: None
    type: ClusterIP
  status:
    loadBalancer: {}
```
    
 Try to make connection to webhook server 

```
root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]# curl -k https://localhost:9883/handle
curl: (56) OpenSSL SSL_read: OpenSSL/3.0.16: error:0A00045C:SSL routines::tlsv13 alert certificate required, errno 0
root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]#

root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]# k logs -n vmware-system-csi vsphere-csi-webhook-5c9665bd94-8xqdp
...
2025/06/05 10:27:57 http: TLS handshake error from [::1]:42366: tls: client didn't provide a certificate
```


Try with actual validation call going to webhook from API server 

```
root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]# k get pvc -n test-ns
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc   Bound    pvc-fe57f20c-f5e8-41ca-8fd2-cb82fb635b33   1Gi        RWO            wcpglobal-storage-profile   <unset>                 32m
root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]#

root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]# k get vs -n test-ns
NAME                         READYTOUSE   SOURCEPVC               SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
example-raw-block-snapshot   true         example-raw-block-pvc                           1Gi           volumesnapshotclass-delete   snapcontent-7e4be6d2-836f-410a-82d8-55a5482cfb2a   12s            14s
root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]#

root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]# k delete -f pvc.yaml -n test-ns        <<< validation done correctly with connection from API server succeeded 
Error from server (Deleting volume with snapshots is not allowed): error when deleting "pvc.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: Deleting volume with snapshots is not allowed
root@4208ffc78632e6ac743d62dd12a35fdc [ ~ ]#

```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
