### PR TITLE
Add WCP capability read support for LinkedClone support

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -566,7 +566,6 @@ data:
   "WCP_VMService_BYOK": "true"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
-  "linked-clone-support": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -574,7 +574,6 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
-  "linked-clone-support": "false"
   "storage-policy-reservation-support": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -574,7 +574,6 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
   "csi-transaction-support": "false"
-  "linked-clone-support": "false"
   "storage-policy-reservation-support": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -572,7 +572,6 @@ data:
   "WCP_VMService_BYOK": "true"
   "sv-pvc-snapshot-protection-finalizer": "false"
   "file-volume-with-vm-service": "false"
-  "linked-clone-support": "false"
   "storage-policy-reservation-support": "false"
 kind: ConfigMap
 metadata:

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1096,10 +1096,10 @@ func (c *K8sOrchestrator) GetAllK8sVolumes() []string {
 	return volumeIDs
 }
 
-// HandleEnablementOfWLDICapability starts a ticker and checks after every 2 minutes if
-// Workload_Domain_Isolation_Supported capability is enabled in capabilities CR or not.
+// HandleLateEnablementOfCapability starts a ticker and checks after every 2 minutes if
+// capability is enabled in capabilities CR or not.
 // If this capability was disabled and now got enabled, then container will be restarted.
