### PR TITLE
PodVM domain isolation usecases for snapshot and static volume

### DIFF
--- a/tests/e2e/csi_snapshot_utils.go
+++ b/tests/e2e/csi_snapshot_utils.go
@@ -700,10 +700,11 @@ func verifyVolumeRestoreOperation(ctx context.Context, client clientset.Interfac
 	}
 	gomega.Expect(volHandle2).NotTo(gomega.BeEmpty())
 
+	var pod *v1.Pod
 	if verifyPodCreation {
 		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
-		pod, err := createPod(ctx, client, namespace, nil,
+		pod, err = createPod(ctx, client, namespace, nil,
 			[]*v1.PersistentVolumeClaim{pvclaim2}, false, execRWXCommandPod1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -753,7 +754,7 @@ func verifyVolumeRestoreOperation(ctx context.Context, client clientset.Interfac
 		gomega.Expect(strings.Contains(output, "Hello message from test into Pod1")).NotTo(gomega.BeFalse())
 		return pvclaim2, persistentvolumes2, pod
 	}
-	return pvclaim2, persistentvolumes2, nil
+	return pvclaim2, persistentvolumes2, pod
 }
 
 // createPVCAndQueryVolumeInCNS creates PVc with a given storage class on a given namespace

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -500,6 +500,7 @@ var (
 	envZone2DatastoreName                 = "ZONE2_DATASTORE_NAME"
 	vmMigrationUserName                   = "VM_MIGRATION_USER_NAME"
 	vmMigrationUserPwd                    = "VM_MIGRATION_USER_PWD"
+	envZone2DatastoreUrl                  = "ZONE2_DATASTORE_URL"
 )
 
 // storage policy usages for storage quota validation

--- a/tests/e2e/mgmt_wrkld_domain_isolation.go
+++ b/tests/e2e/mgmt_wrkld_domain_isolation.go
@@ -32,6 +32,7 @@ import (
 	ctlrclient "sigs.k8s.io/controller-runtime/pkg/client"
 	cnsop "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,6 +50,7 @@ import (
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	snapV1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	snapclient "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 )
 
@@ -228,8 +230,6 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 		ginkgo.By("Create a WCP namespace tagged to zone-2")
 		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
 			topValEndIndex)
-
-		// here fetching zone:zone-2 from topologyAffinityDetails
 		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId,
 			[]string{storageProfileId}, getSvcId(vcRestSessionId),
 			[]string{zone2}, "", "")
@@ -1232,6 +1232,379 @@ var _ bool = ginkgo.Describe("[domain-isolation] Management-Workload-Domain-Isol
 		isMigrateSuccess2, _ := migrateVmsFromDatastore(svcMasterIp, sshClientConfig, zone2DsName, []string{vm2.Name},
 			0)
 		gomega.Expect(isMigrateSuccess2).NotTo(gomega.BeTrue(), "Migration of vms failed")
+	})
 
