### PR TITLE
Adding new cns client for vsphere cns related operations

### DIFF
--- a/tests/e2e/clients/cns/cnsclient.go
+++ b/tests/e2e/clients/cns/cnsclient.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cns
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/tests/e2e/constants"
+)
+
+type CnsClient struct {
+	*soap.Client
+}
+
+var (
+	CnsVolumeManagerInstance = vimtypes.ManagedObjectReference{
+		Type:  "CnsVolumeManager",
+		Value: "cns-volume-manager",
+	}
+)
+
+// NewCnsClient creates and returns a CNS client.
+func NewCnsClient(ctx context.Context, c *vim25.Client) (*CnsClient, error) {
+	sc := c.Client.NewServiceClient(constants.VsanHealthPath, constants.VsanNamespace)
+	return &CnsClient{sc}, nil
+}


### PR DESCRIPTION
[Code-Refactor] This change creates and provides vsphere cns client to tests/utils

This change is part of code refactoring. We are separating all the clients/connections/utils to get rid of tightly coupled code. Please go through this doc for more information:
https://vmw-confluence.broadcom.net/display/spbmbangalore/CSI+e2e+code+refactor

Testing done: Locally tested with csi image creation
https://jenkins-vcf-csifvt.devops.broadcom.net/view/lvn-csi-e2e-pre-check-in/job/wcp-e2e-pre-checkin/36/console