### PR TITLE
[WIP] Csi session manager compatibility

### DIFF
--- a/docs/book/vc_shared_sessions.md
+++ b/docs/book/vc_shared_sessions.md
@@ -1,0 +1,115 @@
+# vSphere Shared Session capability
+
+One problem that can be found when provisioning a large amount of clusters using
+vSphere CSI is vCenter session exhaustion. This happens because every
+workload cluster needs to request a new session to vSphere to do proper reconciliation.
+
+vSphere 8.0U3 and up uses a new approach of session management, that allows the
+creation and sharing of the sessions among different clusters.
+
+A cluster admin can implement a rest API that, once called, requests a new vCenter
+session and shares with CSI. This session will not count on the total generated
+sessions of vSphere, and instead will be a child derived session.
+
+This configuration can be applied on vSphere CSI with the usage of
+the following CSI configuration:
+
+```shell
+[Global]
+ca-file = "/etc/ssl/certs/trusted-certificates.crt"
+[VirtualCenter "your-vcenter-host"]
+datacenters = "datacenter1"
+vc-session-manager-url = "https://some-session-manager/session"
+vc-session-manager-token = "a-secret-token"
+```
+
+The configuration above will make CSI call the shared session rest API and use the
+provided token to authenticate against vSphere, instead of using a username/password.
+
+The parameter provider at `vc-session-manager-token` is sent as a `Authorization: Bearer` token
+to the session manager, and in case this directive is not configured CSI will send the
+Pod Service Account token instead.
+
+Below is an example implementation of a shared session manager rest API. Starting the
+program below and calling `http://127.0.0.1:18080/session` should return a JSON that is expected
+by CSI using session manager to work:
+
+```shell
+$ curl 127.0.0.1:18080/session
+{"token":"cst-VCT-52f8d061-aace-4506-f4e6-fca78293a93f-....."}
+```
+
+**NOTE**: Below implementation is **NOT PRODUCTION READY** and does not implement
+any kind of authentication!
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "log"
+    "net/http"
+    "net/url"
+
+    "github.com/vmware/govmomi"
+    "github.com/vmware/govmomi/session"
+    "github.com/vmware/govmomi/vim25"
+    "github.com/vmware/govmomi/vim25/soap"
+)
+
+const (
+    vcURL      = "https://my-vc.tld"
+    vcUsername = "Administrator@vsphere.local"
+    vcPassword = "somepassword"
+)
+
+var (
+    userPassword = url.UserPassword(vcUsername, vcPassword)
+)
+
+// SharedSessionResponse is the expected response of CPI when using Shared session manager
+type SharedSessionResponse struct {
+    Token string `json:"token"`
+}
+
+func main() {
+    ctx := context.Background()
+    vcURL, err := soap.ParseURL(vcURL)
+    if err != nil {
+        panic(err)
+    }
+    soapClient := soap.NewClient(vcURL, false)
+    c, err := vim25.NewClient(ctx, soapClient)
+    if err != nil {
+        panic(err)
+    }
+    client := &govmomi.Client{
+        Client:         c,
+        SessionManager: session.NewManager(c),
+    }
+    if err := client.SessionManager.Login(ctx, userPassword); err != nil {
+        panic(err)
+    }
+
+    vcsession := func(w http.ResponseWriter, r *http.Request) {
+        clonedtoken, err := client.SessionManager.AcquireCloneTicket(ctx)
+        if err != nil {
+            w.WriteHeader(http.StatusForbidden)
+            return
+        }
+        token := &SharedSessionResponse{Token: clonedtoken}
+        jsonT, err := json.Marshal(token)
+        if err != nil {
+            w.WriteHeader(http.StatusInternalServerError)
+            return
+        }
+        w.WriteHeader(http.StatusOK)
+        w.Write(jsonT)
+    }
+
+    http.HandleFunc("/session", vcsession)
+    log.Printf("starting webserver on port 18080")
+    http.ListenAndServe(":18080", nil)
+}
+```

--- a/pkg/common/cns-lib/vsphere/tagmanager.go
+++ b/pkg/common/cns-lib/vsphere/tagmanager.go
@@ -1,0 +1,29 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/vapi/tags"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// GetTagManager returns tagManager connected to given VirtualCenter.
+func (vc *VirtualCenter) GetTagManager(ctx context.Context) (*tags.Manager, error) {
+	log := logger.GetLogger(ctx)
+	// Validate input.
+	if vc == nil || vc.Client == nil || vc.Client.Client == nil {
+		return nil, fmt.Errorf("vCenter not initialized")
+	}
+
+	if err := vc.Connect(ctx); err != nil {
+		return nil, fmt.Errorf("error connecting to VC: %w", err)
+	}
+
+	vc.tagManager = tags.NewManager(vc.RestClient)
+	if vc.tagManager == nil {
+		return nil, fmt.Errorf("failed to create a tagManager")
+	}
+	log.Infof("New tag manager with useragent '%s'", vc.tagManager.UserAgent)
+	return vc.tagManager, nil
+}

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -2,11 +2,8 @@ package vsphere
 
 import (
 	"context"
-	"crypto/tls"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -14,10 +11,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
-	"github.com/vmware/govmomi/sts"
-	"github.com/vmware/govmomi/vapi/rest"
-	"github.com/vmware/govmomi/vapi/tags"
-	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -302,62 +295,6 @@ func CompareKubernetesMetadata(ctx context.Context, k8sMetaData *cnstypes.CnsKub
 		labelsMatch, spew.Sdump(GetLabelsMapFromKeyValue(k8sMetaData.Labels)),
 		spew.Sdump(GetLabelsMapFromKeyValue(cnsMetaData.Labels)))
 	return labelsMatch
-}
-
-// Signer decodes the certificate and private key and returns SAML token needed
-// for authentication.
-func signer(ctx context.Context, client *vim25.Client, username string, password string) (*sts.Signer, error) {
-	pemBlock, _ := pem.Decode([]byte(username))
-	if pemBlock == nil {
-		return nil, nil
-	}
-	certificate, err := tls.X509KeyPair([]byte(username), []byte(password))
-	if err != nil {
-		return nil, fmt.Errorf("failed to load X509 key pair. Error: %+v", err)
-	}
-	tokens, err := sts.NewClient(ctx, client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create STS client. err: %+v", err)
-	}
-	req := sts.TokenRequest{
-		Certificate: &certificate,
-		Delegatable: true,
-	}
-	signer, err := tokens.Issue(ctx, req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to issue SAML token. err: %+v", err)
-	}
-	return signer, nil
-}
-
-// GetTagManager returns tagManager connected to given VirtualCenter.
-func GetTagManager(ctx context.Context, vc *VirtualCenter) (*tags.Manager, error) {
-	log := logger.GetLogger(ctx)
-	// Validate input.
-	if vc == nil || vc.Client == nil || vc.Client.Client == nil {
-		return nil, fmt.Errorf("vCenter not initialized")
-	}
-
-	restClient := rest.NewClient(vc.Client.Client)
-	signer, err := signer(ctx, vc.Client.Client, vc.Config.Username, vc.Config.Password)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the Signer. Error: %v", err)
-	}
-	if signer == nil {
-		user := url.UserPassword(vc.Config.Username, vc.Config.Password)
-		err = restClient.Login(ctx, user)
-	} else {
-		err = restClient.LoginByToken(restClient.WithSigner(ctx, signer))
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to login for the rest client. Error: %v", err)
-	}
-	tagManager := tags.NewManager(restClient)
-	if tagManager == nil {
-		return nil, fmt.Errorf("failed to create a tagManager")
-	}
-	log.Infof("New tag manager with useragent '%s'", tagManager.UserAgent)
-	return tagManager, nil
 }
 
 // GetCandidateDatastoresInClusters gets the shared datastores and vSAN-direct

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -191,6 +191,12 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 		ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
 		MigrationDataStoreURL:       cfg.VirtualCenter[host].MigrationDataStoreURL,
 		FileVolumeActivated:         cfg.VirtualCenter[host].FileVolumeActivated,
+		VCSessionManagerURL:         cfg.VirtualCenter[host].VCSessionManagerURL,
+		VCSessionManagerToken:       cfg.VirtualCenter[host].VCSessionManagerToken,
+	}
+
+	if vcConfig.VCSessionManagerURL != "" {
+		log.Infof("Using Shared Session Manager: %s", vcConfig.VCSessionManagerURL)
 	}
 
 	log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
@@ -237,6 +243,8 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			QueryLimit:                  cfg.Global.QueryLimit,
 			ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
 			FileVolumeActivated:         cfg.VirtualCenter[vCenterIP].FileVolumeActivated,
+			VCSessionManagerURL:         cfg.VirtualCenter[vCenterIP].VCSessionManagerURL,
+			VCSessionManagerToken:       cfg.VirtualCenter[vCenterIP].VCSessionManagerToken,
 		}
 		if vcConfig.CAFile == "" {
 			vcConfig.CAFile = cfg.Global.CAFile

--- a/pkg/common/cns-lib/vsphere/vc_session_manager.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_manager.go
@@ -1,0 +1,104 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	saFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
+// SharedSessionResponse is the expected structure for a session manager valid
+// token response
+type SharedSessionResponse struct {
+	Token string `json:"token"`
+}
+
+// SharedTokenOptions represents the options that can be used when calling vc session manager
+type SharedTokenOptions struct {
+	// URL is the session manager URL. Eg.: https://my-session-manager/session)
+	URL string
+	// Token is the authorization token that should be passed to session manager
+	Token string
+	// TrustedCertificates contains the certpool of certificates trusted by the client
+	TrustedCertificates *x509.CertPool
+	// InsecureSkipVerify defines if bad certificates requests should be ignored
+	InsecureSkipVerify bool
+	// Timeout defines the client timeout. Defaults to 5 seconds
+	Timeout time.Duration
+	// TokenFile defines a file with token content. Defaults to Kubernetes Service Account file
+	TokenFile string
+}
+
+// GetSharedToken executes an http request on session manager and gets the session manager
+// token that can be reused on govmomi sessions
+func GetSharedToken(ctx context.Context, options SharedTokenOptions) (string, error) {
+	if options.URL == "" {
+		return "", fmt.Errorf("URL of session manager cannot be empty")
+	}
+
+	if options.TokenFile == "" {
+		options.TokenFile = saFile
+	}
+
+	// If the token is empty, we should use service account from the Pod instead
+	if options.Token == "" {
+		saValue, err := os.ReadFile(options.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("failed reading token from service account: %w", err)
+		}
+		options.Token = string(saValue)
+	}
+
+	timeout := 5 * time.Second
+	if options.Timeout != 0 {
+		timeout = options.Timeout
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:            options.TrustedCertificates,
+			InsecureSkipVerify: options.InsecureSkipVerify,
+		},
+	}
+
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+
+	request, err := http.NewRequest(http.MethodGet, options.URL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed creating new http client: %w", err)
+	}
+	authToken := fmt.Sprintf("Bearer %s", options.Token)
+	request.Header.Add("Authorization", authToken)
+
+	resp, err := client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("failed calling vc session manager: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("invalid vc session manager response: %s", resp.Status)
+	}
+
+	token := &SharedSessionResponse{}
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(token); err != nil {
+		return "", fmt.Errorf("failed decoding vc session manager response: %w", err)
+	}
+
+	if token.Token == "" {
+		return "", fmt.Errorf("returned vc session token is empty")
+	}
+	return token.Token, nil
+}

--- a/pkg/common/cns-lib/vsphere/vc_session_manager_test.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_manager_test.go
@@ -1,0 +1,189 @@
+package vsphere_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vclib "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+)
+
+const (
+	validToken    = "validtoken"
+	validResponse = "a-valid-response"
+)
+
+var (
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authZHdr := r.Header.Get("Authorization")
+		if authZHdr != fmt.Sprintf("Bearer %s", validToken) {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if r.URL.Path == "/timeout" {
+			time.Sleep(15 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/invalid-token" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not a json"))
+			return
+		}
+		if r.URL.Path == "/session" {
+			token := vclib.SharedSessionResponse{
+				Token: validResponse,
+			}
+			response, err := json.Marshal(&token)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(response)
+			return
+		}
+		if r.URL.Path == "/empty" {
+			token := vclib.SharedSessionResponse{
+				Token: "",
+			}
+			response, err := json.Marshal(&token)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(response)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+)
+
+func TestGetSharedToken(t *testing.T) {
+	ctx := context.Background()
+	t.Run("when options are invalid", func(t *testing.T) {
+		t.Run("should fail when no URL is sent", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{})
+			assert.ErrorContains(t, err, "URL of session manager cannot be empty")
+		})
+
+		t.Run("should fail when no token is passed and SA token cannot be read", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL: "http://something.tld/lala",
+			})
+			assert.ErrorContains(t, err, "failed reading token from service account: "+
+				"open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory")
+		})
+
+		t.Run("should fail when passed URL is invalid", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:   "https://some-session-manager.tld:xxxxx/session",
+				Token: "anything",
+			})
+			assert.ErrorContains(t, err, "invalid port")
+		})
+	})
+
+	t.Run("when using a valid session manager", func(t *testing.T) {
+		server := httptest.NewTLSServer(handler)
+
+		certpool := x509.NewCertPool()
+		certpool.AddCert(server.Certificate())
+		t.Cleanup(server.Close)
+
+		t.Run("should respect the timeout", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/timeout", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+				Timeout:             5 * time.Millisecond,
+			})
+			assert.ErrorContains(t, err, "context deadline exceeded")
+		})
+		t.Run("should fail when calling an invalid path", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 server.URL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "404 Not Found")
+		})
+		t.Run("should fail when an empty token is returned", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/empty", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "returned vc session token is empty")
+		})
+
+		t.Run("should fail when an invalid json is returned", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/invalid-token", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "failed decoding vc session manager response")
+		})
+
+		t.Run("should fail when no cert is passed and insecureskipverify is false", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:   reqURL,
+				Token: validToken,
+			})
+			assert.ErrorContains(t, err, "tls: failed to verify certificate: x509")
+		})
+
+		t.Run("should return a valid token for the right request and insecureskip=true", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                reqURL,
+				InsecureSkipVerify: true,
+				Token:              validToken,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+
+		t.Run("should return a valid token for the right request and cert", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+
+		t.Run("should return a valid token when using a file as a token", func(t *testing.T) {
+			tokenFile, err := os.CreateTemp("", "")
+			require.NoError(t, err)
+			require.NoError(t, tokenFile.Close())
+			require.NoError(t, os.WriteFile(tokenFile.Name(), []byte(validToken), 0755))
+
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				TokenFile:           tokenFile.Name(),
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+	})
+
+}

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -37,6 +37,8 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -68,6 +70,8 @@ type VirtualCenter struct {
 	Config *VirtualCenterConfig
 	// Client represents the govmomi client instance for the connection.
 	Client *govmomi.Client
+	// RestClient represents the govmomi rest client
+	RestClient *rest.Client
 	// PbmClient represents the govmomi PBM Client instance.
 	PbmClient *pbm.Client
 	// CnsClient represents the CNS client instance.
@@ -76,6 +80,9 @@ type VirtualCenter struct {
 	VsanClient *vsan.Client
 	// VslmClient represents the Vslm client instance.
 	VslmClient *vslm.Client
+	// tagManager represents the tagmanager client instance.
+	tagManager *tags.Manager
+
 	// ClientMutex is used for exclusive connection creation.
 	ClientMutex *sync.Mutex
 }
@@ -151,7 +158,7 @@ type VirtualCenterConfig struct {
 }
 
 // NewClient creates a new govmomi Client instance.
-func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govmomi.Client, error) {
+func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govmomi.Client, *rest.Client, error) {
 	log := logger.GetLogger(ctx)
 	if vc.Config.Scheme == "" {
 		vc.Config.Scheme = DefaultScheme
@@ -160,14 +167,14 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	url, err := soap.ParseURL(net.JoinHostPort(vc.Config.Host, strconv.Itoa(vc.Config.Port)))
 	if err != nil {
 		log.Errorf("failed to parse URL %s with err: %v", url, err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	soapClient := soap.NewClient(url, vc.Config.Insecure)
 	if len(vc.Config.CAFile) > 0 && !vc.Config.Insecure {
 		if err := soapClient.SetRootCAs(vc.Config.CAFile); err != nil {
 			log.Errorf("failed to load CA file: %v", err)
-			return nil, err
+			return nil, nil, err
 		}
 	} else if len(vc.Config.Thumbprint) > 0 && !vc.Config.Insecure {
 		soapClient.SetThumbprint(url.Host, vc.Config.Thumbprint)
@@ -179,13 +186,13 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	vimClient, err := vim25.NewClient(ctx, soapClient)
 	if err != nil {
 		log.Errorf("failed to create new client with err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	err = vimClient.UseServiceVersion("vsan")
 	if err != nil && vc.Config.Host != "127.0.0.1" {
 		// Skipping error for simulator connection for unit tests.
 		log.Errorf("Failed to set vimClient service version to vsan. err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	vimClient.UserAgent = useragent
 	client := &govmomi.Client{
@@ -193,22 +200,24 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 		SessionManager: session.NewManager(vimClient),
 	}
 
-	err = vc.login(ctx, client)
+	restClient := rest.NewClient(client.Client)
+
+	err = vc.login(ctx, client, restClient)
 	if err != nil {
 		log.Errorf("failed to login to vc. err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	s, err := client.SessionManager.UserSession(ctx)
 	if err != nil {
 		log.Errorf("failed to get UserSession. err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	// Refer to this issue - https://github.com/vmware/govmomi/issues/2922
 	// When Session Manager -> UserSession can return nil user session with nil error
 	// so handling the case for nil session.
 	if s == nil {
-		return nil, errors.New("nil session obtained from session manager")
+		return nil, nil, errors.New("nil session obtained from session manager")
 	}
 	log.Infof("New session ID for '%s' = %s", s.UserName, s.Key)
 
@@ -217,19 +226,22 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	}
 	rt := vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(vc.Config.RoundTripperCount))
 	client.RoundTripper = &MetricRoundTripper{"soap", rt}
-	return client, nil
+	return client, restClient, nil
 }
 
 // login calls SessionManager.LoginByToken if certificate and private key are
 // configured. Otherwise, calls SessionManager.Login with user and password.
-func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) error {
+func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client, restClient *rest.Client) error {
 	log := logger.GetLogger(ctx)
 	var err error
 
 	b, _ := pem.Decode([]byte(vc.Config.Username))
 	if b == nil {
-		return client.SessionManager.Login(ctx,
-			neturl.UserPassword(vc.Config.Username, vc.Config.Password))
+		if err := client.SessionManager.Login(ctx, neturl.UserPassword(vc.Config.Username, vc.Config.Password)); err != nil {
+			log.Errorf("error logging soap client: %v", err)
+			return err
+		}
+		return restClient.Login(ctx, neturl.UserPassword(vc.Config.Username, vc.Config.Password))
 	}
 
 	cert, err := tls.X509KeyPair([]byte(vc.Config.Username), []byte(vc.Config.Password))
@@ -246,6 +258,7 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) erro
 
 	req := sts.TokenRequest{
 		Certificate: &cert,
+		Delegatable: true,
 	}
 
 	signer, err := tokens.Issue(ctx, req)
@@ -255,7 +268,11 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) erro
 	}
 
 	header := soap.Header{Security: signer}
-	return client.SessionManager.LoginByToken(client.Client.WithHeader(ctx, header))
+	if err := client.SessionManager.LoginByToken(client.Client.WithHeader(ctx, header)); err != nil {
+		return err
+	}
+
+	return restClient.LoginByToken(restClient.WithSigner(ctx, signer))
 }
 
 // Connect establishes a new connection with vSphere with updated credentials.
@@ -279,6 +296,14 @@ func (vc *VirtualCenter) Connect(ctx context.Context) error {
 					log.Errorf("Could not logout of VC session. Error: %v", logoutErr)
 				}
 			}
+			if vc.RestClient != nil {
+				logoutErr := vc.RestClient.Logout(ctx)
+				if logoutErr != nil {
+					// TODO: On vSphere U3, with a shared session this may return an error as logging
+					// out from Soap also logs out from rest.
+					log.Errorf("Could not logout of VC rest session. Error: %v", logoutErr)
+				}
+			}
 		}()
 	}
 	return err
@@ -295,7 +320,7 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		log.Errorf("failed to get useragent for vCenter session. error: %+v", err)
 		return err
 	}
-	if vc.Client == nil {
+	if vc.Client == nil || vc.RestClient == nil {
 		if vc.Config.ReloadVCConfigForNewClient {
 			err = ReadVCConfigs(ctx, vc)
 			if err != nil {
@@ -303,13 +328,14 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			}
 		}
 		log.Infof("VirtualCenter.connect() creating new client")
-		if vc.Client, err = vc.NewClient(ctx, useragent); err != nil {
+		if vc.Client, vc.RestClient, err = vc.NewClient(ctx, useragent); err != nil {
 			log.Errorf("failed to create govmomi client with err: %v", err)
 			if !vc.Config.Insecure {
 				log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 			}
 			return err
 		}
+
 		log.Infof("VirtualCenter.connect() successfully created new client")
 		return nil
 	}
@@ -319,10 +345,25 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 	// SessionMgr.UserSession(ctx) retrieves and returns the SessionManager's
 	// CurrentSession field. Nil is returned if the session is not
 	// authenticated or timed out.
-	if userSession, err := sessionMgr.UserSession(ctx); err != nil {
+	shouldLogin := false
+
+	userSession, err := sessionMgr.UserSession(ctx)
+	if err != nil {
 		log.Errorf("failed to obtain user session with err: %v", err)
-		return err
-	} else if userSession != nil {
+		// Login again if session is invalid
+		shouldLogin = true
+		//return err <- Check if we really want to return error here or follow with re-login
+	}
+
+	restSession, err := vc.RestClient.Session(ctx)
+	if err != nil {
+		log.Errorf("failed to obtain rest user session with err: %v", err)
+		// Login again if session is invalid
+		shouldLogin = true
+	}
+
+	// No need to re-login
+	if userSession != nil && restSession != nil && !shouldLogin {
 		return nil
 	}
 
@@ -335,6 +376,14 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		}
 	}
 
+	if vc.RestClient != nil {
+		// TODO: On U3 shared session this may return an error, if the Soap logout
+		// happened correctly, but can be safely ignored
+		if err := vc.RestClient.Logout(ctx); err != nil {
+			log.Errorf("failed to logout current rest session. still clearing idle sessions. err: %v", err)
+		}
+	}
+
 	// If session has expired, create a new instance.
 	log.Infof("Creating a new client session as the existing one isn't valid or not authenticated")
 	if vc.Config.ReloadVCConfigForNewClient {
@@ -343,7 +392,7 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			return err
 		}
 	}
-	if vc.Client, err = vc.NewClient(ctx, useragent); err != nil {
+	if vc.Client, vc.RestClient, err = vc.NewClient(ctx, useragent); err != nil {
 		log.Errorf("failed to create govmomi client with err: %v", err)
 		if !vc.Config.Insecure {
 			log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
@@ -382,6 +431,12 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		}
 		vc.VsanClient.RoundTripper = &MetricRoundTripper{"vsan", vc.VsanClient.RoundTripper}
 	}
+
+	// Recreate the Tag Manager client if created using timed out Rest client
+	if vc.tagManager != nil {
+		vc.tagManager = tags.NewManager(vc.RestClient)
+	}
+
 	return nil
 }
 
@@ -485,7 +540,14 @@ func (vc *VirtualCenter) Disconnect(ctx context.Context) error {
 		log.Errorf("failed to logout with err: %v", err)
 		return err
 	}
+
+	// We don't return an error here because logging out from Rest failing
+	// can happen on VC shared sessions
+	if err := vc.RestClient.Logout(ctx); err != nil {
+		log.Errorf("failed to logout rest with err: %v", err)
+	}
 	vc.Client = nil
+	vc.RestClient = nil
 	return nil
 }
 

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -155,6 +155,12 @@ type VirtualCenterConfig struct {
 	ReloadVCConfigForNewClient bool
 	// FileVolumeActivated indicates whether file service has been enabled on any vSAN cluster or not
 	FileVolumeActivated bool
+	// VCSessionManagerURL is the path of a rest api capable of generating vCenter Cloned tokens
+	// to be reused by clients. When this is used, Username and Password configuration are ignored
+	VCSessionManagerURL string
+	// VCSessionManagerToken is the token that should be passed to authenticate against the session manager
+	// If empty, the Pod service account will be used
+	VCSessionManagerToken string
 }
 
 // NewClient creates a new govmomi Client instance.
@@ -234,6 +240,24 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client, restClient *rest.Client) error {
 	log := logger.GetLogger(ctx)
 	var err error
+
+	// If session manager is used, username and password can be discarded/ignored
+	if vc.Config.VCSessionManagerURL != "" {
+		token, err := GetSharedToken(ctx, SharedTokenOptions{
+			URL:   vc.Config.VCSessionManagerURL,
+			Token: vc.Config.VCSessionManagerToken,
+		})
+		if err != nil {
+			log.Errorf("error getting shared session token: %s", err)
+			return err
+		}
+		if err := client.SessionManager.CloneSession(ctx, token); err != nil {
+			log.Errorf("error getting cloned session token: %s", err)
+			return err
+		}
+		restClient.SessionID(client.SessionCookie().Value)
+		return nil
+	}
 
 	b, _ := pem.Decode([]byte(vc.Config.Username))
 	if b == nil {
@@ -510,6 +534,20 @@ func (vc *VirtualCenter) getDatacenters(ctx context.Context, dcPaths []string) (
 		dcs = append(dcs, dc)
 	}
 	return dcs, nil
+}
+
+// GetActiveUser returns the current logged in user. It is fetched from govmomi.Session
+// to reflect the real current user being used
+func (vc *VirtualCenter) GetActiveUser(ctx context.Context) (string, error) {
+	if vc.Client == nil || vc.Client.SessionManager == nil {
+		return "", fmt.Errorf("client or sessionmanager are null")
+	}
+
+	userSession, err := vc.Client.SessionManager.UserSession(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting current user: %w", err)
+	}
+	return userSession.UserName, nil
 }
 
 // GetDatacenters returns Datacenters found on the VirtualCenter. If no

--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -211,7 +211,7 @@ func (vm *VirtualMachine) GetTagManager(ctx context.Context) (*tags.Manager, err
 		log.Errorf("failed to get virtualCenter. Error: %v", err)
 		return nil, err
 	}
-	return GetTagManager(ctx, virtualCenter)
+	return virtualCenter.GetTagManager(ctx)
 }
 
 // GetAncestors returns ancestors of VM.

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -111,7 +111,7 @@ const (
 // Errors
 var (
 	// ErrUsernameMissing is returned when the provided username is empty.
-	ErrUsernameMissing = errors.New("username is missing")
+	ErrUsernameMissing = errors.New("username or session manager configuration are missing")
 
 	// ErrInvalidUsername is returned when vCenter username provided in vSphere config
 	// secret is invalid. e.g. If username is not a fully qualified domain name, then
@@ -119,7 +119,7 @@ var (
 	ErrInvalidUsername = errors.New("username is invalid, make sure it is a fully qualified domain username")
 
 	// ErrPasswordMissing is returned when the provided password is empty.
-	ErrPasswordMissing = errors.New("password is missing")
+	ErrPasswordMissing = errors.New("password or session manager configuration are missing")
 
 	// ErrInvalidVCenterIP is returned when the provided vCenter IP address is
 	// missing from the provided configuration.
@@ -382,15 +382,15 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 
 		if vcConfig.User == "" {
 			vcConfig.User = cfg.Global.User
-			if vcConfig.User == "" {
-				log.Errorf("vcConfig.User is empty for vc %s!", vcServer)
+			if vcConfig.User == "" && vcConfig.VCSessionManagerURL == "" {
+				log.Errorf("vcConfig.User or vcConfig.VCSessionManagerURL should be configured for vc %s!", vcServer)
 				return ErrUsernameMissing
 			}
 		}
 
 		// vCenter server username provided in vSphere config secret should contain domain name,
 		// CSI driver will crash if username doesn't contain domain name.
-		if !isValidvCenterUsernameWithDomain(vcConfig.User) {
+		if !isValidvCenterUsernameWithDomain(vcConfig.User) && vcConfig.VCSessionManagerURL == "" {
 			log.Errorf("username %v specified in vSphere config secret is invalid, "+
 				"make sure that username is a fully qualified domain name.", vcConfig.User)
 			return ErrInvalidUsername
@@ -398,8 +398,8 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 
 		if vcConfig.Password == "" {
 			vcConfig.Password = cfg.Global.Password
-			if vcConfig.Password == "" {
-				log.Errorf("vcConfig.Password is empty for vc %s!", vcServer)
+			if vcConfig.Password == "" && vcConfig.VCSessionManagerURL == "" {
+				log.Errorf("vcConfig.Password or vcConfig.VCSessionManagerURL should be configured for vc %s!", vcServer)
 				return ErrPasswordMissing
 			}
 		}

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -201,6 +201,25 @@ func TestValidateConfigWithValidUsername1(t *testing.T) {
 	}
 }
 
+func TestValidateConfigWithSessionManager(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			VCenterPort:         "443",
+			Datacenters:         "dc1",
+			InsecureFlag:        true,
+			VCSessionManagerURL: "http://xxx.yyy.com/tld",
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as valid session manager was used. Config given - %+v", *cfg)
+	}
+}
+
 func TestValidateConfigWithValidUsername2(t *testing.T) {
 	vcConfigValidUsername := map[string]*VirtualCenterConfig{
 		"1.1.1.1": {

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -157,6 +157,12 @@ type VirtualCenterConfig struct {
 	MigrationDataStoreURL string `gcfg:"migration-datastore-url"`
 	// FileVolumeActivated indicates whether file service has been enabled on any vSAN cluster or not
 	FileVolumeActivated bool
+	// VCSessionManagerURL is the path of a rest api capable of generating vCenter Cloned tokens
+	// to be reused by clients. When this is used, Username and Password configuration are ignored
+	VCSessionManagerURL string `gcfg:"vc-session-manager-url"`
+	// VCSessionManagerToken is the token that should be passed to authenticate against the session manager
+	// If empty, the Pod service account will be used
+	VCSessionManagerToken string `gcfg:"vc-session-manager-token"`
 }
 
 // GCConfig contains information used by guest cluster to access a supervisor

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -34,6 +34,8 @@ import (
 
 	cnssim "github.com/vmware/govmomi/cns/simulator"
 	pbmsim "github.com/vmware/govmomi/pbm/simulator"
+	_ "github.com/vmware/govmomi/vapi/simulator"
+
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
@@ -412,6 +414,7 @@ func configFromVCSimWithTLS(tlsConfig *tls.Config, vcsimParams VcsimParams, inse
 	if err != nil {
 		log.Fatal(err)
 	}
+	model.Service.RegisterEndpoints = true
 
 	model.Service.TLS = tlsConfig
 	s := model.Service.NewServer()

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -13,6 +13,7 @@ import (
 	cnssim "github.com/vmware/govmomi/cns/simulator"
 	"github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/simulator"
+	_ "github.com/vmware/govmomi/vapi/simulator"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	cnsvolumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -56,6 +57,7 @@ func configFromCustomizedSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool)
 		log.Fatal(err)
 	}
 
+	model.Service.RegisterEndpoints = true
 	model.Service.TLS = tlsConfig
 	s := model.Service.NewServer()
 

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -323,7 +323,11 @@ func getDatastoresWithBlockVolumePrivs(ctx context.Context, vc *cnsvsphere.Virtu
 	authMgr := object.NewAuthorizationManager(vc.Client.Client)
 	privIds := []string{DsPriv, SysReadPriv}
 
-	userName := vc.Config.Username
+	userName, err := vc.GetActiveUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Invoke authMgr function HasUserPrivilegeOnEntities.
 	result, err := authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds) // entities empty -> error
 	if err != nil {
@@ -426,10 +430,14 @@ func getFSEnabledClustersWithPriv(ctx context.Context, vc *cnsvsphere.VirtualCen
 		clusterComputeResources = append(clusterComputeResources, clusterComputeResource...)
 	}
 
+	userName, err := vc.GetActiveUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Get Clusters with HostConfigStoragePriv.
 	authMgr := object.NewAuthorizationManager(vc.Client.Client)
 	privIds := []string{HostConfigStoragePriv}
-	userName := vc.Config.Username
 	var entities []vim25types.ManagedObjectReference
 	clusterComputeResourcesMap := make(map[string]*object.ClusterComputeResource)
 	for _, cluster := range clusterComputeResources {

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -313,16 +313,11 @@ func refreshPreferentialDatastores(ctx context.Context) error {
 		return logger.LogNewErrorf(log, "failed to get vCenter instance. Error: %+v", err)
 	}
 	// Get tag manager instance.
-	tagMgr, err := cnsvsphere.GetTagManager(ctx, vc)
+	tagMgr, err := vc.GetTagManager(ctx)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create tag manager. Error: %+v", err)
 	}
-	defer func() {
-		err := tagMgr.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout tagManager. Error: %v", err)
-		}
-	}()
+
 	// Get tags for category reserved for preferred datastore tagging.
 	tagIds, err := tagMgr.ListTagsForCategory(ctx, common.PreferredDatastoresCategory)
 	if err != nil {

--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -82,16 +82,10 @@ func DiscoverTagEntities(ctx context.Context) error {
 				vcenterCfg.Host, err)
 		}
 		// Get tag manager instance.
-		tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+		tagManager, err := vcenter.GetTagManager(ctx)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create tagManager. Error: %v", err)
 		}
-		defer func() {
-			err := tagManager.Logout(ctx)
-			if err != nil {
-				log.Errorf("failed to logout tagManager. Error: %v", err)
-			}
-		}()
 		for _, cat := range categories {
 			topoTags, err := tagManager.GetTagsForCategory(ctx, cat)
 			if err != nil {
@@ -439,17 +433,12 @@ func RefreshPreferentialDatastoresForMultiVCenter(ctx context.Context) error {
 				vcConfig.Host, err)
 		}
 		// Get tag manager instance.
-		tagMgr, err := cnsvsphere.GetTagManager(ctx, vc)
+		tagMgr, err := vc.GetTagManager(ctx)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create tag manager for vCenter %q. Error: %+v",
 				vcConfig.Host, err)
 		}
-		defer func() {
-			err := tagMgr.Logout(ctx)
-			if err != nil {
-				log.Errorf("failed to logout tagManager for vCenter %q. Error: %v", vcConfig.Host, err)
-			}
-		}()
+
 		// Get tags for category reserved for preferred datastore tagging.
 		tagIds, err := tagMgr.ListTagsForCategory(ctx, PreferredDatastoresCategory)
 		if err != nil {

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -223,7 +223,7 @@ func CreateBlockVolumeUtil(
 		clusterID = manager.CnsConfig.Global.SupervisorID
 	}
 	containerCluster := vsphere.GetContainerCluster(clusterID,
-		manager.CnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor,
+		username, clusterFlavor,
 		manager.CnsConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
@@ -517,6 +517,11 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 		}
 	}
 
+	username, err := vc.GetActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
+
 	if filterSuspendedDatastores {
 		datastores, err = vsphere.FilterSuspendedDatastores(ctx, datastores)
 		if err != nil {
@@ -574,10 +579,6 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 		clusterID = cnsConfig.Global.SupervisorID
 	}
 
-	username, err := vc.GetActiveUser(ctx)
-	if err != nil {
-		return nil, csifault.CSIInternalFault, err
-	}
 	var containerClusterArray []cnstypes.CnsContainerCluster
 	containerCluster := vsphere.GetContainerCluster(clusterID,
 		username, clusterFlavor,

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -91,6 +91,11 @@ func CreateBlockVolumeUtil(
 		}
 	}
 
+	username, err := vc.GetActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
+
 	if opts.FilterSuspendedDatastores {
 		sharedDatastores, err = vsphere.FilterSuspendedDatastores(ctx, sharedDatastores)
 		if err != nil {
@@ -401,10 +406,15 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{})
 		datastores = append(datastores, ds.Reference())
 	}
 
+	username, err := params.Vcenter.GetActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
+
 	var containerClusterArray []cnstypes.CnsContainerCluster
 	clusterID := params.CNSConfig.Global.ClusterID
 	containerCluster := vsphere.GetContainerCluster(clusterID,
-		params.CNSConfig.VirtualCenter[params.Vcenter.Config.Host].User, params.ClusterFlavor,
+		username, params.ClusterFlavor,
 		params.CNSConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
@@ -563,9 +573,14 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 	if useSupervisorId {
 		clusterID = cnsConfig.Global.SupervisorID
 	}
+
+	username, err := vc.GetActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
 	var containerClusterArray []cnstypes.CnsContainerCluster
 	containerCluster := vsphere.GetContainerCluster(clusterID,
-		cnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor,
+		username, clusterFlavor,
 		cnsConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -504,17 +504,11 @@ func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine,
 	}
 
 	// Get tag manager instance.
-	tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+	tagManager, err := vcenter.GetTagManager(ctx)
 	if err != nil {
 		log.Errorf("failed to create tagManager. Error: %v", err)
 		return nil, err
 	}
-	defer func() {
-		err := tagManager.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout tagManager. Error: %v", err)
-		}
-	}()
 
 	// Create a map of TopologyCategories with category as key and value as empty string.
 	var isZoneRegion bool

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2281,9 +2281,12 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 		if newVCConfig != nil {
 			var vcenter *cnsvsphere.VirtualCenter
 			newVCConfig.ReloadVCConfigForNewClient = true
+			vcConfig := metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host]
 			if metadataSyncer.host != newVCConfig.Host ||
-				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User != newVCConfig.Username ||
-				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].Password != newVCConfig.Password ||
+				vcConfig.User != newVCConfig.Username ||
+				vcConfig.Password != newVCConfig.Password ||
+				vcConfig.VCSessionManagerURL != newVCConfig.VCSessionManagerURL ||
+				vcConfig.VCSessionManagerToken != newVCConfig.VCSessionManagerToken ||
 				reconnectToVCFromNewConfig {
 				// Verify if new configuration has valid credentials by connecting
 				// to vCenter. Proceed only if the connection succeeds, else return


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** 
Cherry pick of https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3419
This change implements the new shared session capability on vCenter login, supporting a new Rest API that can provide shared tokens for workload clusters
This is a recommit of https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3278 as previous issue causing it to be removed was fixed in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3412

**Testing done**:
Tested on a live environment, doing some long runs and system test. The feature will be used just if the flags/configs are set, otherwise the default behavior will be kept
For this PR

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add support for shared session manager
```
