### PR TITLE
Chore - Refactor Virtual Machine utils

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -33,15 +33,96 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
 const (
 	// DefaultQuerySnapshotLimit constant is already present in pkg/csi/service/common/constants.go
 	// However, using that constant creates an import cycle.
 	// TODO: Refactor to move all the constants into a top level directory.
-	DefaultQuerySnapshotLimit  = int64(128)
+	DefaultQuerySnapshotLimit = int64(128)
+
 	vmOperatorApiVersionPrefix = "vmoperator.vmware.com"
+	virtualMachineCRDName      = "virtualmachines.vmoperator.vmware.com"
 )
+
+var getLatestCRDVersion = kubernetes.GetLatestCRDVersion
+
+// ListVirtualMachines lists all the virtual machines
+// converted to the latest API version(v1alpha4).
+// Since, VM Operator converts all the older API versions to the latest version,
+// this function determines the latest API version of the VirtualMachine CRD and lists the resources.
+func ListVirtualMachines(ctx context.Context, clt client.Client,
+	namespace string) (*vmoperatorv1alpha4.VirtualMachineList, error) {
+	log := logger.GetLogger(ctx)
+
+	version, err := getLatestCRDVersion(ctx, virtualMachineCRDName)
+	if err != nil {
+		log.Errorf("failed to get latest CRD version for %s: %s", virtualMachineCRDName, err)
+		return nil, err
+	}
+
+	vmList := &vmoperatorv1alpha4.VirtualMachineList{}
+	log.Info("Attempting to list virtual machines with the latest API version ", version)
+	switch version {
+	case "v1alpha1":
+		vmAlpha1List := &vmoperatorv1alpha1.VirtualMachineList{}
+		err := clt.List(ctx, vmAlpha1List, client.InNamespace(namespace))
+		if err != nil {
+			log.Error("failed listing virtual machines for v1alpha1: ", err)
+			return nil, err
+		}
+
+		err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachineList_To_v1alpha4_VirtualMachineList(
+			vmAlpha1List, vmList, nil)
+		if err != nil {
+			log.Fatal("Error converting v1alpha1 virtual machines to v1alpha4: ", err)
+			return nil, err
+		}
+	case "v1alpha2":
+		vmAlpha2List := &vmoperatorv1alpha2.VirtualMachineList{}
+		err := clt.List(ctx, vmAlpha2List, client.InNamespace(namespace))
+		if err != nil {
+			log.Error("failed listing virtual machines for v1alpha2: ", err)
+			return nil, err
+		}
+
+		err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachineList_To_v1alpha4_VirtualMachineList(
+			vmAlpha2List, vmList, nil)
+		if err != nil {
+			log.Fatal("Error converting v1alpha2 virtual machines to v1alpha4: ", err)
+			return nil, err
+		}
+	case "v1alpha3":
+		vmAlpha3List := &vmoperatorv1alpha3.VirtualMachineList{}
+		err := clt.List(ctx, vmAlpha3List, client.InNamespace(namespace))
+		if err != nil {
+			log.Error("failed listing virtual machines for v1alpha3: ", err)
+			return nil, err
+		}
+
+		err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachineList_To_v1alpha4_VirtualMachineList(
+			vmAlpha3List, vmList, nil)
+		if err != nil {
+			log.Error("Error converting v1alpha3 virtual machines to v1alpha4: ", err)
+			return nil, err
+		}
+	case "v1alpha4":
+		err := clt.List(context.Background(), vmList, client.InNamespace(namespace))
+		if err != nil {
+			log.Error("failed listing virtual machines for v1alpha4: ", err)
+			return nil, err
+		}
+	default:
+		// XXX: This should ideally never happen.
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"Unsupported version: %s...", version)
+	}
+
+	log.Infof("Successfully listed %d virtual machines in namespace %s",
+		len(vmList.Items), namespace)
+	return vmList, nil
+}
 
 // QueryVolumeUtil helps to invoke query volume API based on the feature
 // state set for using query async volume. If useQueryVolumeAsync is set to
