### PR TITLE
Use VolFromSnapshotOnTargetDs FSS

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -571,7 +571,6 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
-  "vol-from-snapshot-on-target-ds": "false"
   "linked-clone-support": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -571,7 +571,6 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
-  "vol-from-snapshot-on-target-ds": "false"
   "linked-clone-support": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -569,7 +569,6 @@ data:
   "WCP_VMService_BYOK": "false"
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
-  "vol-from-snapshot-on-target-ds": "false"
   "linked-clone-support": "false"
 kind: ConfigMap
 metadata:

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -458,8 +458,9 @@ const (
 	SharedDiskFss = "supports_shared_disks"
 	// CSITranSactionSupport is an FSS for transaction support
 	CSITranSactionSupport = "csi-transaction-support"
-	// VolFromSnapshotOnTargetDs enables creation of volumes from snapshots on different datastores
-	VolFromSnapshotOnTargetDs = "vol-from-snapshot-on-target-ds"
+	// VolFromSnapshotOnTargetDs is a FSS that tells whether creation of volumes from
+	// snapshots on different datastores feature is supported in CSI.
+	VolFromSnapshotOnTargetDs = "supports_vol_from_snapshot_on_target_ds"
 	// LinkedCloneSupport is an FSS that tells whether LinkedClone feature is supported in CSI.
 	LinkedCloneSupport = "linked-clone-support"
 )
