### PR TITLE
Added logic to start profiling service

### DIFF
--- a/manifests/guestcluster/1.31/pvcsi.yaml
+++ b/manifests/guestcluster/1.31/pvcsi.yaml
@@ -200,6 +200,7 @@ spec:
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--enable-profile-server=false"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2112
@@ -270,6 +271,7 @@ spec:
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--enable-profile-server=false"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/guestcluster/1.32/pvcsi.yaml
+++ b/manifests/guestcluster/1.32/pvcsi.yaml
@@ -200,6 +200,7 @@ spec:
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--enable-profile-server=false"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2112
@@ -270,6 +271,7 @@ spec:
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--enable-profile-server=false"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/guestcluster/1.33/pvcsi.yaml
+++ b/manifests/guestcluster/1.33/pvcsi.yaml
@@ -200,6 +200,7 @@ spec:
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--enable-profile-server=false"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2112
@@ -270,6 +271,7 @@ spec:
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--enable-profile-server=false"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -375,6 +375,8 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--enable-profile-server=false"
           ports:
             - containerPort: 2112
               name: prometheus
@@ -446,6 +448,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
             - "--webhook-client-cert-verification"
+            - "--enable-profile-server=false"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -382,6 +382,8 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--enable-profile-server=false"
           ports:
             - containerPort: 2112
               name: prometheus
@@ -453,6 +455,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
             - "--webhook-client-cert-verification"
+            - "--enable-profile-server=false"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -382,6 +382,8 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--enable-profile-server=false"
           ports:
             - containerPort: 2112
               name: prometheus
@@ -453,6 +455,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
             - "--webhook-client-cert-verification"
+            - "--enable-profile-server=false"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -282,6 +282,7 @@ spec:
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--enable-profile-server=false"
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -346,6 +347,7 @@ spec:
             - "--leader-election-retry-period=10s"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--enable-profile-server=false"
           imagePullPolicy: "Always"
           ports:
             - containerPort: 2113


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds profiling endpoints to the `vsphere-csi-controller` and `vsphere-syncer` containers. These endpoints will be useful for collecting performance samples, especially when running in scaled environments, to help identify bottlenecks.

- `vsphere-csi-controller`: profiling server on port **9500**
- `vsphere-syncer`: profiling server on port **9501**

In scaled environments, performance bottlenecks are harder to detect. Enabling profiling allows us to gather heap, CPU, and goroutine profiles during live workloads and improve debugging and optimization workflows.

**Testing done**:
Verified that the containers are up and running with the patch - 
```shell
vsphere-csi-controller-6fd74487db-7m946   7/7     Running   8 (5m39s ago)   16h
vsphere-csi-controller-6fd74487db-cfzl2   7/7     Running   2 (6m42s ago)   16h
vsphere-csi-controller-6fd74487db-jt27f   7/7     Running   8 (5m18s ago)   16h
vsphere-csi-webhook-854fbc5cb5-dq85j      1/1     Running   0               7d4h
vsphere-csi-webhook-854fbc5cb5-lnv7l      1/1     Running   0               3d19h
vsphere-csi-webhook-854fbc5cb5-nzfl4      1/1     Running   0               7d4h
```

Verified that we're able to collect samples from the endpoints -
```shell
curl http://localhost:9501/debug/pprof/heap?seconds=10 > heap.pprof
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3041    0  3041    0     0    297      0 --:--:--  0:00:10 --:--:--   755
``` 

Verified that the samples can be analysed using pprof -
```shell
pprof heap.pprof
File: vsphere-syncer
Build ID: e30f45bbc054ff3ab986af5d86589b35db32fdb6
Type: inuse_space
Time: 2025-06-26 15:59:03 IST
Duration: 10.08s, Total samples = 3.48MB
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 2028.13kB, 56.90% of 3564.65kB total
Showing top 10 nodes out of 34
      flat  flat%   sum%        cum   cum%
 1770.33kB 49.66% 49.66%  1770.33kB 49.66%  io.ReadAll
 -768.26kB 21.55% 28.11%  -768.26kB 21.55%  go.uber.org/zap/zapcore.newCounters (inline)
     514kB 14.42% 42.53%      514kB 14.42%  bufio.NewWriterSize
  512.06kB 14.37% 56.90%   512.06kB 14.37%  internal/profile.init.func2
         0     0% 56.90%  -768.26kB 21.55%  go.uber.org/zap.(*Logger).WithOptions
         0     0% 56.90%  -768.26kB 21.55%  go.uber.org/zap.Config.Build
         0     0% 56.90%  -768.26kB 21.55%  go.uber.org/zap.Config.buildOptions.WrapCore.func5
         0     0% 56.90%  -768.26kB 21.55%  go.uber.org/zap.Config.buildOptions.func1
         0     0% 56.90%  -768.26kB 21.55%  go.uber.org/zap.New
         0     0% 56.90%  -768.26kB 21.55%  go.uber.org/zap.optionFunc.apply
```

**Special notes for your reviewer**:
Profiling is exposed over HTTP endpoints (no auth by default), so consider implications for production use.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Expose pprof profiling endpoints on vsphere-csi-controller (port 9500) and vsphere-syncer (port 9501).
```
