### PR TITLE
Code fix for reading storage policy name for vm service vm regression suite

### DIFF
--- a/tests/e2e/snapshot_vmservice_vm.go
+++ b/tests/e2e/snapshot_vmservice_vm.go
@@ -56,7 +56,6 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 		client                     clientset.Interface
 		namespace                  string
 		datastoreURL               string
-		storagePolicyName          string
 		storageClassName           string
 		storageProfileId           string
 		vcRestSessionId            string
@@ -91,16 +90,13 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 			if !(len(nodeList.Items) > 0) {
 				framework.Failf("Unable to find ready and schedulable Node")
 			}
-			storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
+			storageClassName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 		} else {
-			storagePolicyName = GetAndExpectStringEnvVar(envZonalStoragePolicyName)
+			storageClassName = GetAndExpectStringEnvVar(envZonalStoragePolicyName)
 		}
 
 		// creating vc session
 		vcRestSessionId = createVcSession4RestApis(ctx)
-
-		// reading storage class name for wcp setup "wcpglobal_storage_profile"
-		storageClassName = strings.ReplaceAll(storagePolicyName, "_", "-") // since this is a wcp setup
 
 		// fetching shared datastore url
 		datastoreURL = GetAndExpectStringEnvVar(envSharedDatastoreURL)
@@ -110,7 +106,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 		framework.Logf("dsmoId: %v", dsRef.Value)
 
 		// reading storage profile id of "wcpglobal_storage_profile"
-		storageProfileId = e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+		storageProfileId = e2eVSphere.GetSpbmPolicyID(storageClassName)
 
 		// creating/reading content library
 		contentLibId, err := createAndOrGetContentlibId4Url(vcRestSessionId, GetAndExpectStringEnvVar(envContentLibraryUrl),

--- a/tests/e2e/vmservice_vm.go
+++ b/tests/e2e/vmservice_vm.go
@@ -54,7 +54,6 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		client                     clientset.Interface
 		namespace                  string
 		datastoreURL               string
-		storagePolicyName          string
 		storageClassName           string
 		storageProfileId           string
 		vcRestSessionId            string
@@ -80,9 +79,9 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 			if !(len(nodeList.Items) > 0) {
 				framework.Failf("Unable to find ready and schedulable Node")
 			}
-			storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
+			storageClassName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 		} else {
-			storagePolicyName = GetAndExpectStringEnvVar(envZonalStoragePolicyName)
+			storageClassName = GetAndExpectStringEnvVar(envZonalStoragePolicyName)
 		}
 		bootstrap()
 		isVsanHealthServiceStopped = false
@@ -90,13 +89,11 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 
 		vcRestSessionId = createVcSession4RestApis(ctx)
 
-		storageClassName = strings.ReplaceAll(storagePolicyName, "_", "-") // since this is a wcp setup
-
 		datastoreURL = GetAndExpectStringEnvVar(envSharedDatastoreURL)
 		dsRef := getDsMoRefFromURL(ctx, datastoreURL)
 		framework.Logf("dsmoId: %v", dsRef.Value)
 
-		storageProfileId = e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+		storageProfileId = e2eVSphere.GetSpbmPolicyID(storageClassName)
 		contentLibId, err := createAndOrGetContentlibId4Url(vcRestSessionId, GetAndExpectStringEnvVar(envContentLibraryUrl),
 			dsRef.Value)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1422,8 +1419,8 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		framework.Logf("pvc name :%s", pvcName)
 
 		ginkgo.By("Get storage Policy")
-		ginkgo.By(fmt.Sprintf("storagePolicyName: %s", storagePolicyName))
-		profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+		ginkgo.By(fmt.Sprintf("storagePolicyName: %s", storageClassName))
+		profileID := e2eVSphere.GetSpbmPolicyID(storageClassName)
 		framework.Logf("Profile ID :%s", profileID)
 		scParameters := make(map[string]string)
 		scParameters["storagePolicyID"] = profileID


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing storage policy name for vm service vm regression suite

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Changing storage policy name for vm service vm regression suite

**Testing done**:
Yes
[testlogs.txt](https://github.com/user-attachments/files/21677853/testlogs.txt)

