### PR TITLE
Remove FSS max-pvscsi-targets-per-vm

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -72,7 +72,6 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 				"pv-to-backingdiskobjectid-mapping": "false",
 				"cnsmgr-suspend-create-volume":      "true",
 				"topology-preferential-datastores":  "true",
-				"max-pvscsi-targets-per-vm":         "true",
 				"multi-vcenter-csi-topology":        "true",
 				"listview-tasks":                    "true",
 				"storage-quota-m2":                  "false",

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -364,7 +364,6 @@ func getReleasedVanillaFSS() map[string]struct{} {
 		common.ListVolumes:                    {},
 		common.CnsMgrSuspendCreateVolume:      {},
 		common.TopologyPreferentialDatastores: {},
-		common.MaxPVSCSITargetsPerVM:          {},
 		common.MultiVCenterCSITopology:        {},
 		common.CSIInternalGeneratedClusterID:  {},
 		common.TopologyAwareFileVolume:        {},

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -418,8 +418,6 @@ const (
 	// TopologyPreferentialDatastores is the feature gate for preferential
 	// datastore deployment in topology aware environments.
 	TopologyPreferentialDatastores = "topology-preferential-datastores"
-	// MaxPVSCSITargetsPerVM enables support for 255 volumes per node vm
-	MaxPVSCSITargetsPerVM = "max-pvscsi-targets-per-vm"
 	// MultiVCenterCSITopology is the feature gate for enabling multi vCenter topology support for vSphere CSI driver.
 	MultiVCenterCSITopology = "multi-vcenter-csi-topology"
 	// CSIInternalGeneratedClusterID enables support to generate unique cluster

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-	maxAllowedBlockVolumesPerNode = 59
 	// vCenter 8.0 supports attaching max 255 volumes to Node
 	// Previous vSphere releases supports attaching a max of 59 volumes to Node VM.
 	// Deployment YAML file for Node DaemonSet has ENV MAX_VOLUMES_PER_NODE set to 59 for vsphere-csi-node container
@@ -410,12 +409,7 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 	}
 
 	var maxVolumesPerNode int64
-	var maxAllowedVolumesPerNode int64
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.MaxPVSCSITargetsPerVM) {
-		maxAllowedVolumesPerNode = maxAllowedBlockVolumesPerNodeInvSphere8
-	} else {
-		maxAllowedVolumesPerNode = maxAllowedBlockVolumesPerNode
-	}
+	var maxAllowedVolumesPerNode int64 = maxAllowedBlockVolumesPerNodeInvSphere8
 	if v := os.Getenv("MAX_VOLUMES_PER_NODE"); v != "" {
 		if value, err := strconv.ParseInt(v, 10, 64); err == nil {
 			if value < 0 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Removes obsolete FSS flag max-pvscsi-targets-per-vm

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. Unit tests
2. precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/161/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
