### PR TITLE
Add support for creating volume from snapshot on different datastore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/agiledragon/gomonkey/v2 v2.3.1
+	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/akutz/gofsutil v0.1.2
 	github.com/container-storage-interface/spec v1.9.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Microsoft/hnslib v0.0.8 h1:EBrIiRB7i/UYIXEC2yw22dn+RLzOmsc5S0bw2xf0Qu
 github.com/Microsoft/hnslib v0.0.8/go.mod h1:EYveQJlhKh2obmEIRB3uKN6dBd9pj1frPsrTGFppKuk=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
-github.com/agiledragon/gomonkey/v2 v2.3.1 h1:k+UnUY0EMNYUFUAQVETGY9uUTxjMdnUkP0ARyJS1zzs=
-github.com/agiledragon/gomonkey/v2 v2.3.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
+github.com/agiledragon/gomonkey/v2 v2.13.0 h1:B24Jg6wBI1iB8EFR1c+/aoTg7QN/Cum7YffG8KMIyYo=
+github.com/agiledragon/gomonkey/v2 v2.13.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/akutz/gofsutil v0.1.2 h1:aCdWrZdxajx8kllNQSKaMDpRJWSE2wcyKNy7eDMXkrI=
 github.com/akutz/gofsutil v0.1.2/go.mod h1:09JEF8dR0bTTZMQ1m3/+O1rqQyH2lG1ET34POnpzyxw=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -568,6 +568,7 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
