### PR TITLE
Adjusted timing and resolving test issue in topology and static volum…

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -2422,9 +2422,11 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 			masterIP = GetAndExpectStringEnvVar(svcMasterIP)
 		}
 
+		datastoreName, _, err := e2eVSphere.fetchDatastoreNameFromDatastoreUrl(ctx, fcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		framework.Logf("Get vmdk path from volume handle")
 		if vanillaCluster {
-			vmdk = getVmdkPathFromVolumeHandle(sshClientConfig, masterIP, defaultDatastore.Name(), pv.Spec.CSI.VolumeHandle)
+			vmdk = getVmdkPathFromVolumeHandle(sshClientConfig, masterIP, datastoreName, pv.Spec.CSI.VolumeHandle)
 		}
 		esxHost := GetAndExpectStringEnvVar(envEsxHostIP)
 		ginkgo.By("Delete the vmdk file associasted with the above FCD")

--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -846,7 +846,7 @@ var _ = ginkgo.Describe("[topology-multireplica] Topology-MultiReplica",
 					pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
 					err = fpv.DeletePersistentVolumeClaim(ctx, client, pvclaimsList[i].Name, namespace)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, pollTimeoutShort))
+					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, framework.PodDeleteTimeout))
 					err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
@@ -1103,7 +1103,7 @@ var _ = ginkgo.Describe("[topology-multireplica] Topology-MultiReplica",
 					pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
 					err = fpv.DeletePersistentVolumeClaim(ctx, client, pvclaimsList[i].Name, namespace)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, pollTimeoutShort))
+					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, framework.PodDeleteTimeout))
 					err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
@@ -1632,7 +1632,7 @@ var _ = ginkgo.Describe("[topology-multireplica] Topology-MultiReplica",
 					pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
 					err = fpv.DeletePersistentVolumeClaim(ctx, client, pvclaimsList[i].Name, namespace)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, pollTimeoutShort))
+					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, framework.PodDeleteTimeout))
 					err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
@@ -1883,7 +1883,7 @@ var _ = ginkgo.Describe("[topology-multireplica] Topology-MultiReplica",
 					pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
 					err = fpv.DeletePersistentVolumeClaim(ctx, client, pvclaimsList[i].Name, namespace)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, pollTimeoutShort))
+					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, framework.PodDeleteTimeout))
 					err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
@@ -2265,7 +2265,7 @@ var _ = ginkgo.Describe("[topology-multireplica] Topology-MultiReplica",
 					pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
 					err = fpv.DeletePersistentVolumeClaim(ctx, client, pvclaimsList[i].Name, namespace)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, pollTimeoutShort))
+					framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(ctx, client, pv.Name, poll, framework.PodDeleteTimeout))
 					err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}


### PR DESCRIPTION
**What this PR does / why we need it**: Adjusted timing and resolving test issue in topology and static volume testcases. This holds test fix for:

1. Increasing poll timeout to 5 mins to wait for PV to get deleted in topology multi replica testcases.
2. Fetch correct datastore name in testcase: deleting VMDK when CNS volume is present.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Testing done**: https://gist.github.com/Aishwarya-Hebbar/98bdfc56949587084a052bb8278131a8


