### PR TITLE
fix checkPVCCondition to compare size

### DIFF
--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -186,7 +186,7 @@ func checkPVCCondition(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 			pvc.Namespace, condition.Type)
 		if condition.Type == reqCondition {
 			pvcSize := pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-			if pvcSize == *reqSize {
+			if pvcSize.Value() == reqSize.Value() {
 				log.Infof("PersistentVolumeClaim %s in namespace %s is in %s condition and "+
 					"its request size is %s", pvc.Name, pvc.Namespace, condition.Type, reqSize.String())
 				return true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When volume is expanded in the guest cluster without specifying size format, volume expansion in guest cluster is stuck.

Logs without fix

{"level":"info","time":"2025-07-14T20:16:45.805183031Z","caller":"wcpguest/controller_helper.go:189","msg":"PersistentVolumeClaim 66d7ec6f-48a8-4a41-8b2a-0c29b09a5750-a6176c45-838a-45cb-b774-90fa718bb4a3 in namespace dsm-test-3 is in FileSystemResizePending condition, its desired request size is 39696061952, but current request size is 39696061952","TraceId":"99bfad53-cb49-48e3-b4a1-42556e2930e6"}

 

**Testing done**:
In Progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix checkPVCCondition to compare size
```
