### PR TITLE
Use buildx to build syncer images

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -147,7 +147,7 @@ function build_driver_images_linux() {
 
 function build_syncer_image_linux() {
   echo "building ${SYNCER_IMAGE_NAME}:${VERSION} for linux"
-  docker build \
+  docker buildx build --platform "linux/$ARCH"\
       -f images/syncer/Dockerfile \
       -t "${SYNCER_IMAGE_NAME}":"${VERSION}" \
       --build-arg "VERSION=${VERSION}" \


### PR DESCRIPTION
**What this PR does / why we need it**:
When building mac from arm64 system(like M4 mac) it will create a arm64 image, this cannot be deployed on supervisor cluster


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
➜  vsphere-csi-driver git:(topic/dk016388/xplat_syncer_build) ARCH=amd64 make images                                                                                    

.
.
 => => exporting config sha256:2b1ab39190808dfb8a26477e8ae5dc83745b81b7000f514cdcd68fc4c0641a3d                                                                                                                                                                                                                                                                                                          0.0s
 => => exporting attestation manifest sha256:63053d8edfda4d5dd49ec7d43f3f973f91d0fdfff5125954e03876a9c82102fa                                                                                                                                                                                                                                                                                            0.0s 
 => => exporting manifest list sha256:ecbbdf0f0cdccc5076c5c6728925f1f1c015b44122f4bc10e74a58a6a06869f6                                                                                                                                                                                                                                                                                                   0.0s 
 => => naming to us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v2.1.0-rc.1-2252-g9705c6b4        


➜  vsphere-csi-driver git:(topic/dk016388/xplat_syncer_build) ✗ docker inspect us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v2.1.0-rc.1-2252-g9705c6b4
[
    {
        "Id": "sha256:ecbbdf0f0cdccc5076c5c6728925f1f1c015b44122f4bc10e74a58a6a06869f6",
        "RepoTags": [
            "us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:latest",
            "us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v2.1.0-rc.1-2252-g9705c6b4"
        ],
        "RepoDigests": [
            "us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer@sha256:ecbbdf0f0cdccc5076c5c6728925f1f1c015b44122f4bc10e74a58a6a06869f6"
        ],
        "Parent": "",
        "Comment": "buildkit.dockerfile.v0",
        "Created": "2025-07-04T06:25:24.543697673Z",
        "DockerVersion": "",
        "Author": "",
        "Config": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": null,
            "Image": "",
            "Volumes": null,
            "WorkingDir": "/",
            "Entrypoint": [
                "/bin/vsphere-syncer"
            ],
            "OnBuild": null,
            "Labels": {
                "build-date": "20250629",
                "git_commit": "9705c6b4f12d749309be46cfe92fe0e824987726",
                "name": "Photon OS x86_64/5.0 Base Image",
                "vendor": "VMware"
            }
        },
        "Architecture": "amd64", <===========was able to build a amd64 image on a m4 mac
        "Os": "linux",
        "Size": 47095674,
        "GraphDriver": {
            "Data": null,
            "Name": "overlayfs"
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:bfc04f7803d6ff480027df90f7a39a94b7985e5da415a518edc6337753473775",
                "sha256:a0027cb18c4dffedb12400c9c4d9c92f6c72243fce509159a4605bb64c6331c3",
                "sha256:2975e82f0560cd02add9e757ebe6d84157e967828eb0c2226dd37851c6fe188c",
                "sha256:4a9501d5a7b97b1d9e2a43d86edf59838ed70dfdee4e46ded0ab254b56cf24e1"
            ]
        },
        "Metadata": {
            "LastTagTime": "2025-07-04T06:25:26.209167841Z"
        },
        "Descriptor": {
            "mediaType": "application/vnd.oci.image.index.v1+json",
            "digest": "sha256:ecbbdf0f0cdccc5076c5c6728925f1f1c015b44122f4bc10e74a58a6a06869f6",
            "size": 856
        }
    }
]


```

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
