### PR TITLE
Get the datastore accessible topology from the snapshot

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -531,6 +531,30 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			}
 			// Initiate TKGs HA workflow when the topology requirement contains zone labels only.
 			log.Infof("Topology aware environment detected with requirement: %+v", topologyRequirement)
+
+			// if volume is created from snapshot, get the datastore accessible topology from the snapshot
+			if req.GetVolumeContentSource() != nil {
+				snapshotID := ""
+				if req.GetVolumeContentSource().GetSnapshot() != nil {
+					snapshotID = req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()
+				}
+				log.Infof("Volume %s is created from snapshot %s, get the datastore accessible topology from the snapshot",
+					req.Name, snapshotID)
+				datastoreAccessibleTopology, err := c.getDatastoreAccessibleTopologyForSnapshot(ctx,
+					req.GetVolumeContentSource().GetSnapshot().GetSnapshotId(), storageTopologyType,
+					topologyRequirement, topoSegToDatastoresMap)
+				if err != nil {
+					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+						"failed to get datastore accessible topology. Error: %v", err)
+				}
+				topologyRequirement = &csi.TopologyRequirement{
+					Preferred: datastoreAccessibleTopology,
+					Requisite: datastoreAccessibleTopology,
+				}
+				log.Infof("Replaced with topologyRequirement %+v for creating volume %s from snapshot %s",
+					topologyRequirement, req.Name, snapshotID)
+			}
+
 			sharedDatastores, err = c.topologyMgr.GetSharedDatastoresInTopology(ctx,
 				commoncotypes.WCPTopologyFetchDSParams{
 					TopologyRequirement:    topologyRequirement,
@@ -910,6 +934,80 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 	}
 	return resp, "", nil
+}
+
+func (c *controller) getDatastoreAccessibleTopologyForSnapshot(ctx context.Context, contentSourceSnapshotID string,
+	storageTopologyType string, topologyRequirement *csi.TopologyRequirement,
+	topoSegToDatastoresMap map[string][]*cnsvsphere.DatastoreInfo) ([]*csi.Topology, error) {
+	log := logger.GetLogger(ctx)
+
+	log.Debugf("getDatastoreAccessibleTopologyForSnapshot: contentSourceSnapshotID: %s, storageTopologyType: %s, "+
+		"topologyRequirement %+v, topoSegToDatastoresMap %+v",
+		contentSourceSnapshotID, storageTopologyType, topologyRequirement, topoSegToDatastoresMap)
+
+	vc, err := c.manager.VcenterManager.GetVirtualCenter(ctx, c.manager.VcenterConfig.Host)
+	if err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to get vCenter. Error: %+v", err)
+	}
+
+	if c.topologyMgr == nil {
+		return nil, logger.LogNewErrorCode(log, codes.Internal,
+			"topology manager not initialized.")
+	}
+
+	// Query the datastore of snapshot. By design, snapshot is always located at the same datastore
+	// as the source volume
+	querySelection := cnstypes.CnsQuerySelection{
+		Names: []string{string(cnstypes.QuerySelectionNameTypeDataStoreUrl)},
+	}
+
+	// Parse contentSourceSnapshotID into CNS VolumeID and CNS SnapshotID using "+" as the delimiter
+	cnsVolumeID, _, err := common.ParseCSISnapshotID(contentSourceSnapshotID)
+	if err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to parse snapshot id. Error: %+v", err)
+	}
+	cnsVolumeInfo, err := common.QueryVolumeByID(ctx, c.manager.VolumeManager, cnsVolumeID, &querySelection)
+	if err != nil {
+		return nil, logger.LogNewErrorf(log,
+			"failed to query datastore for the volume %s with error %+v",
+			cnsVolumeID, err)
+	}
+
+	selectedDatastore := cnsVolumeInfo.DatastoreUrl
+	log.Debugf("getDatastoreAccessibleTopologyForSnapshot: selectedDatastore: %s", selectedDatastore)
+
+	if selectedDatastore == "" {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to get datastore for volume %q. Error: %+v",
+			cnsVolumeID, err)
+	}
+
+	// Calculate accessible topology for the provisioned volume.
+	datastoreAccessibleTopologySegments, err := c.topologyMgr.GetTopologyInfoFromNodes(ctx,
+		commoncotypes.WCPRetrieveTopologyInfoParams{
+			DatastoreURL:           selectedDatastore,
+			StorageTopologyType:    storageTopologyType,
+			TopologyRequirement:    topologyRequirement,
+			Vc:                     vc,
+			TopoSegToDatastoresMap: topoSegToDatastoresMap})
+	if err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to find accessible topologies for volume %q. Error: %+v",
+			cnsVolumeID, err)
+	}
+
+	// Convert []map[string]string to []*csi.Topology
+	var datastoreAccessibleTopology []*csi.Topology
+	for _, topoSegments := range datastoreAccessibleTopologySegments {
+		volumeTopology := &csi.Topology{
+			Segments: topoSegments,
+		}
+		datastoreAccessibleTopology = append(datastoreAccessibleTopology, volumeTopology)
+	}
+	log.Infof("getDatastoreAccessibleTopologyForSnapshot: returning topology %+v", datastoreAccessibleTopology)
+	return datastoreAccessibleTopology, nil
 }
 
 // createFileVolume creates a file volume based on the CreateVolumeRequest.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