-func HandleEnablementOfWLDICapability(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
+func HandleLateEnablementOfCapability(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, capability,
 	gcEndpoint, gcPort string) {
 	log := logger.GetLogger(ctx)
 	var restClientConfig *restclient.Config
@@ -1160,12 +1160,9 @@ func HandleEnablementOfWLDICapability(ctx context.Context, clusterFlavor cnstype
 			os.Exit(1)
 		}
 		log.Debugf("WCP cluster capabilities map - %+v", WcpCapabilitiesMap)
-
-		fssVal := WcpCapabilitiesMap[common.WorkloadDomainIsolation]
-		if fssVal {
-			log.Infof("%s capability has been enabled in capabilities CR %s. "+
-				"Restarting the container as capability has changed from false to true.",
-				common.WorkloadDomainIsolation, common.WCPCapabilitiesCRName)
+		if capVal, ok := WcpCapabilitiesMap[capability]; ok && capVal {
+			log.Infof("Capability %s changed state to %t in capabilities CR %s. "+
+				"Restarting the container as capability has changed.", capability, capVal, common.WCPCapabilitiesCRName)
 			os.Exit(1)
 		}
 	}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -454,10 +454,12 @@ const (
 	// VolFromSnapshotOnTargetDs is a FSS that tells whether creation of volumes from
 	// snapshots on different datastores feature is supported in CSI.
 	VolFromSnapshotOnTargetDs = "supports_vol_from_snapshot_on_target_ds"
-	// LinkedCloneSupport is an FSS that tells whether LinkedClone feature is supported in CSI.
-	LinkedCloneSupport = "linked-clone-support"
 	// StoragePolicyReservationSupport is FSS that tells whether StoragePolicyReservation is supported in CSI
 	StoragePolicyReservationSupport = "storage-policy-reservation-support"
+	// LinkedCloneSupport is an FSS that tells whether LinkedClone feature is supported in CSI.
+	LinkedCloneSupport = "supports_FCD_linked_clone"
+	// LinkedCloneSupportFSS is an FSS for LinkedClone support in pvcsi
+	LinkedCloneSupportFSS = "linked-clone-support"
 )
 
 var WCPFeatureStates = map[string]struct{}{
@@ -467,6 +469,7 @@ var WCPFeatureStates = map[string]struct{}{
 	VPCCapabilitySupervisor:    {},
 	VolFromSnapshotOnTargetDs:  {},
 	SharedDiskFss:              {},
+	LinkedCloneSupport:         {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
@@ -475,6 +478,7 @@ var WCPFeatureStates = map[string]struct{}{
 // it will re-fetch the configmap and update the cached configmap.
 var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 	WorkloadDomainIsolation: {},
+	LinkedCloneSupport:      {},
 }
 
 // WCPFeatureAssociatedWithPVCSI contains FSS name used in PVCSI and associated WCP Capability name on a
@@ -483,4 +487,5 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 // or not on the supervisor cluster to decide if effective value of this FSS is enabled or disabled.
 var WCPFeatureStateAssociatedWithPVCSI = map[string]string{
 	WorkloadDomainIsolationFSS: WorkloadDomainIsolation,
+	LinkedCloneSupportFSS:      LinkedCloneSupport,
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Change to support reading WCP capability for CSI LinkedClone support

- Read wcp capability CR when determining fss state
- Add support on pvcsi as well.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin-label/25/

**Manual Testing**:
```
1. Initially the vc fss is explicitly disabled
root@lvn-dvm-10-162-68-11 [ ~ ]# feature-state-util -s FCD_LINKED_CLONE_SUPPORT
disabled

2. Check the capability

root@422cd818952014e7699da683c0e0a814 [ ~ ]# kubectl get capabilities supervisor-capabilities -oyaml
    supports_FCD_linked_clone:
      activated: false

3. Deployment after replacements:

root@422cd818952014e7699da683c0e0a814 [ ~ ]# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-69778d59db-zjtx9   7/7     Running   0          2m33s
vsphere-csi-webhook-d7d7f798d-l2srn       1/1     Running   0          5d16h

4. Enable FSS

root@lvn-dvm-10-162-68-11 [ ~ ]# feature-state-util -e FCD_LINKED_CLONE_SUPPORT
Successfully changed feature state

5. Restart WCP

root@lvn-dvm-10-162-68-11 [ ~ ]# service-control --restart wcp
Successfully restarted service wcp
root@lvn-dvm-10-162-68-11 [ ~ ]# service-control --status wcp
Running:
 wcp


 6. Verify activated


kubectl get capabilities supervisor-capabilities
     supports_FCD_linked_clone:
      activated: true


7. Check pod restarts

root@422cd818952014e7699da683c0e0a814 [ ~ ]# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-69778d59db-zjtx9   7/7     Running   3 (37s ago)   58m
vsphere-csi-webhook-569464dc66-dhh8c      1/1     Running   0             37m


syncer restarted:
kubectl -n vmware-system-csi logs vsphere-csi-controller-69778d59db-zjtx9 -c vsphere-syncer -p|less
{"level":"info","time":"2025-08-07T07:18:40.298014634Z","caller":"k8sorchestrator/k8sorchestrator.go:1164","msg":"Capability supports_FCD_linked_clone changed state to true in capabilities CR supervisor-capabilities. Restarting the container as capability has changed.","TraceId":"b9af7feb-3d0a-4ec6-a77c-ef5562414b1b"}

csi webhook restarted:
2025-08-07T07:19:47.860Z        INFO    k8sorchestrator/k8sorchestrator.go:1164 Capability supports_FCD_linked_clone changed state to true in capabilities CR supervisor-capabilities. Restarting the container as capability has changed.     {"TraceId": "9554e407-c096-4535-bcf8-f7af2e910f7f"}

Note: controller does not restart since there is a live check on the capability each time.

8. Create LinkedClone


root@422cd818952014e7699da683c0e0a814 [ ~ ]# kubectl get pvc -n testns
NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
src-pvc   Bound    pvc-403aae59-35e0-4067-8098-241edf8878c5   1Gi        RWO            wcpglobal-storage-profile   <unset>                 64s
root@422cd818952014e7699da683c0e0a814 [ ~ ]# kubectl get vs -n testns
NAME   READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
vs-2   true         src-pvc                             1Gi           volumesnapshotclass-delete   snapcontent-15ef24ff-25aa-49c2-bc15-d44b9383dfe2   40s            37s


root@422cd818952014e7699da683c0e0a814 [ ~ ]# cat lc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
     csi.vsphere.volume/fast-provisioning : "true"
  name: vs1-lc-1
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  dataSource:
    name: vs-2
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  storageClassName: wcpglobal-storage-profile

root@422cd818952014e7699da683c0e0a814 [ ~ ]# kubectl get pvc -n testns
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
src-pvc    Bound    pvc-403aae59-35e0-4067-8098-241edf8878c5   1Gi        RWO            wcpglobal-storage-profile   <unset>                 3m13s
vs1-lc-1   Bound    pvc-9402c0ee-e0f8-4691-ae09-dfb23c909d3b   1Gi        RWO            wcpglobal-storage-profile   <unset>                 15s

```



**Special notes for your reviewer**:

**Release note**:
```release-note
None
```