### PR TITLE
start zone informers and skip storagepool for multiple zone per cluster

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/wcp_node.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/wcp_node.go
@@ -36,7 +36,7 @@ var clusterComputeResourceMoIds []string
 func (c *K8sOrchestrator) InitializeCSINodes(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 	var err error
-	clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
+	clusterComputeResourceMoIds, _, err = common.GetClusterComputeResourceMoIds(ctx)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to get clusterComputeResourceMoIds. Error: %v", err)
 	}

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -85,7 +85,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
-			clusterComputeResourceMoIds, err := common.GetClusterComputeResourceMoIds(ctx)
+			clusterComputeResourceMoIds, _, err := common.GetClusterComputeResourceMoIds(ctx)
 			if err != nil {
 				log.Errorf("failed to get clusterComputeResourceMoIds. err: %v", err)
 				return err

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -101,7 +101,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
 			var err error
-			clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
+			clusterComputeResourceMoIds, _, err = common.GetClusterComputeResourceMoIds(ctx)
 			if err != nil {
 				log.Errorf("failed to get clusterComputeResourceMoIds. err: %v", err)
 				return err
@@ -123,6 +123,12 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 					log.Infof("Not initializing the CnsRegisterVolume Controller as stretched supervisor is detected.")
 					return nil
 				}
+			}
+		}
+		if isMultipleClustersPerVsphereZoneEnabled {
+			err := commonco.ContainerOrchestratorUtility.StartZonesInformer(ctx, nil, metav1.NamespaceAll)
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to start zone informer. Error: %v", err)
 			}
 		}
 	}

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -441,8 +441,8 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			}, nil
 		})
 
-		patches.ApplyFunc(common.GetClusterComputeResourceMoIds, func(ctx context.Context) ([]string, error) {
-			return []string{"cluster-a", "cluster-b"}, nil
+		patches.ApplyFunc(common.GetClusterComputeResourceMoIds, func(ctx context.Context) ([]string, bool, error) {
+			return []string{"cluster-a", "cluster-b"}, true, nil
 		})
 
 		patches.ApplyMethod(

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -142,7 +142,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 
 		var stretchedSupervisor bool
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
-			clusterComputeResourceMoIds, err := common.GetClusterComputeResourceMoIds(ctx)
+			clusterComputeResourceMoIds, _, err := common.GetClusterComputeResourceMoIds(ctx)
 			if err != nil {
 				log.Errorf("failed to get clusterComputeResourceMoIds. err: %v", err)
 				return err

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -257,7 +257,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			configInfo.Cfg.Global.CAFile = cnsconfig.SupervisorCAFilePath
 		}
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
-			clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
+			clusterComputeResourceMoIds, _, err = common.GetClusterComputeResourceMoIds(ctx)
 			if err != nil {
 				log.Errorf("failed to get clusterComputeResourceMoIds. err: %v", err)
 				return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Start zone Informer in wcp -> controller - Init and for cnsregistervolume.
- added singleton to StartZonesInformer
- updated GetClusterComputeResourceMoIds to return additional boolean value to determine if AZ has multiple vSphere clusters. If any one of the AZ has multiple vSphere Clusters GetClusterComputeResourceMoIds returns true.
- skip init of the stoagepool service when az has multiple vSphere clusters.


**Testing done**:
Unit tests:
```
% go test -v ./pkg/csi/service/common -run '^TestGetClusterComputeResourceMoIds_'

=== RUN   TestGetClusterComputeResourceMoIds_MultipleClustersPerAZ
--- PASS: TestGetClusterComputeResourceMoIds_MultipleClustersPerAZ (0.00s)
=== RUN   TestGetClusterComputeResourceMoIds_SingleClusterPerAZ
--- PASS: TestGetClusterComputeResourceMoIds_SingleClusterPerAZ (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common        0.750s
```

Executed pre-checkin pipeline: 

```
Pre-checkin build: 145
Ran 10 of 1080 Specs in 1378.137 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 1070 Skipped
PASS
```

Verified replacing driver image for the guest cluster controller to confirm no regression is happening in the guest cluster to start zone informer.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
start zone informers and skip storagepool for multiple zone per cluster
```