***Test 1***
Tested in an environment with multi-zone support.
Setting feature state vol-from-snapshot-on-target-ds to true in configmap.
Created a PVC, created a VolumeSnapshot from the PVC, and then tried to create a PVC from the VolumeSnapshot. Since the CNS side changes are not ready, I can't test create a PVC from snapshot and have it land on the different datastore yet.  I printed out messages in the logs to show that it gets the datastore accessible topology from the snapshot if the volume is created from a snapshot, and replaces the topologyRequirement.

```
{"level":"info","time":"2025-07-11T15:06:18.129644349Z","caller":"wcp/controller.go:1285","msg":"CreateVolume: called with args {Name:pvc-3c95412c-0287-431d-8f41-6fc1ee5d22bd CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal csi.storage.k8s.io/pv/name:pvc-3c95412c-0287-431d-8f41-6fc1ee5d22bd csi.storage.k8s.io/pvc/name:test-restore csi.storage.k8s.io/pvc/namespace:divyen-ns csi.storage.k8s.io/sc/name:test-zonal-policy storagePolicyID:dfe8c7f9-021c-435d-8ec4-d7fff29784fd] Secrets:map[] VolumeContentSource:snapshot:<snapshot_id:\"000be7d4-5b3e-499b-b370-43efc052a3b2+3c7f350f-f98a-438a-8a63-9a40d99ebb3b\" >  AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.143958397Z","caller":"wcp/controller.go:533","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > ","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.144033585Z","caller":"wcp/controller.go:537","msg":"Volume is created from snapshot, get the datastore accessible topology from the snapshot","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.144156147Z","caller":"wcp/controller.go:936","msg":"getDatastoreAccessibleTopology: contentSourceSnapshotID: 000be7d4-5b3e-499b-b370-43efc052a3b2+3c7f350f-f98a-438a-8a63-9a40d99ebb3b, storageTopologyType: Zonal","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.206330498Z","caller":"wcp/controller.go:969","msg":"getDatastoreAccessibleTopology: selectedDatastore: ds:///vmfs/volumes/686e9cd0-0d4d5c53-de3c-020036f2be0a/","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.206468061Z","caller":"k8sorchestrator/topology.go:1737","msg":"Topology of the provisioned volume detected as [map[[topology.kubernetes.io/zone:zone-1]]","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a](http://topology.kubernetes.io/zone:zone-1]]%22,%22TraceId%22:%22c9827024-1265-4168-bb58-6d5e8ecd281a)"}

{"level":"info","time":"2025-07-11T15:06:18.206614286Z","caller":"wcp/controller.go:1007","msg":"getDatastoreAccessibleTopology: found 1 topology segments","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.206774985Z","caller":"wcp/controller.go:1016","msg":"getDatastoreAccessibleTopology: returning 1 topology entries","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.206834546Z","caller":"wcp/controller.go:547","msg":"Replaced topologyRequirement for snapshot volume: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > ","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.207000681Z","caller":"k8sorchestrator/topology.go:1612","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c54]","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.22935916Z","caller":"k8sorchestrator/topology.go:1586","msg":"Shared datastores [Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/686e9cc9-f80c44d7-ed4f-020036d39f95/ Datastore: Datastore:datastore-53, datastore URL: ds:///vmfs/volumes/686e9cd0-0d4d5c53-de3c-020036f2be0a/] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > ","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.263855853Z","caller":"vsphere/utils.go:513","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/686e9cc9-f80c44d7-ed4f-020036d39f95/ Datastore: Datastore:datastore-53, datastore URL: ds:///vmfs/volumes/686e9cd0-0d4d5c53-de3c-020036f2be0a/]","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}

{"level":"info","time":"2025-07-11T15:06:18.336061403Z","caller":"common/vsphereutil.go:328","msg":"VolFromSnapshotOnTargetDs is enabled, skip the compatible datastore check","TraceId":"c9827024-1265-4168-bb58-6d5e8ecd281a"}
```

***Test 2***
Tested on another testbed which has partial implementation of CNS side changes. The PVC was created from VolumeSnapshot successfully.
Setting feature state vol-from-snapshot-on-target-ds to true in configmap.

