### PR TITLE
WIP: Use watch instead of poll to check PVC/VolumeSnapshot deletion

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -652,7 +652,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		}
 
 		// Wait for PVC to be deleted from supervisor cluster
-		err = common.WaitForPVCDeleted(ctx, c.supervisorClient,
+		err = common.WaitForPVCDeletedWithWatch(ctx, c.supervisorClient,
 			req.VolumeId, c.supervisorNamespace,
 			time.Duration(getProvisionTimeoutInMin(ctx))*time.Minute)
 		if err != nil {
@@ -1831,7 +1831,7 @@ func (c *controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshot
 		}
 
 		// Wait for VolumeSnapshot to be deleted from supervisor cluster
-		err = common.WaitForVolumeSnapshotDeleted(ctx, c.supervisorSnapshotterClient,
+		err = common.WaitForVolumeSnapshotDeletedWithWatch(ctx, c.supervisorSnapshotterClient,
 			supervisorVolumeSnapshotName, c.supervisorNamespace,
 			time.Duration(getSnapshotTimeoutInMin(ctx))*time.Minute)
 		if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/390/ (passed)
```
Build #390 (Sep 26, 2025, 7:25:17 AM)
xy036828 <br> PR 3453<br>
Ran 14 of 1835 Specs
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 1821 Skipped | 0 Flaked
```

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/430/ (running)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
