### PR TITLE
Remove additional space in fss entry in configmap

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -555,7 +555,7 @@ data:
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
   "WCP_VMService_BYOK": "false"
-  "file-volume-with-vm-service" : "false"
+  "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -563,7 +563,7 @@ data:
   "workload-domain-isolation": "false"
   "WCP_VMService_BYOK": "false"
   "sv-pvc-snapshot-protection-finalizer": "false"
-  "file-volume-with-vm-service" : "false"
+  "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -563,7 +563,7 @@ data:
   "workload-domain-isolation": "false"
   "WCP_VMService_BYOK": "false"
   "sv-pvc-snapshot-protection-finalizer": "false"
-  "file-volume-with-vm-service" : "false"
+  "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Remove additional space in fss entry in csi feature state configmap

**Testing done**:
kubectl apply -f configmap.yaml 
configmap/csi-feature-states created


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove additional space in fss entry in csi feature state configmap
```