+  "vol-from-snapshot-on-target-ds": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -568,6 +568,7 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
+  "vol-from-snapshot-on-target-ds": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -567,6 +567,7 @@ data:
   "WCP_VMService_BYOK": "false"
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
+  "vol-from-snapshot-on-target-ds": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -442,6 +442,8 @@ const (
 	SharedDiskFss = "supports_shared_disks"
 	// CSITranSactionSupport is an FSS for transaction support
 	CSITranSactionSupport = "csi-transaction-support"
+	// VolFromSnapshotOnTargetDs enables creation of volumes from snapshots on different datastores
+	VolFromSnapshotOnTargetDs = "vol-from-snapshot-on-target-ds"
 )
 
 var WCPFeatureStates = map[string]struct{}{

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -48,10 +48,8 @@ const (
 
 var ErrAvailabilityZoneCRNotRegistered = errors.New("AvailabilityZone custom resource not registered")
 
-// GetVCenter returns VirtualCenter object from specified Manager object.
-// Before returning VirtualCenter object, vcenter connection is established if
-// session doesn't exist.
-func GetVCenter(ctx context.Context, manager *Manager) (*cnsvsphere.VirtualCenter, error) {
+// getVCenterInternal is the internal implementation that can be overridden for testing
+var getVCenterInternal = func(ctx context.Context, manager *Manager) (*cnsvsphere.VirtualCenter, error) {
 	var err error
 	log := logger.GetLogger(ctx)
 	vcenter, err := manager.VcenterManager.GetVirtualCenter(ctx, manager.VcenterConfig.Host)
@@ -65,6 +63,13 @@ func GetVCenter(ctx context.Context, manager *Manager) (*cnsvsphere.VirtualCente
 		return nil, err
 	}
 	return vcenter, nil
+}
+
+// GetVCenter returns VirtualCenter object from specified Manager object.
+// Before returning VirtualCenter object, vcenter connection is established if
+// session doesn't exist.
+func GetVCenter(ctx context.Context, manager *Manager) (*cnsvsphere.VirtualCenter, error) {
+	return getVCenterInternal(ctx, manager)
 }
 
 // GetVCenters returns VirtualCenter object from specified Managers object.

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -60,6 +60,7 @@ type CreateBlockVolumeOptions struct {
 	IsVdppOnStretchedSvFssEnabled bool
 	IsByokEnabled                  bool
 	IsCSITransactionSupportEnabled bool
+	VolFromSnapshotOnTargetDs      bool
 }
 
 // CreateBlockVolumeUtil is the helper function to create CNS block volume.
@@ -285,42 +286,47 @@ func CreateBlockVolumeUtil(
 			},
 		}
 
+		// If VolFromSnapshotOnTargetDs is not enabled,
 		// select the compatible datastore for the case of create volume from snapshot
-		// step 1: query the datastore of snapshot. By design, snapshot is always located at the same datastore
-		// as the source volume
-		querySelection := cnstypes.CnsQuerySelection{
-			Names: []string{string(cnstypes.QuerySelectionNameTypeDataStoreUrl)},
-		}
-		cnsVolume, err := QueryVolumeByID(ctx, manager.VolumeManager, cnsVolumeID, &querySelection)
-		if err != nil {
-			return nil, csifault.CSIInternalFault, logger.LogNewErrorf(log,
-				"failed to query datastore for the snapshot %s with error %+v",
-				spec.ContentSourceSnapshotID, err)
-		}
-
-		// step 2: validate if the snapshot datastore is compatible with datastore candidates in create spec
-		var compatibleDatastore vim25types.ManagedObjectReference
-		var foundCompatibleDatastore bool = false
-		for _, dsInfo := range datastoreInfoList {
-			if dsInfo.Info.Url == cnsVolume.DatastoreUrl {
-				log.Infof("compatible datastore found, dsURL = %q, dsRef = %v", dsInfo.Info.Url,
-					dsInfo.Datastore.Reference())
-				compatibleDatastore = dsInfo.Datastore.Reference()
-				foundCompatibleDatastore = true
-				break
+		if !opts.VolFromSnapshotOnTargetDs {
+			// step 1: query the datastore of snapshot. By design, snapshot is always located at the same datastore
+			// as the source volume
+			querySelection := cnstypes.CnsQuerySelection{
+				Names: []string{string(cnstypes.QuerySelectionNameTypeDataStoreUrl)},
 			}
-		}
-		if !foundCompatibleDatastore {
-			return nil, csifault.CSIInternalFault, logger.LogNewErrorf(log,
-				"failed to get the compatible datastore for create volume from snapshot %s with error: %+v",
-				spec.ContentSourceSnapshotID, err)
-		}
+			cnsVolume, err := QueryVolumeByID(ctx, manager.VolumeManager, cnsVolumeID, &querySelection)
+			if err != nil {
+				return nil, csifault.CSIInternalFault, logger.LogNewErrorf(log,
+					"failed to query datastore for the snapshot %s with error %+v",
+					spec.ContentSourceSnapshotID, err)
+			}
 
-		// overwrite the datatstores field in create spec with the compatible datastore
-		log.Infof("Overwrite the datatstores field in create spec %v with the compatible datastore %v "+
-			"when create volume from snapshot %s", createSpec.Datastores, compatibleDatastore,
-			spec.ContentSourceSnapshotID)
-		createSpec.Datastores = []vim25types.ManagedObjectReference{compatibleDatastore}
+			// step 2: validate if the snapshot datastore is compatible with datastore candidates in create spec
+			var compatibleDatastore vim25types.ManagedObjectReference
+			var foundCompatibleDatastore bool = false
+			for _, dsInfo := range datastoreInfoList {
+				if dsInfo.Info.Url == cnsVolume.DatastoreUrl {
+					log.Infof("compatible datastore found, dsURL = %q, dsRef = %v", dsInfo.Info.Url,
+						dsInfo.Datastore.Reference())
+					compatibleDatastore = dsInfo.Datastore.Reference()
+					foundCompatibleDatastore = true
+					break
+				}
+			}
+			if !foundCompatibleDatastore {
+				return nil, csifault.CSIInternalFault, logger.LogNewErrorf(log,
+					"failed to get the compatible datastore for create volume from snapshot %s with error: %+v",
+					spec.ContentSourceSnapshotID, err)
+			}
+
+			// overwrite the datatstores field in create spec with the compatible datastore
+			log.Infof("Overwrite the datatstores field in create spec %v with the compatible datastore %v "+
+				"when create volume from snapshot %s", createSpec.Datastores, compatibleDatastore,
+				spec.ContentSourceSnapshotID)
+			createSpec.Datastores = []vim25types.ManagedObjectReference{compatibleDatastore}
+		} else {
+			log.Infof("VolFromSnapshotOnTargetDs is enabled, skip the compatible datastore check")
+		}
 
 		if opts.IsByokEnabled {
 			// Retrieve the encryption key ID from the source volume
@@ -1009,8 +1015,8 @@ func QueryVolumeSnapshotsByVolumeID(ctx context.Context, volManager cnsvolume.Ma
 	return csiSnapshots, nextToken, nil
 }
 
-// QueryVolumeByID is the helper function to query volume by volumeID.
-func QueryVolumeByID(ctx context.Context, volManager cnsvolume.Manager, volumeID string,
+// queryVolumeByIDInternal is the internal implementation that can be overridden for testing
+var queryVolumeByIDInternal = func(ctx context.Context, volManager cnsvolume.Manager, volumeID string,
 	querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
 	log := logger.GetLogger(ctx)
 	queryFilter := cnstypes.CnsQueryFilter{
@@ -1026,6 +1032,11 @@ func QueryVolumeByID(ctx context.Context, volManager cnsvolume.Manager, volumeID
 		return nil, ErrNotFound
 	}
 	return &queryResult.Volumes[0], nil
+}
+
+func QueryVolumeByID(ctx context.Context, volManager cnsvolume.Manager, volumeID string,
+	querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
+	return queryVolumeByIDInternal(ctx, volManager, volumeID, querySelection)
 }
 
 // Helper function to get DatastoreMoRefs.

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -7,10 +7,112 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
 )
+
+// mockVolumeManager is a mock implementation of cnsvolume.Manager for testing.
+type mockVolumeManager struct {
+	createVolumeFunc func(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+		extraParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error)
+}
+
+func (m *mockVolumeManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+	extraParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+	if m.createVolumeFunc != nil {
+		return m.createVolumeFunc(ctx, spec, extraParams)
+	}
+	return nil, "", nil
+}
+
+// Implement all other required methods from cnsvolume.Manager interface
+func (m *mockVolumeManager) AttachVolume(ctx context.Context, vm *vsphere.VirtualMachine, volumeID string,
+	checkNVMeController bool) (string, string, error) {
+	return "", "", nil
+}
+func (m *mockVolumeManager) DetachVolume(ctx context.Context, vm *vsphere.VirtualMachine,
+	volumeID string) (string, error) {
+	return "", nil
+}
+func (m *mockVolumeManager) DeleteVolume(ctx context.Context, volumeID string, deleteDisk bool) (string, error) {
+	return "", nil
+}
+func (m *mockVolumeManager) UpdateVolumeMetadata(ctx context.Context,
+	spec *cnstypes.CnsVolumeMetadataUpdateSpec) error {
+	return nil
+}
+func (m *mockVolumeManager) UpdateVolumeCrypto(ctx context.Context, spec *cnstypes.CnsVolumeCryptoUpdateSpec) error {
+	return nil
+}
+func (m *mockVolumeManager) QueryVolumeInfo(ctx context.Context,
+	volumeIDList []cnstypes.CnsVolumeId) (*cnstypes.CnsQueryVolumeInfoResult, error) {
+	return nil, nil
+}
+func (m *mockVolumeManager) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+	querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	return nil, nil
+}
+func (m *mockVolumeManager) QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+	querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	return nil, nil
+}
+func (m *mockVolumeManager) QueryVolume(ctx context.Context,
+	queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+	return nil, nil
+}
+func (m *mockVolumeManager) RelocateVolume(ctx context.Context,
+	relocateSpecList ...cnstypes.BaseCnsVolumeRelocateSpec) (*object.Task, error) {
+	return nil, nil
+}
+func (m *mockVolumeManager) ExpandVolume(ctx context.Context, volumeID string, size int64,
+	extraParams interface{}) (string, error) {
+	return "", nil
+}
+func (m *mockVolumeManager) ResetManager(ctx context.Context, vcenter *vsphere.VirtualCenter) error {
+	return nil
+}
+func (m *mockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
+	return nil
+}
+func (m *mockVolumeManager) RegisterDisk(ctx context.Context, path string, name string) (string, error) {
+	return "", nil
+}
+func (m *mockVolumeManager) RetrieveVStorageObject(ctx context.Context,
+	volumeID string) (*types.VStorageObject, error) {
+	return nil, nil
+}
+func (m *mockVolumeManager) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	return nil
+}
+func (m *mockVolumeManager) CreateSnapshot(ctx context.Context, volumeID string, desc string,
+	extraParams interface{}) (*cnsvolume.CnsSnapshotInfo, error) {
+	return nil, nil
+}
+func (m *mockVolumeManager) DeleteSnapshot(ctx context.Context, volumeID string, snapshotID string,
+	extraParams interface{}) (*cnsvolume.CnsSnapshotInfo, error) {
+	return nil, nil
+}
+func (m *mockVolumeManager) QuerySnapshots(ctx context.Context,
+	snapshotQueryFilter cnstypes.CnsSnapshotQueryFilter) (*cnstypes.CnsSnapshotQueryResult, error) {
+	return nil, nil
+}
+func (m *mockVolumeManager) IsListViewReady() bool {
+	return true
+}
+func (m *mockVolumeManager) SetListViewNotReady(ctx context.Context) {}
+func (m *mockVolumeManager) GetOperationStore() cnsvolumeoperationrequest.VolumeOperationRequest {
+	return nil
+}
+func (m *mockVolumeManager) MonitorCreateVolumeTask(ctx context.Context,
+	volumeOperationDetails **cnsvolumeoperationrequest.VolumeOperationRequestDetails, task *object.Task,
+	volNameFromInputSpec, clusterID string) (*cnsvolume.CnsVolumeInfo, string, error) {
+	return nil, "", nil
+}
 
 func TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsCnsVolumeNotFoundFault(t *testing.T) {
 	volumeId := "dummy-id"
@@ -150,4 +252,132 @@ func TestQueryAllVolumeSnapshotsWithQuerySnapshotsUnexpectedFault(t *testing.T) 
 	})
 	_, _, err := QueryAllVolumeSnapshots(context.TODO(), nil, "", 100)
 	assert.Error(t, err)
+}
+
+// TestCreateBlockVolumeFromSnapshotTargetDatastore tests the CreateBlockVolumeUtil function
+// to verify the datastore behavior based on the VolFromSnapshotOnTargetDs flag.
+func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
+	firstDatastoreMoRef := types.ManagedObjectReference{Type: "Datastore", Value: "datastore-first"}
+	secondDatastoreMoRef := types.ManagedObjectReference{Type: "Datastore", Value: "datastore-second"}
+	firstDatastoreURL := "ds:///vmfs/volumes/first-datastore/"
+
+	testCases := []struct {
+		name                      string
+		volFromSnapshotOnTargetDs bool
+		expectedDatastoreCount    int
+		description               string
+		validateFunc              func(t *testing.T, datastores []types.ManagedObjectReference)
+	}{
+		{
+			name:                      "Feature disabled - should overwrite datastores",
+			volFromSnapshotOnTargetDs: false,
+			expectedDatastoreCount:    1,
+			description: "When VolFromSnapshotOnTargetDs is false, datastores should be " +
+				"overwritten with source datastore",
+			validateFunc: func(t *testing.T, datastores []types.ManagedObjectReference) {
+				assert.Equal(t, firstDatastoreMoRef, datastores[0], "Datastore should be the source datastore")
+			},
+		},
+		{
+			name:                      "Feature enabled - should preserve datastores",
+			volFromSnapshotOnTargetDs: true,
+			expectedDatastoreCount:    2,
+			description:               "When VolFromSnapshotOnTargetDs is true, original datastores should be preserved",
+			validateFunc: func(t *testing.T, datastores []types.ManagedObjectReference) {
+				datastoreValues := make([]string, len(datastores))
+				for i, ds := range datastores {
+					datastoreValues[i] = ds.Value
+				}
+				assert.Contains(t, datastoreValues, firstDatastoreMoRef.Value, "First datastore should be preserved")
+				assert.Contains(t, datastoreValues, secondDatastoreMoRef.Value, "Second datastore should be preserved")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mock getVCenterInternal to return a mock VirtualCenter
+			originalGetVCenter := getVCenterInternal
+			getVCenterInternal = func(_ context.Context, _ *Manager) (*vsphere.VirtualCenter, error) {
+				return &vsphere.VirtualCenter{
+					Config: &vsphere.VirtualCenterConfig{
+						Host:            "test-vc",
+						DatacenterPaths: []string{},
+					},
+				}, nil
+			}
+			defer func() { getVCenterInternal = originalGetVCenter }()
+
+			// Mock queryVolumeByIDInternal to return the first datastore URL
+			originalQueryVolumeByID := queryVolumeByIDInternal
+			queryVolumeByIDInternal = func(_ context.Context, _ cnsvolume.Manager, _ string,
+				_ *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
+				return &cnstypes.CnsVolume{DatastoreUrl: firstDatastoreURL}, nil
+			}
+			defer func() { queryVolumeByIDInternal = originalQueryVolumeByID }()
+
+			// Track the create spec passed to CreateVolume
+			var capturedCreateSpec *cnstypes.CnsVolumeCreateSpec
+
+			// Mock VolumeManager.CreateVolume to capture the create spec
+			mockVolumeManager := &mockVolumeManager{
+				createVolumeFunc: func(_ context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+					_ interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+					capturedCreateSpec = spec
+					return &cnsvolume.CnsVolumeInfo{VolumeID: cnstypes.CnsVolumeId{Id: "test-volume-id"}}, "", nil
+				},
+			}
+
+			// Create a test manager with minimal configuration
+			manager := &Manager{
+				VolumeManager: mockVolumeManager,
+				CnsConfig:     &config.Config{},
+			}
+			manager.CnsConfig.Global.ClusterID = "test-cluster"
+			manager.CnsConfig.VirtualCenter = map[string]*config.VirtualCenterConfig{
+				"test-vc": {User: "test-user"},
+			}
+
+			// Create test datastore info objects
+			firstDatastoreInfo := &vsphere.DatastoreInfo{
+				Datastore: &vsphere.Datastore{Datastore: object.NewDatastore(nil, firstDatastoreMoRef)},
+				Info:      &types.DatastoreInfo{Url: firstDatastoreURL},
+			}
+			secondDatastoreInfo := &vsphere.DatastoreInfo{
+				Datastore: &vsphere.Datastore{Datastore: object.NewDatastore(nil, secondDatastoreMoRef)},
+				Info:      &types.DatastoreInfo{Url: "ds:///vmfs/volumes/second-datastore/"},
+			}
+
+			// Create spec with snapshot
+			spec := &CreateVolumeSpec{
+				Name:                    "test-volume",
+				CapacityMB:              1024,
+				VolumeType:              BlockVolumeType,
+				ContentSourceSnapshotID: "source-volume-id+snapshot-id",
+				ScParams:                &StorageClassParams{},
+			}
+
+			// Create options with the test case flag setting
+			opts := CreateBlockVolumeOptions{VolFromSnapshotOnTargetDs: tc.volFromSnapshotOnTargetDs}
+
+			// Create shared datastores list
+			sharedDatastores := []*vsphere.DatastoreInfo{firstDatastoreInfo, secondDatastoreInfo}
+
+			// Call the actual CreateBlockVolumeUtil function
+			// Note that the cluster flavor does not have a significance for this test
+			// because it depends on the VolFromSnapshotOnTargetDs flag.
+			_, _, err := CreateBlockVolumeUtil(context.Background(), cnstypes.CnsClusterFlavorWorkload,
+				manager, spec, sharedDatastores, opts, nil)
+
+			// Verify no error occurred
+			assert.NoError(t, err, "CreateBlockVolumeUtil should not return an error")
+
+			// Verify the datastore behavior
+			assert.NotNil(t, capturedCreateSpec, "Create spec should have been captured")
+			assert.Len(t, capturedCreateSpec.Datastores, tc.expectedDatastoreCount, tc.description)
+
+			// Run the test case specific validation
+			tc.validateFunc(t, capturedCreateSpec.Datastores)
+		})
+	}
 }

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -710,12 +710,15 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		CryptoKeyID:             cryptoKeyID,
 	}
 
