### PR TITLE
Remove dup keys in webhook rules

### DIFF
--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -656,7 +656,6 @@ webhooks:
         operations:  ["CREATE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
-        scope:  "Namespaced"
       - apiVersions: ["v1"]
         operations:  ["CREATE"]
         resources:   ["volumesnapshots"]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Remove duplicate keys in webhook rules of cns-csi yamls

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove duplicate keys in webhook rules of cns-csi yamls
```
