### PR TITLE
Improve RWX volumes with VM service VMs performace during webhook validation

### DIFF
--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -38,6 +38,8 @@ const (
 	DefaultWebhookPort               = 9883
 	DefaultWebhookMetricsBindAddress = "0"
 	devopsUserLabelKey               = "cns.vmware.com/user-created"
+	vmNameLabelKey                   = "cns.vmware.com/vm-name"
+	pvcNameLabelKey                  = "cns.vmware.com/pvc-name"
 )
 
 var (
@@ -268,11 +270,14 @@ func (h *CSISupervisorMutationWebhook) mutateNewCnsFileAccessConfig(ctx context.
 	if newCnsFileAccessConfig.Labels == nil {
 		newCnsFileAccessConfig.Labels = make(map[string]string)
 	}
-	if _, ok := newCnsFileAccessConfig.Labels[devopsUserLabelKey]; ok {
-		log.Debugf("Devops label already present on instance %s", newCnsFileAccessConfig.Name)
-		return admission.Allowed("")
-	}
+
+	// Add VM name and PVC name label.
+	// If someone created this CR with these labels already present, CSI will overrite on them
+	// with the correct values.
 	newCnsFileAccessConfig.Labels[devopsUserLabelKey] = "true"
+	newCnsFileAccessConfig.Labels[vmNameLabelKey] = newCnsFileAccessConfig.Spec.VMName
+	newCnsFileAccessConfig.Labels[pvcNameLabelKey] = newCnsFileAccessConfig.Spec.PvcName
+
 	newRawCnsFileAccessConfig, err := json.Marshal(newCnsFileAccessConfig)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller_test.go
@@ -1,0 +1,93 @@
+package cnsfileaccessconfig
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateVmAndPvc(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	_ = vmoperatorv1alpha4.AddToScheme(scheme)
+
+	ctx := context.TODO()
+
+	tests := []struct {
+		name           string
+		instanceLabels map[string]string
+		vmLabels       map[string]string
+		expectError    bool
+		setupPVC       bool
+	}{
+		{
+			name:           "no instance labels",
+			instanceLabels: nil,
+			expectError:    false,
+		},
+		{
+			name: "labels but not devops user",
+			instanceLabels: map[string]string{
+				"random": "value",
+			},
+			expectError: false,
+		},
+		{
+			name: "devops user with capv label on VM",
+			instanceLabels: map[string]string{
+				devopsUserLabelKey: "true",
+			},
+			vmLabels: map[string]string{
+				capvVmLabelKey + "/cluster": "my-cluster",
+			},
+			expectError: true,
+		},
+		{
+			name: "valid input - no errors",
+			instanceLabels: map[string]string{
+				devopsUserLabelKey: "true",
+			},
+			setupPVC:    true,
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var objects []runtime.Object
+
+			vm := &vmoperatorv1alpha4.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "my-vm",
+					Labels: test.vmLabels,
+				},
+			}
+
+			if test.setupPVC {
+				pvc := &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pvc",
+						Namespace: "default",
+					},
+				}
+				objects = append(objects, pvc)
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+			err := validateVmAndPvc(ctx, test.instanceLabels, "my-instance", "my-pvc", "default", client, vm)
+
+			if test.expectError && err == nil {
+				t.Errorf("expected error but got nil")
+			} else if !test.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Due to the validation being done in webhook, the CPU performance has degraded quite a bit.

To improve this we can do these 2 things:
1. Do CREATE validation only for user created CRs.
2. In mutating webhook, add VM name and PVC in the label so that while listing all CRs in the namespace, only the ones with same VM and PVC can be listed.
3. During CnsFileAccessConfig CR reconciliation, ensure that VM and PVC are not TKG if devops user label is present.

**Testing done**:

### Created by PVCSI:

No lables got added.

```
Name:         test-cluster-e2e-script-node-pool-1-b7x5r-vhclw-nf4tm-a6382d7a-f6d0-40c7-94c0-0fe894387de8-10e6cccf-ae34-492e-8ff1-4f8c673130a3
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2025-08-19T06:16:30Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Owner References:
    API Version:           vmoperator.vmware.com/v1alpha4
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  VirtualMachine
    Name:                  test-cluster-e2e-script-node-pool-1-b7x5r-vhclw-nf4tm
    UID:                   432ec2ff-fb2f-46e1-a44c-7adf001c88a8
  Resource Version:        593725
  UID:                     129d6e47-681b-4bf6-8263-b8011c92d7cc
Spec:
  Pvc Name:  a6382d7a-f6d0-40c7-94c0-0fe894387de8-10e6cccf-ae34-492e-8ff1-4f8c673130a3
  Vm Name:   test-cluster-e2e-script-node-pool-1-b7x5r-vhclw-nf4tm
Status:
  Access Points:
    NFSv3:    host13.cibgst.com:/52ff84e8-92d5-3b0d-757a-d316c4d11331
    NFSv4.1:  host10.cibgst.com:/vsanfs/52ff84e8-92d5-3b0d-757a-d316c4d11331
  Done:       true
Events:
  Type    Reason                        Age   From            Message
  ----    ------                        ----  ----            -------
  Normal  CnsFileAccessConfigSucceeded  12m   cns.vmware.com  Successfully configured access points of VM: "test-cluster-e2e-script-node-pool-1-b7x5r-vhclw-nf4tm" on the volume: "a6382d7a-f6d0-40c7-94c0-0fe894387de8-10e6cccf-ae34-492e-8ff1-4f8c673130a3"
```

### Created by devops user - valid:
Labels got added.

```
Name:         rwm-vm-1
Namespace:    test
Labels:       cns.vmware.com/pvc-name=rwm-pvc
              cns.vmware.com/user-created=true
              cns.vmware.com/vm-name=vm-2
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2025-08-19T06:22:19Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Owner References:
    API Version:           vmoperator.vmware.com/v1alpha4
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  VirtualMachine
    Name:                  vm-2
    UID:                   03db7e56-22c7-4c39-9aee-494314aa35aa
  Resource Version:        597322
  UID:                     f9a8dc52-c427-4930-b8af-8679914b6ccb
Spec:
  Pvc Name:  rwm-pvc
  Vm Name:   vm-2
Status:
  Access Points:
    NFSv3:    host11.cibgst.com:/52b606f8-0b4d-0952-81ec-56c6233ddafa
    NFSv4.1:  host10.cibgst.com:/vsanfs/52b606f8-0b4d-0952-81ec-56c6233ddafa
  Done:       true
Events:
  Type    Reason                        Age   From            Message
  ----    ------                        ----  ----            -------
  Normal  CnsFileAccessConfigSucceeded  8m6s  cns.vmware.com  Successfully configured access points of VM: "vm-2" on the volume: "rwm-pvc"
```
Tried to created another CR with different name but same VM and PVC:

Error from server: error when creating "cfc.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: CnsFileAccessConfig rwm-vm-1 already exists for VM vm-2 and PVC rwm-pvc.
Deleted the CR successfully.

### Created by devops user with TKG VM:

Labels got added but failure observed during ACL configuration.
```
Name:         tkg-rwm-vm-1
Namespace:    test-gc-e2e-demo-ns
Labels:       cns.vmware.com/pvc-name=test-example-vanilla-file-pvc
              cns.vmware.com/user-created=true
              cns.vmware.com/vm-name=test-cluster-e2e-script-node-pool-1-b7x5r-vhclw-nf4tm
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2025-08-19T06:29:12Z
  Generation:          2
  Resource Version:    601559
  UID:                 157755ea-252b-4797-b135-abcdb826ad30
Spec:
  Pvc Name:  test-example-vanilla-file-pvc
  Vm Name:   test-cluster-e2e-script-node-pool-1-b7x5r-vhclw-nf4tm
Status:
  Error:  CnsFileAccessConfig is created by devops user and has TKG VM test-cluster-e2e-script-node-pool-1-b7x5r-vhclw-nf4tm. Invalid combination.
Events:
  Type     Reason                     Age                From            Message
  ----     ------                     ----               ----            -------
  Warning  CnsFileAccessConfigFailed  15s (x5 over 29s)  cns.vmware.com  CnsFileAccessConfig is created by devops user and has TKG VM test-cluster-e2e-script-node-pool-1-b7x5r-vhclw-nf4tm. Invalid combination.
```

Successful VKS pipline: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3472#issuecomment-3199771233
WPC precheckin pipeline: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3472#issuecomment-3199603730  failure is due to bug: 3560225 - unrelated to this change.