### PR TITLE
[WIP]Remove FSS storage-quota-m2

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -560,7 +560,6 @@ data:
   "tkgs-ha": "true"
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
-  "storage-quota-m2": "true"
   "vdpp-on-stretched-supervisor": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -180,11 +180,10 @@ type CreateVolumeExtraParams struct {
 // CreateSnapshotExtraParams consist of values required by the CreateSnapshot interface and
 // are not present in the CNS CreateSnapshot spec.
 type CreateSnapshotExtraParams struct {
-	StorageClassName           string
-	StoragePolicyID            string
-	Namespace                  string
-	Capacity                   *resource.Quantity
-	IsStorageQuotaM2FSSEnabled bool
+	StorageClassName string
+	StoragePolicyID  string
+	Namespace        string
+	Capacity         *resource.Quantity
 }
 
 // DeleteSnapshotExtraParams consist of values required by the DeleteSnapshot interface and
@@ -2487,9 +2486,8 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 		// Local instance of CreateSnapshot details that needs to be persisted.
 		volumeOperationDetails *cnsvolumeoperationrequest.VolumeOperationRequestDetails
 		// error
-		err                        error
-		quotaInfo                  *cnsvolumeoperationrequest.QuotaDetails
-		isStorageQuotaM2FSSEnabled bool
+		err       error
+		quotaInfo *cnsvolumeoperationrequest.QuotaDetails
 	)
 	if extraParams != nil {
 		createSnapParams, ok := extraParams.(*CreateSnapshotExtraParams)
@@ -2498,8 +2496,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 		}
 		log.Debugf("Received CreateSnapshot extraParams: %+v", *createSnapParams)
 
-		isStorageQuotaM2FSSEnabled = createSnapParams.IsStorageQuotaM2FSSEnabled
-		if isStorageQuotaM2FSSEnabled && m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		if m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 			quotaInfo = &cnsvolumeoperationrequest.QuotaDetails{
 				Reserved:         createSnapParams.Capacity,
 				StoragePolicyId:  createSnapParams.StoragePolicyID,
@@ -2581,7 +2578,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 			volumeOperationDetails != nil && volumeOperationDetails.OperationDetails != nil &&
 			volumeOperationDetails.OperationDetails.TaskStatus != taskInvocationStatusInProgress {
 			taskStatus := volumeOperationDetails.OperationDetails.TaskStatus
-			if isStorageQuotaM2FSSEnabled && m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+			if m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 				if (taskStatus == taskInvocationStatusSuccess || taskStatus == taskInvocationStatusError) &&
 					volumeOperationDetails.QuotaDetails != nil {
 					volumeOperationDetails.QuotaDetails.Reserved = resource.NewQuantity(0,
@@ -2652,7 +2649,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 					SnapshotDescription:                 snapshotName,
 					SnapshotLatestOperationCompleteTime: queriedCnsSnapshot.CreateTime,
 				}
-				if isStorageQuotaM2FSSEnabled && m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+				if m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 					log.Infof("get aggregated Snapshot Capacity for volume with volumeID %q", volumeID)
 					aggregatedSnapshotCapacityInMb, err := m.getAggregatedSnapshotSize(ctx, volumeID)
 					if err != nil {
@@ -2751,7 +2748,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 		SnapshotDescription:                 snapshotCreateResult.Snapshot.Description,
 		SnapshotLatestOperationCompleteTime: *createSnapshotsTaskInfo.CompleteTime,
 	}
-	if isStorageQuotaM2FSSEnabled && m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+	if m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		log.Infof("For volumeID %q new AggregatedSnapshotSize is %d and SnapshotLatestOperationCompleteTime is %q",
 			volumeID, snapshotCreateResult.AggregatedSnapshotCapacityInMb, *createSnapshotsTaskInfo.CompleteTime)
 		cnsSnapshotInfo.AggregatedSnapshotCapacityInMb = snapshotCreateResult.AggregatedSnapshotCapacityInMb

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -72,7 +72,6 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 				"max-pvscsi-targets-per-vm":         "true",
 				"multi-vcenter-csi-topology":        "true",
 				"listview-tasks":                    "true",
-				"storage-quota-m2":                  "false",
 				"workload-domain-isolation":         "true",
 				// Adding FSS from `wcp-cluster-capabilities` configmap in supervisor here for simplicity.
 				// TODO: Enable FSS for unit tests after mockControllerVolumeTopology interfaces are implemented

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -415,8 +415,6 @@ const (
 	// PodVMOnStretchedSupervisor is the WCP FSS which determines if PodVM
 	// support is available on stretched supervisor cluster.
 	PodVMOnStretchedSupervisor = "PodVM_On_Stretched_Supervisor_Supported"
-	// StorageQuotaM2 enables support for snapshot quota feature
-	StorageQuotaM2 = "storage-quota-m2"
 	// VdppOnStretchedSupervisor enables support for vDPp workloads on stretched SV clusters
 	VdppOnStretchedSupervisor = "vdpp-on-stretched-supervisor"
 	// CSIDetachOnSupervisor enables CSI to detach the disk from the podvm in a supervisor environment

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -339,7 +339,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 			return err
 		}
 	}
-	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload && isStorageQuotaM2FSSEnabled {
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		cnsBlockVolumeMap := make(map[string]cnstypes.CnsVolume)
 		for _, vol := range queryAllResult.Volumes {
 			// We do not support file volume snapshot, filtering out block volume only.


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes obsolete FSS storage-quota-m2.   Note that there are still unit test failure(s)
due to volumeInfoService needing to be mocked out.   Sending this review out early to
get help with that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
