### PR TITLE
CSI LinkedClone support

### DIFF
--- a/manifests/guestcluster/1.31/pvcsi.yaml
+++ b/manifests/guestcluster/1.31/pvcsi.yaml
@@ -325,6 +325,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--enable-capacity=true"
             - "--capacity-ownerref-level=-1"
+            - "--extra-create-metadata"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
@@ -689,6 +690,7 @@ data:
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
   "sv-pvc-snapshot-protection-finalizer": "false"
+  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.32/pvcsi.yaml
+++ b/manifests/guestcluster/1.32/pvcsi.yaml
@@ -64,7 +64,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list", "patch" ]
+    verbs: [ "get", "list", "patch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]
@@ -325,6 +325,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--enable-capacity=true"
             - "--capacity-ownerref-level=-1"
+            - "--extra-create-metadata"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
@@ -689,6 +690,7 @@ data:
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
   "sv-pvc-snapshot-protection-finalizer": "false"
+  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.33/pvcsi.yaml
+++ b/manifests/guestcluster/1.33/pvcsi.yaml
@@ -64,7 +64,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list", "patch" ]
+    verbs: [ "get", "list", "patch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]
@@ -325,6 +325,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--enable-capacity=true"
             - "--capacity-ownerref-level=-1"
+            - "--extra-create-metadata"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
@@ -670,6 +671,7 @@ data:
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
   "sv-pvc-snapshot-protection-finalizer": "false"
+  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -563,6 +563,7 @@ data:
   "WCP_VMService_BYOK": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
+  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states
@@ -646,7 +647,7 @@ webhooks:
         path: "/validate"
     rules:
       - apiGroups:   [""]
-        apiVersions: ["v1", "v1beta1"]
+        apiVersions: ["v1"]
         operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
@@ -654,6 +655,10 @@ webhooks:
         apiVersions: ["v1alpha1"]
         operations: ["CREATE", "DELETE"]
         resources:   ["cnsfileaccessconfigs"]
+      - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "DELETE"]
+        resources:   ["volumesnapshots"]
         scope:       "Namespaced"
     sideEffects: None
     admissionReviewVersions: ["v1"]

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -572,6 +572,7 @@ data:
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
   "vol-from-snapshot-on-target-ds": "false"
+  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states
@@ -661,7 +662,7 @@ webhooks:
         scope: "Namespaced"
       - apiGroups:   ["snapshot.storage.k8s.io"]
         apiVersions: ["v1"]
-        operations:  ["CREATE"]
+        operations:  ["CREATE", "DELETE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
       - apiGroups:   ["cns.vmware.com"]
@@ -690,8 +691,8 @@ webhooks:
         path: "/mutate"
     rules:
       - apiGroups: [""]
-        apiVersions: ["v1", "v1beta1"]
-        operations: ["CREATE", "UPDATE"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
         resources: ["persistentvolumeclaims"]
         scope: "Namespaced"
       - apiGroups:   ["cns.vmware.com"]

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -572,6 +572,7 @@ data:
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
   "vol-from-snapshot-on-target-ds": "false"
+  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states
@@ -655,13 +656,13 @@ webhooks:
         path: "/validate"
     rules:
       - apiGroups:   [""]
-        apiVersions: ["v1", "v1beta1"]
+        apiVersions: ["v1"]
         operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
-      - apiGroups:   ["snapshot.storage.k8s.io"]
+      - apiGroups: ["snapshot.storage.k8s.io"]
         apiVersions: ["v1"]
-        operations:  ["CREATE"]
+        operations:  ["CREATE", "DELETE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
       - apiGroups:   ["cns.vmware.com"]
@@ -690,8 +691,8 @@ webhooks:
         path: "/mutate"
     rules:
       - apiGroups: [""]
-        apiVersions: ["v1", "v1beta1"]
-        operations: ["CREATE", "UPDATE"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
         resources: ["persistentvolumeclaims"]
         scope: "Namespaced"
       - apiGroups:   ["cns.vmware.com"]

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -570,6 +570,7 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "vol-from-snapshot-on-target-ds": "false"
+  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states
@@ -653,13 +654,13 @@ webhooks:
         path: "/validate"
     rules:
       - apiGroups:   [""]
-        apiVersions: ["v1", "v1beta1"]
+        apiVersions: ["v1"]
         operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
       - apiGroups:   ["snapshot.storage.k8s.io"]
         apiVersions: ["v1"]
-        operations:  ["CREATE"]
+        operations:  ["CREATE", "DELETE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
       - apiGroups:   ["cns.vmware.com"]
@@ -688,8 +689,8 @@ webhooks:
         path: "/mutate"
     rules:
       - apiGroups: [""]
-        apiVersions: ["v1", "v1beta1"]
-        operations: ["CREATE", "UPDATE"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
         resources: ["persistentvolumeclaims"]
         scope: "Namespaced"
       - apiGroups:   ["cns.vmware.com"]

--- a/pkg/common/cns-lib/vsphere/cns.go
+++ b/pkg/common/cns-lib/vsphere/cns.go
@@ -33,7 +33,6 @@ func NewCnsClient(ctx context.Context, c *vim25.Client) (*cns.Client, error) {
 		return nil, err
 	}
 	cnsClient.RoundTripper = &MetricRoundTripper{"cns", cnsClient.RoundTripper}
-
 	return cnsClient, nil
 }
 

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"sync"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/simulator/vpx"
 	"google.golang.org/grpc/codes"
@@ -377,6 +379,32 @@ func (c *FakeK8SOrchestrator) StartZonesInformer(ctx context.Context, restClient
 // GetZonesForNamespace fetches the zones associated with a namespace when
 // WorkloadDomainIsolation is supported in supervisor.
 func (c *FakeK8SOrchestrator) GetZonesForNamespace(ns string) map[string]struct{} {
+	return nil
+}
+
+func (c *FakeK8SOrchestrator) IsLinkedCloneRequest(ctx context.Context, pvcName string,
+	pvcNamespace string) (bool, error) {
+	return false, nil
+}
+
+func (c *FakeK8SOrchestrator) GetLinkedCloneVolumeSnapshotSourceUUID(ctx context.Context, pvcName string,
+	pvcNamespace string) (string, error) {
+	return "", nil
+}
+
+func (c *FakeK8SOrchestrator) PreLinkedCloneCreateAction(ctx context.Context, pvcNamespace string,
+	pvcName string) error {
+	return nil
+}
+
+func (c *FakeK8SOrchestrator) GetVolumeSnapshotPVCSource(ctx context.Context, volumeSnapshotNamespace string,
+	volumeSnapshotName string) (*v1.PersistentVolumeClaim, error) {
+
+	return nil, nil
+}
+
+func (c *FakeK8SOrchestrator) UpdatePersistentVolumeLabel(ctx context.Context, pvName string,
+	key string, value string) error {
 	return nil
 }
 

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
+
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	storagev1 "k8s.io/api/storage/v1"
 	restclient "k8s.io/client-go/rest"
@@ -104,6 +106,17 @@ type COCommonInterface interface {
 	// GetZonesForNamespace fetches the zones associated with a namespace when
 	// WorkloadDomainIsolation is supported in supervisor.
 	GetZonesForNamespace(ns string) map[string]struct{}
+	// PreLinkedCloneCreateAction updates the PVC label with the values specified in map
+	PreLinkedCloneCreateAction(ctx context.Context, pvcNamespace string, pvcName string) error
+	// GetLinkedCloneVolumeSnapshotSourceUUID retrieves the source of the LinkedClone.
+	GetLinkedCloneVolumeSnapshotSourceUUID(ctx context.Context, pvcName string, pvcNamespace string) (string, error)
+	// GetVolumeSnapshotPVCSource retrieves the PVC from which the VolumeSnapshot was taken.
+	GetVolumeSnapshotPVCSource(ctx context.Context, volumeSnapshotNamespace string, volumeSnapshotName string) (
+		*v1.PersistentVolumeClaim, error)
+	// IsLinkedCloneRequest checks if the pvc is a linked clone request
+	IsLinkedCloneRequest(ctx context.Context, pvcName string, pvcNamespace string) (bool, error)
+	// UpdatePersistentVolumeLabel Updates the PV label with the specified key value.
+	UpdatePersistentVolumeLabel(ctx context.Context, pvName string, key string, value string) error
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -38,6 +38,12 @@ const (
 	// AttributeDiskType is a PersistentVolume's attribute.
 	AttributeDiskType = "type"
 
+	// LinkedClonePVCLabel indicates if the PVC is a linked clone
+	LinkedClonePVCLabel = "linked-clone"
+
+	// VolumeContextAttributeLinkedCloneVolumeSnapshotSourceUID is a PersistentVolume's attribute.
+	VolumeContextAttributeLinkedCloneVolumeSnapshotSourceUID = "linked-clone-source-uid"
+
 	// AttributeDatastoreURL represents URL of the datastore in the StorageClass.
 	// For Example: DatastoreURL: "ds:///vmfs/volumes/5c9bb20e-009c1e46-4b85-0200483b2a97/".
 	AttributeDatastoreURL = "datastoreurl"
@@ -83,6 +89,15 @@ const (
 
 	// AttributeStorageClassName represents name of the Storage Class.
 	AttributeStorageClassName = "csi.storage.k8s.io/sc/name"
+
+	// AttributeIsLinkedClone represents if this is a linked clone request
+	AttributeIsLinkedClone = "csi.vsphere.volume/fast-provisioning"
+
+	// AttributeIsLinkedCloneKey represents if this is a linked clone request
+	AttributeIsLinkedCloneKey = "csi.vsphere.k8s.io/linked-clone"
+
+	// LinkedCloneCountLabel represents linkedclone count label
+	LinkedCloneCountLabel = "csi.vsphere.volume/linked-clone-count"
 
 	// HostMoidAnnotationKey represents the Node annotation key that has the value
 	// of VC's ESX host moid of this node.
@@ -347,6 +362,9 @@ const (
 
 	// WCPCapabilitiesCRName is the name of the CR where WCP component's capabilities are stored
 	WCPCapabilitiesCRName = "supervisor-capabilities"
+
+	// AnnKeyLinkedClone is the linked clone annotation on the PVC
+	AnnKeyLinkedClone = "csi.vsphere.volume/fast-provisioning"
 )
 
 // Supported container orchestrators.
@@ -442,6 +460,8 @@ const (
 	CSITranSactionSupport = "csi-transaction-support"
 	// VolFromSnapshotOnTargetDs enables creation of volumes from snapshots on different datastores
 	VolFromSnapshotOnTargetDs = "vol-from-snapshot-on-target-ds"
+	// LinkedCloneSupport is an FSS that tells whether LinkedClone feature is supported in CSI.
+	LinkedCloneSupport = "linked-clone-support"
 )
 
 var WCPFeatureStates = map[string]struct{}{

--- a/pkg/csi/service/common/types.go
+++ b/pkg/csi/service/common/types.go
@@ -92,6 +92,7 @@ type CreateVolumeSpec struct {
 	VsanDatastoreURL        string // Datastore URL used by host local volumes (vSAN Direct/vSAN SNA)
 	ContentSourceSnapshotID string // SnapshotID from VolumeContentSource in CreateVolumeRequest
 	CryptoKeyID             *CryptoKeyID
+	IsLinkedCloneRequest    bool
 }
 
 // StorageClassParams represents the storage class parameterss

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -284,11 +284,13 @@ func CreateBlockVolumeUtil(
 			SnapshotId: cnstypes.CnsSnapshotId{
 				Id: cnsSnapshotID,
 			},
+			LinkedClone: spec.IsLinkedCloneRequest,
 		}
 
 		// If VolFromSnapshotOnTargetDs is not enabled,
 		// select the compatible datastore for the case of create volume from snapshot
-		if !opts.VolFromSnapshotOnTargetDs {
+		// If it's a LinkedClone, then choose the same datastore as the source volume.
+		if spec.IsLinkedCloneRequest || !opts.VolFromSnapshotOnTargetDs {
 			// step 1: query the datastore of snapshot. By design, snapshot is always located at the same datastore
 			// as the source volume
 			querySelection := cnstypes.CnsQuerySelection{

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -63,6 +63,7 @@ func validateCreateBlockReqParam(paramName, value string) bool {
 		paramName == common.AttributePvcName ||
 		paramName == common.AttributePvcNamespace ||
 		paramName == common.AttributeStorageClassName ||
+		paramName == common.AttributeIsLinkedCloneKey ||
 		(paramName == common.AttributeHostLocal && strings.EqualFold(value, "true"))
 }
 

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -89,6 +89,11 @@ func validateGuestClusterCreateVolumeRequest(ctx context.Context, req *csi.Creat
 				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 					"Volume parameter %s is not a valid GC CSI parameter", param)
 			}
+		case common.AttributePvcNamespace:
+		case common.AttributePvcName:
+		case common.AttributePvName:
+		case common.AttributeStorageClassName:
+			log.Debugf("Attribute: %s, Value: %s", param, val)
 		default:
 			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"Volume parameter %s is not a valid GC CSI parameter", param)
@@ -213,7 +218,8 @@ func getAccessMode(accessMode csi.VolumeCapability_AccessMode_Mode) v1.Persisten
 // getPersistentVolumeClaimSpecWithStorageClass return the PersistentVolumeClaim spec with specified storage class
 func getPersistentVolumeClaimSpecWithStorageClass(pvcName string, namespace string, diskSize string,
 	storageClassName string, pvcAccessMode v1.PersistentVolumeAccessMode, annotations map[string]string,
-	labels map[string]string, finalizers []string, volumeSnapshotName string) *v1.PersistentVolumeClaim {
+	labels map[string]string, finalizers []string, volumeSnapshotName string,
+	isLinkedCloneRequest bool) *v1.PersistentVolumeClaim {
 	claim := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pvcName,
@@ -243,6 +249,10 @@ func getPersistentVolumeClaimSpecWithStorageClass(pvcName string, namespace stri
 			Name:     volumeSnapshotName,
 		}
 		claim.Spec.DataSource = localObjectReference
+	}
+
+	if isLinkedCloneRequest {
+		claim.Annotations[common.AttributeIsLinkedClone] = "true"
 	}
 	return claim
 }

--- a/pkg/internalapis/cnsvolumeinfo/config/cns.vmware.com_cnsvolumeinfoes.yaml
+++ b/pkg/internalapis/cnsvolumeinfo/config/cns.vmware.com_cnsvolumeinfoes.yaml
@@ -62,6 +62,9 @@ spec:
                 validaggregatedsnapshotsize:
                   description: ValidAggregatedSnapshotSize defines if the presented AggregatedSnapshotSize is valid.
                   type: boolean
+                isLinkedClone:
+                  description: Indicates if the volume is a Linked Clone
+                  type: boolean
                 aggregatedsnapshotsize:
                   anyOf:
                     - type: integer

--- a/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
+++ b/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
@@ -59,6 +59,9 @@ type CNSVolumeInfoSpec struct {
 	// Associated time stamp of the create or delete snapshot task completion.
 	// This is used to ordering concurrent snapshots on same volume.
 	SnapshotLatestOperationCompleteTime metav1.Time `json:"snapshotlatestoperationcompletetime"`
+
+	// IsLinkedClone reports if the volume is linked clone volume
+	IsLinkedClone bool `json:"isLinkedClone"`
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -63,6 +63,7 @@ var (
 	featureGateByokEnabled                    bool
 	featureFileVolumesWithVmServiceEnabled    bool
 	featureIsSharedDiskEnabled                bool
+	featureIsLinkedCloneSupportEnabled        bool
 )
 
 // watchConfigChange watches on the webhook configuration directory for changes
@@ -151,11 +152,14 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 		featureIsSharedDiskEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.SharedDiskFss)
 		featureFileVolumesWithVmServiceEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.FileVolumesWithVmService)
+		featureIsLinkedCloneSupportEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupport)
 
-		if err := startCNSCSIWebhookManager(ctx, enableWebhookClientCertVerification); err != nil {
+		if err := startCNSCSIWebhookManager(ctx, enableWebhookClientCertVerification,
+			containerOrchestratorUtility); err != nil {
 			return fmt.Errorf("unable to run the webhook manager: %w", err)
 		}
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		featureIsLinkedCloneSupportEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupport)
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		startPVCSIWebhookManager(ctx)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
@@ -171,6 +175,8 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		featureGateTopologyAwareFileVolumeEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.TopologyAwareFileVolume)
+		featureFileVolumesWithVmServiceEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
+			common.FileVolumesWithVmService)
 
 		if featureGateCsiMigrationEnabled || featureGateBlockVolumeSnapshotEnabled {
 			certs, err := tls.LoadX509KeyPair(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile)

--- a/pkg/syncer/admissionhandler/validatepvc.go
+++ b/pkg/syncer/admissionhandler/validatepvc.go
@@ -3,8 +3,14 @@ package admissionhandler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -16,8 +22,10 @@ import (
 )
 
 const (
-	ExpandVolumeWithSnapshotErrorMessage = "Expanding volume with snapshots is not allowed"
-	DeleteVolumeWithSnapshotErrorMessage = "Deleting volume with snapshots is not allowed"
+	ExpandVolumeWithSnapshotErrorMessage   = "Expanding volume with snapshots is not allowed"
+	ExpandLinkedCloneVolumeErrorMessage    = "Expanding linked clone volume is not allowed"
+	UpdateLinkedCloneVolumeAnnErrorMessage = "Cannot update linked clone volume annotations after creation"
+	DeleteVolumeWithSnapshotErrorMessage   = "Deleting volume with snapshots is not allowed"
 )
 
 // validatePVC helps validate AdmissionReview requests for PersistentVolumeClaim.
@@ -63,10 +71,10 @@ func validatePVC(ctx context.Context, req *admissionv1.AdmissionRequest) *admiss
 				Allowed: true,
 			}
 		}
-
+		var newPVC corev1.PersistentVolumeClaim
 		var newReq resource.Quantity
 		if req.Operation != admissionv1.Delete {
-			newPVC := corev1.PersistentVolumeClaim{}
+			newPVC = corev1.PersistentVolumeClaim{}
 			log.Debugf("JSON req.Object.Raw: %v", string(req.Object.Raw))
 			// req.Object is null for DELETE operations.
 			if err := json.Unmarshal(req.Object.Raw, &newPVC); err != nil {
@@ -76,7 +84,6 @@ func validatePVC(ctx context.Context, req *admissionv1.AdmissionRequest) *admiss
 					Allowed: true,
 				}
 			}
-
 			newReq = newPVC.Spec.Resources.Requests[corev1.ResourceStorage]
 		} else {
 			reclaimPolicy, err := getPVReclaimPolicyForPVC(ctx, oldPVC)
@@ -116,6 +123,58 @@ func validatePVC(ctx context.Context, req *admissionv1.AdmissionRequest) *admiss
 				} else if req.Operation == admissionv1.Delete {
 					result = &metav1.Status{
 						Reason: DeleteVolumeWithSnapshotErrorMessage,
+					}
+				}
+			} else {
+				// Determine the state of the linked clone annotation on the old PVC
+				oldPVCHasLinkedCloneAnn := metav1.HasAnnotation(oldPVC.ObjectMeta, common.AttributeIsLinkedClone)
+				oldPVCLinkedCloneIsFalse := oldPVCHasLinkedCloneAnn && oldPVC.Annotations[common.AnnKeyLinkedClone] == "false"
+
+				// Determine the state of the linked clone annotation on the new PVC
+				newPVCHasLinkedCloneAnn := metav1.HasAnnotation(newPVC.ObjectMeta, common.AttributeIsLinkedClone)
+				newPVCLinkedCloneIsTrue := newPVCHasLinkedCloneAnn && newPVC.Annotations[common.AnnKeyLinkedClone] == "true"
+
+				if !oldPVCHasLinkedCloneAnn && newPVCHasLinkedCloneAnn {
+					// Scenario 1: Adding the linked clone annotation where it didn't exist before
+					allowed = false
+					result = &metav1.Status{
+						Reason: UpdateLinkedCloneVolumeAnnErrorMessage,
+					}
+				} else if oldPVCLinkedCloneIsFalse && newPVCLinkedCloneIsTrue {
+					// Scenario 2: Changing the linked clone annotation from "false" to "true"
+					allowed = false
+					result = &metav1.Status{
+						Reason: UpdateLinkedCloneVolumeAnnErrorMessage,
+					}
+				}
+			}
+		}
+		if featureIsLinkedCloneSupportEnabled && allowed {
+			// If the LinkedClone PVC annotation is being removed
+			if req.Operation == admissionv1.Update {
+				oldPVCLinkedClone := metav1.HasAnnotation(oldPVC.ObjectMeta, common.AttributeIsLinkedClone) &&
+					oldPVC.Annotations[common.AnnKeyLinkedClone] == "true"
+
+				if oldPVCLinkedClone {
+					newPVCLinkedClone := metav1.HasAnnotation(newPVC.ObjectMeta, common.AttributeIsLinkedClone) &&
+						newPVC.Annotations[common.AnnKeyLinkedClone] == "true"
+
+					if !newPVCLinkedClone {
+						allowed = false
+						result = &metav1.Status{
+							Reason: UpdateLinkedCloneVolumeAnnErrorMessage,
+						}
+					}
+				}
+			}
+			// If the LinkedClone PVC is being expanded
+			if req.Operation == admissionv1.Update && newReq.Cmp(oldReq) > 0 && allowed {
+				if metav1.HasAnnotation(oldPVC.ObjectMeta, common.AttributeIsLinkedClone) {
+					if oldPVC.Annotations[common.AnnKeyLinkedClone] == "true" {
+						allowed = false
+						result = &metav1.Status{
+							Reason: ExpandLinkedCloneVolumeErrorMessage,
+						}
 					}
 				}
 			}
@@ -188,4 +247,267 @@ func getSnapshotsForPVC(ctx context.Context, ns string, name string) ([]snapshot
 	}
 
 	return result, nil
+}
+
+// validateGuestPVCOperation helps validate AdmissionReview requests for PersistentVolumeClaim.
+func validateGuestPVCOperation(ctx context.Context, req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	log := logger.GetLogger(ctx)
+	isLinkedCLoneRequest := false
+	log.Debugf("validateGuestPVCOperation called with the request %s/%s", req.Namespace, req.Name)
+	if !featureIsLinkedCloneSupportEnabled {
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	if req.Kind.Kind != "PersistentVolumeClaim" || req.Operation != admissionv1.Create {
+		// Skip for non create operations
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	// Unmarshal the object as PVC
+	pvc := corev1.PersistentVolumeClaim{}
+	err := json.Unmarshal(req.Object.Raw, &pvc)
+	if err != nil {
+		log.Errorf("error deserializing pvc: %v. failing validation.", err)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: fmt.Sprintf("error deserializing pvc. error: %v, failing validation.", err),
+			},
+		}
+	}
+	log.Debugf("validateGuestPVCOperation called with the PVC request %+v", pvc)
+
+	if metav1.HasAnnotation(pvc.ObjectMeta, common.AttributeIsLinkedClone) {
+		if pvc.Annotations[common.AnnKeyLinkedClone] == "true" {
+			isLinkedCLoneRequest = true
+		}
+	}
+
+	if !isLinkedCLoneRequest {
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	isFileVolumeRequest := slices.Contains(pvc.Spec.AccessModes, corev1.ReadWriteMany) &&
+		len(pvc.Spec.AccessModes) == 1
+
+	if isFileVolumeRequest {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: "cannot create a linked clone for a file volume",
+			},
+		}
+	}
+
+	// ValidateLinkedCloneRequest validates the various conditions necessary for a valid linkedclone request.
+	// 1. The PVC datasource needs to be of type VolumeSnapshot
+	// 2. The storageclass associated LinkedClone PVC should be the same the source PVC
+	// 3. The size should be the same as the source PVC
+	// 4. Should not be a second level LinkedClone
+	// 5. VS is not under deletion
+	// 6. VS is Ready
+	// Note: order does not matter
+
+	dataSource, err := k8sorchestrator.GetPVCDataSource(ctx, &pvc)
+	if err != nil {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: fmt.Sprintf("failed to get data source for PVC. error: %v, failing validation.", err),
+			},
+		}
+	}
+	// Check if the data source field is set at all.
+	if dataSource == nil {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: "datasource not specified for linked clone PVC request",
+			},
+		}
+	}
+
+	// Validate the APIGroup. It should be "snapshot.storage.k8s.io"
+	if dataSource.APIVersion != "snapshot.storage.k8s.io" {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: "datasource type is incorrect for linked clone pvc request, epxected snapshot.storage.k8s.io",
+			},
+		}
+	}
+
+	// Validate the Kind. It must be "VolumeSnapshot".
+	if dataSource.Kind != "VolumeSnapshot" {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: "datasource Kind is incorrect for linked clone request, epxected VolumeSnapshot",
+			},
+		}
+	}
+
+	k8sClient, err := k8s.NewClient(ctx)
+	if err != nil {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: fmt.Sprintf("failed to get k8s client when validating linkedclone request"+
+					" with error: %v", err),
+			},
+		}
+	}
+
+	snapClient, err := k8s.NewSnapshotterClient(ctx)
+	if err != nil {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: fmt.Sprintf("failed to get snapshotterClient when validating linkedclone request"+
+					" with error: %v", err),
+			},
+		}
+	}
+
+	volumeSnapshot, err := snapClient.SnapshotV1().VolumeSnapshots(dataSource.Namespace).Get(ctx, dataSource.Name,
+		metav1.GetOptions{})
+	if err != nil {
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: fmt.Sprintf("error getting snapshot %s/%s from api server when validating linked clone "+
+					"request, error: %v", dataSource.Namespace, dataSource.Name, err),
+			},
+		}
+	}
+
+	if volumeSnapshot.ObjectMeta.DeletionTimestamp != nil {
+		errMsg := fmt.Sprintf("LinkedClone %s/%s source VolumeSnapshot %s/%s is marked for deletion, "+
+			"failing linkedclone request", pvc.Namespace, pvc.Name, dataSource.Namespace, dataSource.Name)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+
+	// Validate that the VolumeSnapshot is Ready
+	if volumeSnapshot.Status == nil {
+		errMsg := fmt.Sprintf("volumesnapshot %s status unavailable, failing linkedclone request",
+			volumeSnapshot.Name)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+
+	// Validate that ReadyToUse is set
+	if volumeSnapshot.Status != nil && volumeSnapshot.Status.ReadyToUse == nil {
+		errMsg := fmt.Sprintf("volumeSnapshot %s is ReadyToUse is unavailable, failing linkedclone request",
+			volumeSnapshot.Name)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+
+	// Check if the VolumeSnapshot is ready
+	if !*volumeSnapshot.Status.ReadyToUse {
+		errMsg := fmt.Sprintf("volumeSnapshot %s is not ready", volumeSnapshot.Name)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+
+	// Retrieve the source PVC from the VolumeSnapshot
+	sourcePVCName := volumeSnapshot.Spec.Source.PersistentVolumeClaimName
+	sourcePVC, err := k8sClient.CoreV1().PersistentVolumeClaims(volumeSnapshot.Namespace).Get(ctx, *sourcePVCName,
+		metav1.GetOptions{})
+	if err != nil {
+		errMsg := fmt.Sprintf("error getting source PVC %v from api server: %v", *sourcePVCName, err)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+
+	// The storageclass associated LinkedClone PVC should be the same the source PVC
+	sourcePVCStorageClassName := sourcePVC.Spec.StorageClassName
+	same := strings.Compare(*pvc.Spec.StorageClassName, *sourcePVCStorageClassName)
+	if same != 0 {
+		errMsg := fmt.Sprintf("StorageClass mismatch, LinkedClone StorageClass: %s, source PVC StorageClass: %s",
+			*pvc.Spec.StorageClassName, *sourcePVCStorageClassName)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+
+	// the size should be same
+	sourcePVCSize, ok1 := sourcePVC.Spec.Resources.Requests[corev1.ResourceStorage]
+	linkedClonePVCSize, ok2 := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if !ok1 {
+		errMsg := fmt.Sprintf("source PVC %s does not have a storage request defined", sourcePVC.Name)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+	if !ok2 {
+		errMsg := fmt.Sprintf("linkedClone PVC %s does not have a storage request defined", pvc.Name)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+	szResult := sourcePVCSize.Cmp(linkedClonePVCSize)
+	if szResult != 0 {
+		errMsg := fmt.Sprintf("size mismatch, Source PVC: %s LinkedClone PVC: %s",
+			sourcePVCSize.String(), linkedClonePVCSize.String())
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+
+	// should not be a second level LinkedClone
+	if metav1.HasAnnotation(sourcePVC.ObjectMeta, common.AnnKeyLinkedClone) {
+		errMsg := fmt.Sprintf("cannot create a LinkedClone " +
+			"from a VolumeSnapshot that is created from another LinkedClone")
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: errMsg,
+			},
+		}
+	}
+
+	// return AdmissionResponse result
+	return &admissionv1.AdmissionResponse{
+		Allowed: true,
+	}
 }

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -578,7 +578,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 			capacityInBytes := capacityInMb * common.MbInBytes
 			capacity := resource.NewQuantity(capacityInBytes, resource.BinarySI)
 			err = r.volumeInfoService.CreateVolumeInfoWithPolicyInfo(ctx, volumeID, instance.Namespace,
-				volume.StoragePolicyId, storageClassName, vc.Config.Host, capacity)
+				volume.StoragePolicyId, storageClassName, vc.Config.Host, capacity, false)
 			if err != nil {
 				log.Errorf("failed to store volumeID %q namespace %s StoragePolicyID %q StorageClassName %q and vCenter %q "+
 					"in CNSVolumeInfo CR. Error: %+v", volumeID, instance.Namespace, volume.StoragePolicyId,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for LinkedClone on Supervisor and Guest


Primary Changes in the driver are:

1. CSI Webhook on Supervisor
- Update the mutating webhook to add LinkedClone label if the LinkedClone annotation is present, this is necessary for UI
- Prevent deletion of VolumeSnapshot if there LinkedClone was created from it
- Add validations in webhook to prevent expanding a LinkedClone PVC
- Add validations in webhook to prevent LinkedClone annotation modification


2. PVCSI Webhook on Guest
- Introduce mutating webhook
- The mutating webhook adds LinkedClone label on PVC if it's a LinkedClone request
- PVCSI webhook does validation similar to the extension service.


3. Supervisor controller changes
- Detect if the request is a LinkedClone PVC by reading the parameters populated by the custom external-provisioner
- Updated CNSVolumeInfo to have a bool indicating if this is a LinkedClone
- Same the volumesnapshot namespace and name in the volume attribute context, this shows up in the PV

4. Guest controller changes
- Detect if LinkedClone from PVC annotation
- Add LinkedClone label on PVC in guest
- Determine topology requirement from the source PVC in supervisor

5. Syncer changes
- Update cnsvolumeinfo if the PVC is determined to be a LinkedClone

6. General changes:
- remove UPDATE from mutating webhook configuration

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Supervisor Testing
[LinkedClone Supervisor Testing.log](https://github.com/user-attachments/files/21013052/LinkedClone.Supervisor.Testing.log)


Guest Testing
[LinkedClone Guest Testing.log](https://github.com/user-attachments/files/21013058/LinkedClone.Guest.Testing.log)



**Special notes for your reviewer**:

**Release note**:
```release-note
CSI LinkedClone Support for WCP and Guest
```