+	volFromSnapshotOnTargetDs := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.VolFromSnapshotOnTargetDs)
 	createVolumeOpts := common.CreateBlockVolumeOptions{
 		FilterSuspendedDatastores:      filterSuspendedDatastores,
 		UseSupervisorId:                isTKGSHAEnabled,
 		IsVdppOnStretchedSvFssEnabled:  isVdppOnStretchedSVEnabled,
 		IsByokEnabled:                  isByokEnabled,
 		IsCSITransactionSupportEnabled: isCSITransactionSupportEnabled,
+		VolFromSnapshotOnTargetDs:      volFromSnapshotOnTargetDs,
 	}
 
 	var (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for creating volume from snapshot on a different datastore.
Support is only added for WCP.

In the original code, Datastores field in createSpec is first populated with compatible datastores for a new volume regardless of whether the volume is being created from a snapshot or not. After that, there is logic to find the source datastore where the snapshot is located if the volume is being created from a snapshot and Datastores in createSpec will be overwritten with the source datastore. CNS will create the volume on the source datastore.

In this PR, Datastores in createSpec will only be overwritten if the volume is being created from a snapshot and if the feature is disabled.
Otherwise, it will not be overwritten. In this case, CNS will decide where to place the volume.
Basically with this feature, vSphere CSI will no longer prevent a volume created from a snapshot from being placed on a datastore that is different from the source datastore.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Setting feature state vol-from-snapshot-on-target-ds in configmap.
Without enabling feature state vol-from-snapshot-on-target-ds:
```
root@4213eb58e334b7180f08b8fd227a9e0a [ ~ ]# kubectl create -f pvc.yaml
persistentvolumeclaim/test-pvc created

root@4213eb58e334b7180f08b8fd227a9e0a [ ~ ]# kubectl get pvc -n test-ns
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-pvc   Bound    pvc-a1bfacbd-1bed-4150-8ddb-b95918b944fe   1Gi        RWO            wcpglobal-storage-profile   <unset>                 11s

root@4213eb58e334b7180f08b8fd227a9e0a [ ~ ]# kubectl create -f snapshot.yaml
volumesnapshot.snapshot.storage.k8s.io/test-snapshot created
root@4213eb58e334b7180f08b8fd227a9e0a [ ~ ]# kubectl get volumesnapshot -n test-ns
NAME            READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
test-snapshot   true         test-pvc                            1Gi           volumesnapshotclass-delete   snapcontent-77b11659-860c-491a-8098-0a03522e1064   14s            13s


apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-restore
  namespace: test-ns
spec:
  storageClassName: wcpglobal-storage-profile
  dataSource:
    name: test-snapshot
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi

root@4213eb58e334b7180f08b8fd227a9e0a [ ~ ]# kubectl create -f restore.yaml
persistentvolumeclaim/test-restore created

root@4213eb58e334b7180f08b8fd227a9e0a [ ~ ]# kubectl get pvc -n test-ns
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-pvc       Bound    pvc-a1bfacbd-1bed-4150-8ddb-b95918b944fe   1Gi        RWO            wcpglobal-storage-profile   <unset>                 5m6s
test-restore   Bound    pvc-f4c12e3c-7c05-45d2-a7b8-a31f90eb0eab   1Gi        RWO            wcpglobal-storage-profile   <unset>                 8s
```
Creating volume from snapshot was successful. The following messages were in vSphere CSI driver logs. It showed the original code path was executed by overwriting the datastores with the compatible datastore.

```
{"level":"info","time":"2025-07-03T15:50:46.515286273Z","caller":"common/vsphereutil.go:309","msg":"compatible datastore found, dsURL = \"ds:///vmfs/volumes/6861620d-c0a73799-d40b-02004f5dddc2/\", dsRef = Datastore:datastore-37","TraceId":"ac7c8a9b-7ce3-4299-852f-7b2985226001"}
{"level":"info","time":"2025-07-03T15:50:46.515926492Z","caller":"common/vsphereutil.go:323","msg":"Overwrite the datatstores field in create spec [Datastore:datastore-36 Datastore:datastore-37] with the compatible datastore Datastore:datastore-37 when create volume from snapshot abfa48ae-9bc8-462c-87a8-0658128de18b+9ec06107-82d4-4e1c-9bae-3b6f404ecd2d","TraceId":"ac7c8a9b-7ce3-4299-852f-7b2985226001"}
{"level":"info","time":"2025-07-03T15:50:46.527528491Z","caller":"volume/manager.go:557","msg":"QuotaInfo during CreateVolume call: {Reserved:1Gi StoragePolicyId:2081b2e4-ab19-4702-b64b-a36f1b77a9c1 StorageClassName:wcpglobal-storage-profile Namespace:test-ns AggregatedSnapshotSize:<nil> SnapshotLatestOperationCompleteTime:0001-01-01 00:00:00 +0000 UTC}","TraceId":"ac7c8a9b-7ce3-4299-852f-7b2985226001"}
```

Added  vol-from-snapshot-on-target-ds: “true” in the configmap to enable the feature state.

```
root@422b417c38c9e6389e1ab032cb35fcdd [ ~ ]# cat restore6.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-restore6
  namespace: test-ns
spec:
  storageClassName: new-storage-policy
  dataSource:
    name: test-snapshot
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi

kubectl create -f restore6.yaml

root@422b417c38c9e6389e1ab032cb35fcdd [ ~ ]# kubectl get pvc -n test-ns
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-pvc        Bound    pvc-a3413cd3-1052-4adb-ae83-87bd12f9b3e6   1Gi        RWO            wcpglobal-storage-profile   <unset>                 3d6h
test-restore    Bound    pvc-924b0726-4d99-448a-b631-1e3fc3437429   1Gi        RWO            wcpglobal-storage-profile   <unset>                 3d6h
test-restore6   Bound    pvc-71fdba5c-41c6-454e-9f93-1d71e055fd40   1Gi        RWO            new-storage-policy          <unset>                 7s
```

The new PVC was created successfully. vSphere CSI logs showed the FSS was enabled and the datastore was not overwritten.

```
{"level":"info","time":"2025-07-07T20:10:36.18796207Z","caller":"common/vsphereutil.go:328","msg":"VolFromSnapshotOnTargetDs is enabled, skip the compatible datastore check","TraceId":"81c07345-e72a-4206-9776-994e20f032d1"}
{"level":"info","time":"2025-07-07T20:10:36.188127225Z","caller":"common/vsphereutil.go:329","msg":"Do not Overwrite the datatstores field in create spec [Datastore:datastore-36 Datastore:datastore-37] when create volume from snapshot ab0ede4b-31b3-4113-8582-c567aab241f5+b815308c-2ea5-4884-8747-36971c24245b","TraceId":"81c07345-e72a-4206-9776-994e20f032d1"}
……
{"level":"info","time":"2025-07-07T20:10:37.923160302Z","caller":"volume/manager.go:456","msg":"CreateVolume: VolumeName: \"pvc-71fdba5c-41c6-454e-9f93-1d71e055fd40\", opId: \"4b84c44a\"","TraceId":"81c07345-e72a-4206-9776-994e20f032d1"}
{"level":"info","time":"2025-07-07T20:10:37.926427133Z","caller":"volume/util.go:329","msg":"Volume created successfully. VolumeName: \"pvc-71fdba5c-41c6-454e-9f93-1d71e055fd40\", volumeID: \"3b501170-3d59-4164-b241-6d453f4462b7\"","TraceId":"81c07345-e72a-4206-9776-994e20f032d1"}
……
{"level":"info","time":"2025-07-07T20:10:37.946607471Z","caller":"wcp/controller.go:1253","msg":"Volume created successfully. Volume Handle: \"3b501170-3d59-4164-b241-6d453f4462b7\", PV Name: \"pvc-71fdba5c-41c6-454e-9f93-1d71e055fd40\"","TraceId":"81c07345-e72a-4206-9776-994e20f032d1"}
```


**Special notes for your reviewer**:

**Release note**:
```release-note
Adds support for creating volume from snapshot on different datastore.
```
