### PR TITLE
Performance Improvement - Optimize WCP controller publish volume

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/vmware/govmomi/simulator"
@@ -350,9 +351,15 @@ func (c *FakeK8SOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string,
 	return "", false
 }
 
-// GetPVCNameFromCSIVolumeID retrieves the pvc name from volumeID.
-func (c *FakeK8SOrchestrator) GetPVCNameFromCSIVolumeID(volumeID string) (string, bool) {
-	return "", false
+// GetPVCNameFromCSIVolumeID returns `pvc name` and `pvc namespace` for the given volumeID using volumeIDToPvcMap.
+func (c *FakeK8SOrchestrator) GetPVCNameFromCSIVolumeID(volumeID string) (string, string, bool) {
+	if strings.Contains(volumeID, "invalid") {
+		// Simulate a case where the volumeID is invalid and does not correspond to any PVC.
+		return "", "", false
+	}
+
+	// Simulate a case where the volumeID corresponds to a PVC.
+	return "mock-pvc", "mock-namespace", true
 }
 
 // InitializeCSINodes creates CSINode instances for each K8s node with the appropriate topology keys.

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -94,8 +94,8 @@ type COCommonInterface interface {
 	// GetPVNameFromCSIVolumeID retrieves the pv name from the volumeID.
 	// This method will not return pv name in case of in-tree migrated volumes
 	GetPVNameFromCSIVolumeID(volumeID string) (string, bool)
-	// GetPVCNameFromCSIVolumeID returns PV claim name for the volume ID
-	GetPVCNameFromCSIVolumeID(volumeID string) (string, bool)
+	// GetPVCNameFromCSIVolumeID returns `pvc name` and `pvc namespace` for the given volumeID using volumeIDToPvcMap.
+	GetPVCNameFromCSIVolumeID(volumeID string) (string, string, bool)
 	// InitializeCSINodes creates CSINode instances for each K8s node with the appropriate topology keys.
 	InitializeCSINodes(ctx context.Context) error
 	// StartZonesInformer starts a dynamic informer which listens on Zones CR in

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1867,7 +1868,14 @@ func (c *K8sOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string, boo
 	return c.volumeIDToNameMap.get(volumeID)
 }
 
-// GetPVCNameFromCSIVolumeID retrieves the pvc name from volumeID using volumeIDToPvcMap.
-func (c *K8sOrchestrator) GetPVCNameFromCSIVolumeID(volumeID string) (string, bool) {
-	return c.volumeIDToPvcMap.get(volumeID)
+// GetPVCNameFromCSIVolumeID returns `pvc name` and `pvc namespace` for the given volumeID using volumeIDToPvcMap.
+func (c *K8sOrchestrator) GetPVCNameFromCSIVolumeID(volumeID string) (
+	pvcName string, pvcNamespace string, exists bool) {
+	namespacedName, ok := c.volumeIDToPvcMap.get(volumeID)
+	if !ok {
+		return
+	}
+
+	parts := strings.Split(namespacedName, "/")
+	return parts[1], parts[0], true
 }

--- a/pkg/csi/service/wcp/controller_helper_test.go
+++ b/pkg/csi/service/wcp/controller_helper_test.go
@@ -1,0 +1,162 @@
+package wcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+func TestGetPodVMUUID(t *testing.T) {
+	logger.SetLoggerLevel(logger.DevelopmentLogLevel)
+	containerOrchOriginal := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	newK8sClientOriginal := newK8sClient
+	defer func() {
+		newK8sClient = newK8sClientOriginal
+		commonco.ContainerOrchestratorUtility = containerOrchOriginal
+	}()
+
+	t.Run("WhenPVCDoesNotExist", func(t *testing.T) {
+		// Execute
+		_, err := getPodVMUUID(context.Background(), "invalid-mock-volume", "")
+
+		// Verify
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "failed to get PVC name")
+	})
+
+	t.Run("WhenCreatingK8sClientFails", func(t *testing.T) {
+		// Setup
+		newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
+			return nil, assert.AnError
+		}
+
+		// Execute
+		_, err := getPodVMUUID(context.Background(), "mock-volume-id", "mock-node-name")
+
+		// Verify
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "failed to create kubernetes client")
+	})
+
+	t.Run("WhenListingPodsFails", func(t *testing.T) {
+		// Setup
+		newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
+			c := fake.Clientset{}
+			c.PrependReactor("list", "pods",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, assert.AnError
+				},
+			)
+			return &c, nil
+		}
+
+		// Assert
+		_, err := getPodVMUUID(context.Background(), "mock-volume-id", "mock-node-name")
+
+		// Verify
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "listing pods in the namespace \"mock-namespace\" failed")
+	})
+
+	t.Run("WhenPodNotFound", func(t *testing.T) {
+		// Setup
+		newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
+			c := fake.Clientset{}
+			c.PrependReactor("list", "pods",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, nil // No pods found
+				},
+			)
+			return &c, nil
+		}
+
+		// Execute
+		_, err := getPodVMUUID(context.Background(), "mock-volume-id", "mock-node-name")
+
+		// Verify
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "failed to find pod for pvc")
+	})
+
+	t.Run("WhenPodDoesNotHaveVMUUIDAnn", func(t *testing.T) {
+		// Setup
+		newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
+			// register a few pods
+			p1 := newMockPod("mock-pod", "mock-namespace", "mock-node-name",
+				[]string{"mock-pvc"}, nil, v1.PodPending)
+			p2 := newMockPod("mock-pod-2", "mock-namespace", "mock-node-name-2",
+				nil, nil, v1.PodRunning)
+			p3 := newMockPod("mock-pod-3", "mock-namespace", "mock-node-name-3",
+				[]string{"mock-pvc2"}, map[string]string{"vmUUID": "mock-vm-uuid-2"}, v1.PodRunning)
+			return fake.NewClientset(p1, p2, p3), nil
+		}
+
+		// Execute
+		_, err := getPodVMUUID(context.Background(), "mock-volume-id", "mock-node-name")
+
+		// Verify
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "\"vmware-system-vm-uuid\" annotation not found on pod \"mock-pod\"")
+	})
+
+	t.Run("WhenPodFoundWithVMUUID", func(t *testing.T) {
+		// Setup
+		newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
+			// register a few pods
+			p1 := newMockPod("mock-pod", "mock-namespace", "mock-node-name",
+				[]string{"mock-pvc"}, map[string]string{"vmware-system-vm-uuid": "mock-vm-uuid"}, v1.PodPending)
+			p2 := newMockPod("mock-pod-2", "mock-namespace", "mock-node-name-2",
+				nil, nil, v1.PodRunning)
+			p3 := newMockPod("mock-pod-3", "mock-namespace", "mock-node-name-3",
+				[]string{"mock-pvc2"}, map[string]string{"vmUUID": "mock-vm-uuid-2"}, v1.PodRunning)
+			return fake.NewClientset(p1, p2, p3), nil
+		}
+
+		// Execute
+		vmUUID, err := getPodVMUUID(context.Background(), "mock-volume-id", "mock-node-name")
+
+		// Verify
+		assert.Nil(t, err)
+		assert.Equal(t, "mock-vm-uuid", vmUUID)
+	})
+}
+
+func newMockPod(name, namespace, nodeName string, volumes []string,
+	annotations map[string]string, phase v1.PodPhase) *v1.Pod {
+	vols := make([]v1.Volume, len(volumes))
+	for i, vol := range volumes {
+		vols[i] = v1.Volume{
+			Name: vol,
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					ClaimName: vol,
+				},
+			},
+		}
+	}
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: v1.PodSpec{
+			NodeName: nodeName,
+			Volumes:  vols,
+		},
+		Status: v1.PodStatus{
+			Phase: phase,
+		},
+	}
+}

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/cnsunregistervolume_controller.go
@@ -19,7 +19,6 @@ package cnsunregistervolume
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -217,12 +216,9 @@ func (r *ReconcileCnsUnregisterVolume) Reconcile(ctx context.Context,
 	pvName, pvfound := commonco.ContainerOrchestratorUtility.GetPVNameFromCSIVolumeID(instance.Spec.VolumeID)
 	if pvfound {
 		log.Infof("found PV: %q for the volumd Id: %q", pvName, instance.Spec.VolumeID)
-		pvcNamewithNamespace, pvcfound := commonco.ContainerOrchestratorUtility.
+		pvcName, pvcNamespace, pvcFound := commonco.ContainerOrchestratorUtility.
 			GetPVCNameFromCSIVolumeID(instance.Spec.VolumeID)
-		if pvcfound {
-			parts := strings.Split(pvcNamewithNamespace, "/")
-			pvcNamespace = parts[0]
-			pvcName = parts[1]
+		if pvcFound {
 			log.Infof("found PVC: %q in the namespace:%q for the volumd Id: %q", pvcName, pvcNamespace,
 				instance.Spec.VolumeID)
 		} else {

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.pb.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.pb.go
@@ -541,10 +541,11 @@ func (c *k8SCloudOperatorClient) GetStorageVMotionPlan(ctx context.Context, in *
 // K8SCloudOperatorServer is the server API for K8SCloudOperator service.
 type K8SCloudOperatorServer interface {
 	//
-	// GetPodVMUUIDAnnotation gets the PV by querying the API server refering to the volumeID in the request.
+	// Deprecated: Do not use. This method is deprecated and will be removed in future versions.
+	// GetPodVMUUIDAnnotation gets the PV by querying the API server referring to the volumeID in the request.
 	// Retrieves the PVC name and Namespace from the PV spec.
 	//
-	// It then gets the vmuuid annotation from the pod satisfying the below conditions
+	// It then gets the VM UUID from the annotations from the pod satisfying the below conditions
 	// 1. Pod Scheduled on node with name "nodeName"
 	// 2. Pod is in pending state in the same namespace as pvc specified using "pvcNamespace"
 	// 3. Pod has a volume with name "pvcName" associated with it

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.proto
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.proto
@@ -23,10 +23,11 @@ import "github.com/container-storage-interface/spec/csi.proto";
 // Interface exported by the server
 service K8sCloudOperator {
    /*
-   * GetPodVMUUIDAnnotation gets the PV by querying the API server refering to the volumeID in the request.
+   * Deprecated: Do not use. This method is deprecated and will be removed in future versions.
+   * GetPodVMUUIDAnnotation gets the PV by querying the API server referring to the volumeID in the request.
    * Retrieves the PVC name and Namespace from the PV spec.
    *
-   * It then gets the vmuuid annotation from the pod satisfying the below conditions
+   * It then gets the VM UUID from the annotations from the pod satisfying the below conditions
    * 1. Pod Scheduled on node with name "nodeName"
    * 2. Pod is in pending state in the same namespace as pvc specified using "pvcNamespace"
    * 3. Pod has a volume with name "pvcName" associated with it


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when WCP controller tries to attach a volume to a node, it does so by first finding the UUID of the VM(on the node) on which the Pod is scheduled to run. The controller does this by interacting with the **k8s Cloud Operator** running the syncer container via gRPC.
The syncer in turn performs a **highly inefficient** operation to figure out the VM UUID. We have observed frequent timeouts because of this in scaled environments - 

```
2024-08-12T10:49:16.801596875Z stderr F {"level":"error","time":"2024-08-12T10:49:16.589835974Z","caller":"wcp/controller_helper.go:308","msg":"Failed to get the pod vmuuid annotation from the k8s cloud operator service. Error: rpc error: code = Unknown desc = the server was unable to return a response in the time allotted, but may still be processing the request (get persistentvolumes)","TraceId":"81ea8122-f8ad-4100-82e2-8aa0681560fb","
```

This PR address the above bottleneck by changing the controller logic to find out the VM UUID using existing caches.
It also introduces unit tests for the new functions introduced and also deprecates `GetPodVMUUIDAnnotation`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Test steps**:
To test this at a decent scale, 
1. Create 500 pods with 1 PVC(10Gi) each in a namespace
2. Some or many of the pods should fail with `ProviderFailed` and `PodVMCreationFailed` errors
3. Verify that the volume attachment operation is successful for **all the pods** that have the VM UUID annotation
4. For pods without this annotation, the attach operation should fail

**Observations**:
Out of 500 pods created,
- 120 of them came to running state(evidence in `success_pods.txt`)
- 22 of them were in error state with VM UUID annotation with the attach operation being successful(evidence in `failed_pods_with_annotation.txt`)
- Remaining pods were in error state without the VM UUID annotation

<details><summary>Script used</summary>
<p>

```shell
#!/bin/bash

# for each pod in the namespace pod-vm-uuid-ann, if the status is Running, print the pod name and the vm uuid from the annotations to success_pods.txt
# else output the pod name and the annotations to failed_pods.txt

NAMESPACE="pod-vm-uuid-ann"
ANNOTATION_KEY="vmware-system-vm-uuid"
SUCCESS_FILE="success_pods.txt"
FAILED_FILE="failed_pods.txt"

kubectl get pods -n "$NAMESPACE" -o json | jq -r --arg ANNOTATION_KEY "$ANNOTATION_KEY" '
  .items[] |
  select(.status.phase == "Running") |
  "\(.metadata.name) \(.metadata.annotations[$ANNOTATION_KEY])"' > "$SUCCESS_FILE"

kubectl get pods -n "$NAMESPACE" -o json | jq -r --arg ANNOTATION_KEY "$ANNOTATION_KEY" '
.items[] |
select(.status.phase != "Running" and .metadata.annotations[$ANNOTATION_KEY] != null) |
"\(.metadata.name)"' > "$FAILED_FILE"
```

</p>
</details> 

[success_pods.txt](https://github.com/user-attachments/files/21183963/success_pods.txt)
[failed_pods_with_annotation.txt](https://github.com/user-attachments/files/21183964/failed_pods.txt)
[failed_pods_with_annotation_describe.txt](https://github.com/user-attachments/files/21183966/failed_pods_describe.txt)

Also `failed_pods_with_annotation_describe.txt` captures the events of all the failed pods which clearly indicates that the attach operation was successful.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
6. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Performance Improvement - Optimize WCP controller publish volume
```