@@ -338,95 +419,6 @@ func GetVirtualMachineAllApiVersions(ctx context.Context, vmKey types.Namespaced
 }
 func isKindNotFound(errMsg string) bool {
 	return strings.Contains(errMsg, "no matches for kind") || strings.Contains(errMsg, "no kind is registered")
-}
-func GetVirtualMachineListAllApiVersions(ctx context.Context, namespace string,
-	vmOperatorClient client.Client) (*vmoperatorv1alpha4.VirtualMachineList, error) {
-	log := logger.GetLogger(ctx)
-	vmListV1alpha1 := &vmoperatorv1alpha1.VirtualMachineList{}
-	vmListV1alpha2 := &vmoperatorv1alpha2.VirtualMachineList{}
-	vmListV1alpha3 := &vmoperatorv1alpha3.VirtualMachineList{}
-	vmListV1alpha4 := &vmoperatorv1alpha4.VirtualMachineList{}
-	var err error
-	if namespace != "" {
-		// get list of virtualmachine for specific namespace
-		log.Infof("list virtualmachines for namespace %s", namespace)
-		err = vmOperatorClient.List(ctx, vmListV1alpha4, client.InNamespace(namespace))
-		if err != nil && isKindNotFound(err.Error()) {
-			err = vmOperatorClient.List(ctx, vmListV1alpha3, client.InNamespace(namespace))
-			if err != nil && isKindNotFound(err.Error()) {
-				err := vmOperatorClient.List(ctx, vmListV1alpha2, client.InNamespace(namespace))
-				if err != nil && isKindNotFound(err.Error()) {
-					err := vmOperatorClient.List(ctx, vmListV1alpha1, client.InNamespace(namespace))
-					if err != nil {
-						return nil, err
-					} else {
-						log.Info("converting v1alpha1 VirtualMachineList to v1alpha4 VirtualMachineList")
-						err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachineList_To_v1alpha4_VirtualMachineList(
-							vmListV1alpha1, vmListV1alpha4, nil)
-						if err != nil {
-							return nil, err
-						}
-					}
-				} else if err == nil {
-					log.Info("converting v1alpha2 VirtualMachineList to v1alpha4 VirtualMachineList")
-					err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachineList_To_v1alpha4_VirtualMachineList(
-						vmListV1alpha2, vmListV1alpha4, nil)
-					if err != nil {
-						return nil, err
-					}
-				}
-			} else if err == nil {
-				log.Info("converting v1alpha3 VirtualMachineList to v1alpha4 VirtualMachineList")
-				err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachineList_To_v1alpha4_VirtualMachineList(
-					vmListV1alpha3, vmListV1alpha4, nil)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-	} else {
-		// get list of virtualmachine without providing namespace (all)
-		log.Info("list all virtualmachines")
-		err = vmOperatorClient.List(ctx, vmListV1alpha4)
-		if err != nil && isKindNotFound(err.Error()) {
-			err = vmOperatorClient.List(ctx, vmListV1alpha3)
-			if err != nil && isKindNotFound(err.Error()) {
-				err := vmOperatorClient.List(ctx, vmListV1alpha2)
-				if err != nil && isKindNotFound(err.Error()) {
-					err := vmOperatorClient.List(ctx, vmListV1alpha1)
-					if err != nil {
-						return nil, err
-					} else {
-						log.Info("converting v1alpha1 VirtualMachineList to v1alpha4 VirtualMachineList")
-						err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachineList_To_v1alpha4_VirtualMachineList(
-							vmListV1alpha1, vmListV1alpha4, nil)
-						if err != nil {
-							return nil, err
-						}
-					}
-				} else if err == nil {
-					log.Info("converting v1alpha2 VirtualMachineList to v1alpha4 VirtualMachineList")
-					err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachineList_To_v1alpha4_VirtualMachineList(
-						vmListV1alpha2, vmListV1alpha4, nil)
-					if err != nil {
-						return nil, err
-					}
-				}
-			} else if err == nil {
-				log.Info("converting v1alpha3 VirtualMachineList to v1alpha4 VirtualMachineList")
-				err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachineList_To_v1alpha4_VirtualMachineList(
-					vmListV1alpha3, vmListV1alpha4, nil)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-	}
-	if err != nil {
-		return nil, err
-	}
-	log.Infof("successfully fetched the virtual machines for namespace %s", namespace)
-	return vmListV1alpha4, nil
 }
 
 func PatchVirtualMachine(ctx context.Context, vmOperatorClient client.Client,

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -167,7 +167,7 @@ func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.Cont
 			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to get client for group %s with error: %+v", vmoperatorv1alpha4.GroupName, err)
 		}
-		vmList, err := utils.GetVirtualMachineListAllApiVersions(ctx, "", vmOperatorClient)
+		vmList, err := utils.ListVirtualMachines(ctx, vmOperatorClient, "")
 		if err != nil {
 			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to list virtualmachines with error: %+v", err)

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -51,8 +52,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"slices"
 
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
@@ -1338,7 +1337,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 
 		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
-			vmList, err := utils.GetVirtualMachineListAllApiVersions(ctx, c.supervisorNamespace, c.vmOperatorClient)
+			vmList, err := utils.ListVirtualMachines(ctx, c.vmOperatorClient, c.supervisorNamespace)
 			if err != nil {
 				msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
 				log.Error(msg)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"embed"
 	"flag"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -75,6 +76,7 @@ func GetKubeConfig(ctx context.Context) (*restclient.Config, error) {
 	log := logger.GetLogger(ctx)
 	var config *restclient.Config
 	var err error
+	// TODO-perf: can this be cached?
 	kubecfgPath := getKubeConfigPath(ctx)
 	if kubecfgPath != "" {
 		log.Debugf("k8s client using kubeconfig from %s", kubecfgPath)
@@ -642,4 +644,37 @@ func getCRDFromManifest(ctx context.Context, embedFS embed.FS, fileName string) 
 		return nil, err
 	}
 	return &crd, nil
+}
+
+// GetLatestCRDVersion retrieves the latest version of a Custom Resource Definition (CRD) by its name.
+func GetLatestCRDVersion(ctx context.Context, crdName string) (string, error) {
+	log := logger.GetLogger(ctx)
+	config, err := GetKubeConfig(ctx)
+	if err != nil {
+		log.Errorf("Failed to get KubeConfig. err: %s", err)
+		return "", err
+	}
+
+	c, err := apiextensionsclientset.NewForConfig(config)
+	if err != nil {
+		log.Errorf("Failed to create API extensions client. err: %s", err)
+		return "", err
+	}
+
+	crd, err := c.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get CRD %s. Error: %s", crdName, err)
+		return "", err
+	}
+
+	for _, version := range crd.Spec.Versions {
+		if version.Storage {
+			// This is the storage version, which is the latest version.
+			return version.Name, nil
+		}
+	}
+
+	err = fmt.Errorf("no storage version found for CRD %s", crdName)
+	log.Error(err)
+	return "", err
 }

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -792,7 +792,7 @@ func updateSVPVC(ctx context.Context, client client.Client,
 func isVmCrPresent(ctx context.Context, vmOperatorClient client.Client,
 	vmuuid string, namespace string) (*vmoperatorv1alpha4.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
-	vmList, err := utils.GetVirtualMachineListAllApiVersions(ctx, namespace, vmOperatorClient)
+	vmList, err := utils.ListVirtualMachines(ctx, vmOperatorClient, namespace)
 	if err != nil {
 		msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
 		log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
@@ -379,7 +379,7 @@ func validateVolumeNotInUse(ctx context.Context, volumeID string, pvcName string
 		return err
 	}
 
-	vmList, err := utils.GetVirtualMachineListAllApiVersions(ctx, pvcNamespace, vmOperatorClient)
+	vmList, err := utils.ListVirtualMachines(ctx, vmOperatorClient, pvcNamespace)
 	if err != nil {
 		msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
 		log.Error(msg)


### PR DESCRIPTION
**What this PR does / why we need it**:
The Virtual Machine List introduced as part of #3259 has multiple nested loops which are essentially trying to find the latest version of the VM present in the cluster and use that to list the VMs. This PR refactors the logic and makes the execution more deterministic and effective.
Also, this PR introduces tests to ensure the results are as expected.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3259 

**Testing done**:

**Integration Testing:**
Since we already have the unit tests, it is sufficient to test the integration with any one end-to-end workflow. I chose to use CNS Unregister API. Below are the test results - 

1. Created two VMs in a namespace
2. Attached a volume to one of the VMs
3. Created CNSUnregisterVolume API to unregister the above volume
4. As expected, unregistration failed and in the debug logs I can see that syncer container was able to list both the VMs .

<details><summary>Evidence</summary>
<p>

Kubectl output:
```
kubectl -n test-list-vm get virtualmachines
NAME          POWER-STATE   AGE
vm-svc-vm-1   PoweredOn     59m
vm-svc-vm-2   PoweredOn     30m
```

Logs:
```
2025-07-08T06:31:59.386Z	INFO	utils/utils.go:66	Attempting to list virtual machines with the latest API version v1alpha4
2025-07-08T06:31:59.396Z	INFO	utils/utils.go:127	Successfully listed 2 virtual machines in namespace test-list-vm
2025-07-08T06:31:59.396Z	DEBUG	cnsunregistervolume/cnsunregistervolume_controller.go:389	Found 2 VirtualMachines in namespace test-list-vm
2025-07-08T06:31:59.396Z	DEBUG	cnsunregistervolume/cnsunregistervolume_controller.go:391	Checking if volume 1cf9d273-d689-41c3-8fe1-8c34c21e6de6 is in use by VirtualMachine vm-svc-vm-1 in namespace test-list-vm
2025-07-08T06:31:59.396Z	DEBUG	cnsunregistervolume/cnsunregistervolume_controller.go:399	Volume 1cf9d273-d689-41c3-8fe1-8c34c21e6de6 is in use by VirtualMachine vm-svc-vm-1 in namespace test-list-vm
2025-07-08T06:31:59.396Z	ERROR	cnsunregistervolume/cnsunregistervolume_controller.go:246	cannot unregister the volume 1cf9d273-d689-41c3-8fe1-8c34c21e6de6 as it's in use by VirtualMachine vm-svc-vm-1 in namespace test-list-vm
sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*ReconcileCnsUnregisterVolume).Reconcile
	/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go:246
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
	/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224
```

</p>
</details> 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
