### PR TITLE
CSI Support for Consumer ViratualMachine Snapshots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,9 +23,9 @@ require (
 	github.com/pkg/sftp v1.13.6
 	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
-	github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250509154507-b93e51fc90fa
+	github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250729185616-b3910fb93c83
 	github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa
-	github.com/vmware/govmomi v0.52.0-alpha.0.0.20250806225047-fa600e0bc283
+	github.com/vmware/govmomi v0.52.0-alpha.0.0.20250807230438-0eee109f1f2c
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/sync v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -289,12 +289,12 @@ github.com/thecodeteam/gofsutil v0.1.2 h1:FL87mBzZeeuDMZm8hpYLFcYylQdq6bbm8UQ1oc
 github.com/thecodeteam/gofsutil v0.1.2/go.mod h1:7bDOpr2aMnmdm9RTdxBEeqdOr+8RpnQhsB/VUEI3DgM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
-github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250509154507-b93e51fc90fa h1:LRfm1EMc+L96FzMOwujwbifo6pd/dkBJ4QhofuYNzBw=
-github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250509154507-b93e51fc90fa/go.mod h1:V0JbH4beGCU+q7yqnWUYYOuDij0ut5i1iBO4cyzg+tM=
+github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250729185616-b3910fb93c83 h1:EvjDjVpO5x4W/ITTjkfzdABa0NHxaqXGaasvOQfCJ2g=
+github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250729185616-b3910fb93c83/go.mod h1:f2zOJg30nPEsBBF0SlSw5hin1cZs2L5lDdB1t0gzqnc=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa h1:4MKu14YJ7J54O6QKmT4ds5EUpysWLLtQRMff73cVkmU=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa/go.mod h1:8tiuyYslzjLIUmOlXZuGKQdQP2ZgWGCVhVeyptmZYnk=
-github.com/vmware/govmomi v0.52.0-alpha.0.0.20250806225047-fa600e0bc283 h1:bHQhigLaGJxz73T0+k1ZtOP/1UNjBp85UwRjJ+0BFwU=
-github.com/vmware/govmomi v0.52.0-alpha.0.0.20250806225047-fa600e0bc283/go.mod h1:ZJ5Zd2wDGRzsTRBqA1jpqtbyoe8mRok1rWiPsrL8c7k=
+github.com/vmware/govmomi v0.52.0-alpha.0.0.20250807230438-0eee109f1f2c h1:1nMVFr1CBMSNLLjsfx3QPfZ5k0R1/O29QX/A2X0w3RQ=
+github.com/vmware/govmomi v0.52.0-alpha.0.0.20250807230438-0eee109f1f2c/go.mod h1:ZJ5Zd2wDGRzsTRBqA1jpqtbyoe8mRok1rWiPsrL8c7k=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 h1:S2dVYn90KE98chqDkyE9Z4N61UnQd+KOfgp5Iu53llk=

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -129,6 +129,9 @@ rules:
   - apiGroups: ["nsx.vmware.com"]
     resources: ["namespacenetworkinfos"]
     verbs: ["get", "list"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachinesnapshots"]
+    verbs: ["get", "list", "patch", "update", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/apis/cnsoperator/register.go
+++ b/pkg/apis/cnsoperator/register.go
@@ -75,6 +75,10 @@ var (
 	CnsStoragePolicyReservationSingular = "storagepolicyreservation"
 	// CnsStoragePolicyReservationPlural is plural of StoragePolicyReservation
 	CnsStoragePolicyReservationPlural = "storagepolicyreservations"
+	// CnsVirtualMachineSnapshotSingular is Singular of VirtualMachineSnapshot
+	CnsVirtualMachineSnapshotSingular = "vitualmachinesnapshot"
+	// CnsVirtualMachineSnapshotPlural is plural of VirtualMachineSnapshot
+	CnsVirtualMachineSnapshotPlural = "vitualmachinesnapshots"
 )
 
 var (

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -223,3 +223,8 @@ func (m *MockVolumeManager) BatchAttachVolumes(ctx context.Context,
 	}
 	return []cnsvolume.BatchAttachResult{}, "", nil
 }
+
+func (m *MockVolumeManager) SyncVolume(ctx context.Context,
+	syncVolumeSpecs []cnstypes.CnsSyncVolumeSpec) (string, error) {
+	return "", nil
+}

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -546,7 +546,8 @@ func UpdateVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
 		}
 	}
 	if err != nil {
-		log.Errorf("UpdateVirtualMachine: error while updating virtualmachine name: %s, err %v", vmV1alpha4.Name, err)
+		log.Errorf("UpdateVirtualMachine: error while updating virtualmachine name: %s, err %v",
+			vmV1alpha4.Name, err)
 		return err
 	}
 	log.Infof("UpdateVirtualMachine: successfully updated the virtualmachine, name: %s", vmV1alpha4.Name)

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -456,6 +456,9 @@ const (
 	LinkedCloneSupport = "supports_FCD_linked_clone"
 	// LinkedCloneSupportFSS is an FSS for LinkedClone support in pvcsi
 	LinkedCloneSupportFSS = "linked-clone-support"
+	// WCPVMServiceVMSnapshots is a supervisor capability indicating
+	// if supports_VM_service_VM_snapshots FSS is enabled
+	WCPVMServiceVMSnapshots = "supports_VM_service_VM_snapshots"
 )
 
 var WCPFeatureStates = map[string]struct{}{
@@ -467,6 +470,7 @@ var WCPFeatureStates = map[string]struct{}{
 	SharedDiskFss:                   {},
 	LinkedCloneSupport:              {},
 	StoragePolicyReservationSupport: {},
+	WCPVMServiceVMSnapshots:         {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
@@ -476,6 +480,7 @@ var WCPFeatureStates = map[string]struct{}{
 var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 	WorkloadDomainIsolation: {},
 	LinkedCloneSupport:      {},
+	WCPVMServiceVMSnapshots: {},
 }
 
 // WCPFeatureAssociatedWithPVCSI contains FSS name used in PVCSI and associated WCP Capability name on a

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -129,6 +129,10 @@ func (m *mockVolumeManager) BatchAttachVolumes(ctx context.Context,
 	return []cnsvolume.BatchAttachResult{}, "", nil
 }
 
+func (m *mockVolumeManager) SyncVolume(ctx context.Context,
+	syncVolumeSpecs []cnstypes.CnsSyncVolumeSpec) (string, error) {
+	return "", nil
+}
 func TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsCnsVolumeNotFoundFault(t *testing.T) {
 	volumeId := "dummy-id"
 	patches := gomonkey.ApplyFunc(utils.QuerySnapshotsUtil, func(_ context.Context, _ cnsvolume.Manager,

--- a/pkg/syncer/cnsoperator/controller/add_virtualmachinesnapshot.go
+++ b/pkg/syncer/cnsoperator/controller/add_virtualmachinesnapshot.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, virtualmachinesnapshot.Add)
+}

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -213,6 +213,11 @@ func (m *mockVolumeManager) CreateVolume(ctx context.Context, spec *cnstypes.Cns
 	return nil, "", nil
 }
 
+func (m *mockVolumeManager) SyncVolume(ctx context.Context,
+	syncVolumeSpecs []cnstypes.CnsSyncVolumeSpec) (string, error) {
+	return "", nil
+}
+
 type mockCOCommon struct{}
 
 func (m *mockCOCommon) EnableFSS(ctx context.Context, featureName string) error {

--- a/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -1,0 +1,478 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualmachinesnapshot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	corev1 "k8s.io/api/core/v1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	commonconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer"
+)
+
+const (
+	defaultMaxWorkerThreadsForVirtualMachineSnapshot = 10
+	allowedRetriesToPatchCNSVolumeInfo               = 5
+	SyncVolumeFinalizer                              = "cns.vmware.com/syncvolume"
+	VMSnapshotFinalizer                              = "vmoperator.vmware.com/virtualmachinesnapshot"
+)
+
+var (
+	// backOffDuration is a map of virtualmachinesnapshot name's to the time after which
+	// a request for this instance will be requeued.
+	// Initialized to 1 second for new instances and for instances whose latest
+	// reconcile operation succeeded.
+	// If the reconcile fails, backoff is incremented exponentially.
+	backOffDuration         map[apitypes.NamespacedName]time.Duration
+	backOffDurationMapMutex = sync.Mutex{}
+)
+
+// Add creates a new VirtualMachineSnapshot Controller and adds it to the Manager,
+// ConfigurationInfo and VirtualCenterTypes. The Manager will set fields on the
+// Controller and start it when the Manager is Started.
+func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
+	configInfo *commonconfig.ConfigurationInfo, volumeManager volumes.Manager) error {
+	ctx, log := logger.GetNewContextWithLogger()
+
+	var coCommonInterface commonco.COCommonInterface
+	var err error
+	var volumeInfoService cnsvolumeinfo.VolumeInfoService
+	// VirtualMachineSnapshot quota validation is only supported on WCP.
+	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx,
+			common.Kubernetes, clusterFlavor, &syncer.COInitParams)
+		if err != nil {
+			log.Errorf("failed to create CO agnostic interface. Er	r: %v", err)
+			return err
+		}
+		var err error
+		if !coCommonInterface.IsFSSEnabled(ctx, common.WCPVMServiceVMSnapshots) {
+			log.Info("Not initializing the VirtualMachineSnapshot Controller as " +
+				"this feature is disabled on the cluster")
+			return nil
+		}
+		log.Info("Creating CnsVolumeInfo Service to persist mapping for VolumeID to storage policy info")
+		volumeInfoService, err = cnsvolumeinfo.InitVolumeInfoService(ctx)
+		if err != nil {
+			return logger.LogNewErrorf(log, "error initializing volumeInfoService. Error: %+v", err)
+		}
+		log.Info("Successfully initialized VolumeInfoService")
+	} else {
+		log.Info("Not initializing VirtualMachineSnapshot Controller as guest/vanilla cluster is detected.")
+		return nil
+	}
+	// Initializes kubernetes client.
+	k8sclient, err := k8s.NewClient(ctx)
+	if err != nil {
+		log.Errorf("Creating Kubernetes client failed. Err: %v", err)
+		return err
+	}
+	restClientConfig, err := k8s.GetKubeConfig(ctx)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to initialize rest clientconfig. Error: %+v", err)
+		log.Error(msg)
+		return err
+	}
+	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatorv1alpha4.GroupName)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to initialize vmOperatorClient. Error: %+v", err)
+		log.Error(msg)
+		return err
+	}
+
+	// eventBroadcaster broadcasts events on virtualmachinesnapshot instances to the
+	// event sink.
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(
+		&typedcorev1.EventSinkImpl{
+			Interface: k8sclient.CoreV1().Events(""),
+		},
+	)
+	logger := ctrl.Log.WithName("controllers").WithName("VirtualMachineSnapshot")
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: apis.GroupName})
+	return add(mgr, newReconciler(mgr, configInfo, volumeManager,
+		recorder, vmOperatorClient, volumeInfoService, logger))
+}
+
+// newReconciler returns a new reconcile.Reconciler.
+func newReconciler(mgr manager.Manager, configInfo *commonconfig.ConfigurationInfo,
+	volumeManager volumes.Manager, recorder record.EventRecorder, vmOperatorClient client.Client,
+	volumeInfoService cnsvolumeinfo.VolumeInfoService, logger logr.Logger) reconcile.Reconciler {
+	return &ReconcileVirtualMachineSnapshot{
+		client:            mgr.GetClient(),
+		scheme:            mgr.GetScheme(),
+		configInfo:        configInfo,
+		volumeManager:     volumeManager,
+		recorder:          recorder,
+		vmOperatorClient:  vmOperatorClient,
+		volumeInfoService: volumeInfoService,
+		Logger:            logger,
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler.
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	ctx, log := logger.GetNewContextWithLogger()
+	maxWorkerThreads := getMaxWorkerThreadsToReconcileVirtualMachineSnapshot(ctx)
+	// Create a new controller.
+	c, err := controller.New("virtualmachinesnapshot-controller", mgr,
+		controller.Options{Reconciler: r, MaxConcurrentReconciles: maxWorkerThreads})
+	if err != nil {
+		log.Errorf("Failed to create new VirtualMachineSnapshot controller with error: %+v", err)
+		return err
+	}
+	backOffDuration = make(map[apitypes.NamespacedName]time.Duration)
+	// Watch for changes to primary resource VirtualMachineSnapshot.
+	err = c.Watch(source.Kind(mgr.GetCache(),
+		&vmoperatorv1alpha4.VirtualMachineSnapshot{},
+		&handler.TypedEnqueueRequestForObject[*vmoperatorv1alpha4.VirtualMachineSnapshot]{}))
+	if err != nil {
+		log.Errorf("Failed to watch for changes to VirtualMachineSnapshot resource with error: %+v", err)
+		return err
+	}
+	return nil
+}
+
+// blank assignment to verify that ReconcileVirtualMachineSnapshot implements
+// reconcile.Reconciler.
+var _ reconcile.Reconciler = &ReconcileVirtualMachineSnapshot{}
+
+// ReconcileVirtualMachineSnapshot reconciles a VirtualMachineSnapshot object.
+type ReconcileVirtualMachineSnapshot struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver.
+	client            client.Client
+	scheme            *runtime.Scheme
+	configInfo        *commonconfig.ConfigurationInfo
+	volumeManager     volumes.Manager
+	recorder          record.EventRecorder
+	volumeInfoService cnsvolumeinfo.VolumeInfoService
+	vmOperatorClient  client.Client
+	Logger            logr.Logger
+}
+
+// Reconcile reads that state of the cluster for a VirtualMachineSnapshot object and
+// makes changes based on the state read and what is in VirtualMachineSnapshot.Spec.
+// Note:
+// The Controller will requeue the Request to be processed again if the returned
+// error is non-nil or Result.Requeue is true. Otherwise, upon completion it
+// will remove the work from the queue.
+func (r *ReconcileVirtualMachineSnapshot) Reconcile(ctx context.Context,
+	request reconcile.Request) (reconcile.Result, error) {
+	traceId := uuid.NewString()
+	logger := r.Logger.WithValues("name", request.NamespacedName, "trace", traceId)
+	now := time.Now()
+	logger.Info("Reconcile Started")
+	defer func() {
+		logger.Info("Reconcile Completed", "Time Taken", time.Since(now))
+	}()
+	// Fetch the VirtualMachineSnapshot instance.
+	vmSnapshot := &vmoperatorv1alpha4.VirtualMachineSnapshot{}
+	err := r.client.Get(ctx, request.NamespacedName, vmSnapshot)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("resource not found. Ignoring since object must be deleted",
+				"VMSnapshotName", request.Name, "VMSnapshotNamespace", request.Namespace)
+			return reconcile.Result{}, nil
+		}
+		logger.Error(err, "error while fetch the VirtualMachineSnapshot",
+			"VMSnapshotName", request.Name, "VMSnapshotNamespace", request.Namespace)
+		// Error reading the object - return with err.
+		return reconcile.Result{}, err
+	}
+
+	// Initialize backOffDuration for the instance, if required.
+	backOffDurationMapMutex.Lock()
+	var timeout time.Duration
+	if _, exists := backOffDuration[request.NamespacedName]; !exists {
+		backOffDuration[request.NamespacedName] = time.Second
+	}
+	timeout = backOffDuration[request.NamespacedName]
+	backOffDurationMapMutex.Unlock()
+
+	logger.Info("Reconciling virtualmachinesnapshot",
+		"VMSnapshotName", request.Name, "VMSnapshotNamespace", request.Namespace)
+	err = r.reconcileNormal(ctx, logger, vmSnapshot)
+	if err != nil {
+		return reconcile.Result{RequeueAfter: timeout}, err
+	}
+	backOffDurationMapMutex.Lock()
+	delete(backOffDuration, request.NamespacedName)
+	backOffDurationMapMutex.Unlock()
+	return reconcile.Result{}, nil
+}
+func (r *ReconcileVirtualMachineSnapshot) reconcileNormal(ctx context.Context, logger logr.Logger,
+	vmsnapshot *vmoperatorv1alpha4.VirtualMachineSnapshot) error {
+	deleteVMSnapshot := false
+	if vmsnapshot.DeletionTimestamp.IsZero() {
+		// If the finalizer is not present, add it.
+		logger.Info("reconcileNormal: Adding finalizer on virtualmachinesnapshot cr", "VMSnapshotName", vmsnapshot.Name,
+			"VMSnapshotNamespace", vmsnapshot.Namespace, "Finalizer", SyncVolumeFinalizer)
+		vmSnapshotPatch := client.MergeFrom(vmsnapshot.DeepCopy())
+		if controllerutil.AddFinalizer(vmsnapshot, SyncVolumeFinalizer) {
+			err := r.client.Patch(ctx, vmsnapshot, vmSnapshotPatch)
+			if err != nil {
+				logger.Error(err, "reconcileNormal: error while add finalizer to virtualmachinesnapshot CR",
+					"VMSnapshotName", vmsnapshot.Name, "VMSnapshotNamespace", vmsnapshot.Name)
+				return err
+			}
+			return nil
+		}
+	}
+	if !vmsnapshot.DeletionTimestamp.IsZero() &&
+		controllerutil.ContainsFinalizer(vmsnapshot, SyncVolumeFinalizer) {
+		if !controllerutil.ContainsFinalizer(vmsnapshot, VMSnapshotFinalizer) {
+			logger.Info("reconcileNormal: virtualmachinesnapshot is set to delete",
+				"VMSnapshotName", vmsnapshot.Name, "VMSnapshotNamespace", vmsnapshot.Namespace)
+			deleteVMSnapshot = true
+		} else {
+			logger.Info("reconcileNormal: virtualmachinesnapshot is set to delete, "+
+				"expecting to remove VMSnapshotFinalizer first", "VMSnapshotName", vmsnapshot.Name,
+				"VMSnapshotNamespace", vmsnapshot.Namespace)
+			return nil
+		}
+	}
+	// Check for the annotation "csi.vsphere.volume.sync: Requested"
+	syncVolumeAnnotation := strings.ToLower(vmsnapshot.Annotations["csi.vsphere.volume.sync"])
+	// process quota validation if annotation value is "Requested"
+	// annotation value is set to "Requested" by vm-service when snapshot is completed successfully.
+	if syncVolumeAnnotation == "requested" || deleteVMSnapshot {
+		// if found fetch vmsnapshot and pvcs and pvs
+		vmKey := apitypes.NamespacedName{
+			Namespace: vmsnapshot.Namespace,
+			Name:      vmsnapshot.Spec.VMRef.Name,
+		}
+		logger.Info("reconcileNormal: get virtulal machine", "VirtualMachineName", vmKey.Name,
+			"VirtualMachineNamespace", vmKey.Namespace)
+		virtualMachine, _, err := utils.GetVirtualMachineAllApiVersions(ctx, vmKey,
+			r.vmOperatorClient)
+		if err != nil {
+			logger.Error(err, "could not get VirtualMachine", "VirtualMachineName", vmKey.Name,
+				"VirtualMachineNamespace", vmKey.Namespace)
+			return err
+		}
+		logger.Info("reconcileNormal: sync and update storage quota for vmsnapshot",
+			"VMSnapshotName", vmsnapshot.Name, "VMSnapshotNamespace", vmsnapshot.Namespace)
+		err = r.syncVolumesAndUpdateCNSVolumeInfo(ctx, logger, virtualMachine)
+		if err != nil {
+			logger.Error(err, "Failed to validate VirtualMachineSnapshot", "VMSnapshotName", vmsnapshot.Name,
+				"VMSnapshotNamespace", vmsnapshot.Namespace)
+			return err
+		}
+		logger.Info("reconcileNormal: successfully synced and updated storage quota for vmsnapshot",
+			"VMSnapshotName", vmsnapshot.Name, "VMSnapshotNamespace", vmsnapshot.Namespace)
+		if deleteVMSnapshot {
+			logger.Info("deleting virtualmachinesnapshot", "VMSnapshotName", vmsnapshot.Name,
+				"VMSnapshotNamespace", vmsnapshot.Namespace, "SyncVolumeFinalizer", SyncVolumeFinalizer)
+			vmSnapshotPatch := client.MergeFrom(vmsnapshot.DeepCopy())
+			if controllerutil.RemoveFinalizer(vmsnapshot, SyncVolumeFinalizer) {
+				err = r.client.Patch(ctx, vmsnapshot, vmSnapshotPatch)
+				if err != nil {
+					logger.Error(err, "failed to remove finalizer for VirtualMachineSnapshot CR",
+						"VMSnapshotName", vmsnapshot.Name, "VMSnapshotNamespace", vmsnapshot.Namespace)
+					return err
+				}
+				return nil
+			}
+		}
+		// Update VMSnapshot CR annotation to "csi.vsphere.volume.sync: completed"
+		logger.Info("reconcileNormal: update vmsnapshot annotation value to completed",
+			"VMSnapshotName", vmsnapshot.Name, "VMSnapshotNamespace", vmsnapshot.Namespace)
+		vmSnapshotPatch := client.MergeFrom(vmsnapshot.DeepCopy())
+		vmsnapshot.Annotations["csi.vsphere.volume.sync"] = "completed"
+		err = r.client.Patch(ctx, vmsnapshot, vmSnapshotPatch)
+		if err != nil {
+			logger.Error(err, "could not update VirtualMachineSnapshot CR",
+				"VMSnapshotName", vmsnapshot.Name, "VMSnapshotNamespace", vmsnapshot.Namespace)
+			return err
+		}
+		logger.Info("reconcileNormal: successfully updated vmsnapshot",
+			"VMSnapshotName", vmsnapshot.Name, "VMSnapshotNamespace", vmsnapshot.Namespace)
+	}
+	return nil
+}
+
+// getMaxWorkerThreadsToReconcileVirtualMachineSnapshot returns the maximum number
+// of worker threads which can be run to reconcile VirtualMachineSnapshot instances.
+// If environment variable WORKER_THREADS_VIRTUAL_MACHINE_SNAPSHOT is set and valid,
+// return the value read from environment variable. Otherwise, use the default
+// value.
+func getMaxWorkerThreadsToReconcileVirtualMachineSnapshot(ctx context.Context) int {
+	log := logger.GetLogger(ctx)
+	workerThreads := defaultMaxWorkerThreadsForVirtualMachineSnapshot
+	envVal := os.Getenv("WORKER_THREADS_VIRTUAL_MACHINE_SNAPSHOT")
+	if envVal == "" {
+		log.Debugf("WORKER_THREADS_VIRTUAL_MACHINE_SNAPSHOT is not set. Picking the default value %d",
+			defaultMaxWorkerThreadsForVirtualMachineSnapshot)
+		return workerThreads
+	}
+	value, err := strconv.Atoi(envVal)
+	if err != nil {
+		log.Warnf("Invalid value for WORKER_THREADS_VIRTUAL_MACHINE_SNAPSHOT: %s. Using default value %d",
+			envVal, defaultMaxWorkerThreadsForVirtualMachineSnapshot)
+		return workerThreads
+	}
+	switch {
+	case value <= 0 || value > defaultMaxWorkerThreadsForVirtualMachineSnapshot:
+		log.Warnf("Value %s for WORKER_THREADS_VIRTUAL_MACHINE_SNAPSHOT is invalid. Using default value %d",
+			envVal, defaultMaxWorkerThreadsForVirtualMachineSnapshot)
+	default:
+		workerThreads = value
+		log.Debugf("Maximum number of worker threads to reconcile VirtualMachineSnapshot is set to %d",
+			workerThreads)
+	}
+	return workerThreads
+}
+
+// syncVolumesAndUpdateCNSVolumeInfo will fetch the volume-ids attached to virtualmachine
+// will call SyncVolume API with sync mode SPACE_USAGE and volume-id list
+// after volume sync is successful it will fetch the aggregated size of all related volumes
+// will update the relevant CNSVolumeInfo for each volume which will update the storage policy usage.
+func (r *ReconcileVirtualMachineSnapshot) syncVolumesAndUpdateCNSVolumeInfo(ctx context.Context,
+	logger logr.Logger, vm *vmoperatorv1alpha4.VirtualMachine) error {
+	var err error
+	cnsVolumeIds := []cnstypes.CnsVolumeId{}
+	syncMode := []string{string(cnstypes.CnsSyncVolumeModeSPACE_USAGE)}
+	for _, vmVolume := range vm.Spec.Volumes {
+		pvcKey := apitypes.NamespacedName{
+			Namespace: vm.Namespace,
+			Name:      vmVolume.Name,
+		}
+		pvc := &corev1.PersistentVolumeClaim{}
+		err = r.client.Get(ctx, pvcKey, pvc, &client.GetOptions{})
+		if err != nil {
+			logger.Error(err, "syncVolumesAndUpdateCNSVolumeInfo: error get pvc",
+				"PVCName", vmVolume.Name, "PVCNamespace", vm.Namespace)
+			return err
+		}
+		if pvc.Spec.VolumeName != "" {
+			pvKey := apitypes.NamespacedName{
+				Name: pvc.Spec.VolumeName,
+			}
+			pv := &corev1.PersistentVolume{}
+			err = r.client.Get(ctx, pvKey, pv, &client.GetOptions{})
+			if err != nil {
+				logger.Error(err, "syncVolumesAndUpdateCNSVolumeInfo: could not get the volume for pvc",
+					"PVCName", pvc.Name, "PVCNamespace", vm.Namespace)
+				return err
+			}
+			if pv.Spec.CSI != nil && pv.Spec.CSI.VolumeHandle != "" {
+				cnsVolId := cnstypes.CnsVolumeId{Id: pv.Spec.CSI.VolumeHandle}
+				cnsVolumeIds = append(cnsVolumeIds, cnsVolId)
+				syncVolumeSpecs := []cnstypes.CnsSyncVolumeSpec{
+					{
+						VolumeId: cnsVolId,
+						SyncMode: syncMode,
+					},
+				}
+				// Trigger CNS VolumeSync API for identified volume-lds and Fetch Latest Aggregated snapshot size
+				logger.Info("syncVolumesAndUpdateCNSVolumeInfo: Trigger CNS VolumeSync API for volume",
+					"VolumeId", cnsVolId)
+				syncVolumeFaultType, err := r.volumeManager.SyncVolume(ctx, syncVolumeSpecs)
+				if err != nil {
+					logger.Error(err, "syncVolumesAndUpdateCNSVolumeInfo: error while sync volume",
+						"cnsfault", syncVolumeFaultType, "VolumeId", cnsVolId)
+					return err
+				}
+			}
+		} else {
+			err = fmt.Errorf("could not find the PV associated with PVC %s/%s",
+				vm.Namespace, vmVolume.Name)
+			logger.Error(err, "syncVolumesAndUpdateCNSVolumeInfo: pv not found")
+			return err
+		}
+	}
+	// fetch updated cns volumes
+	queryFilter := cnstypes.CnsQueryFilter{
+		VolumeIds: cnsVolumeIds,
+	}
+	queryResult, err := r.volumeManager.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		logger.Error(err, "syncVolumesAndUpdateCNSVolumeInfo: error while query volumes from cns")
+		return err
+	}
+	if queryResult != nil && len(queryResult.Volumes) > 0 {
+		for _, cnsvolume := range queryResult.Volumes {
+			val, ok := cnsvolume.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+			if ok {
+				logger.Info("syncVolumesAndUpdateCNSVolumeInfo: fetched aggregated capacity for volume",
+					"AggregatedSnapshotCapacityInMb", val.AggregatedSnapshotCapacityInMb,
+					"VolumeId", cnsvolume.VolumeId.Id)
+				//  Update CNSVolumeInfo with latest aggregated Size and Update SPU used value.
+				patch, err := common.GetCNSVolumeInfoPatch(ctx, val.AggregatedSnapshotCapacityInMb,
+					cnsvolume.VolumeId.Id) // TODO: UDPATE to value returned
+				if err != nil {
+					logger.Error(err, "syncVolumesAndUpdateCNSVolumeInfo: failed to get cnsvolumeinfo patch")
+					return err
+				}
+				patchBytes, err := json.Marshal(patch)
+				if err != nil {
+					logger.Error(err, "syncVolumesAndUpdateCNSVolumeInfo: error while json marshal")
+					return err
+				}
+				err = r.volumeInfoService.PatchVolumeInfo(ctx, cnsvolume.VolumeId.Id,
+					patchBytes, allowedRetriesToPatchCNSVolumeInfo)
+				if err != nil {
+					logger.Error(err, "syncVolumesAndUpdateCNSVolumeInfo: "+
+						"failed to patch cnsvolumeinfo")
+					return err
+				}
+			} else {
+				err = fmt.Errorf("unable to retrieve CnsBlockBackingDetails for volumeID %s",
+					cnsvolume.VolumeId.Id)
+				logger.Error(err, "syncVolumesAndUpdateCNSVolumeInfo: "+
+					"could not retrieve CnsBlockBackingDetails")
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
@@ -304,6 +305,10 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	}
 	if err := wcpcapapis.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Errorf("failed to set the scheme for Cns operator. Err: %+v", err)
+		return err
+	}
+	if err := vmoperatorv1alpha4.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Errorf("failed to set the scheme for vm operator. Err: %+v", err)
 		return err
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CSI Support for Consumer ViratualMachine Snapshots 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing :

Logs:
```
root@423140ed660d5a390b66dbb478cb8cae [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml 
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml 
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get pvc
NAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc    Bound    pvc-9475b505-ae58-4c3b-a108-d05142ed7f72   5Gi        RWO            wcpglobal-storage-profile   <unset>                 4d16h
example-raw-block-pvc2   Bound    pvc-41e83449-0e9a-4ad8-a954-d5f86224fa9d   5Gi        RWO            wcpglobal-storage-profile   <unset>                 4d16h
example-raw-block-pvc3   Bound    pvc-b9a3ce30-c8db-43c6-b9f7-a247e886c595   5Gi        RWO            wcpglobal-storage-profile   <unset>                 4d16h
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get pod -o wide
NAME                     READY   STATUS    RESTARTS   AGE     IP          NODE                                NOMINATED NODE   READINESS GATES
example-raw-block-pod2   1/1     Running   0          4d16h   192.0.2.2   my-cluster-np-1-ttdt5-frlvq-trcgc   <none>           <none>
example-raw-block-pod3   1/1     Running   0          4d16h   192.0.2.3   my-cluster-np-1-ttdt5-frlvq-trcgc   <none>           <none>
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# export KUBECONFIG=
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                               STORAGECLASS                VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-57fc4cc4-09b7-4de1-86b0-0cad64873fcf   5Gi        RWO            Delete           Bound    test-ns/47688609-84d9-4496-bb20-108a0800b58a-41e83449-0e9a-4ad8-a954-d5f86224fa9d   wcpglobal-storage-profile   <unset>                          4d16h
pvc-5e86a199-2273-420f-8520-ff261de08ba3   5Gi        RWO            Delete           Bound    test-ns/47688609-84d9-4496-bb20-108a0800b58a-b9a3ce30-c8db-43c6-b9f7-a247e886c595   wcpglobal-storage-profile   <unset>                          4d16h
pvc-84dbc86b-4cae-4618-961d-fccf67b07e9f   5Gi        RWO            Delete           Bound    test-ns/47688609-84d9-4496-bb20-108a0800b58a-9475b505-ae58-4c3b-a108-d05142ed7f72   wcpglobal-storage-profile   <unset>                          4d16h
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# 
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get vm -n test-ns my-cluster-np-1-ttdt5-frlvq-trcgc
NAME                                POWER-STATE   AGE
my-cluster-np-1-ttdt5-frlvq-trcgc   PoweredOn     4d23h
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get vm -n test-ns my-cluster-np-1-ttdt5-frlvq-trcgc -o yaml
apiVersion: vmoperator.vmware.com/v1alpha4
kind: VirtualMachine
metadata:
  creationTimestamp: "2025-08-15T12:47:02Z"
  ...
  name: my-cluster-np-1-ttdt5-frlvq-trcgc
  namespace: test-ns
  ...
spec:
  biosUUID: 4c0bbe2e-08d3-4de1-9c48-97a3055fc38b
  ...
  ...
  storageClass: wcpglobal-storage-profile
  suspendMode: TrySoft
  volumes:
  - name: 47688609-84d9-4496-bb20-108a0800b58a-41e83449-0e9a-4ad8-a954-d5f86224fa9d
    persistentVolumeClaim:
      claimName: 47688609-84d9-4496-bb20-108a0800b58a-41e83449-0e9a-4ad8-a954-d5f86224fa9d
  - name: 47688609-84d9-4496-bb20-108a0800b58a-b9a3ce30-c8db-43c6-b9f7-a247e886c595
    persistentVolumeClaim:
      claimName: 47688609-84d9-4496-bb20-108a0800b58a-b9a3ce30-c8db-43c6-b9f7-a247e886c595
status:
  biosUUID: 4c0bbe2e-08d3-4de1-9c48-97a3055fc38b
  changeBlockTracking: false
  ...
  ...
  powerState: PoweredOn 
  ...
  uniqueID: vm-164
  volumes:
  - attached: true
    diskUUID: 6000C292-6f4a-e9f0-ab5d-a91223ffb4fd
    limit: 20Gi
    name: my-cluster-np-1-ttdt5-frlvq-trcgc
    requested: 20Gi
    type: Classic
    used: 17172Mi
  - attached: true
    diskUUID: 6000C292-a4f1-986d-2b7f-bc9ed89cd27c
    limit: 5Gi
    name: 47688609-84d9-4496-bb20-108a0800b58a-41e83449-0e9a-4ad8-a954-d5f86224fa9d
    requested: 5Gi
    type: Managed
    used: 36Mi
  - attached: true
    diskUUID: 6000C294-c6b3-a722-c612-29d50326635a
    limit: 5Gi
    name: 47688609-84d9-4496-bb20-108a0800b58a-b9a3ce30-c8db-43c6-b9f7-a247e886c595
    requested: 5Gi
    type: Managed
    used: 36Mi
  zone: domain-c11
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get vmsnapshot -A
No resources found
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# cat vmsnapshot.yaml 
apiVersion: vmoperator.vmware.com/v1alpha4
kind: VirtualMachineSnapshot
metadata:
  name: my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot
  namespace: test-ns
spec:
  vmRef:
    apiVersion: vmoperator.vmware.com/v1alpha4
    kind: VirtualMachine
    name: my-cluster-np-1-ttdt5-frlvq-trcgc
  memory: false
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get vm -n test-ns my-cluster-np-1-ttdt5-frlvq-trcgc
NAME                                POWER-STATE   AGE
my-cluster-np-1-ttdt5-frlvq-trcgc   PoweredOn     4d23h
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k apply -f vmsnapshot.yaml 
virtualmachinesnapshot.vmoperator.vmware.com/my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot created
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get vmsnapshot -A
NAMESPACE   NAME                                         AGE
test-ns     my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot   4s
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get vmsnapshot  my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot -o yaml
Error from server (NotFound): virtualmachinesnapshots.vmoperator.vmware.com "my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot" not found
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get vmsnapshot  my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot -n test-ns -o yaml
apiVersion: vmoperator.vmware.com/v1alpha4
kind: VirtualMachineSnapshot
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
    ...
  creationTimestamp: "2025-08-20T11:48:59Z"
  finalizers:
  - cns.vmware.com/syncvolume
  - vmoperator.vmware.com/virtualmachinesnapshot
  generation: 2
  name: my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot
  namespace: test-ns
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha4
    kind: VirtualMachine
    name: my-cluster-np-1-ttdt5-frlvq-trcgc
    uid: e6ce7c03-ee84-4246-a884-3ac0bcd3de2d
  resourceVersion: "5212005"
  uid: f2890022-f6e6-4f7c-adbc-80978cc2e6da
spec:
  vmRef:
    apiVersion: vmoperator.vmware.com/v1alpha4
    kind: VirtualMachine
    name: my-cluster-np-1-ttdt5-frlvq-trcgc
status:
  conditions:
  - lastTransitionTime: "2025-08-20T11:49:04Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotReady
  uniqueID: snapshot-174
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k edit vmsnapshot  my-cluster-np-1-ttdt5-frlvq-trcgc-snapsho -n test-ns 
Error from server (NotFound): virtualmachinesnapshots.vmoperator.vmware.com "my-cluster-np-1-ttdt5-frlvq-trcgc-snapsho" not found
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k edit vmsnapshot  my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot -n test-ns 
virtualmachinesnapshot.vmoperator.vmware.com/my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot edited
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get vmsnapshot  my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot -n test-ns -o yaml
apiVersion: vmoperator.vmware.com/v1alpha4
kind: VirtualMachineSnapshot
metadata:
  annotations:
    csi.vsphere.volume.sync: completed
    ...
  creationTimestamp: "2025-08-20T11:48:59Z"
  finalizers:
  - cns.vmware.com/syncvolume
  - vmoperator.vmware.com/virtualmachinesnapshot
  generation: 2
  name: my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot
  namespace: test-ns
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha4
    kind: VirtualMachine
    name: my-cluster-np-1-ttdt5-frlvq-trcgc
    uid: e6ce7c03-ee84-4246-a884-3ac0bcd3de2d
  resourceVersion: "5212940"
  uid: f2890022-f6e6-4f7c-adbc-80978cc2e6da
spec:
  vmRef:
    apiVersion: vmoperator.vmware.com/v1alpha4
    kind: VirtualMachine
    name: my-cluster-np-1-ttdt5-frlvq-trcgc
status:
  conditions:
  - lastTransitionTime: "2025-08-20T11:49:04Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotReady
  uniqueID: snapshot-174
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k delete virtualmachinesnapshot  -n test-ns  my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot
virtualmachinesnapshot.vmoperator.vmware.com "my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot" deleted
^Croot@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# get vmsnapshot  my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot -n test-ns -o yaml
apiVersion: vmoperator.vmware.com/v1alpha4
kind: VirtualMachineSnapshot
metadata:
  annotations:
    csi.vsphere.volume.sync: completed
    kubectl.kubernetes.io/last-applied-configuration: |
    ...
  creationTimestamp: "2025-08-20T11:48:59Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2025-08-20T11:51:14Z"
  finalizers:
  - cns.vmware.com/syncvolume
  generation: 3
  name: my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot
  namespace: test-ns
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha4
    kind: VirtualMachine
    name: my-cluster-np-1-ttdt5-frlvq-trcgc
    uid: e6ce7c03-ee84-4246-a884-3ac0bcd3de2d
  resourceVersion: "5213715"
  uid: f2890022-f6e6-4f7c-adbc-80978cc2e6da
spec:
  vmRef:
    apiVersion: vmoperator.vmware.com/v1alpha4
    kind: VirtualMachine
    name: my-cluster-np-1-ttdt5-frlvq-trcgc
status:
  conditions:
  - lastTransitionTime: "2025-08-20T11:49:04Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotReady
  uniqueID: snapshot-174
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# k get vmsnapshot  my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot -n test-ns -o yaml
Error from server (NotFound): virtualmachinesnapshots.vmoperator.vmware.com "my-cluster-np-1-ttdt5-frlvq-trcgc-snapshot" not found
root@421cd4d86cd2a4aef0524380bcf09b3e [ ~ ]# 

```
vsphere-syncer logs  
[vmsnapshot_create_delete.log](https://github.com/user-attachments/files/21920689/vmsnapshot_create_delete.log)

manual testing logs:
[delete_vm_snapshot_syncer.log](https://github.com/user-attachments/files/21920694/delete_vm_snapshot_syncer.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
CSI Support for Consumer ViratualMachine Snapshots
```
