### PR TITLE
Performance Improvement - Reduce `unstructured` usages from Storage Pools

### DIFF
--- a/pkg/apis/storagepool/cns/v1alpha1/storagepool_types.go
+++ b/pkg/apis/storagepool/cns/v1alpha1/storagepool_types.go
@@ -44,7 +44,7 @@ type StoragePoolStatus struct {
 	Capacity *PoolCapacity `json:"capacity,omitempty"`
 	// Error that has occurred on the storage pool. Present only when there is an error.
 	// +optional
-	Error StoragePoolError `json:"error,omitempty"`
+	Error *StoragePoolError `json:"error,omitempty"`
 	// DiskDecomm indicates the status of disk decommission for the given storagepool
 	// +optional
 	DiskDecomm map[string]string `json:"diskDecomm,omitempty"`

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -35,9 +35,8 @@ import (
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/apimachinery/pkg/types"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns/v1alpha1"
@@ -399,23 +398,24 @@ func getDatastoreURLFromStoragePool(ctx context.Context, spName string) (string,
 	}
 
 	// create a new StoragePool client.
-	spclient, err := dynamic.NewForConfig(cfg)
+	c, err := k8s.NewClientForGroup(ctx, cfg, spv1alpha1.SchemeGroupVersion.Group)
 	if err != nil {
 		return "", fmt.Errorf("failed to create StoragePool client using config. Err: %+v", err)
 	}
-	spResource := spv1alpha1.SchemeGroupVersion.WithResource("storagepools")
 
+	sp := &spv1alpha1.StoragePool{}
 	// Get StoragePool with spName.
-	sp, err := spclient.Resource(spResource).Get(ctx, spName, metav1.GetOptions{})
+	err = c.Get(ctx, types.NamespacedName{Name: spName}, sp)
 	if err != nil {
 		return "", fmt.Errorf("failed to get StoragePool with name %s: %+v", spName, err)
 	}
 
 	// extract the datastoreUrl field.
-	datastoreURL, found, err := unstructured.NestedString(sp.Object, "spec", "parameters", "datastoreUrl")
-	if !found || err != nil {
+	datastoreURL, found := sp.Spec.Parameters["datastoreUrl"]
+	if !found {
 		return "", fmt.Errorf("failed to find datastoreUrl in StoragePool %s", spName)
 	}
+
 	return datastoreURL, nil
 }
 
@@ -429,31 +429,30 @@ func getStoragePoolInfo(ctx context.Context, spName string) ([]string, string, e
 	}
 
 	// Create a new StoragePool client.
-	spClient, err := dynamic.NewForConfig(cfg)
+	c, err := k8s.NewClientForGroup(ctx, cfg, spv1alpha1.SchemeGroupVersion.Group)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create StoragePool client using config. Err: %+v", err)
 	}
-	spResource := spv1alpha1.SchemeGroupVersion.WithResource("storagepools")
 
 	// Get StoragePool with spName.
-	sp, err := spClient.Resource(spResource).Get(ctx, spName, metav1.GetOptions{})
+	sp := &spv1alpha1.StoragePool{}
+	err = c.Get(ctx, types.NamespacedName{Name: spName}, sp)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get StoragePool with name %s: %+v", spName, err)
 	}
 
 	// Extract the accessibleNodes field.
-	accessibleNodes, found, err := unstructured.NestedStringSlice(sp.Object, "status", "accessibleNodes")
-	if !found || err != nil {
-		return nil, "", fmt.Errorf("failed to find datastoreUrl in StoragePool %s", spName)
+	if len(sp.Status.AccessibleNodes) == 0 {
+		return nil, "", fmt.Errorf("failed to find accessible nodes in StoragePool %s", spName)
 	}
 
 	// Get the storage pool type.
-	poolType, found, err := unstructured.NestedString(sp.Object, "metadata", "labels", spTypeKey)
-	if !found || err != nil {
+	poolType, found := sp.ObjectMeta.Labels[spTypeKey]
+	if !found {
 		return nil, "", fmt.Errorf("failed to find pool type in StoragePool %s", spName)
 	}
 
-	return accessibleNodes, poolType, nil
+	return sp.Status.AccessibleNodes, poolType, nil
 }
 
 // isValidAccessibilityRequirements validates if the given accessibility

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -56,6 +56,7 @@ import (
 
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	migrationv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration/v1alpha1"
+	storagepoolAPIs "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool"
 	wcpcapapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/wcpcapabilities"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -286,15 +287,21 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 			log.Errorf("failed to add CNSVolumeInfo to scheme with error: %+v", err)
 			return nil, err
 		}
+
+		err = storagepoolAPIs.AddToScheme(scheme)
+		if err != nil {
+			log.Errorf("failed to add StoragePool scheme with error :%+v", err)
+			return nil, err
+		}
 	}
