### PR TITLE
fix MonitorCreateVolumeTask to handle CNS Fault

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -480,7 +480,8 @@ func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
 		} else {
 			// Validate if the volume is already registered.
 			faultType = ExtractFaultTypeFromVolumeResponseResult(ctx, volumeOperationRes)
-			resp, err := validateCreateVolumeResponseFault(ctx, volNameFromInputSpec, volumeOperationRes)
+			var resp *CnsVolumeInfo
+			resp, err = validateCreateVolumeResponseFault(ctx, volNameFromInputSpec, volumeOperationRes)
 			if err == nil {
 				*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, resp.VolumeID.Id, "", 0,
 					(*volumeOperationDetails).QuotaDetails,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixes a variable shadowing issue in volume creation fault handling by replacing := with = to ensure errors from validateCreateVolumeResponseFault() are correctly propagated.

This is a regression caused by https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3350 


**Testing done**:
Verified Creating PVC which can cause CNSFault. Fault is handled properly.

```
Name:          test-pvc
Namespace:     svc-tkg-domain-c54
StorageClass:  vm-encryption-policy
Status:        Pending
Volume:
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age                  From                                                                                          Message
  ----     ------                ----                 ----                                                                                          -------
  Warning  ProvisioningFailed    2m19s                csi.vsphere.vmware.com_420b170e9a2eab3e014c4845aa5fa8d8_9e4c0e68-6ac9-423b-9d50-c629c742f7b5  failed to provision volume with StorageClass "vm-encryption-policy": rpc error: code = Internal desc = failed to create volume. Error: failed to create volume with fault: "(*types.LocalizedMethodFault)(0xc0004f5b60)({\n DynamicData: (types.DynamicData) {\n },\n Fault: (*types.CnsFault)(0xc000d10330)({\n  MethodFault: (types.MethodFault) {\n   FaultCause: (*types.LocalizedMethodFault)(0xc0004f5de0)({\n    DynamicData: (types.DynamicData) {\n    },\n    Fault: (*types.RuntimeFault)(0xc0003a6000)({\n     MethodFault: (types.MethodFault) {\n      FaultCause: (*types.LocalizedMethodFault)(<nil>),\n      FaultMessage: ([]types.LocalizableMessage) (len=1 cap=1) {\n       (types.LocalizableMessage) {\n        DynamicData: (types.DynamicData) {\n        },\n        Key: (string) (len=50) \"com.vmware.vim.vpxd.encryption.noDefaultKmipServer\",\n        Arg: ([]types.KeyAnyValue) <nil>,\n        Message: (string) (len=70) \"Cannot apply encryption policy. You must set the default key provider.\"\n       }\n      }\n     }\n    }),\n    LocalizedMessage: (string) (len=20) \"RuntimeFault.summary\"\n   }),\n   FaultMessage: ([]types.LocalizableMessage) <nil>\n  },\n  Reason: (string) (len=16) \"VSLM task failed\"\n }),\n LocalizedMessage: (string) (len=32) \"CnsFault error: VSLM task failed\"\n})\n"
```

Pre-checkin:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/183/

```
Ran 10 of 1080 Specs in 1248.625 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 1070 Skipped
PASS

Ginkgo ran 1 suite in 21m16.137975112s
Test Suite Passed
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix MonitorCreateVolumeTask to handle CNS Fault
```
