### PR TITLE
Enable WCP_VMService_BYOK FSS by default

### DIFF
--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -505,7 +505,7 @@ data:
   "vdpp-on-stretched-supervisor": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
-  "WCP_VMService_BYOK": "false"
+  "WCP_VMService_BYOK": "true"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -560,7 +560,7 @@ data:
   "vdpp-on-stretched-supervisor": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
-  "WCP_VMService_BYOK": "false"
+  "WCP_VMService_BYOK": "true"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
   "linked-clone-support": "false"

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -567,7 +567,7 @@ data:
   "vdpp-on-stretched-supervisor": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
-  "WCP_VMService_BYOK": "false"
+  "WCP_VMService_BYOK": "true"
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -567,7 +567,7 @@ data:
   "vdpp-on-stretched-supervisor": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
-  "WCP_VMService_BYOK": "false"
+  "WCP_VMService_BYOK": "true"
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -566,7 +566,7 @@ data:
   "vdpp-on-stretched-supervisor": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
-  "WCP_VMService_BYOK": "false"
+  "WCP_VMService_BYOK": "true"
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "vol-from-snapshot-on-target-ds": "false"


### PR DESCRIPTION
**What this PR does / why we need it**:
The WCP_VMService_BYOK FSS enables support for EncryptionClass, allowing encryption of VMs and PVCs deployed in a Supervisor namespace.

**Testing done**:
Platform Scale/Perf Testing

**Special notes for your reviewer**:
Feature state already enabled in vCenter.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
