### PR TITLE
Add WCP capability read support for LinkedClone support

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -566,7 +566,6 @@ data:
   "WCP_VMService_BYOK": "true"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
-  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -571,7 +571,6 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
-  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -571,7 +571,6 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
-  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -569,7 +569,6 @@ data:
   "WCP_VMService_BYOK": "true"
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
-  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1096,10 +1096,10 @@ func (c *K8sOrchestrator) GetAllK8sVolumes() []string {
 	return volumeIDs
 }
 
-// HandleEnablementOfWLDICapability starts a ticker and checks after every 2 minutes if
-// Workload_Domain_Isolation_Supported capability is enabled in capabilities CR or not.
+// HandleLateEnablementOfCapability starts a ticker and checks after every 2 minutes if
+// Workload_Domain_Isolation_Supported, supports_FCD_linked_clone capability is enabled in capabilities CR or not.
 // If this capability was disabled and now got enabled, then container will be restarted.
-func HandleEnablementOfWLDICapability(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
+func HandleLateEnablementOfCapability(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 	gcEndpoint, gcPort string) {
 	log := logger.GetLogger(ctx)
 	var restClientConfig *restclient.Config
@@ -1161,11 +1161,12 @@ func HandleEnablementOfWLDICapability(ctx context.Context, clusterFlavor cnstype
 		}
 		log.Debugf("WCP cluster capabilities map - %+v", WcpCapabilitiesMap)
 
-		fssVal := WcpCapabilitiesMap[common.WorkloadDomainIsolation]
-		if fssVal {
-			log.Infof("%s capability has been enabled in capabilities CR %s. "+
-				"Restarting the container as capability has changed from false to true.",
-				common.WorkloadDomainIsolation, common.WCPCapabilitiesCRName)
+		lcFssVal := WcpCapabilitiesMap[common.LinkedCloneSupport]
+		wldiFssVal := WcpCapabilitiesMap[common.WorkloadDomainIsolation]
+		if wldiFssVal || lcFssVal {
+			log.Infof("WorkloadDomainIsolation capability state: %t, LinkedCloneSupport capability state: %t"+
+				" has changed in capabilities CR %s. Restarting the container as capability has changed.",
+				wldiFssVal, lcFssVal, common.WCPCapabilitiesCRName)
 			os.Exit(1)
 		}
 	}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -455,7 +455,9 @@ const (
 	// snapshots on different datastores feature is supported in CSI.
 	VolFromSnapshotOnTargetDs = "supports_vol_from_snapshot_on_target_ds"
 	// LinkedCloneSupport is an FSS that tells whether LinkedClone feature is supported in CSI.
-	LinkedCloneSupport = "linked-clone-support"
+	LinkedCloneSupport = "supports_FCD_linked_clone"
+	// LinkedCloneSupportFSS is an FSS for LinkedClone support in pvcsi
+	LinkedCloneSupportFSS = "linked-clone-support"
 )
 
 var WCPFeatureStates = map[string]struct{}{
@@ -464,6 +466,7 @@ var WCPFeatureStates = map[string]struct{}{
 	WorkloadDomainIsolation:    {},
 	VPCCapabilitySupervisor:    {},
 	VolFromSnapshotOnTargetDs:  {},
+	LinkedCloneSupport:         {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
@@ -472,6 +475,7 @@ var WCPFeatureStates = map[string]struct{}{
 // it will re-fetch the configmap and update the cached configmap.
 var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 	WorkloadDomainIsolation: {},
+	LinkedCloneSupport:      {},
 }
 
 // WCPFeatureAssociatedWithPVCSI contains FSS name used in PVCSI and associated WCP Capability name on a
@@ -480,4 +484,5 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 // or not on the supervisor cluster to decide if effective value of this FSS is enabled or disabled.
 var WCPFeatureStateAssociatedWithPVCSI = map[string]string{
 	WorkloadDomainIsolationFSS: WorkloadDomainIsolation,
+	LinkedCloneSupportFSS:      LinkedCloneSupport,
 }

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -155,8 +155,10 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 	// some init() function which can initialize required things when capability value changes from false to true.
 	isWorkloadDomainIsolationSupported := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.WorkloadDomainIsolationFSS)
-	if !isWorkloadDomainIsolationSupported {
-		go k8sorchestrator.HandleEnablementOfWLDICapability(ctx, cnstypes.CnsClusterFlavorGuest,
+	isLinkedCloneSupported := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.LinkedCloneSupportFSS)
+	if !isWorkloadDomainIsolationSupported || !isLinkedCloneSupported {
+		go k8sorchestrator.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 			config.GC.Endpoint, config.GC.Port)
 	}
 	if isWorkloadDomainIsolationSupported {
@@ -352,7 +354,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			}
 		}
 
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupport) {
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS) {
 			// Check if this is a LinkedClone request
 			isLinkedCloneRequest, err = commonco.ContainerOrchestratorUtility.IsLinkedCloneRequest(ctx, pvcName, pvcNamespace)
 			if err != nil {
@@ -408,7 +410,8 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					finalizers = append(finalizers, cnsoperatortypes.CNSVolumeFinalizer)
 				}
 
-				if isLinkedCloneRequest && commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupport) {
+				if isLinkedCloneRequest && commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+					common.LinkedCloneSupportFSS) {
 					labels[common.LinkedClonePVCLabel] = "true"
 				}
 				claim := getPersistentVolumeClaimSpecWithStorageClass(supervisorPVCName, c.supervisorNamespace,

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -300,8 +300,8 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		// capability value changes from false to true.
 		IsWorkloadDomainIsolationSupported = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.WorkloadDomainIsolation)
-		if !IsWorkloadDomainIsolationSupported {
-			go k8sorchestrator.HandleEnablementOfWLDICapability(ctx, clusterFlavor, "", "")
+		if !IsWorkloadDomainIsolationSupported || !IsLinkedCloneSupportFSSEnabled {
+			go k8sorchestrator.HandleLateEnablementOfCapability(ctx, clusterFlavor, "", "")
 		}
 		if IsWorkloadDomainIsolationSupported {
 			volumeTopologyService, err = commonco.ContainerOrchestratorUtility.InitTopologyServiceInController(ctx)
@@ -321,8 +321,9 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		// workload-isolation-domain feature we are restarting the container when capability changes dynamically from
 		// false to true, but for other features instead of restarting CSI container, if possible we can implement
 		// some init() function which can initialize required things when capability value changes from false to true.
-		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) {
-			go k8sorchestrator.HandleEnablementOfWLDICapability(ctx, clusterFlavor,
+		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
+			!commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS) {
+			go k8sorchestrator.HandleLateEnablementOfCapability(ctx, clusterFlavor,
 				metadataSyncer.configInfo.Cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Change to support reading WCP capability for CSI LinkedClone support

- Read wcp capability CR when determining fss state
- Add support on pvcsi as well.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin-label/25/

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