-	client, err := client.New(config, client.Options{
+
+	c, err := client.New(config, client.Options{
 		Scheme: scheme,
 	})
 	if err != nil {
 		log.Errorf("failed to create client for group %s with err: %+v", groupName, err)
 	}
-	return client, err
-
+	return c, err
 }
 
 // NewCnsFileAccessConfigWatcher creates a new ListWatch for VirtualMachines

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -26,9 +26,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns/v1alpha1"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
@@ -56,12 +57,9 @@ const (
 // DiskDecommController is responsible for watching and processing disk
 // decommission request.
 type DiskDecommController struct {
-	migrationCntlr   *migrationController
-	k8sDynamicClient dynamic.Interface
-	spResource       *schema.GroupVersionResource
-	pvResource       *schema.GroupVersionResource
-	pvcResource      *schema.GroupVersionResource
-	spWatch          watch.Interface
+	migrationCntlr *migrationController
+	k8sClient      client.Client
+	spWatch        watch.Interface
 	// Stores the current disk decommission mode ("ensureAccessibility"/
 	// "evacuateAll"/none) of a SP to evaluate whether or not a new event is a
 	// request for disk decommissioning of a SP. Keys are SP name and values
@@ -232,28 +230,46 @@ func (w *DiskDecommController) DecommissionDisk(ctx context.Context, storagePool
 			return
 		}
 
-		pvcToMigrate := make([]*unstructured.Unstructured, 0)
+		pvcToMigrate := make([]v1.PersistentVolumeClaim, 0)
 		for pvName, targetSPName := range svMotionPlan {
-			pv, err := w.k8sDynamicClient.Resource(*w.pvResource).Get(ctx, pvName, metav1.GetOptions{})
+			pv := &v1.PersistentVolume{}
+			err := w.k8sClient.Get(ctx, types.NamespacedName{Name: pvName}, pv)
 			if err != nil {
 				log.Errorf("Failed to get PV resource %v. Error: %v", pvName, err)
 				migrationFailed = true
 				break
 			}
-			pvcName, _, _ := unstructured.NestedString(pv.Object, "spec", "claimRef", "name")
-			namespace, found, err := unstructured.NestedString(pv.Object, "spec", "claimRef", "namespace")
-			if pvcName == "" || !found || err != nil {
+
+			if pv.Spec.ClaimRef == nil ||
+				pv.Spec.ClaimRef.Name == "" ||
+				pv.Spec.ClaimRef.Namespace == "" {
 				log.Errorf("Failed to get PVC bounded to PV %v. Error: %v", pvName, err)
 				migrationFailed = true
 				break
 			}
-			pvc, err := addTargetSPAnnotationOnPVC(ctx, pvcName, namespace, targetSPName)
+
+			pvcName := pv.Spec.ClaimRef.Namespace
+			namespace := pv.Spec.ClaimRef.Namespace
+			err = addTargetSPAnnotationOnPVC(ctx, pvcName, namespace, targetSPName)
 			if err != nil {
-				log.Errorf("Failed to add target SP annotation to PVC %v. Error: %v", pvcName, err)
+				log.Errorf("Failed to add target SP annotation to PVC %s. Error: %s", pvcName, err)
 				migrationFailed = true
 				break
 			}
-			pvcToMigrate = append(pvcToMigrate, pvc)
+
+			pvc := &v1.PersistentVolumeClaim{}
+			err = w.k8sClient.Get(ctx, types.NamespacedName{
+				Name:      pvcName,
+				Namespace: namespace,
+			}, pvc)
+			if err != nil {
+				log.Errorf("Unable to get the PVC %s in namespace %s. Error: %s",
+					pvcName, namespace, err)
+				migrationFailed = false
+				break
+			}
+
+			pvcToMigrate = append(pvcToMigrate, *pvc)
 		}
 
 		_, unsuccessfulMigrations := w.migrationCntlr.MigrateVolumes(ctx, pvcToMigrate, true)
@@ -266,35 +282,34 @@ func (w *DiskDecommController) DecommissionDisk(ctx context.Context, storagePool
 func initDiskDecommController(ctx context.Context, migrationCntlr *migrationController) (*DiskDecommController, error) {
 	log := logger.GetLogger(ctx)
 	log.Infof("Starting disk decommission controller")
-	k8sDynamicClient, spResource, err := getSPClient(ctx)
+	k8sClient, err := getK8sClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &DiskDecommController{}
-	w.k8sDynamicClient = k8sDynamicClient
+	w.k8sClient = k8sClient
 	w.migrationCntlr = migrationCntlr
-	w.spResource = spResource
-	w.pvResource = &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}
-	w.pvcResource = &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
 	w.diskDecommMode = make(map[string]string)
 	w.execSemaphore = semaphore.NewWeighted(1)
 
 	// Get all the pvc resource for which targetSPAnnotationKey annotations
 	// exists. This will give us list of all pending migrations.
-	pvcList, err := w.k8sDynamicClient.Resource(*w.pvcResource).Namespace(v1.NamespaceAll).List(
-		ctx, metav1.ListOptions{})
+
+	pvcList := &v1.PersistentVolumeClaimList{}
+	err = w.k8sClient.List(ctx, pvcList)
 	if err != nil {
 		return w, err
 	}
 
-	pvcToMigrate := make([]*unstructured.Unstructured, 0)
+	pvcToMigrate := make([]v1.PersistentVolumeClaim, 0)
 	for _, pvc := range pvcList.Items {
-		targetSPName, _, _ := unstructured.NestedString(pvc.Object, "metadata", "annotations", targetSPAnnotationKey)
-		if targetSPName != "" {
-			pvcToMigrate = append(pvcToMigrate, &pvc)
+		if pvc.ObjectMeta.Annotations != nil &&
+			pvc.ObjectMeta.Annotations[targetSPAnnotationKey] != "" {
+			pvcToMigrate = append(pvcToMigrate, pvc)
 		}
 	}
+
 	w.migrationCntlr.MigrateVolumes(ctx, pvcToMigrate, false)
 
 	// Start StoragePool watch to look for events putting SP under disk
@@ -306,14 +321,16 @@ func initDiskDecommController(ctx context.Context, migrationCntlr *migrationCont
 	go w.watchStoragePool(ctx)
 
 	// Get all sp resource.
-	spList, err := w.k8sDynamicClient.Resource(*w.spResource).List(ctx, metav1.ListOptions{})
+	spList := &v1alpha1.StoragePoolList{}
+	err = w.k8sClient.List(ctx, spList)
 	if err != nil {
 		return w, err
 	}
+
 	// Make progress on StoragePool which are under disk decommission.
 	for _, sp := range spList.Items {
 		spName := sp.GetName()
-		if w.shouldEnterDiskDecommission(ctx, &sp) && spName != "" {
+		if w.shouldEnterDiskDecommission(ctx, sp) && spName != "" {
 			maintenanceMode := w.diskDecommMode[spName]
 			go w.DecommissionDisk(ctx, spName, maintenanceMode)
 		}
@@ -333,6 +350,8 @@ func (w *DiskDecommController) renewStoragePoolWatch(ctx context.Context) error 
 	// When that happens, we may need to do a full remediation, hence we change
 	// from 30m (default) to 24h.
 	timeout := int64(60 * 60 * 24) // 24 hours.
+	// The below watch returns `unstructured` events which is something we are trying to avoid.
+	// TODO: check if there is a way to create a watch for StoragePool type.
 	w.spWatch, err = spClient.Resource(*spResource).Watch(ctx, metav1.ListOptions{
 		TimeoutSeconds: &timeout,
 	})
@@ -340,7 +359,13 @@ func (w *DiskDecommController) renewStoragePoolWatch(ctx context.Context) error 
 		log.Errorf("Failed to start StoragePool watch. Error: %v", err)
 		return err
 	}
-	w.k8sDynamicClient = spClient
+
+	k8sClient, err := getK8sClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	w.k8sClient = k8sClient
 	return nil
 }
 
@@ -367,14 +392,22 @@ func (w *DiskDecommController) watchStoragePool(ctx context.Context) {
 				}
 				continue
 			}
-			sp, ok := e.Object.(*unstructured.Unstructured)
+			event, ok := e.Object.(*unstructured.Unstructured)
 			if !ok {
 				log.Warnf("Object in StoragePool watch event is not of type *unstructured.Unstructured, but of type %T",
 					e.Object)
 				continue
 			}
-			spName := sp.GetName()
-			if ok := w.shouldEnterDiskDecommission(ctx, sp); ok {
+
+			spName := event.GetName()
+			sp := &v1alpha1.StoragePool{}
+			err := w.k8sClient.Get(ctx, types.NamespacedName{Name: spName}, sp)
+			if err != nil {
+				log.Warnf("Unable to get StoragePool with name " + spName)
+				continue
+			}
+
+			if ok := w.shouldEnterDiskDecommission(ctx, *sp); ok {
 				maintenanceMode := w.diskDecommMode[spName]
 				log.Infof("Got enter disk decommission request for StoragePool %v with MM %v", spName, maintenanceMode)
 				go w.DecommissionDisk(ctx, spName, maintenanceMode)
@@ -384,31 +417,29 @@ func (w *DiskDecommController) watchStoragePool(ctx context.Context) {
 	log.Info("watchStoragePool ends")
 }
 
-func (w *DiskDecommController) shouldEnterDiskDecommission(ctx context.Context, sp *unstructured.Unstructured) bool {
+func (w *DiskDecommController) shouldEnterDiskDecommission(ctx context.Context, sp v1alpha1.StoragePool) bool {
 	log := logger.GetLogger(ctx)
-	spName := sp.GetName()
-	driver, found, _ := unstructured.NestedString(sp.Object, "spec", "driver")
-	if !found || driver != csitypes.Name || spName == "" {
-		log.Warnf("StoragePool watch event for %v does not correspond to %v driver.", spName, csitypes.Name)
+	if sp.Spec.Driver != csitypes.Name {
+		log.Warnf("StoragePool watch event for %s does not correspond to %s driver.", sp.Name, csitypes.Name)
 		return false
 	}
-	drainMode, found, err := unstructured.NestedString(sp.Object, "spec", "parameters", drainModeField)
-	if err != nil {
-		log.Warnf("Error reading the drain mode from StoragePool event of %v. Error: %v", spName, err)
-		return false
-	}
+
+	drainMode, found := sp.Spec.Parameters[drainModeField]
 	defer func() {
 		if !found {
-			delete(w.diskDecommMode, spName)
+			delete(w.diskDecommMode, sp.Name)
 		} else {
-			w.diskDecommMode[spName] = drainMode
+			w.diskDecommMode[sp.Name] = drainMode
 		}
 	}()
+
 	if (drainMode == fullDataEvacuationMM || drainMode == ensureAccessibilityMM || drainMode == noMigrationMM) &&
-		drainMode != w.diskDecommMode[spName] {
+		drainMode != w.diskDecommMode[sp.Name] {
 		// Check if status field is already populated.
-		drainStatus, _, _ := unstructured.NestedString(sp.Object, "status", "diskDecomm", drainStatusField)
-		if drainStatus != drainFailStatus && drainStatus != drainSuccessStatus {
+		drainStatus, ok := sp.Status.DiskDecomm[drainStatusField]
+		if !ok || (drainStatus != drainFailStatus && drainStatus != drainSuccessStatus) {
+			// Should enter disk decommission mode if either
+			// the drainMode is not present in the status(just started) or the drain is unfinished.
 			return true
 		}
 	}

--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -31,7 +31,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	types2 "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns/v1alpha1"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
@@ -333,37 +334,39 @@ func (c *SpController) getVsanHostCapacities(ctx context.Context) (map[string]*c
 // actual state of a StoragePool in the WCP cluster.
 func (c *SpController) applyIntendedState(ctx context.Context, state *intendedState) error {
 	log := logger.GetLogger(ctx)
-	spClient, spResource, err := getSPClient(ctx)
+	k8sClient, err := getK8sClient(ctx)
 	if err != nil {
 		return err
 	}
+
 	// Get StoragePool with spName and Update if already present, otherwise
 	// Create resource.
-	sp, err := spClient.Resource(*spResource).Get(ctx, state.spName, metav1.GetOptions{})
+	sp := &v1alpha1.StoragePool{}
+	err = k8sClient.Get(ctx, types2.NamespacedName{Name: state.spName}, sp)
 	if err != nil {
 		var statusErr *k8serrors.StatusError
 		ok := errors.As(err, &statusErr)
 		if ok && statusErr.Status().Reason == metav1.StatusReasonNotFound {
 			log.Infof("Creating StoragePool instance for %s", state.spName)
-			sp := state.createUnstructuredStoragePool(ctx)
-			newSp, err := spClient.Resource(*spResource).Create(ctx, sp, metav1.CreateOptions{})
+			sp, err = state.createStoragePool(ctx, k8sClient)
 			if err != nil {
-				log.Errorf("Error creating StoragePool %s. Err: %+v", state.spName, err)
+				log.Errorf("Error creating StoragePool %s. Err: %s", state.spName, err)
 				return err
 			}
-			log.Debugf("Successfully created StoragePool %v", newSp)
+
+			log.Debug("Successfully created StoragePool " + sp.Name)
 		}
 	} else {
 		// StoragePool already exists, so Update it. We don't expect
 		// ConflictErrors since updates are synchronized with a lock.
 		log.Debugf("Updating StoragePool instance for %s", state.spName)
-		sp := state.updateUnstructuredStoragePool(ctx, sp)
-		newSp, err := spClient.Resource(*spResource).Update(ctx, sp, metav1.UpdateOptions{})
+		sp, err = state.updateStoragePool(ctx, k8sClient, *sp)
 		if err != nil {
 			log.Errorf("Error updating StoragePool %s. Err: %+v", state.spName, err)
 			return err
 		}
-		log.Debugf("Successfully updated StoragePool %v", newSp)
+
+		log.Debug("Successfully updated StoragePool " + sp.Name)
 	}
 
 	// Update the underlying dsType in the all the compatible storage classes
@@ -502,24 +505,30 @@ func (c *SpController) deleteIntendedState(ctx context.Context, spName string) (
 
 func deleteStoragePool(ctx context.Context, spName string) error {
 	log := logger.GetLogger(ctx)
-	spClient, spResource, err := getSPClient(ctx)
+	k8sClient, err := getK8sClient(ctx)
 	if err != nil {
 		return err
 	}
-	sp, err := spClient.Resource(*spResource).Get(ctx, spName, metav1.GetOptions{})
+
+	sp := &v1alpha1.StoragePool{}
+	err = k8sClient.Get(ctx, types2.NamespacedName{Name: spName}, sp)
 	if err != nil {
-		log.Errorf("Error getting StoragePool instance %s. Err: %v", spName, err)
+		log.Errorf("Error getting StoragePool instance %s. Err: %s", spName, err)
 		return err
 	}
-	driver, found, err := unstructured.NestedString(sp.Object, "spec", "driver")
-	if found && err == nil && driver == csitypes.Name {
-		log.Infof("Deleting StoragePool %s", spName)
-		err := spClient.Resource(*spResource).Delete(ctx, spName, *metav1.NewDeleteOptions(0))
-		if err != nil {
-			log.Errorf("Error deleting StoragePool %s. Err: %v", spName, err)
-			return err
-		}
+
+	if sp.Spec.Driver != csitypes.Name {
+		log.Info("Cannot delete StoragePool " + spName + " as it is not created by " + csitypes.Name)
+		return nil
 	}
+
+	log.Infof("Deleting StoragePool " + spName)
+	err = k8sClient.Delete(ctx, sp, client.GracePeriodSeconds(0))
+	if err != nil {
+		log.Errorf("Error deleting StoragePool %s. Err: %s", spName, err)
+		return err
+	}
+
 	return nil
 }
 
@@ -541,74 +550,57 @@ func (state *intendedState) getStoragePoolError() *v1alpha1.StoragePoolError {
 	return nil
 }
 
-func (state *intendedState) createUnstructuredStoragePool(ctx context.Context) *unstructured.Unstructured {
-	sp := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "cns.vmware.com/v1alpha1",
-			"kind":       "StoragePool",
-			"metadata": map[string]interface{}{
-				"name": state.spName,
-				"labels": map[string]string{
-					spTypeLabelKey: strings.ReplaceAll(state.dsType, spTypePrefix, ""),
-				},
-			},
-			"spec": map[string]interface{}{
-				"driver": csitypes.Name,
-				"parameters": map[string]interface{}{
-					"datastoreUrl": state.url,
-				},
-			},
-			"status": map[string]interface{}{
-				"accessibleNodes":          state.nodes,
-				"compatibleStorageClasses": state.compatSC,
-				"capacity": map[string]interface{}{
-					"total":            state.capacity.Value(),
-					"freeSpace":        state.freeSpace.Value(),
-					"allocatableSpace": state.allocatableSpace.Value(),
-				},
+func (state *intendedState) createStoragePool(ctx context.Context, c client.Client) (*v1alpha1.StoragePool, error) {
+	sp := &v1alpha1.StoragePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: state.spName,
+			Labels: map[string]string{
+				spTypeLabelKey: strings.ReplaceAll(state.dsType, spTypePrefix, ""),
 			},
 		},
+		Spec: v1alpha1.StoragePoolSpec{
+			Driver: csitypes.Name,
+			Parameters: map[string]string{
+				"datastoreUrl": state.url,
+			},
+		},
+		Status: v1alpha1.StoragePoolStatus{
+			AccessibleNodes:          state.nodes,
+			CompatibleStorageClasses: state.compatSC,
+			Capacity: &v1alpha1.PoolCapacity{
+				Total:            state.capacity,
+				FreeSpace:        state.freeSpace,
+				AllocatableSpace: state.allocatableSpace,
+			},
+			Error: state.getStoragePoolError(),
+		},
 	}
-	spErr := state.getStoragePoolError()
-	if spErr != nil {
-		setNestedField(ctx, sp.Object, spErr.State, "status", "error", "state")
-		setNestedField(ctx, sp.Object, spErr.Message, "status", "error", "message")
-	}
-	return sp
+	err := c.Create(ctx, sp)
+	return sp, err
 }
 
-func (state *intendedState) updateUnstructuredStoragePool(ctx context.Context,
-	sp *unstructured.Unstructured) *unstructured.Unstructured {
-	log := logger.GetLogger(ctx)
-	setNestedField(ctx, sp.Object, state.url, "spec", "parameters", "datastoreUrl")
-	setNestedField(ctx, sp.Object, strings.ReplaceAll(state.dsType, spTypePrefix, ""),
-		"metadata", "labels", spTypeLabelKey)
-	setNestedField(ctx, sp.Object, state.capacity.Value(), "status", "capacity", "total")
-	setNestedField(ctx, sp.Object, state.freeSpace.Value(), "status", "capacity", "freeSpace")
-	setNestedField(ctx, sp.Object, state.allocatableSpace.Value(), "status", "capacity", "allocatableSpace")
-	err := unstructured.SetNestedStringSlice(sp.Object, state.nodes, "status", "accessibleNodes")
-	if err != nil {
-		log.Errorf("err: %v", err)
+func (state *intendedState) updateStoragePool(ctx context.Context, c client.Client,
+	sp v1alpha1.StoragePool) (*v1alpha1.StoragePool, error) {
+	if sp.Spec.Parameters == nil {
+		sp.Spec.Parameters = make(map[string]string)
 	}
-	err = unstructured.SetNestedStringSlice(sp.Object, state.compatSC, "status", "compatibleStorageClasses")
-	if err != nil {
-		log.Errorf("err: %v", err)
+	sp.Spec.Parameters["datastoreUrl"] = state.url
+	if sp.ObjectMeta.Labels == nil {
+		sp.ObjectMeta.Labels = make(map[string]string)
 	}
-	spErr := state.getStoragePoolError()
-	if spErr != nil {
-		setNestedField(ctx, sp.Object, spErr.State, "status", "error", "state")
-		setNestedField(ctx, sp.Object, spErr.Message, "status", "error", "message")
-	} else {
-		unstructured.RemoveNestedField(sp.Object, "status", "error")
+	sp.ObjectMeta.Labels[spTypeLabelKey] = strings.ReplaceAll(state.dsType, spTypePrefix, "")
+	poolCapacity := v1alpha1.PoolCapacity{
+		Total:            state.capacity,
+		FreeSpace:        state.freeSpace,
+		AllocatableSpace: state.allocatableSpace,
 	}
-	return sp
-}
+	sp.Status.Capacity = &poolCapacity
+	sp.Status.AccessibleNodes = state.nodes
+	sp.Status.CompatibleStorageClasses = state.compatSC
+	sp.Status.Error = state.getStoragePoolError()
 
-func setNestedField(ctx context.Context, obj map[string]interface{}, value interface{}, fields ...string) {
-	log := logger.GetLogger(ctx)
-	if err := unstructured.SetNestedField(obj, value, fields...); err != nil {
-		log.Errorf("err: %v", err)
-	}
+	err := c.Update(ctx, &sp)
+	return &sp, err
 }
 
 // isCapacityChangeSignificant returns true if the capacity change from old to


### PR DESCRIPTION
### What this PR does / why we need it
Even though Storage Pools are created and maintained by the syncer container, there are numerous usages of unstructured unmarshaling when interacting with storage pool resources. This has caused a significant performance hit in in scaled environments.
The aim of this story is to reduce these usages as much as possible.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # N/A

### Testing SP Creation
**Steps:**
1. Delete existing storage pools
2. Verify new CRs are created by syncer
3. Verify if the newly created CRs match the older CRs in terms of data

**Observations:**
<details><summary>Old Storage Pools</summary>
<p>

```yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePool
  metadata:
    creationTimestamp: "2025-07-14T12:12:12Z"
    generation: 4597
    labels:
      cns.vmware.com/StoragePoolType: VMFS
    name: storagepool-sharedvmfs-0
    resourceVersion: "3734937"
    uid: 5aca738b-035d-43e3-9cc1-a9bebe94ca7c
  spec:
    driver: csi.vsphere.vmware.com
    parameters:
      datastoreUrl: ds:///vmfs/volumes/6874ed10-7d1d06d1-e4c2-02007de38fb7/
  status:
    accessibleNodes:
    - lvn-dvm-10-162-238-3.dvm.lvn.broadcom.net
    - lvn-dvm-10-162-234-142.dvm.lvn.broadcom.net
    - lvn-dvm-10-162-233-74.dvm.lvn.broadcom.net
    capacity:
      allocatableSpace: 146476168642
      freeSpace: 152579342336
      total: 375541202944
    compatibleStorageClasses:
    - vm-encryption-policy
    - vm-encryption-policy-latebinding
    - wcpglobal-storage-profile-latebinding
    - wcpglobal-storage-profile
kind: List
metadata:
  resourceVersion: ""
```

</p>
</details> 

<details><summary>New Storage Pools</summary>
<p>

```yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePool
  metadata:
    creationTimestamp: "2025-07-18T09:18:23Z"
    generation: 4
    labels:
      cns.vmware.com/StoragePoolType: VMFS
    name: storagepool-sharedvmfs-0
    resourceVersion: "3804804"
    uid: d84f8c4d-4aff-42f8-a67f-3da9e6faa5f2
  spec:
    driver: csi.vsphere.vmware.com
    parameters:
      datastoreUrl: ds:///vmfs/volumes/6874ed10-7d1d06d1-e4c2-02007de38fb7/
  status:
    accessibleNodes:
    - lvn-dvm-10-162-233-74.dvm.lvn.broadcom.net
    - lvn-dvm-10-162-238-3.dvm.lvn.broadcom.net
    - lvn-dvm-10-162-234-142.dvm.lvn.broadcom.net
    capacity:
      allocatableSpace: "146476168642"
      freeSpace: "152579342336"
      total: "375541202944"
    compatibleStorageClasses:
    - vm-encryption-policy
    - vm-encryption-policy-latebinding
    - wcpglobal-storage-profile-latebinding
    - wcpglobal-storage-profile
kind: List
metadata:
  resourceVersion: ""

```

</p>
</details> 

  **Test Results:** Verified that all the necessary fields have same data.

### Disk Decommission Workflow[WIP]
Since this is not an easy flow to test all scenarios, we're going to run the regression suite with my changes and verify.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
 