### PR TITLE
validate CNSRegistreVolume to disallow registering volume not accessible to active clusters on namespace

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -1,0 +1,522 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnsregistervolume
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/object"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer"
+)
+
+type mockVolumeManager struct {
+	createVolumeFunc func(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+		ctxParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error)
+}
+
+func (m *mockVolumeManager) AttachVolume(ctx context.Context, vm *cnsvsphere.VirtualMachine,
+	volumeID string, checkNVMeController bool) (string, string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) DetachVolume(ctx context.Context, vm *cnsvsphere.VirtualMachine,
+	volumeID string) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) DeleteVolume(ctx context.Context, volumeID string, deleteDisk bool) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) UpdateVolumeMetadata(ctx context.Context,
+	spec *cnstypes.CnsVolumeMetadataUpdateSpec) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) UpdateVolumeCrypto(ctx context.Context, spec *cnstypes.CnsVolumeCryptoUpdateSpec) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) QueryVolumeInfo(ctx context.Context,
+	volumeIDList []cnstypes.CnsVolumeId) (*cnstypes.CnsQueryVolumeInfoResult, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+	querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) QueryVolume(ctx context.Context,
+	queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) RelocateVolume(ctx context.Context,
+	relocateSpecList ...cnstypes.BaseCnsVolumeRelocateSpec) (*object.Task, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) ExpandVolume(ctx context.Context, volumeID string,
+	size int64, extraParams interface{}) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.VirtualCenter) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) RegisterDisk(ctx context.Context, path string, name string) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) RetrieveVStorageObject(ctx context.Context,
+	volumeID string) (*vim25types.VStorageObject, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) CreateSnapshot(ctx context.Context, volumeID string,
+	desc string, extraParams interface{}) (*cnsvolume.CnsSnapshotInfo, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) DeleteSnapshot(ctx context.Context, volumeID string,
+	snapshotID string, extraParams interface{}) (*cnsvolume.CnsSnapshotInfo, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) QuerySnapshots(ctx context.Context,
+	snapshotQueryFilter cnstypes.CnsSnapshotQueryFilter) (*cnstypes.CnsSnapshotQueryResult, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) MonitorCreateVolumeTask(ctx context.Context,
+	volumeOperationDetails **cnsvolumeoperationrequest.VolumeOperationRequestDetails,
+	task *object.Task, volNameFromInputSpec, clusterID string) (*cnsvolume.CnsVolumeInfo, string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) GetOperationStore() cnsvolumeoperationrequest.VolumeOperationRequest {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) IsListViewReady() bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) SetListViewNotReady(ctx context.Context) {
+
+}
+
+func (m *mockVolumeManager) QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+	querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	return &cnstypes.CnsQueryResult{
+		Volumes: []cnstypes.CnsVolume{
+			{
+				VolumeId:        cnstypes.CnsVolumeId{Id: "dummy-volume-id"},
+				DatastoreUrl:    "dummy-ds-url",
+				StoragePolicyId: "dummy-storage-policy-id",
+			},
+		},
+	}, nil
+
+}
+
+func (m *mockVolumeManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+	ctxParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+	if m.createVolumeFunc != nil {
+		return m.createVolumeFunc(ctx, spec, ctxParams)
+	}
+	return nil, "", nil
+}
+
+type mockCOCommon struct{}
+
+func (m *mockCOCommon) IsFSSEnabled(ctx context.Context, featureName string) bool {
+	return true
+}
+
+func (m *mockCOCommon) IsCNSCSIFSSEnabled(ctx context.Context, featureName string) bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) IsPVCSIFSSEnabled(ctx context.Context, featureName string) bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) EnableFSS(ctx context.Context, featureName string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) DisableFSS(ctx context.Context, featureName string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) IsFakeAttachAllowed(ctx context.Context, volumeID string,
+	volumeManager cnsvolume.Manager) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) MarkFakeAttached(ctx context.Context, volumeID string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) ClearFakeAttached(ctx context.Context, volumeID string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) InitTopologyServiceInController(ctx context.Context) (commoncotypes.ControllerTopologyService,
+	error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) InitTopologyServiceInNode(ctx context.Context) (commoncotypes.NodeTopologyService, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetNodesForVolumes(ctx context.Context, volumeIds []string) map[string][]string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetNodeIDtoNameMap(ctx context.Context) map[string]string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetFakeAttachedVolumes(ctx context.Context, volumeIDs []string) map[string]bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetVolumeAttachment(ctx context.Context,
+	volumeId string, nodeName string) (*storagev1.VolumeAttachment, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetAllVolumes() []string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetAllK8sVolumes() []string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) AnnotateVolumeSnapshot(ctx context.Context, volumeSnapshotName string,
+	volumeSnapshotNamespace string, annotations map[string]string) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetConfigMap(ctx context.Context, name string, namespace string) (map[string]string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) CreateConfigMap(ctx context.Context, name string, namespace string,
+	data map[string]string, isImmutable bool) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetCSINodeTopologyInstancesList() []interface{} {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetCSINodeTopologyInstanceByName(nodeName string) (item interface{}, exists bool, err error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetPVNameFromCSIVolumeID(volumeID string) (string, bool) {
+	return "", false
+}
+
+func (m *mockCOCommon) GetPVCNameFromCSIVolumeID(volumeID string) (string, string, bool) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) InitializeCSINodes(ctx context.Context) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) StartZonesInformer(ctx context.Context,
+	restClientConfig *restclient.Config, namespace string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) PreLinkedCloneCreateAction(ctx context.Context, pvcNamespace string,
+	pvcName string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetLinkedCloneVolumeSnapshotSourceUUID(ctx context.Context,
+	pvcName string, pvcNamespace string) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetVolumeSnapshotPVCSource(ctx context.Context, volumeSnapshotNamespace string,
+	volumeSnapshotName string) (*corev1.PersistentVolumeClaim, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) IsLinkedCloneRequest(ctx context.Context, pvcName string, pvcNamespace string) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) UpdatePersistentVolumeLabel(ctx context.Context, pvName string, key string, value string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) GetZonesForNamespace(ns string) map[string]struct{} {
+	return map[string]struct{}{"zone-a": {}}
+}
+
+func (m *mockCOCommon) GetActiveClustersForNamespaceInRequestedZones(ctx context.Context,
+	ns string, zones []string) ([]string, error) {
+	return []string{"cluster-a"}, nil
+}
+
+var _ = Describe("Reconcile Accessibility Logic", func() {
+	var (
+		scheme   *runtime.Scheme
+		r        *ReconcileCnsRegisterVolume
+		ctx      context.Context
+		patches  *gomonkey.Patches
+		instance cnsregistervolumev1alpha1.CnsRegisterVolume
+	)
+
+	commonco.ContainerOrchestratorUtility = &mockCOCommon{}
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		_ = clientgoscheme.AddToScheme(scheme)
+		scheme.AddKnownTypes(schema.GroupVersion{
+			Group:   "cnsoperator.vmware.com",
+			Version: "v1alpha1",
+		}, &cnsregistervolumev1alpha1.CnsRegisterVolume{}, &cnsregistervolumev1alpha1.CnsRegisterVolumeList{})
+
+		ctx = context.Background()
+
+		crv := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-volume",
+				Namespace: "test-ns",
+			},
+			Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+				PvcName:    "test-pvc",
+				VolumeID:   "dummy-volume-id",
+				AccessMode: "ReadWriteOnce",
+			},
+		}
+		// Create fake client with instance preloaded
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&instance).
+			Build()
+		_ = fakeClient.Create(ctx, crv)
+
+		mockVolMgr := &mockVolumeManager{
+			createVolumeFunc: func(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+				ctxParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+				return &cnsvolume.CnsVolumeInfo{
+					VolumeID: cnstypes.CnsVolumeId{Id: "fake-volume-id"},
+				}, "", nil
+			},
+		}
+		r = &ReconcileCnsRegisterVolume{
+			client:        fakeClient,
+			scheme:        scheme,
+			volumeManager: mockVolMgr,
+		}
+		patches = gomonkey.NewPatches()
+	})
+
+	AfterEach(func() {
+		patches.Reset()
+	})
+
+	It("should disallow registering volume not accessible to active clusters on namespace", func() {
+		patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(ctx context.Context,
+			config *config.ConfigurationInfo, reinitialize bool) (*cnsvsphere.VirtualCenter, error) {
+			return &cnsvsphere.VirtualCenter{}, nil
+		})
+
+		patches.ApplyFunc(common.QueryVolumeByID, func(ctx context.Context, vm cnsvolume.Manager,
+			volumeID string, querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
+			return &cnstypes.CnsVolume{
+				VolumeId:        cnstypes.CnsVolumeId{Id: volumeID},
+				DatastoreUrl:    "dummy-ds-url",
+				StoragePolicyId: "dummy-storage-policy-id",
+			}, nil
+		})
+
+		patches.ApplyFunc(common.GetClusterComputeResourceMoIds, func(ctx context.Context) ([]string, error) {
+			return []string{"cluster-a", "cluster-b"}, nil
+		})
+
+		patches.ApplyMethod(
+			reflect.TypeOf(&mockCOCommon{}), // concrete type pointer
+			"GetZonesForNamespace",
+			func(_ *mockCOCommon, ns string) map[string]struct{} {
+				return map[string]struct{}{"zone-b": {}}
+			})
+
+		patches.ApplyMethod(reflect.TypeOf(&mockCOCommon{}), "GetActiveClustersForNamespaceInRequestedZones",
+			func(_ commonco.COCommonInterface, ctx context.Context, ns string, zones []string) ([]string, error) {
+				return []string{"cluster-a"}, nil
+			})
+
+		patches.ApplyFunc(isDatastoreAccessibleToAZClusters,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter, azToClusters map[string][]string, ds string) bool {
+				return false
+			})
+
+		patches.ApplyFunc(setInstanceError, func(ctx context.Context, r *ReconcileCnsRegisterVolume,
+			instance *cnsregistervolumev1alpha1.CnsRegisterVolume, msg string) {
+			// no-op
+		})
+
+		patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(ctx context.Context,
+			config *config.ConfigurationInfo, reinitialize bool) (*cnsvsphere.VirtualCenter, error) {
+			return &cnsvsphere.VirtualCenter{
+				Config: &cnsvsphere.VirtualCenterConfig{
+					Host: "dummy-vcenter",
+				},
+			}, nil
+		})
+
+		patches.ApplyFunc(constructCreateSpecForInstance, func(
+			r *ReconcileCnsRegisterVolume,
+			instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
+			host string,
+			isTKGSHAEnabled bool,
+		) *cnstypes.CnsVolumeCreateSpec {
+			return &cnstypes.CnsVolumeCreateSpec{
+				Name:       "fake-volume",
+				VolumeType: "BLOCK",
+			}
+		})
+
+		patches.ApplyFunc(
+			common.DeleteVolumeUtil,
+			func(ctx context.Context, volumeManager cnsvolume.Manager, volumeID string,
+				forceDelete bool) (string, error) {
+				return "", nil
+			},
+		)
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-volume",
+				Namespace: "test-ns",
+			},
+		}
+
+		result, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{RequeueAfter: 0}))
+	})
+})
+
+func TestCnsRegisterVolumeController(t *testing.T) {
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	// Set required FSS to true for unit test
+	workloadDomainIsolationEnabled = true
+	syncer.IsPodVMOnStretchSupervisorFSSEnabled = true
+	isMultipleClustersPerVsphereZoneEnabled = true
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CnsRegisterVolumeController Suite")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is required for static volume registration on the deployment with multiple clusters per zone.
PR validates to disallow registering volume if it is not accessible to active cluster from zones assigned to namespace.

**Testing done**:
Verified no regression is observed.

```
# cat cnsregistervolume.yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: register-volume-6c8b7db8-5cc5-4725-968d-178946638709
  namespace: divyen-ns
spec:
  pvcName: static-pvc
  volumeID: 6c8b7db8-5cc5-4725-968d-178946638709
  accessMode: ReadWriteOnce


# kubectl create -f cnsregistervolume.yaml -n divyen-ns
cnsregistervolume.cns.vmware.com/register-volume-6c8b7db8-5cc5-4725-968d-178946638709 created

# kubectl describe CnsRegisterVolume register-volume-6c8b7db8-5cc5-4725-968d-178946638709 -n divyen-ns
Name:         register-volume-6c8b7db8-5cc5-4725-968d-178946638709
Namespace:    divyen-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsRegisterVolume
Metadata:
  Creation Timestamp:  2025-07-17T23:26:09Z
  Generation:          2
  Owner References:
    API Version:           v1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  PersistentVolumeClaim
    Name:                  static-pvc
    UID:                   2aae7e70-7bc6-45de-b581-14b098aa7c0c
  Resource Version:        7194748
  UID:                     839493e5-d777-4bc0-88c5-cb00f186a34c
Spec:
  Access Mode:  ReadWriteOnce
  Pvc Name:     static-pvc
  Volume ID:    6c8b7db8-5cc5-4725-968d-178946638709
Status:
  Registered:  true
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  CnsRegisterVolumeSucceeded  62s   cns.vmware.com  Successfully registered the volume on namespace: divyen-ns
```

Unit test result

```
% cd pkg/syncer/cnsoperator/controller/cnsregistervolume 
% go test -v
=== RUN   TestCnsRegisterVolumeController
Running Suite: CnsRegisterVolumeController Suite - /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsregistervolume
======================================================================================================================================================================
Random Seed: 1753033257

Will run 1 of 1 specs
{"level":"info","time":"2025-07-20T10:40:57.412822-07:00","caller":"cnsregistervolume/cnsregistervolume_controller.go:241","msg":"Reconciling CnsRegisterVolume with instance: \"test-volume\" from namespace: \"test-ns\". timeout \"1s\" seconds"}
{"level":"info","time":"2025-07-20T10:40:57.413221-07:00","caller":"cnsregistervolume/cnsregistervolume_controller.go:274","msg":"Creating CNS volume: &{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:test-volume GenerateName: Namespace:test-ns SelfLink: UID: ResourceVersion:1 Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[]} Spec:{PvcName:test-pvc VolumeID:dummy-volume-id AccessMode:ReadWriteOnce DiskURLPath:} Status:{Registered:false Error:}} for CnsRegisterVolume request with name: \"test-volume\" on namespace: \"test-ns\""}
{"level":"info","time":"2025-07-20T10:40:57.413237-07:00","caller":"cnsregistervolume/cnsregistervolume_controller.go:303","msg":"Created CNS volume with volumeID: fake-volume-id"}
{"level":"info","time":"2025-07-20T10:40:57.413243-07:00","caller":"cnsregistervolume/cnsregistervolume_controller.go:307","msg":"Querying volume: fake-volume-id for CnsRegisterVolume request with name: \"test-volume\" on namespace: \"test-ns\""}
{"level":"error","time":"2025-07-20T10:40:57.413828-07:00","caller":"cnsregistervolume/cnsregistervolume_controller.go:354","msg":"Volume: fake-volume-id present on datastore: dummy-ds-url is not accessible to any of the active cluster on the namespace: [cluster-a]","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume.(*ReconcileCnsRegisterVolume).Reconcile\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go:354\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume.init.func1.3\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go:506\ngithub.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/vendor/github.com/onsi/ginkgo/v2/internal/node.go:475\ngithub.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:894"}
•

Ran 1 of 1 Specs in 0.003 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestCnsRegisterVolumeController (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume   0.756s

```

Precheck-in tests passed

https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-e2e-pre-checkin_FixedTestbed/7/

```
Ran 9 of 1080 Specs in 1495.758 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 1071 Skipped
PASS

```


**Special notes for your reviewer**:
Testing on the environment with multiple cluster per zone is not done yet. Once we have setup available, we can validate this change on such environment


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
validate CNSRegistreVolume to disallow registering volume not accessible to active clusters on namespace
```
