### PR TITLE
Add missing dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -149,3 +149,9 @@ replace (
 	k8s.io/sample-controller => k8s.io/sample-controller v0.35.0
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.1
 )
+
+// The below fixes the "go list -m all" execution
+replace (
+	k8s.io/endpointslice => k8s.io/endpointslice v0.35.0
+	k8s.io/externaljwt => k8s.io/externaljwt v0.35.0
+)


### PR DESCRIPTION
**What this PR does / why we need it**:
When using `go list -mod=readonly -m all` the command fails on k8s.io/endpointslice and k8s.io/externaljwt as they are part of kubernetes.

**Testing done**:
Tested with `go list -mod=readonly -m all` returns non-zero output with list of dependencies.

**Special notes for your reviewer**:
This has been investigated when rebasing for OpenShift, we are making sure we can compile the driver offline which means we need all dependencies mentioned in `go.mod`.

**Release note**:
```release-note
NONE
```