@@ -469,6 +470,7 @@ var WCPFeatureStates = map[string]struct{}{
 	CSIDetachOnSupervisor:      {},
 	WorkloadDomainIsolation:    {},
 	VPCCapabilitySupervisor:    {},
+	VolFromSnapshotOnTargetDs:  {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
* This PR checks supervisor capability supports_vol_from_snapshot_on_target_ds and decides whether to skip the code that restricts a volume to be created from a snapshot to be on the same datastore where the snapshot is located.
* Removes the flag from the deployment yaml as we don't need to use configmap to check the FSS any more.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Supervisor capability `supports_vol_from_snapshot_on_target_ds` is enabled on the testbed.
```
kubectl get capabilities supervisor-capabilities -o yaml

apiVersion: iaas.vmware.com/v1alpha1
kind: Capabilities
  name: supervisor-capabilities
  resourceVersion: "9847"
  uid: ad8e904c-7deb-4757-8253-f570fb761df0
spec:
  infra:
……
  - enabled: true
    name: supports_vol_from_snapshot_on_target_ds
    userFacing: false
……
  - description: supports_vol_from_snapshot_on_target_ds indicates whether or not
      this Supervisor supports creating volume from snapshot on different datastore
    enabled: true
    name: supports_vol_from_snapshot_on_target_ds
    userFacing: false
……
    supports_vol_from_snapshot_on_target_ds:
      activated: true
```

Created a PVC test-pvc, created a VolumeSnapshot test-snapshot, created a PVC test-restore from VolumeSnapshot.

```
root@420b40712e19ab89d86f79282f09f8a1 [ ~ ]# kubectl get pvc -n test-ns
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-pvc       Bound    pvc-a5d28b8c-1694-41dc-b9ae-90bab80539c3   1Gi        RWO            wcpglobal-storage-profile   <unset>                 15m
test-restore   Bound    pvc-ad16fc56-ed4a-4c46-82df-7412639eb54f   1Gi        RWO            wcpglobal-storage-profile   <unset>                 14m

root@420b40712e19ab89d86f79282f09f8a1 [ ~ ]# kubectl get volumesnapshot -n test-ns
NAME            READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
test-snapshot   true         test-pvc                            1Gi           volumesnapshotclass-delete   snapcontent-61988682-c907-496a-99c6-49f64c0267a5   14m            14m
```

vSphere CSI logs showed that “Supervisor capability \"supports_vol_from_snapshot_on_target_ds\" is set to true” and “VolFromSnapshotOnTargetDs is enabled, skip the compatible datastore check”. This means it went through the correct code path.

```
{"level":"info","time":"2025-07-22T02:26:43.571152723Z","caller":"wcp/controller.go:555","msg":"Volume pvc-ad16fc56-ed4a-4c46-82df-7412639eb54f is created from snapshot 5a56c74b-8de8-44de-988d-b6c52f75633a+52c9e81c-9889-4ab8-a669-7b0e622db696, get the datastore accessible topology from the snapshot","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
…
{"level":"info","time":"2025-07-22T02:26:43.791196391Z","caller":"wcp/controller.go:1050","msg":"getDatastoreAccessibleTopologyForSnapshot: returning topology [segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > ]","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
…
{"level":"info","time":"2025-07-22T02:26:43.791373634Z","caller":"wcp/controller.go:568","msg":"Replaced with topologyRequirement requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > >  for creating volume pvc-ad16fc56-ed4a-4c46-82df-7412639eb54f from snapshot 5a56c74b-8de8-44de-988d-b6c52f75633a+52c9e81c-9889-4ab8-a669-7b0e622db696","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
{"level":"info","time":"2025-07-22T02:26:43.818745627Z","caller":"k8sorchestrator/topology.go:1586","msg":"Shared datastores [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/68731677-cd8c0d8e-9778-0200467d489e/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/6873167a-339091ce-1b35-0200467d489e/] for topologyRequirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c38\" > > ","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
{"level":"info","time":"2025-07-22T02:26:43.837326772Z","caller":"k8sorchestrator/k8sorchestrator.go:1196","msg":"Feature \"supports_vol_from_snapshot_on_target_ds\" is a WCP defined feature state. Reading the capabilities CR \"supervisor-capabilities\".","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
{"level":"info","time":"2025-07-22T02:26:43.837415509Z","caller":"k8sorchestrator/k8sorchestrator.go:1218","msg":"Supervisor capability \"supports_vol_from_snapshot_on_target_ds\" is set to true","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
{"level":"info","time":"2025-07-22T02:26:43.849395532Z","caller":"vsphere/utils.go:539","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/68731677-cd8c0d8e-9778-0200467d489e/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/6873167a-339091ce-1b35-0200467d489e/]","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
{"level":"info","time":"2025-07-22T02:26:43.894569932Z","caller":"common/vsphereutil.go:330","msg":"VolFromSnapshotOnTargetDs is enabled, skip the compatible datastore check","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
{"level":"info","time":"2025-07-22T02:26:43.909075512Z","caller":"volume/manager.go:558","msg":"QuotaInfo during CreateVolume call: {Reserved:1Gi StoragePolicyId:664bf721-a3bc-4d08-b797-0dfb2be23232 StorageClassName:wcpglobal-storage-profile Namespace:test-ns AggregatedSnapshotSize:<nil> SnapshotLatestOperationCompleteTime:0001-01-01 00:00:00 +0000 UTC}","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
{"level":"info","time":"2025-07-22T02:26:45.791399093Z","caller":"volume/manager.go:457","msg":"CreateVolume: VolumeName: \"pvc-ad16fc56-ed4a-4c46-82df-7412639eb54f\", opId: \"475af8ed\"","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
{"level":"info","time":"2025-07-22T02:26:45.79800478Z","caller":"volume/util.go:329","msg":"Volume created successfully. VolumeName: \"pvc-ad16fc56-ed4a-4c46-82df-7412639eb54f\", volumeID: \"c698146d-af73-4251-be50-e876d0b3bbbd\"","TraceId":"ea95eb70-dacd-40ee-ae86-d323e9676b5b"}
```
Unit tests also passed.
```
=== RUN   TestCreateBlockVolumeFromSnapshotTargetDatastore
=== RUN   TestCreateBlockVolumeFromSnapshotTargetDatastore/Feature_disabled_-_should_overwrite_datastores
{"level":"info","time":"2025-07-15T21:16:59.288688062Z","caller":"common/vsphereutil.go:311","msg":"compatible datastore found, dsURL = \"ds:///vmfs/volumes/first-datastore/\", dsRef = Datastore:datastore-first"}
{"level":"info","time":"2025-07-15T21:16:59.288774043Z","caller":"common/vsphereutil.go:325","msg":"Overwrite the datatstores field in create spec [Datastore:datastore-first Datastore:datastore-second] with the compatible datastore Datastore:datastore-first when create volume from snapshot source-volume-id+snapshot-id"}
=== RUN   TestCreateBlockVolumeFromSnapshotTargetDatastore/Feature_enabled_-_should_preserve_datastores
{"level":"info","time":"2025-07-15T21:16:59.289980536Z","caller":"common/vsphereutil.go:330","msg":"VolFromSnapshotOnTargetDs is enabled, skip the compatible datastore check"}
--- PASS: TestCreateBlockVolumeFromSnapshotTargetDatastore (0.00s)
    --- PASS: TestCreateBlockVolumeFromSnapshotTargetDatastore/Feature_disabled_-_should_overwrite_datastores (0.00s)
    --- PASS: TestCreateBlockVolumeFromSnapshotTargetDatastore/Feature_enabled_-_should_preserve_datastores (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common	0.909s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Uses VolFromSnapshotOnTargetDs WCP FSS
```
