### PR TITLE
Validate DataSourceRef for CnsRegisterVolume

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -49,6 +49,16 @@ const (
 	scResourceNameSuffix = ".storageclass.storage.k8s.io/requests.storage"
 )
 
+var (
+	// Supported data source types for PVCs
+	supportedDataSourceTypes = []struct {
+		apiGroup string
+		kind     string
+	}{
+		{"vmoperator.vmware.com", "VirtualMachine"},
+	}
+)
+
 // isDatastoreAccessibleToCluster verifies if the datastoreUrl is accessible to
 // cluster with clusterID.
 func isDatastoreAccessibleToCluster(ctx context.Context, vc *vsphere.VirtualCenter,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is to support PVCs in captured blueprints use case.
- In the existing code, it allows an existing PVC to be used by CnsRegiserVolume. However, there isn't any validation for the DataSourceRef field. This means any DataSourceRef would be allowed to be used.
- This PR tightens the validation. It checks if there is an existing PVC for CnsRegisterVolume and whether there is a valid DataSourceRef. If a DataSourceRef exists but not supported, fail the operation.
- TODO: In a followup PR, we will add validation for topology annotation on PVC. If the topology annotation is added on an existing PVC, the topology of the volume must be compatible with that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/140/ (passed)
```
Build #140 (Aug 13, 2025, 7:46:03 AM)
xy036828 <br> PR 3449<br>
Ran 10 of 1080 Specs in 1286.027 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 1070 Skipped
PASS

Ginkgo ran 1 suite in 21m47.168354942s
Test Suite Passed
```

VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/286 (passed)
```
Build #286 (Aug 14, 2025, 6:38:34 AM)
xy036828 <br> PR 3449<br>
Ran 6 of 1080 Specs in 506.852 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 1074 Skipped
PASS

Ginkgo ran 1 suite in 8m50.12847442s
Test Suite Passed
```

Manual testing:
```
root@422447ee696fb43deecf644dff4325ea [ ~ ]# cat pop-pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pop-pvc
  namespace: test-ns
spec:
  storageClassName: wcpglobal-storage-profile
  dataSourceRef:
    apiGroup: vmoperator.vmware.com
    kind: VirtualMachine
    name: my-vm-1
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi


root@422447ee696fb43deecf644dff4325ea [ ~ ]# kubectl create -f pop-pvc.yaml
persistentvolumeclaim/pop-pvc created
root@422447ee696fb43deecf644dff4325ea [ ~ ]# kubectl get pvc -n test-ns
NAME      STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pop-pvc   Pending                                      wcpglobal-storage-profile   <unset>                 6s


root@422447ee696fb43deecf644dff4325ea [ ~ ]# cat register.yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: static-volume
  namespace: test-ns
spec:
  volumeID: 1a27144d-8e66-4816-aea4-51bb6388d0f0
  accessMode: ReadWriteOnce
  pvcName: pop-pvc

root@422447ee696fb43deecf644dff4325ea [ ~ ]# kubectl create -f register.yaml
cnsregistervolume.cns.vmware.com/static-volume created

root@422447ee696fb43deecf644dff4325ea [ ~ ]# kubectl get cnsregistervolume -n test-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-08-13T14:29:57Z"
    generation: 2
    name: static-volume
    namespace: test-ns
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: PersistentVolumeClaim
      name: pop-pvc
      uid: fabe749c-88e8-43af-a078-6d8103c8b661
    resourceVersion: "10293876"
    uid: f31db484-aa58-4e34-ad84-e73b991a389d
  spec:
    accessMode: ReadWriteOnce
    pvcName: pop-pvc
    volumeID: 1a27144d-8e66-4816-aea4-51bb6388d0f0
  status:
    registered: true
kind: List
metadata:
  resourceVersion: ""

root@422447ee696fb43deecf644dff4325ea [ ~ ]# kubectl get pvc -n test-ns
NAME      STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pop-pvc   Bound    static-pv-1a27144d-8e66-4816-aea4-51bb6388d0f0   1Gi        RWO            wcpglobal-storage-profile   <unset>                 9m4s
```

Syncer Logs:
```
2025-08-13T14:29:57.698Z        INFO    cnsregistervolume/cnsregistervolume_controller.go:248   Reconciling CnsRegisterVolume with instance: "static-volume" from namespace: "test-ns". timeout "1s" seconds
2025-08-13T14:29:58.380Z        INFO    cnsregistervolume/cnsregistervolume_controller.go:310   Created CNS volume with volumeID: 1a27144d-8e66-4816-aea4-51bb6388d0f0
2025-08-13T14:29:58.699Z        INFO    cnsregistervolume/cnsregistervolume_controller.go:527   PV: static-pv-1a27144d-8e66-4816-aea4-51bb6388d0f0 not found. Creating a new PV
2025-08-13T14:29:58.747Z        INFO    cnsregistervolume/cnsregistervolume_controller.go:546   PV: static-pv-1a27144d-8e66-4816-aea4-51bb6388d0f0 is created successfully

2025-08-13T14:29:58.755Z        INFO    cnsregistervolume/cnsregistervolume_controller.go:789   Existing PVC pop-pvc in namespace test-ns has valid DataSourceRef (apiGroup: vmoperator.vmware.com, kind: VirtualMachine), can reuse
2025-08-13T14:29:58.755Z        INFO    cnsregistervolume/cnsregistervolume_controller.go:573   PVC: pop-pvc already exists
2025-08-13T14:29:58.755Z        INFO    cnsregistervolume/cnsregistervolume_controller.go:602   PVC pop-pvc in namespace test-ns has valid DataSourceRef with apiGroup: vmoperator.vmware.com, kind: VirtualMachine, name: my-vm-1
2025-08-13T14:30:07.624Z        INFO    cnsregistervolume/cnsregistervolume_controller.go:638   PVC: pop-pvc is bound
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add validation for DataSourceRef in an existing PVC for CnsRegisterVolume.
```
