### PR TITLE
Fix - Backoff duration bug for duplicate entries

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -64,7 +65,7 @@ const (
 // for new instances and for instances whose latest reconcile operation
 // succeeded. If the reconcile fails, backoff is incremented exponentially.
 var (
-	backOffDuration         map[string]time.Duration
+	backOffDuration         map[types.NamespacedName]time.Duration
 	backOffDurationMapMutex = sync.Mutex{}
 )
 
@@ -175,7 +176,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	backOffDuration = make(map[string]time.Duration)
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 	// Watch for changes to primary resource CnsFileAccessConfig.
 	err = c.Watch(source.Kind(
@@ -233,10 +234,10 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 	// Initialize backOffDuration for the instance, if required.
 	backOffDurationMapMutex.Lock()
 	var timeout time.Duration
-	if _, exists := backOffDuration[instance.Name]; !exists {
-		backOffDuration[instance.Name] = time.Second
+	if _, exists := backOffDuration[request.NamespacedName]; !exists {
+		backOffDuration[request.NamespacedName] = time.Second
 	}
-	timeout = backOffDuration[instance.Name]
+	timeout = backOffDuration[request.NamespacedName]
 	backOffDurationMapMutex.Unlock()
 
 	// Get the virtualmachine instance
@@ -286,7 +287,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 			}
 			// Cleanup instance entry from backOffDuration map.
 			backOffDurationMapMutex.Lock()
-			delete(backOffDuration, instance.Name)
+			delete(backOffDuration, request.NamespacedName)
 			backOffDurationMapMutex.Unlock()
 			return reconcile.Result{}, nil
 		}
@@ -322,7 +323,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 		}
 		// Cleanup instance entry from backOffDuration map.
 		backOffDurationMapMutex.Lock()
-		delete(backOffDuration, instance.Name)
+		delete(backOffDuration, request.NamespacedName)
 		backOffDurationMapMutex.Unlock()
 		return reconcile.Result{}, nil
 	}
@@ -334,7 +335,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 		log.Infof("CnsFileAccessConfig instance: %q on namespace: %q has status marked as done. Skipping reconcile.",
 			instance.Name, instance.Namespace)
 		backOffDurationMapMutex.Lock()
-		delete(backOffDuration, instance.Name)
+		delete(backOffDuration, request.NamespacedName)
 		backOffDurationMapMutex.Unlock()
 		return reconcile.Result{}, nil
 	}
@@ -452,7 +453,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 	}
 
 	backOffDurationMapMutex.Lock()
-	delete(backOffDuration, instance.Name)
+	delete(backOffDuration, request.NamespacedName)
 	backOffDurationMapMutex.Unlock()
 	return reconcile.Result{}, nil
 }
@@ -679,17 +680,21 @@ func recordEvent(ctx context.Context, r *ReconcileCnsFileAccessConfig,
 	instance *cnsfileaccessconfigv1alpha1.CnsFileAccessConfig, eventtype string, msg string) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("Event type is %s", eventtype)
+	namespacedName := types.NamespacedName{
+		Name:      instance.Name,
+		Namespace: instance.Namespace,
+	}
 	switch eventtype {
 	case v1.EventTypeWarning:
 		// Double backOff duration.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[instance.Name] = backOffDuration[instance.Name] * 2
+		backOffDuration[namespacedName] = backOffDuration[namespacedName] * 2
 		r.recorder.Event(instance, v1.EventTypeWarning, "CnsFileAccessConfigFailed", msg)
 		backOffDurationMapMutex.Unlock()
 	case v1.EventTypeNormal:
 		// Reset backOff duration to one second.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[instance.Name] = time.Second
+		backOffDuration[namespacedName] = time.Second
 		r.recorder.Event(instance, v1.EventTypeNormal, "CnsFileAccessConfigSucceeded", msg)
 		backOffDurationMapMutex.Unlock()
 	}

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -61,7 +61,7 @@ const defaultMaxWorkerThreadsForCSINodeTopology = 1
 // for new instances and for instances whose latest reconcile operation
 // succeeded. If the reconcile fails, backoff is incremented exponentially.
 var (
-	backOffDuration         map[string]time.Duration
+	backOffDuration         map[types.NamespacedName]time.Duration
 	backOffDurationMapMutex = sync.Mutex{}
 )
 
@@ -159,7 +159,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Initialize backoff duration map.
-	backOffDuration = make(map[string]time.Duration)
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 	// Predicates are used to determine under which conditions the reconcile
 	// callback will be made for an instance.
@@ -253,10 +253,10 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 	// Initialize backOffDuration for the instance, if required.
 	backOffDurationMapMutex.Lock()
 	var timeout time.Duration
