### PR TITLE
Set FileVolumesWithVmService FSS in workload cluster flavour

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -149,6 +149,8 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		featureGateByokEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.WCP_VMService_BYOK)
 		featureIsSharedDiskEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.SharedDiskFss)
+		featureFileVolumesWithVmServiceEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
+			common.FileVolumesWithVmService)
 
 		if err := startCNSCSIWebhookManager(ctx, enableWebhookClientCertVerification); err != nil {
 			return fmt.Errorf("unable to run the webhook manager: %w", err)
@@ -169,8 +171,6 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		featureGateTopologyAwareFileVolumeEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.TopologyAwareFileVolume)
-		featureFileVolumesWithVmServiceEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
-			common.FileVolumesWithVmService)
 
 		if featureGateCsiMigrationEnabled || featureGateBlockVolumeSnapshotEnabled {
 			certs, err := tls.LoadX509KeyPair(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Set FileVolumesWithVmService FSS in workload cluster flavour instead of vanilla.

**Testing done**:
With FSS enabled, I was not able to create a CnsFileAccessConfig CR with the same VM+PVC combination:

```
root@421dd3dabcc798938524a01a62705c31 [ ~ ]# k apply -f cnsfileaccess.yaml 
Error from server: error when creating "cnsfileaccess.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: CnsFileAccessConfig test10-rwm-vm-5 already exists for VM vm-test10-1 and PVC rwm-pvc-test10-3
```

With FSS disabled, I was able to create CnsFileAccessConfig CR with the same VM+PVC combination:

```
root@421dd3dabcc798938524a01a62705c31 [ ~ ]# k apply -f cnsfileaccess.yaml 
cnsfileaccessconfig.cns.vmware.com/test10-rwm-vm-6 created
```