### PR TITLE
Adding test clients for vpxd and vsan

### DIFF
--- a/tests/e2e/clients/vc/vcclient.go
+++ b/tests/e2e/clients/vc/vcclient.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package vc
+
+import (
+	"context"
+	"fmt"
+	neturl "net/url"
+
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/vim25"
+	"sigs.k8s.io/vsphere-csi-driver/v3/tests/e2e/constants"
+	"sigs.k8s.io/vsphere-csi-driver/v3/tests/e2e/env"
+)
+
+const (
+	RoundTripperDefaultCount = 3
+)
+
+// This function creates a new client for vpxd connection.
+func NewClient(ctx context.Context, vCenterIp string,
+	vCenterIpPort string, user string, password string) *govmomi.Client {
+	isPrivateNetwork := env.GetBoolEnvVarOrDefault("IS_PRIVATE_NETWORK", false)
+	if isPrivateNetwork {
+		vCenterIp = env.GetStringEnvVarOrDefault("LOCAL_HOST_IP", constants.DefaultlocalhostIP)
+	}
+	url, err := neturl.Parse(fmt.Sprintf("https://%s:%s/sdk",
+		vCenterIp, vCenterIpPort))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	url.User = neturl.UserPassword(user, password)
+	client, err := govmomi.NewClient(ctx, url, true)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = client.UseServiceVersion(constants.VsanNamespace)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(RoundTripperDefaultCount))
+	return client
+}

--- a/tests/e2e/clients/vsan/vsanclient.go
+++ b/tests/e2e/clients/vsan/vsanclient.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package vsan
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"sigs.k8s.io/vsphere-csi-driver/v3/tests/e2e/constants"
+)
+
+// VsanClient struct holds vim and soap client
+type VsanClient struct {
+	Vim25Client   *vim25.Client
+	ServiceClient *soap.Client
+}
+
+// newVsanHealthSvcClient returns vSANhealth client.
+func NewVsanHealthSvcClient(ctx context.Context, client *vim25.Client) (*VsanClient, error) {
+	sc := client.Client.NewServiceClient(constants.VsanHealthPath, constants.VsanNamespace)
+	return &VsanClient{client, sc}, nil
+}


### PR DESCRIPTION
Adding test clients for vpxd and vsan to be used in e2e tests and utils.

These clients can be used to invoke their respective apis, Which intern can be used for verification purposes.

Testing done: Yes
https://jenkins-vcf-csifvt.devops.broadcom.net/view/lvn-csi-e2e-pre-check-in/job/wcp-e2e-pre-checkin/48/