### PR TITLE
Remove volume-health fss

### DIFF
--- a/manifests/guestcluster/1.33/pvcsi.yaml
+++ b/manifests/guestcluster/1.33/pvcsi.yaml
@@ -660,7 +660,6 @@ metadata:
 apiVersion: v1
 data:
   "volume-extend": "true"
-  "volume-health": "true"
   "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false" # Do not enable for guest cluster, Refer PR#2386 for details

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -547,7 +547,6 @@ spec:
 apiVersion: v1
 data:
   "volume-extend": "true"
-  "volume-health": "true"
   "online-volume-extend": "true"
   "file-volume": "true"
   "trigger-csi-fullsync": "false"

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -55,7 +55,6 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 			featureStatesLock: &sync.RWMutex{},
 			featureStates: map[string]string{
 				"volume-extend":                     "true",
-				"volume-health":                     "true",
 				"csi-migration":                     "true",
 				"file-volume":                       "true",
 				"block-volume-snapshot":             "true",

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
@@ -33,6 +33,11 @@ var (
 	cancel context.CancelFunc
 )
 
+const (
+	feature_flag_1 = "feature_flag_1"
+	feature_flag_2 = "feature_flag_2"
+)
+
 func init() {
 	// Create context
 	ctx, cancel = context.WithCancel(context.Background())
@@ -44,8 +49,8 @@ func init() {
 // Scenario 2: FSS is disabled both in SV and GC
 func TestIsFSSEnabledInGcWithSync(t *testing.T) {
 	svFSS := map[string]string{
-		"volume-extend": "true",
-		"volume-health": "false",
+		feature_flag_1: "true",
+		feature_flag_2: "false",
 	}
 	svFSSConfigMapInfo := FSSConfigMapInfo{
 		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
@@ -54,8 +59,8 @@ func TestIsFSSEnabledInGcWithSync(t *testing.T) {
 		featureStatesLock:  &sync.RWMutex{},
 	}
 	internalFSS := map[string]string{
-		"volume-extend": "true",
-		"volume-health": "false",
+		feature_flag_1: "true",
+		feature_flag_2: "false",
 	}
 	internalFSSConfigMapInfo := FSSConfigMapInfo{
 		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
@@ -68,13 +73,13 @@ func TestIsFSSEnabledInGcWithSync(t *testing.T) {
 		clusterFlavor: cnstypes.CnsClusterFlavorGuest,
 		internalFSS:   internalFSSConfigMapInfo,
 	}
-	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_1)
 	if !isEnabled {
-		t.Errorf("volume-extend feature state is disabled!")
+		t.Errorf("%s feature state is disabled!", feature_flag_1)
 	}
-	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_2)
 	if isEnabled {
-		t.Errorf("volume-health feature state is enabled!")
+		t.Errorf("%s feature state is enabled!", feature_flag_2)
 	}
 }
 
@@ -83,8 +88,8 @@ func TestIsFSSEnabledInGcWithSync(t *testing.T) {
 // Scenario 2: FSS is disabled in SV but enabled in GC
 func TestIsFSSEnabledInGcWithoutSync(t *testing.T) {
 	svFSS := map[string]string{
-		"volume-extend": "true",
-		"volume-health": "false",
+		feature_flag_1: "true",
+		feature_flag_2: "false",
 	}
 	svFSSConfigMapInfo := FSSConfigMapInfo{
 		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
@@ -93,8 +98,8 @@ func TestIsFSSEnabledInGcWithoutSync(t *testing.T) {
 		featureStatesLock:  &sync.RWMutex{},
 	}
 	internalFSS := map[string]string{
-		"volume-extend": "false",
-		"volume-health": "true",
+		feature_flag_1: "false",
+		feature_flag_2: "true",
 	}
 	internalFSSConfigMapInfo := FSSConfigMapInfo{
 		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
@@ -107,13 +112,13 @@ func TestIsFSSEnabledInGcWithoutSync(t *testing.T) {
 		clusterFlavor: cnstypes.CnsClusterFlavorGuest,
 		internalFSS:   internalFSSConfigMapInfo,
 	}
-	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_1)
 	if isEnabled {
-		t.Errorf("volume-extend feature state is enabled!")
+		t.Errorf("%s feature state is enabled!", feature_flag_1)
 	}
-	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_2)
 	if isEnabled {
-		t.Errorf("volume-health feature state is enabled!")
+		t.Errorf("%s feature state is enabled!", feature_flag_2)
 	}
 }
 
@@ -122,8 +127,8 @@ func TestIsFSSEnabledInGcWithoutSync(t *testing.T) {
 // Scenario 2: Missing feature state
 func TestIsFSSEnabledInGcWrongValues(t *testing.T) {
 	svFSS := map[string]string{
-		"volume-extend": "true",
-		"volume-health": "true",
+		feature_flag_1: "true",
+		feature_flag_2: "true",
 	}
 	svFSSConfigMapInfo := FSSConfigMapInfo{
 		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
@@ -132,7 +137,7 @@ func TestIsFSSEnabledInGcWrongValues(t *testing.T) {
 		featureStatesLock:  &sync.RWMutex{},
 	}
 	internalFSS := map[string]string{
-		"volume-extend": "enabled",
+		feature_flag_1: "enabled",
 	}
 	internalFSSConfigMapInfo := FSSConfigMapInfo{
 		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
@@ -146,22 +151,22 @@ func TestIsFSSEnabledInGcWrongValues(t *testing.T) {
 		internalFSS:   internalFSSConfigMapInfo,
 	}
 	// Wrong value given
-	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_1)
 	if isEnabled {
-		t.Errorf("volume-extend feature state is enabled even when it was assigned a wrong value!")
+		t.Errorf("%s feature state is enabled even when it was assigned a wrong value!", feature_flag_1)
 	}
 	// Feature state missing
-	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_2)
 	if isEnabled {
-		t.Errorf("Non existing feature state volume-health is enabled!")
+		t.Errorf("Non existing feature state %s is enabled!", feature_flag_2)
 	}
 }
 
 // TestIsFSSEnabledInSV tests IsFSSEnabled in Supervisor flavor - all scenarios
 func TestIsFSSEnabledInSV(t *testing.T) {
 	svFSS := map[string]string{
-		"volume-extend": "true",
-		"volume-health": "false",
+		feature_flag_1:  "true",
+		feature_flag_2:  "false",
 		"csi-migration": "enabled",
 	}
 	svFSSConfigMapInfo := FSSConfigMapInfo{
@@ -174,13 +179,13 @@ func TestIsFSSEnabledInSV(t *testing.T) {
 		supervisorFSS: svFSSConfigMapInfo,
 		clusterFlavor: cnstypes.CnsClusterFlavorWorkload,
 	}
-	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_1)
 	if !isEnabled {
-		t.Errorf("volume-extend feature state is disabled!")
+		t.Errorf("%s feature state is disabled!", feature_flag_1)
 	}
-	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_2)
 	if isEnabled {
-		t.Errorf("volume-health feature state is enabled!")
+		t.Errorf("%s feature state is enabled!", feature_flag_2)
 	}
 	// Wrong value given
 	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "csi-migration")
@@ -218,9 +223,9 @@ func TestIsFSSEnabledWithWrongClusterFlavor(t *testing.T) {
 	k8sOrchestrator := K8sOrchestrator{
 		clusterFlavor: "Vanila",
 	}
-	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_1)
 	if isEnabled {
-		t.Errorf("volume-extend feature state enabled even when cluster flavor is wrong")
+		t.Errorf("%s feature state enabled even when cluster flavor is wrong", feature_flag_1)
 	}
 }
 

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -359,8 +359,6 @@ const (
 const (
 	// Default interval to check if the feature is enabled or not.
 	DefaultFeatureEnablementCheckInterval = 1 * time.Minute
-	// VolumeHealth is the feature flag name for volume health.
-	VolumeHealth = "volume-health"
 	// VolumeExtend is feature flag name for volume expansion.
 	VolumeExtend = "volume-extend"
 	// OnlineVolumeExtend guards the feature for online volume expansion.

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -58,7 +58,6 @@ var (
 	featureGateCsiMigrationEnabled            bool
 	featureGateBlockVolumeSnapshotEnabled     bool
 	featureGateTKGSHaEnabled                  bool
-	featureGateVolumeHealthEnabled            bool
 	featureGateTopologyAwareFileVolumeEnabled bool
 	featureGateByokEnabled                    bool
 	featureFileVolumesWithVmServiceEnabled    bool
@@ -145,7 +144,6 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		featureGateTKGSHaEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
-		featureGateVolumeHealthEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.VolumeHealth)
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		featureGateByokEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.WCP_VMService_BYOK)
 		featureIsSharedDiskEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.SharedDiskFss)

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -172,11 +172,9 @@ func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request
 				return
 			}
 		}
-		if featureGateVolumeHealthEnabled {
-			resp = validatePVCAnnotationForVolumeHealth(ctx, req)
-			if !resp.Allowed {
-				return
-			}
+		resp = validatePVCAnnotationForVolumeHealth(ctx, req)
+		if !resp.Allowed {
+			return
 		}
 		if featureGateBlockVolumeSnapshotEnabled {
 			admissionResp := validatePVC(ctx, &req.AdmissionRequest)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -822,12 +822,8 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		go func() {
 			for ; true; <-volumeHealthTicker.C {
 				ctx, log = logger.GetNewContextWithLogger()
-				if !metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.VolumeHealth) {
-					log.Warnf("VolumeHealth feature is disabled on the cluster")
-				} else {
-					log.Infof("getVolumeHealthStatus is triggered")
-					csiGetVolumeHealthStatus(ctx, k8sClient, metadataSyncer)
-				}
+				log.Infof("getVolumeHealthStatus is triggered")
+				csiGetVolumeHealthStatus(ctx, k8sClient, metadataSyncer)
 			}
 		}()
 		if IsPodVMOnStretchSupervisorFSSEnabled {
@@ -855,16 +851,12 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		go func() {
 			for ; true; <-volumeHealthEnablementTicker.C {
 				ctx, log = logger.GetNewContextWithLogger()
-				if !metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.VolumeHealth) {
-					log.Debugf("VolumeHealth feature is disabled on the cluster")
-				} else {
-					if err := initVolumeHealthReconciler(ctx, k8sClient, metadataSyncer.supervisorClient); err != nil {
-						log.Warnf("Error while initializing volume health reconciler. Err:%+v. Retry will be triggered at %v",
-							err, time.Now().Add(common.DefaultFeatureEnablementCheckInterval))
-						continue
-					}
-					break
+				if err := initVolumeHealthReconciler(ctx, k8sClient, metadataSyncer.supervisorClient); err != nil {
+					log.Warnf("Error while initializing volume health reconciler. Err:%+v. Retry will be triggered at %v",
+						err, time.Now().Add(common.DefaultFeatureEnablementCheckInterval))
+					continue
 				}
+				break
 			}
 		}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove obsolete feature flag 'volume-health.'  Also includes a change to a unit test to remove 'volume-extend' feature flag string value.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Testing done:
Unit tests

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