-	if _, exists := backOffDuration[instance.Name]; !exists {
-		backOffDuration[instance.Name] = time.Second
+	if _, exists := backOffDuration[request.NamespacedName]; !exists {
+		backOffDuration[request.NamespacedName] = time.Second
 	}
-	timeout = backOffDuration[instance.Name]
+	timeout = backOffDuration[request.NamespacedName]
 	backOffDurationMapMutex.Unlock()
 
 	// Get NodeVM instance.
@@ -342,7 +342,7 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 
 	// On successful event, remove instance from backOffDuration.
 	backOffDurationMapMutex.Lock()
-	delete(backOffDuration, instance.Name)
+	delete(backOffDuration, request.NamespacedName)
 	backOffDurationMapMutex.Unlock()
 	log.Infof("Successfully updated topology labels for nodeVM %q", instance.Name)
 	return reconcile.Result{}, nil
@@ -385,10 +385,10 @@ func (r *ReconcileCSINodeTopology) reconcileForGuest(ctx context.Context, reques
 	func() {
 		backOffDurationMapMutex.Lock()
 		defer backOffDurationMapMutex.Unlock()
-		if _, exists := backOffDuration[instance.Name]; !exists {
-			backOffDuration[instance.Name] = time.Second
+		if _, exists := backOffDuration[request.NamespacedName]; !exists {
+			backOffDuration[request.NamespacedName] = time.Second
 		}
-		timeout = backOffDuration[instance.Name]
+		timeout = backOffDuration[request.NamespacedName]
 	}()
 
 	// Fetch topology labels for guest worker node backed by vmop VM.
@@ -412,7 +412,7 @@ func (r *ReconcileCSINodeTopology) reconcileForGuest(ctx context.Context, reques
 	func() {
 		backOffDurationMapMutex.Lock()
 		defer backOffDurationMapMutex.Unlock()
-		delete(backOffDuration, instance.Name)
+		delete(backOffDuration, request.NamespacedName)
 	}()
 
 	log.Infof("Successfully updated topology labels for worker %q in %s",
@@ -452,6 +452,10 @@ func updateCRStatus(ctx context.Context, r *ReconcileCSINodeTopology, instance *
 	status csinodetopologyv1alpha1.CRDStatus, eventMessage string) error {
 	log := logger.GetLogger(ctx)
 
+	namespacedName := types.NamespacedName{
+		Name:      instance.Name,
+		Namespace: instance.Namespace,
+	}
 	instance.Status.Status = status
 	switch status {
 	case csinodetopologyv1alpha1.CSINodeTopologySuccess:
@@ -462,7 +466,7 @@ func updateCRStatus(ctx context.Context, r *ReconcileCSINodeTopology, instance *
 	case csinodetopologyv1alpha1.CSINodeTopologyError:
 		// Increase backoff duration for the instance.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[instance.Name] = backOffDuration[instance.Name] * 2
+		backOffDuration[namespacedName] = backOffDuration[namespacedName] * 2
 		backOffDurationMapMutex.Unlock()
 
 		// Record an event on the CR.

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
@@ -163,7 +163,7 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 				supervisorNamespace: testSupervisorNamespace,
 			}
 
-			backOffDuration = make(map[string]time.Duration)
+			backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the type of the `backOffDuration` map used in the reconcilers from `map[string]time.Duration` to `map[types.NamespacedName]time.Duration`. This fix is required to backoff with **accurate duration** during failures for resources with same names across different namespaces.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Since the changes in all the reconcilers are identical, testing the solution with one CR should suffice. I have tested my changes using CNS Unregister Volume CRs. 

<details><summary>Test Steps</summary>
<p>

1. Create pod1 that consumes pvc1 in namespace `backoff-1`.
2. Create pod2 that consumes pvc2 in namespace `backoff-2`.
3. Create CNS Unregister Volume CRs with the same name in both namespaces at different times.
   - Create CR in namespace `backoff-1` first, then create CR in namespace `backoff-2`.
4. Both the CRs should perpetually stay in pending status as the Volumes are in use and the reconciler would keep backing them off.
4. The backoff duration for the CR in namespace `backoff-1` should be calculated based on the failure of unregistering pvc1.
5. The backoff duration for the CR in namespace `backoff-2` should be calculated based on the failure of unregistering pvc2.
6. Verify that the backoff duration for each CR is correctly calculated and does not interfere with each other.

</p>
</details> 

<details><summary>Evidence</summary>
<p>

```text
2025-06-30T11:11:25.951Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-1". timeout "1s" seconds
2025-06-30T11:11:25.977Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-1". timeout "2s" seconds
2025-06-30T11:11:26.979Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-1". timeout "4s" seconds
2025-06-30T11:11:31.011Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-1". timeout "8s" seconds
2025-06-30T11:11:39.035Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-1". timeout "16s" seconds
2025-06-30T11:11:55.054Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-1". timeout "32s" seconds
2025-06-30T11:12:27.077Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-1". timeout "1m4s" seconds
2025-06-30T11:13:31.100Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-1". timeout "2m8s" seconds
```

```text
2025-06-30T11:14:17.579Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-2". timeout "1s" seconds
2025-06-30T11:14:17.621Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-2". timeout "2s" seconds
2025-06-30T11:14:18.621Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-2". timeout "4s" seconds
2025-06-30T11:14:22.648Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-2". timeout "8s" seconds
2025-06-30T11:14:30.672Z        INFO    cnsunregistervolume/cnsunregistervolume_controller.go:206       Reconciling CnsUnregisterVolume instance "unregister1" from namespace "backoff-2". timeout "16s" seconds
```

</p>
</details> 

**Result:** As evidenced in the logs, the backoff duration calculation is unique to each custom resource - even if they have same names but live in different namespaces.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix reconcilers to apply backoff correctly for identically named resources in different namespaces by using `NamespacedName` as the map key.
```
