### PR TITLE
Add SPR labels to PVC if needed

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -560,7 +560,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	// Create PVC mapping to above created PV.
 	log.Infof("Creating PVC: %s", instance.Spec.PvcName)
 	pvcSpec, err := getPersistentVolumeClaimSpec(ctx, instance.Spec.PvcName, instance.Namespace, capacityInMb,
-		storageClassName, accessMode, pvName, datastoreAccessibleTopology)
+		storageClassName, accessMode, pvName, datastoreAccessibleTopology, instance)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to create spec for PVC: %q. Error: %v", instance.Spec.PvcName, err)
 		log.Errorf(msg)

--- a/pkg/syncer/cnsoperator/types/types.go
+++ b/pkg/syncer/cnsoperator/types/types.go
@@ -36,4 +36,9 @@ const (
 
 	// VSphereCSIDriverName is the vsphere CSI driver name
 	VSphereCSIDriverName = "csi.vsphere.vmware.com"
+
+	// Label that points to a VM name. This is added to CNSRegisterVolume CR and PVC.
+	LabelVirtualMachineName = "vm.consumer.storage.com/name"
+	// Label that points to a StoragePolicyReservation CR name. This is added to CNSRegisterVolume CR and PVC.
+	LabelStoragePolicyReservationName = "quota.storage.vmware.com/storagepolicyreservation-name"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR checks if the following labels are on CNSRegisterVolume. If so, they will be added to PVC created by the CNSRegisterVolume controller.
```
  labels:
    vm.consumer.storage.com/name: vm-1
    quota.storage.vmware.com/storagepolicyreservation-name: test-spr
```
This is part of StoragePolicyReservation feature. These labels tells the storage quota webhook that a PVC's quota is already reserved by StoragePolicyReservation as part of a VM.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/47/ (passed)


```
Build #250 (Aug 4, 2025, 10:44:38 AM)
xy036828 <br> PR 3463<br>
Ran 10 of 1080 Specs in 1216.675 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 1070 Skipped
PASS

Ginkgo ran 1 suite in 20m36.311746125s
Test Suite Passed
```

Manual Testing:
```
Created a PVC.

Changed persistentVolumeReclaimPolicy to Retain.
root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get pv pvc-87c313af-f653-4f18-9867-55d63093b212 -o yaml | grep persistentVolumeReclaimPolicy
  persistentVolumeReclaimPolicy: Retain

Deleted PVC and PV. The volumeHandle 4e577a4f-6667-4a34-94de-6c99e27b4564 should still be valid.

Enabled FSS.
root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get configmap csi-feature-states -n vmware-system-csi -o yaml | grep storage-policy-reservation-support
  storage-policy-reservation-support: "true"

Construct CNSRegisterVolume with labels using the above volumeHandle:
root@4212c70cc858f2019b374d2841863006 [ ~ ]# cat register.yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: static-volume
  namespace: test-ns
  labels:
    vm.consumer.storage.com/name: vm-1
    quota.storage.vmware.com/storagepolicyreservation-name: test-spr
spec:
  volumeID: 4e577a4f-6667-4a34-94de-6c99e27b4564
  accessMode: ReadWriteOnce
  pvcName: static-pvc

root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl create -f register.yaml
cnsregistervolume.cns.vmware.com/static-volume created

root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get pvc -n test-ns
NAME         STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
static-pvc   Bound    static-pv-4e577a4f-6667-4a34-94de-6c99e27b4564   1Gi        RWO            wcpglobal-storage-profile   <unset>                 7s

PVC created by CNSRegisterVolume with labels.

root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get pvc static-pvc -n test-ns -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"domain-c38"}]'
    pv.kubernetes.io/bind-completed: "yes"
  creationTimestamp: "2025-08-04T18:30:35Z"
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    quota.storage.vmware.com/storagepolicyreservation-name: test-spr <<== label added
    vm.consumer.storage.com/name: vm-1 <<== label added
  name: static-pvc
  namespace: test-ns
  resourceVersion: "5149325"
  uid: 44783475-f7ac-462a-bf12-28aa8b281016
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: wcpglobal-storage-profile
  volumeMode: Filesystem
  volumeName: static-pv-4e577a4f-6667-4a34-94de-6c99e27b4564
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound

Disabled FSS.
root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get configmap csi-feature-states -n vmware-system-csi -o yaml | grep storage-policy-reservation-support
  storage-policy-reservation-support: "false"

Create CNSRegisterVolume with labels again. This time the labels are not added to the PVCs because FSS is disabled.
root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl create -f register.yaml
cnsregistervolume.cns.vmware.com/static-volume created

root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get pvc -n test-ns
NAME         STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
static-pvc   Bound    static-pv-4e577a4f-6667-4a34-94de-6c99e27b4564   1Gi        RWO            wcpglobal-storage-profile   <unset>                 4s

root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get pvc -n test-ns -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"domain-c38"}]'
      pv.kubernetes.io/bind-completed: "yes"
    creationTimestamp: "2025-08-05T01:52:52Z"
    finalizers:
    - kubernetes.io/pvc-protection
    name: static-pvc
    namespace: test-ns
    resourceVersion: "5405768"
    uid: c1596a2f-de76-439a-838e-b7f83839e779
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: wcpglobal-storage-profile
    volumeMode: Filesystem
    volumeName: static-pv-4e577a4f-6667-4a34-94de-6c99e27b4564
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
```

Unit tests passed:
```
xy036828broadcom.net@KWH0FXLFYR cnsregistervolume % go test -run TestCnsRegisterVolumeController
Running Suite: CnsRegisterVolumeController Suite - /Users/xy036828broadcom.net/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsregistervolume
=======================================================================================================================================================================================
Random Seed: 1754339403

Will run 4 of 4 specs
......
Ran 4 of 4 Specs in 0.004 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume	0.463s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add StoragePolicyReservation label and VM label to PVC if they are on CNSRegisterVolume.
```
