### PR TITLE
Remove FSS multi-vcenter-csi-topology

### DIFF
--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -45,6 +45,8 @@ type FakeK8SOrchestrator struct {
 	// RWMutex to synchronize access to 'featureStates' field from multiple callers
 	featureStatesLock *sync.RWMutex
 	featureStates     map[string]string
+	// CSINodeTopology instances for topology testing
+	csiNodeTopologyInstances []interface{}
 }
 
 func (c *FakeK8SOrchestrator) HandleLateEnablementOfCapability(

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/simulator/vpx"
@@ -388,12 +389,22 @@ func (c *FakeK8SOrchestrator) CreateConfigMap(ctx context.Context, name string, 
 
 // GetCSINodeTopologyInstancesList lists CSINodeTopology instances for a given cluster.
 func (c *FakeK8SOrchestrator) GetCSINodeTopologyInstancesList() []interface{} {
-	return nil
+	return c.csiNodeTopologyInstances
 }
 
 // GetCSINodeTopologyInstanceByName fetches the CSINodeTopology instance for a given node name in the cluster.
 func (c *FakeK8SOrchestrator) GetCSINodeTopologyInstanceByName(nodeName string) (
 	item interface{}, exists bool, err error) {
+	// Search through stored CSINodeTopology instances
+	for _, instance := range c.csiNodeTopologyInstances {
+		if unstructuredObj, ok := instance.(*unstructured.Unstructured); ok {
+			// Get the name from the metadata
+			name := unstructuredObj.GetName()
+			if name == nodeName {
+				return instance, true, nil
+			}
+		}
+	}
 	return nil, false, nil
 }
 
@@ -482,6 +493,11 @@ func (c *FakeK8SOrchestrator) UpdatePersistentVolumeLabel(ctx context.Context, p
 func (c *FakeK8SOrchestrator) GetActiveClustersForNamespaceInRequestedZones(ctx context.Context,
 	targetNS string, requestedZones []string) ([]string, error) {
 	return nil, nil
+}
+
+// SetCSINodeTopologyInstances sets the CSINodeTopology instances for testing
+func (c *FakeK8SOrchestrator) SetCSINodeTopologyInstances(instances []interface{}) {
+	c.csiNodeTopologyInstances = instances
 }
 
 // configFromVCSim starts a vcsim instance and returns config for use against the

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -70,7 +70,6 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 			"use-csinode-id":                    "true",
 			"pv-to-backingdiskobjectid-mapping": "false",
 			"cnsmgr-suspend-create-volume":      "true",
-			"multi-vcenter-csi-topology":        "true",
 			"listview-tasks":                    "true",
 			"storage-quota-m2":                  "false",
 			"workload-domain-isolation":         "true",

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -115,6 +115,20 @@ func GetAuthorizationServices(ctx context.Context, vcs []*cnsvsphere.VirtualCent
 	return authManagerInstances, nil
 }
 
+// GetAuthorizationServices returns the AuthManager instances
+func GetAuthorizationServiceForTesting(ctx context.Context,
+	vc *cnsvsphere.VirtualCenter,
+	blockVolumeMap map[string]*cnsvsphere.DatastoreInfo,
+	fsEnabledClusterToDsMap map[string][]*cnsvsphere.DatastoreInfo) (*AuthManager, error) {
+	authManagerInstance = &AuthManager{
+		datastoreMapForBlockVolumes: blockVolumeMap,
+		fsEnabledClusterToDsMap:     fsEnabledClusterToDsMap,
+		rwMutex:                     sync.RWMutex{},
+		vcenter:                     vc,
+	}
+	return authManagerInstance, nil
+}
+
 // GetDatastoreMapForBlockVolumes returns a DatastoreMapForBlockVolumes. This
 // map maps datastore url to datastore info which need to be used when creating
 // block volume.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -395,7 +395,6 @@ func getReleasedVanillaFSS() map[string]struct{} {
 		common.CSIWindowsSupport:             {},
 		common.ListVolumes:                   {},
 		common.CnsMgrSuspendCreateVolume:     {},
-		common.MultiVCenterCSITopology:       {},
 		common.CSIInternalGeneratedClusterID: {},
 		common.TopologyAwareFileVolume:       {},
 	}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -408,8 +408,6 @@ const (
 	PVtoBackingDiskObjectIdMapping = "pv-to-backingdiskobjectid-mapping"
 	// Block Create Volume for datastores that are in suspended mode
 	CnsMgrSuspendCreateVolume = "cnsmgr-suspend-create-volume"
-	// MultiVCenterCSITopology is the feature gate for enabling multi vCenter topology support for vSphere CSI driver.
-	MultiVCenterCSITopology = "multi-vcenter-csi-topology"
 	// CSIInternalGeneratedClusterID enables support to generate unique cluster
 	// ID internally if user doesn't provide it in vSphere config secret.
 	CSIInternalGeneratedClusterID = "csi-internal-generated-cluster-id"

--- a/pkg/csi/service/vanilla/controller_topology_test.go
+++ b/pkg/csi/service/vanilla/controller_topology_test.go
@@ -28,9 +28,15 @@ import (
 	"github.com/google/uuid"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+	_ "github.com/vmware/govmomi/vapi/simulator"
+	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -45,7 +51,9 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
+	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/csinodetopology/v1alpha1"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
@@ -161,8 +169,8 @@ func (f *FakeNodeManagerTopology) GetAllNodes(ctx context.Context) ([]*cnsvspher
 
 func (f *FakeNodeManagerTopology) GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine,
 	error) {
-	// This function is required only for multi VC env.
-	return nil, nil
+	// For topology testing, return all nodes since we're working with a single vCenter
+	return f.cnsNodeManager.GetAllNodes(ctx)
 }
 
 // generateNodeLabels adds region and zone specific labels on all nodeVMs generated using vcsim
@@ -379,12 +387,12 @@ func getControllerTestWithTopology(t *testing.T) *controllerTestTopology {
 		// GetVirtualCenterManager returns a singleton instance of VirtualCenterManager,
 		// so it could have already registered VCs as part of previous unit test run from
 		// same folder.
-		// Unregister old VCs and register new VC.
+		// Unregister old VCs.
 		err = vcManager.UnregisterAllVirtualCenters(ctxtopology)
 		if err != nil {
 			t.Fatal(err)
 		}
-		vcenter, err := vcManager.RegisterVirtualCenter(ctxtopology, vcenterconfig)
+		vcenter, err := cnsvsphere.GetVirtualCenterInstanceForVCenterConfig(ctxtopology, vcenterconfig, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -393,6 +401,13 @@ func getControllerTestWithTopology(t *testing.T) *controllerTestTopology {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// Set up real tags in vcsim for topology testing
+		err = setupRealTagsInVCSim(ctxtopology, vcenter)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		fakeOpStore, err := unittestcommon.InitFakeVolumeOperationRequestInterface()
 		if err != nil {
 			t.Fatal(err)
@@ -477,21 +492,35 @@ func getControllerTestWithTopology(t *testing.T) *controllerTestTopology {
 			t.Fatalf("Failed to add mock node labels, err = %v", err)
 		}
 
+		fakeAuthMgr := &FakeAuthManager{
+			vcenter: vcenter,
+		}
+
 		c := &controller{
 			manager:  manager,
 			managers: managers,
 			nodeMgr:  nodeManager,
-			authMgr: &FakeAuthManager{
-				vcenter: vcenter,
-			},
+			authMgr:  fakeAuthMgr,
+			authMgrs: make(map[string]*common.AuthManager),
 			topologyMgr: &FakeTopologyManager{
 				nodeLabels: mockNodeLabels,
 			},
+			topologyCalc: &defaultTopologyCalculator{}, // Use real topology calculation for topology tests
 		}
+		c.authMgrs[vcenterconfig.Host], _ =
+			common.GetAuthorizationServiceForTesting(ctxtopology,
+				vcenter, fakeAuthMgr.GetDatastoreMapForBlockVolumes(ctxtopology), nil)
+
 		commonco.ContainerOrchestratorUtility, err =
 			unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
 		if err != nil {
 			t.Fatalf("Failed to create co agnostic interface. err=%v", err)
+		}
+
+		// Create CSINodeTopology instances for topology testing
+		err = createCSINodeTopologyInstances(ctxtopology, mockNodeLabels, nodeManager, commonco.ContainerOrchestratorUtility)
+		if err != nil {
+			t.Fatalf("Failed to create CSINodeTopology instances. err=%v", err)
 		}
 		controllerTestInstanceTopology = &controllerTestTopology{
 			controller:     c,
@@ -583,4 +612,199 @@ func TestCreateVolumeWithAccessibilityRequirements(t *testing.T) {
 	if len(queryResult.Volumes) != 0 {
 		t.Fatalf("Volume should not exist after deletion with ID: %s", volID)
 	}
+}
+
+// createCSINodeTopologyInstances creates CSINodeTopology instances based on the node labels
+func createCSINodeTopologyInstances(ctx context.Context, nodeLabels map[string]map[string]string,
+	nodeManager *FakeNodeManagerTopology, co commonco.COCommonInterface) error {
+
+	var instances []interface{}
+	nodeIndex := 1
+
+	for nodeUUID, labels := range nodeLabels {
+		// Get the node name from the node manager
+		nodeName := fmt.Sprintf("k8s-node-%d", nodeIndex)
+		nodeIndex++
+
+		// Create topology labels array
+		var topologyLabels []csinodetopologyv1alpha1.TopologyLabel
+		for key, value := range labels {
+			topologyLabels = append(topologyLabels, csinodetopologyv1alpha1.TopologyLabel{
+				Key:   key,
+				Value: value,
+			})
+		}
+
+		// Create CSINodeTopology instance
+		instance := &csinodetopologyv1alpha1.CSINodeTopology{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "cns.vmware.com/v1alpha1",
+				Kind:       "CSINodeTopology",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+			Spec: csinodetopologyv1alpha1.CSINodeTopologySpec{
+				NodeID:   nodeName,
+				NodeUUID: nodeUUID,
+			},
+			Status: csinodetopologyv1alpha1.CSINodeTopologyStatus{
+				Status:         csinodetopologyv1alpha1.CSINodeTopologySuccess,
+				TopologyLabels: topologyLabels,
+				ErrorMessage:   "",
+			},
+		}
+
+		// Convert to unstructured for storage
+		unstructuredObj := &unstructured.Unstructured{}
+		unstructuredMap, err := convertToUnstructured(instance)
+		if err != nil {
+			return fmt.Errorf("failed to convert CSINodeTopology to unstructured: %v", err)
+		}
+		unstructuredObj.Object = unstructuredMap
+
+		instances = append(instances, unstructuredObj)
+	}
+
+	// Set the instances in the fake container orchestrator
+	if fakeOrchestrator, ok := co.(*unittestcommon.FakeK8SOrchestrator); ok {
+		fakeOrchestrator.SetCSINodeTopologyInstances(instances)
+	} else {
+		return fmt.Errorf("container orchestrator is not a FakeK8SOrchestrator")
+	}
+
+	return nil
+}
+
+// convertToUnstructured converts a typed object to an unstructured map
+func convertToUnstructured(obj interface{}) (map[string]interface{}, error) {
+	// This is a simplified conversion - in a real implementation, you might use
+	// runtime.DefaultUnstructuredConverter.ToUnstructured
+	switch v := obj.(type) {
+	case *csinodetopologyv1alpha1.CSINodeTopology:
+		return map[string]interface{}{
+			"apiVersion": v.APIVersion,
+			"kind":       v.Kind,
+			"metadata": map[string]interface{}{
+				"name": v.Name,
+			},
+			"spec": map[string]interface{}{
+				"nodeID":   v.Spec.NodeID,
+				"nodeuuid": v.Spec.NodeUUID,
+			},
+			"status": map[string]interface{}{
+				"status":         string(v.Status.Status),
+				"topologyLabels": convertTopologyLabelsToUnstructured(v.Status.TopologyLabels),
+				"errorMessage":   v.Status.ErrorMessage,
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported type: %T", obj)
+	}
+}
+
+// convertTopologyLabelsToUnstructured converts topology labels to unstructured format
+func convertTopologyLabelsToUnstructured(labels []csinodetopologyv1alpha1.TopologyLabel) []interface{} {
+	var result []interface{}
+	for _, label := range labels {
+		result = append(result, map[string]interface{}{
+			"key":   label.Key,
+			"value": label.Value,
+		})
+	}
+	return result
+}
+
+// setupRealTagsInVCSim creates real vSphere tags and categories in vcsim instead of using mocks
+func setupRealTagsInVCSim(ctx context.Context, vcenter *cnsvsphere.VirtualCenter) error {
+	log := logger.GetLogger(ctx)
+
+	// Create REST client for tag management
+	restClient := rest.NewClient(vcenter.Client.Client)
+	err := restClient.Login(ctx, simulator.DefaultLogin)
+	if err != nil {
+		return fmt.Errorf("failed to login to REST client: %v", err)
+	}
+
+	// Create tag manager
+	tagManager := tags.NewManager(restClient)
+	if tagManager == nil {
+		return fmt.Errorf("failed to create tag manager")
+	}
+
+	log.Infof("Created tag manager with useragent: %s", tagManager.UserAgent)
+
+	// Create k8s-region category
+	regionCategoryID, err := cnsvsphere.CreateNewCategory(ctx, "k8s-region", "SINGLE", tagManager)
+	if err != nil {
+		return fmt.Errorf("failed to create k8s-region category: %v", err)
+	}
+
+	// Create k8s-zone category
+	zoneCategoryID, err := cnsvsphere.CreateNewCategory(ctx, "k8s-zone", "SINGLE", tagManager)
+	if err != nil {
+		return fmt.Errorf("failed to create k8s-zone category: %v", err)
+	}
+
+	// Create region tags
+	region1TagID, err := cnsvsphere.CreateNewTag(ctx, regionCategoryID, "region-1", "Region 1 tag", tagManager)
+	if err != nil {
+		return fmt.Errorf("failed to create region-1 tag: %v", err)
+	}
+
+	region2TagID, err := cnsvsphere.CreateNewTag(ctx, regionCategoryID, "region-2", "Region 2 tag", tagManager)
+	if err != nil {
+		return fmt.Errorf("failed to create region-2 tag: %v", err)
+	}
+
+	// Create zone tags
+	zone1TagID, err := cnsvsphere.CreateNewTag(ctx, zoneCategoryID, "zone-1", "Zone 1 tag", tagManager)
+	if err != nil {
+		return fmt.Errorf("failed to create zone-1 tag: %v", err)
+	}
+
+	zone2TagID, err := cnsvsphere.CreateNewTag(ctx, zoneCategoryID, "zone-2", "Zone 2 tag", tagManager)
+	if err != nil {
+		return fmt.Errorf("failed to create zone-2 tag: %v", err)
+	}
+
+	// Get datacenter references to attach tags
+	datacenters, err := vcenter.GetDatacenters(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get datacenters: %v", err)
+	}
+
+	// Attach tags to datacenters
+	// DC0 gets region-1 and zone-1
+	// DC1 gets region-2 and zone-2
+	for i, datacenter := range datacenters {
+		dcRef := datacenter.Datacenter.Reference()
+
+		if i == 0 {
+			// DC0 - region-1, zone-1
+			err = cnsvsphere.AttachTag(ctx, region1TagID, dcRef, tagManager)
+			if err != nil {
+				return fmt.Errorf("failed to attach region-1 tag to DC0: %v", err)
+			}
+			err = cnsvsphere.AttachTag(ctx, zone1TagID, dcRef, tagManager)
+			if err != nil {
+				return fmt.Errorf("failed to attach zone-1 tag to DC0: %v", err)
+			}
+			log.Infof("Attached region-1 and zone-1 tags to DC0")
+		} else if i == 1 {
+			// DC1 - region-2, zone-2
+			err = cnsvsphere.AttachTag(ctx, region2TagID, dcRef, tagManager)
+			if err != nil {
+				return fmt.Errorf("failed to attach region-2 tag to DC1: %v", err)
+			}
+			err = cnsvsphere.AttachTag(ctx, zone2TagID, dcRef, tagManager)
+			if err != nil {
+				return fmt.Errorf("failed to attach zone-2 tag to DC1: %v", err)
+			}
+			log.Infof("Attached region-2 and zone-2 tags to DC1")
+		}
+	}
+
+	log.Infof("Successfully set up real tags in vcsim")
+	return nil
 }

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -111,7 +111,6 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		}
 	}
 
-	isMultiVCFSSEnabled := coCommonInterface.IsFSSEnabled(ctx, common.MultiVCenterCSITopology)
 	// Initialize kubernetes client.
 	k8sclient, err := k8s.NewClient(ctx)
 	if err != nil {
@@ -129,12 +128,12 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme,
 		corev1.EventSource{Component: csinodetopologyv1alpha1.GroupName})
 	return add(mgr, newReconciler(mgr, configInfo, recorder,
-		enableTKGsHAinGuest, isMultiVCFSSEnabled, vmOperatorClient, supervisorNamespace))
+		enableTKGsHAinGuest, vmOperatorClient, supervisorNamespace))
 }
 
 // newReconciler returns a new `reconcile.Reconciler`.
 func newReconciler(mgr manager.Manager, configInfo *cnsconfig.ConfigurationInfo, recorder record.EventRecorder,
-	enableTKGsHAinGuest bool, isMultiVCFSSEnabled bool, vmOperatorClient client.Client,
+	enableTKGsHAinGuest bool, vmOperatorClient client.Client,
 	supervisorNamespace string) reconcile.Reconciler {
 	return &ReconcileCSINodeTopology{
 		client:              mgr.GetClient(),
@@ -142,7 +141,6 @@ func newReconciler(mgr manager.Manager, configInfo *cnsconfig.ConfigurationInfo,
 		configInfo:          configInfo,
 		recorder:            recorder,
 		enableTKGsHAinGuest: enableTKGsHAinGuest,
-		isMultiVCFSSEnabled: isMultiVCFSSEnabled,
 		vmOperatorClient:    vmOperatorClient,
 		supervisorNamespace: supervisorNamespace}
 }

--- a/pkg/syncer/cnsoperator/controller/triggercsifullsync/triggercsifullsync_controller.go
+++ b/pkg/syncer/cnsoperator/controller/triggercsifullsync/triggercsifullsync_controller.go
@@ -84,7 +84,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return nil
 	}
 
-	if coCommonInterface.IsFSSEnabled(ctx, common.MultiVCenterCSITopology) && len(configInfo.Cfg.VirtualCenter) > 1 {
+	if len(configInfo.Cfg.VirtualCenter) > 1 {
 		log.Infof("Not initializing the TriggerCsiFullSync Controller as it is a multi VC deployment.")
 		return nil
 	}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -79,21 +79,14 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			err      error
 			vcconfig *cnsvsphere.VirtualCenterConfig
 		)
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.MultiVCenterCSITopology) {
-			vcconfig, err = cnsvsphere.GetVirtualCenterConfig(ctx, cnsOperator.configInfo.Cfg)
-			if err != nil {
-				log.Errorf("failed to get VirtualCenterConfig. Err: %+v", err)
-				return err
-			}
-			vCenter, err = cnsvsphere.GetVirtualCenterInstanceForVCenterConfig(ctx, vcconfig, false)
-			if err != nil {
-				return err
-			}
-		} else {
-			vCenter, err = cnsvsphere.GetVirtualCenterInstance(ctx, cnsOperator.configInfo, false)
-			if err != nil {
-				return err
-			}
+		vcconfig, err = cnsvsphere.GetVirtualCenterConfig(ctx, cnsOperator.configInfo.Cfg)
+		if err != nil {
+			log.Errorf("failed to get VirtualCenterConfig. Err: %+v", err)
+			return err
+		}
+		vCenter, err = cnsvsphere.GetVirtualCenterInstanceForVCenterConfig(ctx, vcconfig, false)
+		if err != nil {
+			return err
 		}
 
 		volumeManager, err = volumes.GetManager(ctx, vCenter, nil, false, false, false, clusterFlavor)

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -124,7 +124,7 @@ func TestSyncerWorkflows(t *testing.T) {
 	configInfo := &cnsconfig.ConfigurationInfo{}
 	configInfo.Cfg = csiConfig
 
-	virtualCenter, err = cnsvsphere.GetVirtualCenterInstance(ctx, configInfo, false)
+	virtualCenter, err = cnsvsphere.GetVirtualCenterInstanceForVCenterConfig(ctx, cnsVCenterConfig, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,9 +154,12 @@ func TestSyncerWorkflows(t *testing.T) {
 	}
 
 	// Initialize metadata syncer object.
-	metadataSyncer = &metadataSyncInformer{}
+	metadataSyncer = &metadataSyncInformer{
+		volumeManagers: make(map[string]cnsvolumes.Manager),
+	}
 	metadataSyncer.configInfo = configInfo
 	metadataSyncer.volumeManager = volumeManager
+	metadataSyncer.volumeManagers[virtualCenter.Config.Host] = volumeManager
 	metadataSyncer.host = virtualCenter.Config.Host
 	volumeOperationsLock = make(map[string]*sync.Mutex)
 	volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Removes obsolete FSS multi-vcenter-csi-topology.  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. vks precheckin
 kr026574 <br> PR 3399<br>
Ran 6 of 1080 Specs in 543.313 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 1074 Skipped
PASS

2.wcp precheckin
jc005865 <br> PR 3399<br>
Ran 14 of 1080 Specs in 2260.106 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 1066 Skipped
PASS

3. vanilla precheckin

rg011844 <br> PR 3399<br>------------------------------

Ran 0 of 348 Specs in 0.097 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 348 Skipped

(I think that status line is a bug.   test logs do show the pipeline actually ran some tests).

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