+	/*
+		Testcase-21
+		snapshot creation with zones addition and removal in between
+		Test Steps:
+		1. On a WCP namespace which is tagged to zone-1 and has zonal and shared storage policy added.
+		2. Create multiple PVCs on a scale with RWO access modes and use both binding modes WFFC
+		and Immediate for each different PVC
+		3. Add new zone zone-2 to the namespace
+		4. Create deployment pods using the PVC created above.
+		4. Verify PVC reaches to Bound state.
+		6. Verify PVC annotation and PV affinity details.
+		7. Verify Pods reach the running state.
+		8. Verify Pod node annotation.
+		9. Mark zone-2 tag for removal.
+		10. Add new zone zone-3 to the namespace.
+		11. Take snapshot of few PVCs created above.
+		12. Wait for the snapshot to get created successfully.
+		13. Restore the snapshot created above to create new volumes
+		and attach it to a new pods.
+		14. Wait for restored volumes to reach the Bound state.
+		15. Verify PVC annotation and PV affinity details.
+		16. Wait for Pods to reach running state.
+		17. Verify pod node annotation.
+		18. Perform cleanup - delete pods, volumes and namespace.
+	*/
+
+	ginkgo.It("Snapshot creation with zones addition and removal", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		restoredPVCs := []*v1.PersistentVolumeClaim{}
+		restoredPods := []*v1.Pod{}
+		restoredVolHandles := []string{}
+		pvs := []*v1.PersistentVolume{}
+
+		// Read zone-1 storage policy "immediate and latebinding" for pvc creation
+		zonalPolicyName := GetAndExpectStringEnvVar(envZonal1StoragePolicyName)
+		zonalStorageProfileId := e2eVSphere.GetSpbmPolicyID(zonalPolicyName)
+		zonalPolicyNameWffc := zonalPolicyName + "-latebinding"
+
+		// Read shared storage policy for pvc creation
+		sharedPolicyName := GetAndExpectStringEnvVar(envIsolationSharedStoragePolicyName)
+		sharedStorageProfileId := e2eVSphere.GetSpbmPolicyID(sharedPolicyName)
+
+		// Get corresponding storage classes
+		ginkgo.By("Read storage policies tagged to WCP namespace")
+		storageClassNames := []string{zonalPolicyNameWffc, sharedPolicyName}
+		storageClasses := make([]*storagev1.StorageClass, len(storageClassNames))
+		for i, name := range storageClassNames {
+			sc, err := client.StorageV1().StorageClasses().Get(ctx, name, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			storageClasses[i] = sc
+		}
+		zonalStorageClass := storageClasses[0]
+		sharedStorageClass := storageClasses[1]
+
+		// Create WCP namespace
+		ginkgo.By("Create a WCP namespace and tag it to zone-1")
+		namespace, statuscode, err := createtWcpNsWithZonesAndPolicies(
+			vcRestSessionId,
+			[]string{zonalStorageProfileId, sharedStorageProfileId},
+			getSvcId(vcRestSessionId),
+			[]string{zone1}, "", "",
+		)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
+		defer func() {
+			delTestWcpNs(vcRestSessionId, namespace)
+			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
+		}()
+
+		// Create PVCs
+		ginkgo.By("Create 2 PVCs with different binding modes")
+		storageClassList := []*storagev1.StorageClass{zonalStorageClass, sharedStorageClass}
+		pvcList := []*v1.PersistentVolumeClaim{}
+		for _, sc := range storageClassList {
+			pvc, err := createPVC(ctx, client, namespace, labelsMap, "", sc, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvcList = append(pvcList, pvc)
+		}
+		defer func() {
+			ginkgo.By("Delete PVCs")
+			for _, pvc := range pvcList {
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, pvc.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Waiting for CNS volumes to be deleted")
+			for _, pv := range pvs {
+				err := e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		// Extend namespace to zone-2
+		ginkgo.By("Add zone-2 to WCP namespace")
+		err = addZoneToWcpNs(vcRestSessionId, namespace, topologyAffinityDetails[topologyCategories[0]][1])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Create deployments using PVCs
+		ginkgo.By("Creating Deployments using PVCs")
+		deployments := []*appsv1.Deployment{}
+		depSpecs := [][]*v1.PersistentVolumeClaim{
+			{pvcList[0], pvcList[1]},
+			{pvcList[2]},
+		}
+		for _, pvcSet := range depSpecs {
+			dep, err := createDeployment(ctx, client, 1, labelsMap, nil, namespace,
+				pvcSet, execRWXCommandPod1, false, busyBoxImageOnGcr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			deployments = append(deployments, dep)
+		}
+		defer func() {
+			ginkgo.By("Delete Deployments")
+			for _, dep := range deployments {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, dep.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		// Wait for PVCs to bound
+		ginkgo.By("Wait for PVCs to be in bound state")
+		pvs, err = fpv.WaitForPVClaimBoundPhase(ctx, client, pvcList, pollTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
+
+		// Verify deployment-based affinity annotations
+		ginkgo.By("Verify svc pv affinity, pvc annotation and pod node affinity for Deployments")
+		for _, dep := range deployments {
+			err := verifyPvcAnnotationPvAffinityPodAnnotationInSvc(ctx, client, nil, nil, dep, namespace, allowedTopologies)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// Modify namespace topology
+		ginkgo.By("Mark zone-2 for removal from WCP namespace")
+		err = markZoneForRemovalFromWcpNs(vcRestSessionId, namespace, topologyAffinityDetails[topologyCategories[0]][1])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Add zone-3 to WCP namespace")
+		err = addZoneToWcpNs(vcRestSessionId, namespace, topologyAffinityDetails[topologyCategories[0]][2])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Create VolumeSnapshotClass
+		ginkgo.By("Create volume snapshot class")
+		volumeSnapshotClass, err := createVolumeSnapshotClass(ctx, snapc, deletionPolicy)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Create snapshots
+		var snapshots []*snapV1.VolumeSnapshot
+		var snapshotContents []*snapV1.VolumeSnapshotContent
+		var snapshotCreatedList, snapshotContentCreatedList []bool
+
+		for i, pvc := range pvcList {
+			ginkgo.By(fmt.Sprintf("Create dynamic volume snapshot for PVC %d", i+1))
+			volHandle := pvs[i].Spec.CSI.VolumeHandle
+			vs, vsc, snapCreated, vscCreated, _, _, err := createDynamicVolumeSnapshot(
+				ctx, namespace, snapc, volumeSnapshotClass, pvc, volHandle, diskSize, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			snapshots = append(snapshots, vs)
+			snapshotContents = append(snapshotContents, vsc)
+			snapshotCreatedList = append(snapshotCreatedList, snapCreated)
+			snapshotContentCreatedList = append(snapshotContentCreatedList, vscCreated)
+		}
+		defer func() {
+			ginkgo.By("Perform cleanup of snapshots")
+			ginkgo.By("Delete Snapshots")
+			for i := range snapshots {
+				if snapshotCreatedList[i] {
+					framework.Logf("Deleting volume snapshot %s", snapshots[i].Name)
+					deleteVolumeSnapshotWithPandoraWait(ctx, snapc, namespace, snapshots[i].Name, pandoraSyncWaitTime)
+
+					framework.Logf("Waiting for snapshot content to be deleted: %s", snapshots[i].Name)
+					err := waitForVolumeSnapshotContentToBeDeletedWithPandoraWait(
+						ctx, snapc, *snapshots[i].Status.BoundVolumeSnapshotContentName, pandoraSyncWaitTime)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+				if snapshotContentCreatedList[i] {
+					err := deleteVolumeSnapshotContent(ctx, snapshotContents[i], snapc, pandoraSyncWaitTime)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+
+			ginkgo.By("Delete restored volume snapshots")
+			for i := range restoredPVCs {
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, restoredPVCs[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(restoredVolHandles[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		// Restore snapshots
+		ginkgo.By("Restore volume snapshots and create pods from restored PVCs")
+		for i := 1; i < len(snapshots); i++ {
+			snapshot := snapshots[i]
+			ginkgo.By(fmt.Sprintf("Restoring from snapshot %d: %s", i, snapshot.Name))
+			pvc, pvs, pod := verifyVolumeRestoreOperation(ctx, client,
+				namespace, storageClassList[i], snapshot, diskSize, true)
+			gomega.Expect(len(pvs)).To(gomega.BeNumerically(">", 0))
+			gomega.Expect(pod).NotTo(gomega.BeNil())
+
+			volHandle := pvs[0].Spec.CSI.VolumeHandle
+			if guestCluster {
+				volHandle = getVolumeIDFromSupervisorCluster(volHandle)
+			}
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+
+			restoredPVCs = append(restoredPVCs, pvc)
+			restoredPods = append(restoredPods, pod)
+			restoredVolHandles = append(restoredVolHandles, volHandle)
+		}
+		defer func() {
+			ginkgo.By("Cleanup restored Pods")
+			for i := range restoredPVCs {
+				if restoredPods[i] != nil {
+					err := fpod.DeletePodWithWait(ctx, client, restoredPods[i])
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}()
+
+		// Verify pod-based affinity annotations
+		ginkgo.By("Verify svc pv affinity, pvc annotation and pod node affinity for restored Pods")
+		for _, pod := range restoredPods {
+			err := verifyPvcAnnotationPvAffinityPodAnnotationInSvc(ctx, client, nil, pod, nil, namespace, allowedTopologies)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	/* Testcase - 22
+	   static volume
+	   Test Steps:
+	   1. Create a namespace add zone-2 to it and tag a zonal policy of zone-2
+	   2. Create FCD with valid zonal policy. Make sure the storage policy has sufficient quota and note the FCD ID
+	   3. Call CNSRegisterVolume API by specifying VolumeID, AccessMode set to "ReadWriteOnce” and PVC Name
+	   4. Wait for some time to get the status of CRD Verify the CRD status should be successful.
+	   5. CNS operator creates PV and PVC.
+	   6. Verify Bidirectional reference between PV and PVC - validate volumeName,
+	   storage class, PVC name, namespace and the size.
+	   7. Verify PV and PVC’s are bound
+	   8. Verify node affinity on PV.
+	   9. Invoke CNS query API, to validate volume is registered in CNS and volume shows the PV PVC information
+	   10. Create a Pod using the PVC created above.
+	   11. Wait for Pod to reach running state.
+	   12. Get VolumeSnapshotClass "volumesnapshotclass-delete" from supervisor cluster.
+	   13. Create a volume snapshot for the static PVC.
+	   14. Verify snapshot created successfully.
+	   15. Restore snapshot and create a pod
+	   16. verify pod pvc affinty
+	   17. Perform cleanup: delete pods, snapshot, volume and namespace
+	*/
+
+	ginkgo.It("Static volume creation using zonal2 policy", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// reading zonal storage policy of zone-2 workload domain
+		storagePolicyName = GetAndExpectStringEnvVar(envZonal2StoragePolicyName)
+		storageProfileId = e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+		storageDatastoreUrlZone2 := GetAndExpectStringEnvVar(envZone2DatastoreUrl)
+
+		ginkgo.By("Read zonal storage class of zone2")
+		storageclass, err := client.StorageV1().StorageClasses().Get(ctx, storagePolicyName, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		/*
+			EX - zone -> zone-1, zone-2, zone-3, zone-4
+			so topValStartIndex=1 and topValEndIndex=2 will fetch the 1st index value from topology map string
+		*/
+		topValStartIndex := 1
+		topValEndIndex := 2
+
+		ginkgo.By("Create a WCP namespace tagged to zone-2")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+		namespace, statuscode, err = createtWcpNsWithZonesAndPolicies(vcRestSessionId,
+			[]string{storageProfileId}, getSvcId(vcRestSessionId),
+			[]string{zone2}, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(statuscode).To(gomega.Equal(status_code_success))
+		defer func() {
+			delTestWcpNs(vcRestSessionId, namespace)
+			gomega.Expect(waitForNamespaceToGetDeleted(ctx, client, namespace, poll, pollTimeout)).To(gomega.Succeed())
+		}()
+
+		ginkgo.By("Create static volume")
+		_, _, staticPvc, staticPv, err := createStaticVolumeOnSvc(ctx, client,
+			namespace, storageDatastoreUrlZone2, storagePolicyName)
+		defer func() {
+			ginkgo.By("Delete PVC")
+			err = fpv.DeletePersistentVolumeClaim(ctx, client, staticPvc.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(staticPv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating a Deployment using pvc")
+		dep, err := createDeployment(ctx, client, 1, labelsMap, nil, namespace,
+			[]*v1.PersistentVolumeClaim{staticPvc}, execRWXCommandPod1, false, busyBoxImageOnGcr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		podList, err := fdep.GetPodsForDeployment(ctx, client, dep)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Delete Deployment")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, dep.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify the volume is accessible and Read/write is possible")
+		output := readFileFromPod(namespace, podList.Items[0].Name, filePathPod1)
+		gomega.Expect(strings.Contains(output, "Hello message from Pod1")).NotTo(gomega.BeFalse())
+
+		writeDataOnFileFromPod(namespace, podList.Items[0].Name, filePathPod1, "Hello message from test into Pod1")
+		output = readFileFromPod(namespace, podList.Items[0].Name, filePathPod1)
+		gomega.Expect(strings.Contains(output, "Hello message from test into Pod1")).NotTo(gomega.BeFalse())
+
+		ginkgo.By("Verify svc pv affinity, pvc annotation and pod node affinity")
+		err = verifyPvcAnnotationPvAffinityPodAnnotationInSvc(ctx, client, nil, nil, dep, namespace,
+			allowedTopologies)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Create volume snapshot class")
+		volumeSnapshotClass, err := createVolumeSnapshotClass(ctx, snapc, deletionPolicy)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Create a dynamic volume snapshot")
+		volumeSnapshot, snapshotContent, snapshotCreated,
+			snapshotContentCreated, snapshotId, _, err := createDynamicVolumeSnapshot(ctx, namespace, snapc, volumeSnapshotClass,
+			staticPvc, staticPv.Spec.CSI.VolumeHandle, diskSize, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			if snapshotContentCreated {
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+
+			if snapshotCreated {
+				framework.Logf("Deleting volume snapshot")
+				deleteVolumeSnapshotWithPandoraWait(ctx, snapc, namespace, volumeSnapshot.Name, pandoraSyncWaitTime)
+
+				framework.Logf("Wait till the volume snapshot is deleted")
+				err = waitForVolumeSnapshotContentToBeDeletedWithPandoraWait(ctx, snapc,
+					*volumeSnapshot.Status.BoundVolumeSnapshotContentName, pandoraSyncWaitTime)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Restore volume snapshot and create pod using it")
+		pvclaim2, persistentVolumes2, pod2 := verifyVolumeRestoreOperation(ctx, client,
+			namespace, storageclass, volumeSnapshot, diskSize, true)
+		volHandle2 := persistentVolumes2[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle2).NotTo(gomega.BeEmpty())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(ctx, client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volHandle2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Delete Dynamic snapshot")
+		snapshotCreated, snapshotContentCreated, err = deleteVolumeSnapshot(ctx, snapc, namespace,
+			volumeSnapshot, pandoraSyncWaitTime, staticPv.Spec.CSI.VolumeHandle, snapshotId, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR holds 2 usecases for domain isolation feature. 
First testcases will create/restore/delete snapshots with zones addition and removal.
Second usecase verifies static volume creation on a particular zone.

**Testing done**:
Yes
[tc21.txt](https://github.com/user-attachments/files/20720233/tc21.txt)
[tc22.txt](https://github.com/user-attachments/files/20720265/tc22.txt)


**Special notes for your reviewer**:

ps031044@P2XQC4DXP0 vsphere-csi-driver % golangci-lint run --enable=lll
ps031044@P2XQC4DXP0 vsphere-csi-driver % 
