### PR TITLE
Added a negative test case for cluster distribution

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	cryptoRand "crypto/rand"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -8116,4 +8117,17 @@ func createtWcpNsWithZonesAndPolicies(
 	_, statusCode := invokeVCRestAPIPostRequest(vcRestSessionId, nsCreationUrl, reqBody)
 
 	return namespace, statusCode, nil
+}
+
+// Generates random string of requested length
+func genrateRandomString(length int) (string, error) {
+	var generatedString string
+	rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, length+2)
+	_, err := cryptoRand.Read(b)
+	if err != nil {
+		return generatedString, fmt.Errorf("error marshalling request body: %w", err)
+	}
+	generatedString = fmt.Sprintf("%x", b)[2 : length+2]
+	return generatedString, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a negative testcase to check for PVC stays in Pending when cluster distribution name has more than 128 char.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Adding a negative testcase to check for PVC stays in Pending when cluster distribution name has more than 128 char.

**Testing done**:
Yes.
https://gist.github.com/bn023052/481390e8cd8c44307a33beae099ec831

**Special notes for your reviewer**:
nayakb@RKJX93P79D vsphere-csi-driver % /Users/nayakb/go/bin/golangci-lint run --enable=lll --timeout 10m
nayakb@RKJX93P79D vsphere-csi-driver % 