```
root@422b417c38c9e6389e1ab032cb35fcdd [ ~ ]# cat restore7.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-restore7
  namespace: test-ns
spec:
  storageClassName: new-storage-policy
  dataSource:
    name: test-snapshot
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi

root@422b417c38c9e6389e1ab032cb35fcdd [ ~ ]# kubectl get pvc -n test-ns
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-pvc        Bound    pvc-a3413cd3-1052-4adb-ae83-87bd12f9b3e6   1Gi        RWO            wcpglobal-storage-profile   <unset>                 7d3h
test-restore    Bound    pvc-924b0726-4d99-448a-b631-1e3fc3437429   1Gi        RWO            wcpglobal-storage-profile   <unset>                 7d2h
test-restore6   Bound    pvc-71fdba5c-41c6-454e-9f93-1d71e055fd40   1Gi        RWO            new-storage-policy          <unset>                 3d20h
test-restore7   Bound    pvc-a97e3928-bac0-461c-aeed-f8ae310691c0   1Gi        RWO            new-storage-policy          <unset>                 3m57s

{"level":"info","time":"2025-07-11T16:44:13.158393246Z","caller":"wcp/controller.go:1285","msg":"CreateVolume: called with args {Name:pvc-a97e3928-bac0-461c-aeed-f8ae310691c0 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[csi.storage.k8s.io/pv/name:pvc-a97e3928-bac0-461c-aeed-f8ae310691c0 csi.storage.k8s.io/pvc/name:test-restore7 csi.storage.k8s.io/pvc/namespace:test-ns csi.storage.k8s.io/sc/name:new-storage-policy storagePolicyID:49e6db8a-94bd-4a14-9ce7-019516dd9dee] Secrets:map[] VolumeContentSource:snapshot:<snapshot_id:\"ab0ede4b-31b3-4113-8582-c567aab241f5+b815308c-2ea5-4884-8747-36971c24245b\" >  AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"66271591-897b-4395-b393-64a51136452a"}

{"level":"info","time":"2025-07-11T16:44:13.172842199Z","caller":"wcp/controller.go:533","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > > ","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:13.172888559Z","caller":"wcp/controller.go:537","msg":"Volume is created from snapshot, get the datastore accessible topology from the snapshot","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:13.172922901Z","caller":"wcp/controller.go:936","msg":"getDatastoreAccessibleTopology: contentSourceSnapshotID: ab0ede4b-31b3-4113-8582-c567aab241f5+b815308c-2ea5-4884-8747-36971c24245b, storageTopologyType: ","TraceId":"66271591-897b-4395-b393-64a51136452a"}

{"level":"info","time":"2025-07-11T16:44:13.221205414Z","caller":"wcp/controller.go:969","msg":"getDatastoreAccessibleTopology: selectedDatastore: ds:///vmfs/volumes/68674a08-851654df-659e-02000c3e906d/","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:13.254421746Z","caller":"k8sorchestrator/topology.go:1737","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:domain-c38]]","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:13.254579159Z","caller":"wcp/controller.go:1007","msg":"getDatastoreAccessibleTopology: found 1 topology segments","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:13.254638337Z","caller":"wcp/controller.go:1016","msg":"getDatastoreAccessibleTopology: returning 1 topology entries","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:13.254685775Z","caller":"wcp/controller.go:547","msg":"Replaced topologyRequirement for snapshot volume: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > > ","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:13.254758908Z","caller":"k8sorchestrator/topology.go:1612","msg":"Clusters matching topology requirement \"domain-c38\" are [domain-c38]","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:13.278022972Z","caller":"k8sorchestrator/topology.go:1586","msg":"Shared datastores [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/68674a08-851654df-659e-02000c3e906d/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/68674a0a-48f65dcc-6d0f-02000ca8b3e3/] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > > ","TraceId":"66271591-897b-4395-b393-64a51136452a"}

{"level":"info","time":"2025-07-11T16:44:13.302689653Z","caller":"vsphere/utils.go:513","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/68674a08-851654df-659e-02000c3e906d/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/68674a0a-48f65dcc-6d0f-02000ca8b3e3/]","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:13.357470875Z","caller":"common/vsphereutil.go:328","msg":"VolFromSnapshotOnTargetDs is enabled, skip the compatible datastore check","TraceId":"66271591-897b-4395-b393-64a51136452a"}

{"level":"info","time":"2025-07-11T16:44:15.491663421Z","caller":"volume/manager.go:456","msg":"CreateVolume: VolumeName: \"pvc-a97e3928-bac0-461c-aeed-f8ae310691c0\", opId: \"4b8640b0\"","TraceId":"66271591-897b-4395-b393-64a51136452a"}
{"level":"info","time":"2025-07-11T16:44:15.495159133Z","caller":"volume/util.go:329","msg":"Volume created successfully. VolumeName: \"pvc-a97e3928-bac0-461c-aeed-f8ae310691c0\", volumeID: \"5e2afca8-fa5e-461c-a70a-b12599d8abaa\"","TraceId":"66271591-897b-4395-b393-64a51136452a"}
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Get the datastore accessible topology from the snapshot if volume is created from a snapshot.
```
