### PR TITLE
Update RBAC for K8s version 1.32 for volumesnapshots to allow namespace reconciler to watch volumesnapshots

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -98,7 +98,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list", "patch", "update" ]
+    verbs: [ "get", "list", "patch", "update", "watch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds missing RBAC permission needed for namespace reconciler to process finalizers on supervisor volumesnapshots created for guest cluster volumesnapshots for 1.32 K8s version. Original RBAC was added to older K8S versions as a part of PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3275

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
N/A for this PR.
The PR cannot be verified on the current pipeline infrastructure and the verification will be done while integrating with Supervsior

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update RBAC for K8s version 1.32 for volumesnapshots to allow namespace reconciler to watch volumesnapshots
```
