### PR TITLE
Fix 1.31 manifest file where apiVersion was removed incorrectly

### DIFF
--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -198,8 +198,8 @@ rules:
 - apiGroups: ["cns.vmware.com"]
   resources: ["cnsfileaccessconfigs"]
   verbs: ["get", "list", "watch", "create", "delete"]
-apiVersion: rbac.authorization.k8s.io/v1
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: vmware-system-csi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix 1.31 manifest file where apiVersion was removed incorrectly