### PR TITLE
Fix a problem populating topology segments to datastores map for create volume from snapshot

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -63,6 +63,32 @@ import (
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
+// DatastoreRetriever interface abstracts vSphere datastore operations for testability
+type DatastoreRetriever interface {
+	// GetCandidateDatastoresInCluster retrieves candidate datastores for a specific cluster
+	GetCandidateDatastoresInCluster(ctx context.Context, vc *cnsvsphere.VirtualCenter, clusterID string,
+		includeVSANDirect bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error)
+	// GetSharedDatastoresInClusters retrieves shared datastores across multiple clusters
+	GetSharedDatastoresInClusters(ctx context.Context, clusterMorefs []string,
+		vc *cnsvsphere.VirtualCenter) ([]*cnsvsphere.DatastoreInfo, error)
+}
+
+// VSphereDatastoreRetriever implements DatastoreRetriever using real vSphere operations
+type VSphereDatastoreRetriever struct{}
+
+// GetCandidateDatastoresInCluster implements DatastoreRetriever interface
+func (v *VSphereDatastoreRetriever) GetCandidateDatastoresInCluster(ctx context.Context,
+	vc *cnsvsphere.VirtualCenter, clusterID string, includeVSANDirect bool) ([]*cnsvsphere.DatastoreInfo,
+	[]*cnsvsphere.DatastoreInfo, error) {
+	return cnsvsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterID, includeVSANDirect)
+}
+
+// GetSharedDatastoresInClusters implements DatastoreRetriever interface
+func (v *VSphereDatastoreRetriever) GetSharedDatastoresInClusters(ctx context.Context,
+	clusterMorefs []string, vc *cnsvsphere.VirtualCenter) ([]*cnsvsphere.DatastoreInfo, error) {
+	return getSharedDatastoresInClusters(ctx, clusterMorefs, vc)
+}
+
 var (
 	// controllerVolumeTopologyInstance is a singleton instance of controllerVolumeTopology
 	// created for vanilla flavor.
@@ -164,6 +190,8 @@ type wcpControllerVolumeTopology struct {
 	k8sConfig *restclient.Config
 	// azInformer is an informer instance on the AvailabilityZone custom resource.
 	azInformer cache.SharedIndexInformer
+	// datastoreRetriever provides abstraction for vSphere datastore operations
+	datastoreRetriever DatastoreRetriever
 }
 
 // InitTopologyServiceInController returns a singleton implementation of the
@@ -279,8 +307,9 @@ func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
 					return nil, err
 				}
 				wcpControllerVolumeTopologyInstance = &wcpControllerVolumeTopology{
-					k8sConfig:  config,
-					azInformer: *azInformer,
+					k8sConfig:          config,
+					azInformer:         *azInformer,
+					datastoreRetriever: &VSphereDatastoreRetriever{},
 				}
 			}
 		} else {
@@ -1504,7 +1533,8 @@ func (volTopology *wcpControllerVolumeTopology) GetSharedDatastoresInTopology(ct
 		// Call GetCandidateDatastores for each cluster moref. Ignore the vsanDirectDatastores for now.
 		if !isPodVMOnStretchedSupervisorEnabled {
 			// This code block assume we have 1 Cluster Per AZ
-			accessibleDs, _, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, params.Vc, clusterMorefs[0], false)
+			accessibleDs, _, err := volTopology.datastoreRetriever.GetCandidateDatastoresInCluster(ctx,
+				params.Vc, clusterMorefs[0], false)
 			if err != nil {
 				return nil, logger.LogNewErrorf(log,
 					"failed to find candidate datastores to place volume in cluster %q. Error: %v",
@@ -1512,16 +1542,23 @@ func (volTopology *wcpControllerVolumeTopology) GetSharedDatastoresInTopology(ct
 			}
 			params.TopoSegToDatastoresMap[zone] = accessibleDs
 			sharedDatastores = append(sharedDatastores, accessibleDs...)
+			log.Debugf("PodVMOnStretchedSupervisor Not Enabled. Topology: %+v, Zone: %s, "+
+				"Topology Segments to Datastore Map: %+v, Datastores: %v",
+				params.TopologyRequirement, zone, params.TopoSegToDatastoresMap, sharedDatastores)
 		} else {
 			// This code block adds support for multiple vSphere Clusters Per AZ
 			// sharedDatastores will be calculated for all clusters within AZ
-			sharedDatastoresForclusterMorefs, err := getSharedDatastoresInClusters(ctx, clusterMorefs, params.Vc)
+			sharedDatastoresForclusterMorefs, err := volTopology.datastoreRetriever.GetSharedDatastoresInClusters(ctx,
+				clusterMorefs, params.Vc)
 			if err != nil {
 				return nil, logger.LogNewErrorf(log, "failed to get shared datastores "+
 					"for clusters: %v, err: %v", clusterMorefs, err)
 			}
 			params.TopoSegToDatastoresMap[zone] = sharedDatastoresForclusterMorefs
 			sharedDatastores = append(sharedDatastores, sharedDatastoresForclusterMorefs...)
+			log.Debugf("PodVMOnStretchedSupervisor Enabled. Topology: %+v, Zone: %s, "+
+				"Topology Segments to Datastore Map: %+v, Datastores: %v",
+				params.TopologyRequirement, zone, params.TopoSegToDatastoresMap, sharedDatastores)
 		}
 	}
 	log.Infof("Shared datastores %v for topologyRequirement: %+v", sharedDatastores,

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology_wcp_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology_wcp_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sorchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	v1 "k8s.io/api/core/v1"
+
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
+)
+
+// MockDatastoreRetriever implements DatastoreRetriever interface for testing
+type MockDatastoreRetriever struct {
+	// ClusterDatastores maps cluster IDs to their available datastores
+	ClusterDatastores map[string][]*cnsvsphere.DatastoreInfo
+}
+
+// GetCandidateDatastoresInCluster implements DatastoreRetriever interface for testing
+func (m *MockDatastoreRetriever) GetCandidateDatastoresInCluster(
+	ctx context.Context,
+	vc *cnsvsphere.VirtualCenter,
+	clusterID string,
+	includeVSANDirect bool,
+) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+	if datastores, exists := m.ClusterDatastores[clusterID]; exists {
+		return datastores, nil, nil
+	}
+	return nil, nil, nil
+}
+
+// GetSharedDatastoresInClusters implements DatastoreRetriever interface for testing
+func (m *MockDatastoreRetriever) GetSharedDatastoresInClusters(
+	ctx context.Context,
+	clusterMorefs []string,
+	vc *cnsvsphere.VirtualCenter,
+) ([]*cnsvsphere.DatastoreInfo, error) {
+	if len(clusterMorefs) == 0 {
+		return nil, nil
+	}
+
+	// Start with datastores from first cluster
+	var sharedDatastores []*cnsvsphere.DatastoreInfo
+	if firstClusterDatastores, exists := m.ClusterDatastores[clusterMorefs[0]]; exists {
+		sharedDatastores = append(sharedDatastores, firstClusterDatastores...)
+	}
+
+	// For each subsequent cluster, keep only datastores that are also in that cluster
+	for i := 1; i < len(clusterMorefs); i++ {
+		clusterID := clusterMorefs[i]
+		clusterDatastores, exists := m.ClusterDatastores[clusterID]
+		if !exists {
+			return []*cnsvsphere.DatastoreInfo{}, nil // No datastores for this cluster
+		}
+
+		var intersection []*cnsvsphere.DatastoreInfo
+		for _, sharedDS := range sharedDatastores {
+			for _, clusterDS := range clusterDatastores {
+				if sharedDS.Info.Url == clusterDS.Info.Url {
+					intersection = append(intersection, sharedDS)
+					break
+				}
+			}
+		}
+		sharedDatastores = intersection
+
+		// If no intersection found, return empty (not error for test purposes)
+		if len(sharedDatastores) == 0 {
+			return []*cnsvsphere.DatastoreInfo{}, nil
+		}
+	}
+
+	return sharedDatastores, nil
+}
+
+// Helper function to create datastore info for testing
+func createDatastoreInfo(name, url string) *cnsvsphere.DatastoreInfo {
+	return &cnsvsphere.DatastoreInfo{
+		Info: &vimtypes.DatastoreInfo{
+			Name: name,
+			Url:  url,
+		},
+	}
+}
+
+// Helper function to create topology requirement
+func createTopologyRequirement(zones []string) *csi.TopologyRequirement {
+	var preferred []*csi.Topology
+	for _, zone := range zones {
+		preferred = append(preferred, &csi.Topology{
+			Segments: map[string]string{
+				v1.LabelTopologyZone: zone,
+			},
+		})
+	}
+	return &csi.TopologyRequirement{
+		Preferred: preferred,
+	}
+}
+
+func TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test datastores
+	datastore114 := createDatastoreInfo("datastore-114", "ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/")
+	datastore204 := createDatastoreInfo("datastore-204", "ds:///vmfs/volumes/6f7b8796-8da795e6/")
+	datastore205 := createDatastoreInfo("datastore-205", "ds:///vmfs/volumes/d3cec85f-c18d869d/")
+	datastore203 := createDatastoreInfo("datastore-203", "ds:///vmfs/volumes/d1377884-6e1032bb/")
+
+	tests := []struct {
+		name                     string
+		isPodVMEnabled           bool
+		azClusterMap             map[string]string
+		azClustersMap            map[string][]string
+		clusterDatastores        map[string][]*cnsvsphere.DatastoreInfo
+		topologyRequirement      *csi.TopologyRequirement
+		expectedSharedDatastores []*cnsvsphere.DatastoreInfo
+		expectedTopoSegMap       map[string][]*cnsvsphere.DatastoreInfo
+		expectError              bool
+		expectedDatastores       *int // nil means use len(expectedSharedDatastores)
+		expectedZones            *int // nil means use len(expectedTopoSegMap)
+	}{
+		{
+			name:           "Single cluster per AZ - isPodVMOnStretchedSupervisorEnabled false",
+			isPodVMEnabled: false,
+			azClusterMap: map[string]string{
+				"zone-1": "domain-c117",
+				"zone-2": "domain-c128",
+				"zone-3": "domain-c139",
+			},
+			clusterDatastores: map[string][]*cnsvsphere.DatastoreInfo{
+				"domain-c117": {datastore114, datastore205}, // zone-1
+				"domain-c128": {datastore114, datastore203}, // zone-2
+				"domain-c139": {datastore114, datastore204}, // zone-3
+			},
+			topologyRequirement: createTopologyRequirement([]string{"zone-3", "zone-1", "zone-2"}),
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{
+				datastore114, datastore204, // zone-3
+				datastore114, datastore205, // zone-1
+				datastore114, datastore203, // zone-2
+			},
+			expectedTopoSegMap: map[string][]*cnsvsphere.DatastoreInfo{
+				"zone-1": {datastore114, datastore205},
+				"zone-2": {datastore114, datastore203},
+				"zone-3": {datastore114, datastore204},
+			},
+		},
+		{
+			name:           "Multiple clusters per AZ - isPodVMOnStretchedSupervisorEnabled true",
+			isPodVMEnabled: true,
+			azClustersMap: map[string][]string{
+				"zone-1": {"domain-c117"},
+				"zone-2": {"domain-c128"},
+				"zone-3": {"domain-c139"},
+			},
+			clusterDatastores: map[string][]*cnsvsphere.DatastoreInfo{
+				"domain-c117": {datastore114, datastore205}, // zone-1
+				"domain-c128": {datastore114, datastore203}, // zone-2
+				"domain-c139": {datastore114, datastore204}, // zone-3
+			},
+			topologyRequirement: createTopologyRequirement([]string{"zone-3", "zone-1", "zone-2"}),
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{
+				datastore114, datastore204, // zone-3
+				datastore114, datastore205, // zone-1
+				datastore114, datastore203, // zone-2
+			},
+			expectedTopoSegMap: map[string][]*cnsvsphere.DatastoreInfo{
+				"zone-1": {datastore114, datastore205},
+				"zone-2": {datastore114, datastore203},
+				"zone-3": {datastore114, datastore204},
+			},
+		},
+		{
+			name:           "Multiple clusters per AZ - isPodVMOnStretchedSupervisorEnabled false",
+			isPodVMEnabled: false,
+			azClusterMap: map[string]string{
+				"zone-1": "domain-c117", // When isPodVMEnabled=false, only first cluster is used
+				"zone-2": "domain-c128",
+				"zone-3": "domain-c139",
+			},
+			azClustersMap: map[string][]string{
+				"zone-1": {"domain-c117", "domain-c118"}, // Multiple clusters, but only first will be used
+				"zone-2": {"domain-c128", "domain-c129"},
+				"zone-3": {"domain-c139", "domain-c140"},
+			},
+			clusterDatastores: map[string][]*cnsvsphere.DatastoreInfo{
+				"domain-c117": {datastore114, datastore205}, // zone-1, first cluster (used)
+				"domain-c118": {datastore114, datastore203}, // zone-1, second cluster (ignored)
+				"domain-c128": {datastore114, datastore203}, // zone-2, first cluster (used)
+				"domain-c129": {datastore114, datastore204}, // zone-2, second cluster (ignored)
+				"domain-c139": {datastore114, datastore204}, // zone-3, first cluster (used)
+				"domain-c140": {datastore114, datastore205}, // zone-3, second cluster (ignored)
+			},
+			topologyRequirement: createTopologyRequirement([]string{"zone-3", "zone-1", "zone-2"}),
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{
+				datastore114, datastore204, // zone-3 (only from domain-c139)
+				datastore114, datastore205, // zone-1 (only from domain-c117)
+				datastore114, datastore203, // zone-2 (only from domain-c128)
+			},
+			expectedTopoSegMap: map[string][]*cnsvsphere.DatastoreInfo{
+				"zone-1": {datastore114, datastore205}, // Only from domain-c117
+				"zone-2": {datastore114, datastore203}, // Only from domain-c128
+				"zone-3": {datastore114, datastore204}, // Only from domain-c139
+			},
+		},
+		{
+			name:           "Nil preferred topology requirement",
+			isPodVMEnabled: false,
+			azClusterMap:   map[string]string{"zone-1": "domain-c117"},
+			clusterDatastores: map[string][]*cnsvsphere.DatastoreInfo{
+				"domain-c117": {datastore114, datastore205},
+			},
+			topologyRequirement: &csi.TopologyRequirement{
+				Preferred: nil,
+			},
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{},
+			expectedTopoSegMap:       map[string][]*cnsvsphere.DatastoreInfo{},
+		},
+		{
+			name:           "Zone not found in azClusterMap",
+			isPodVMEnabled: false,
+			azClusterMap: map[string]string{
+				"zone-1":       "domain-c117",
+				"zone-unknown": "domain-c999",
+			},
+			clusterDatastores: map[string][]*cnsvsphere.DatastoreInfo{
+				"domain-c117": {datastore114, datastore205},
+				// domain-c999 not in clusterDatastores, so will return empty
+			},
+			topologyRequirement:      createTopologyRequirement([]string{"zone-unknown"}),
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{},
+			expectedTopoSegMap:       map[string][]*cnsvsphere.DatastoreInfo{"zone-unknown": {}},
+		},
+		{
+			name:           "Single zone with multiple datastores - isPodVMOnStretchedSupervisorEnabled false",
+			isPodVMEnabled: false,
+			azClusterMap: map[string]string{
+				"zone-1": "domain-c117",
+			},
+			clusterDatastores: map[string][]*cnsvsphere.DatastoreInfo{
+				"domain-c117": {datastore114, datastore205, datastore203, datastore204},
+			},
+			topologyRequirement: createTopologyRequirement([]string{"zone-1"}),
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{
+				datastore114, datastore205, datastore203, datastore204,
+			},
+			expectedTopoSegMap: map[string][]*cnsvsphere.DatastoreInfo{
+				"zone-1": {datastore114, datastore205, datastore203, datastore204},
+			},
+		},
+		{
+			name:           "Empty topology requirement",
+			isPodVMEnabled: false,
+			azClusterMap:   map[string]string{"zone-1": "domain-c117"},
+			topologyRequirement: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{},
+			},
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{},
+			expectedTopoSegMap:       map[string][]*cnsvsphere.DatastoreInfo{},
+		},
+		{
+			name:           "Zone with no datastores",
+			isPodVMEnabled: false,
+			azClusterMap:   map[string]string{"zone-1": "domain-c117"},
+			clusterDatastores: map[string][]*cnsvsphere.DatastoreInfo{
+				"domain-c117": {}, // Empty slice
+			},
+			topologyRequirement:      createTopologyRequirement([]string{"zone-1"}),
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{},
+			expectedTopoSegMap: map[string][]*cnsvsphere.DatastoreInfo{
+				"zone-1": {},
+			},
+		},
+		{
+			name:           "Multiple clusters with no shared datastores",
+			isPodVMEnabled: true,
+			azClustersMap: map[string][]string{
+				"zone-1": {"domain-c117", "domain-c118"},
+			},
+			clusterDatastores: map[string][]*cnsvsphere.DatastoreInfo{
+				"domain-c117": {createDatastoreInfo("datastore-205", "ds:///vmfs/volumes/d3cec85f-c18d869d/")},
+				"domain-c118": {createDatastoreInfo("datastore-203", "ds:///vmfs/volumes/d1377884-6e1032bb/")},
+			},
+			topologyRequirement:      createTopologyRequirement([]string{"zone-1"}),
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{},
+			expectedTopoSegMap: map[string][]*cnsvsphere.DatastoreInfo{
+				"zone-1": {},
+			},
+		},
+		{
+			name:           "Multiple zones with mixed results",
+			isPodVMEnabled: false,
+			azClusterMap: map[string]string{
+				"zone-1":       "domain-c117",
+				"zone-2":       "domain-c128",
+				"zone-unknown": "domain-c999", // This zone won't have datastores
+			},
+			clusterDatastores: map[string][]*cnsvsphere.DatastoreInfo{
+				"domain-c117": {datastore114},
+				"domain-c128": {datastore114},
+				// domain-c999 not in clusterDatastores map
+			},
+			topologyRequirement: createTopologyRequirement([]string{"zone-1", "zone-2", "zone-unknown"}),
+			expectedSharedDatastores: []*cnsvsphere.DatastoreInfo{
+				datastore114, datastore114, // datastore114 from zone-1 and zone-2
+			},
+			expectedTopoSegMap: map[string][]*cnsvsphere.DatastoreInfo{
+				"zone-1":       {datastore114},
+				"zone-2":       {datastore114},
+				"zone-unknown": {}, // Empty but present
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up global variables to simulate the real environment
+			originalIsPodVMEnabled := isPodVMOnStretchedSupervisorEnabled
+			originalAzClusterMap := azClusterMap
+			originalAzClustersMap := azClustersMap
+
+			// Set test values
+			isPodVMOnStretchedSupervisorEnabled = tt.isPodVMEnabled
+			azClusterMap = tt.azClusterMap
+			azClustersMap = tt.azClustersMap
+
+			// Restore original values after test
+			defer func() {
+				isPodVMOnStretchedSupervisorEnabled = originalIsPodVMEnabled
+				azClusterMap = originalAzClusterMap
+				azClustersMap = originalAzClustersMap
+			}()
+
+			// Create mock VC
+			var mockVC *cnsvsphere.VirtualCenter
+
+			// Create mock datastore retriever with test data
+			mockRetriever := &MockDatastoreRetriever{
+				ClusterDatastores: tt.clusterDatastores,
+			}
+
+			// Create a wcpControllerVolumeTopology instance with dependency injection
+			wcpTopology := &wcpControllerVolumeTopology{
+				datastoreRetriever: mockRetriever,
+			}
+
+			// Prepare test parameters
+			topoSegToDatastoresMap := make(map[string][]*cnsvsphere.DatastoreInfo)
+			params := commoncotypes.WCPTopologyFetchDSParams{
+				TopologyRequirement:    tt.topologyRequirement,
+				Vc:                     mockVC,
+				TopoSegToDatastoresMap: topoSegToDatastoresMap,
+			}
+
+			// Execute the function
+			result, err := wcpTopology.GetSharedDatastoresInTopology(ctx, params)
+
+			// Validate results
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+				return
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Check shared datastores count
+			expectedDatastoreCount := len(tt.expectedSharedDatastores)
+			if tt.expectedDatastores != nil {
+				expectedDatastoreCount = *tt.expectedDatastores
+			}
+			if len(result) != expectedDatastoreCount {
+				t.Errorf("GetSharedDatastoresInTopology() returned %d datastores, expected %d",
+					len(result), expectedDatastoreCount)
+			}
+
+			// Check TopoSegToDatastoresMap is populated correctly
+			expectedZoneCount := len(tt.expectedTopoSegMap)
+			if tt.expectedZones != nil {
+				expectedZoneCount = *tt.expectedZones
+			}
+			if len(topoSegToDatastoresMap) != expectedZoneCount {
+				t.Errorf("TopoSegToDatastoresMap has %d zones, expected %d",
+					len(topoSegToDatastoresMap), expectedZoneCount)
+			}
+
+			// Validate each zone in TopoSegToDatastoresMap
+			for zone, expectedDatastores := range tt.expectedTopoSegMap {
+				actualDatastores, exists := topoSegToDatastoresMap[zone]
+				if !exists {
+					t.Errorf("TopoSegToDatastoresMap missing zone %s", zone)
+					continue
+				}
+
+				if len(actualDatastores) != len(expectedDatastores) {
+					t.Errorf("Zone %s has %d datastores, expected %d",
+						zone, len(actualDatastores), len(expectedDatastores))
+					continue
+				}
+
+				// Check that all expected datastores are present
+				for _, expectedDS := range expectedDatastores {
+					found := false
+					for _, actualDS := range actualDatastores {
+						if actualDS.Info.Url == expectedDS.Info.Url {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("Zone %s missing expected datastore %s", zone, expectedDS.Info.Url)
+					}
+				}
+			}
+
+			// Validate that shared datastores contain expected datastores
+			for _, expectedDS := range tt.expectedSharedDatastores {
+				found := false
+				for _, actualDS := range result {
+					if actualDS.Info.Url == expectedDS.Info.Url {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Shared datastores missing expected datastore %s", expectedDS.Info.Url)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The changes are for WCP controller:
- For creating a regular volume without a datasource, calling GetSharedDatastoresInTopology once is sufficient.
- For creating volume from snapshot in WCP, we first need to retrieve topology segments to datastores map by calling GetSharedDatastoresInTopology. Then we will find the topology segments based on the datastore where the snapshot is located. Then we call GetSharedDatastoresInTopology again to find the datastore.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
The topology segments to datastores map was not populated when calling GetSharedDatastoresInTopology in the stretched supervisor with multiple topology segments environment. As a result, no datastore is found to create a volume from a snapshot. This PR fixes the issue.

**Testing done**:
Pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/75/ (passed)
```
Build #75 (Aug 11, 2025, 6:10:57 AM)
xy036828 <br> PR 3477<br>
Ran 10 of 1080 Specs in 1196.727 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 1070 Skipped
PASS

Ginkgo ran 1 suite in 20m17.792672308s
Test Suite Passed
```

Manual testing:
Tested on a testbed with stretched supervisor with multiple topology segments.
```
root@4216b08795d5cd62e6e912fe72149d00 [ ~ ]# kubectl describe sc zonal-ds-policy-229
Name:                  zonal-ds-policy-229
IsDefaultClass:        No
Annotations:           cns.vmware.com/StoragePoolTypeHint=cns.vmware.com/NFS
Provisioner:           csi.vsphere.vmware.com
Parameters:            StorageTopologyType=Zonal,storagePolicyID=f7a94a17-9221-4c6f-af3c-79d570252495
AllowVolumeExpansion:  True
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
Events:                <none>

root@4216b08795d5cd62e6e912fe72149d00 [ ~ ]# kubectl get pvc -n e2e-namespace
NAME           STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS          VOLUMEATTRIBUTESCLASS   AGE
test-pvc       Bound         pvc-bf107230-2714-4f3c-b135-bd4bf07ac4fe   1Gi        RWO            zonal-ds-policy-229   <unset>                 2d

root@4216b08795d5cd62e6e912fe72149d00 [ ~ ]# kubectl get volumesnapshot -n e2e-namespace
NAME            READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
test-snapshot   true         test-pvc                            1Gi           volumesnapshotclass-delete   snapcontent-bc720a6b-32f4-4f77-a091-930f479eedbf   2d             2d

Create volume from snapshot.
root@4216b08795d5cd62e6e912fe72149d00 [ ~ ]# cat restore.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-restore
  namespace: e2e-namespace
spec:
  storageClassName: zonal-ds-policy-229
  dataSource:
    name: test-snapshot
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi

root@4216b08795d5cd62e6e912fe72149d00 [ ~ ]# kubectl create -f restore.yaml
persistentvolumeclaim/test-restore created

root@4216b08795d5cd62e6e912fe72149d00 [ ~ ]# kubectl get pvc -n e2e-namespace
NAME           STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS          VOLUMEATTRIBUTESCLASS   AGE
test-pvc       Bound         pvc-bf107230-2714-4f3c-b135-bd4bf07ac4fe   1Gi        RWO            zonal-ds-policy-229   <unset>                 2d
test-restore   Bound         pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb   1Gi        RWO            zonal-ds-policy-229   <unset>                 2m31s

root@4216b08795d5cd62e6e912fe72149d00 [ ~ ]# kubectl describe pvc test-restore -n e2e-namespace
Name:          test-restore
Namespace:     e2e-namespace
StorageClass:  zonal-ds-policy-229
Status:        Bound
Volume:        pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"zone-1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Sun Aug 10 20:00:05 UTC 2025
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
DataSource:
  APIGroup:  snapshot.storage.k8s.io
  Kind:      VolumeSnapshot
  Name:      test-snapshot
Used By:     <none>
Events:
  Type    Reason                 Age                 From                                                                                          Message
  ----    ------                 ----                ----                                                                                          -------
  Normal  Provisioning           88s                 csi.vsphere.vmware.com_4216b08795d5cd62e6e912fe72149d00_b50d09ca-a1b0-4bc3-84aa-1ccc14f22f37  External provisioner is provisioning volume for claim "e2e-namespace/test-restore"
  Normal  ExternalProvisioning   82s (x8 over 3m4s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  82s                 csi.vsphere.vmware.com_4216b08795d5cd62e6e912fe72149d00_b50d09ca-a1b0-4bc3-84aa-1ccc14f22f37  Successfully provisioned volume pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb

root@4216b08795d5cd62e6e912fe72149d00 [ ~ ]# kubectl describe pv pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb
Name:              pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name:
                   volume.kubernetes.io/provisioner-deletion-secret-namespace:
Finalizers:        [external-provisioner.volume.kubernetes.io/finalizer kubernetes.io/pv-protection]
StorageClass:      zonal-ds-policy-229
Status:            Bound
Claim:             e2e-namespace/test-restore
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:
  Required Terms:
    Term 0:        topology.kubernetes.io/zone in [zone-1]
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      0728c923-f32f-48e1-b8f9-966438d722b6
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1754855876914-6579-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

vSphere csi logs:
```
2025-08-10T19:59:58.761Z        INFO    wcp/controller.go:1607  CreateVolume: called with args {Name:pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal csi.storage.k8s.io/pv/name:pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb csi.storage.k8s.io/pvc/name:test-restore csi.storage.k8s.io/pvc/namespace:e2e-namespace csi.storage.k8s.io/sc/name:zonal-ds-policy-229 csi.vsphere.k8s.io/linked-clone:false storagePolicyID:f7a94a17-9221-4c6f-af3c-79d570252495] Secrets:map[] VolumeContentSource:snapshot:<snapshot_id:"098c1e2a-9bc3-468e-8cbd-a1daad1131a8+b7f11da0-310d-456f-84e1-2b8e4a8ee339" >  AccessibilityRequirements:requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}  {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}

2025-08-10T19:59:58.809Z        DEBUG   wcp/controller.go:564   Calling GetSharedDatastoresInTopology: storageTopologyType: Zonal, topologyRequirement requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > , topoSegToDatastoresMap map[]       {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}

2025-08-10T19:59:58.852Z        DEBUG   k8sorchestrator/topology.go:1620        PodVMOnStretchedSupervisor Enabled. Topology: requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > , Zone: zone-3, Topology Segments to Datastore Map: map[zone-3:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-204, datastore URL: ds:///vmfs/volumes/6f7b8796-8da795e6/]], Datastores: [Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-204, datastore URL: ds:///vmfs/volumes/6f7b8796-8da795e6/]      {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}

2025-08-10T19:59:58.940Z        DEBUG   wcp/controller.go:578   After calling GetSharedDatastoresInTopology: storageTopologyType: Zonal, topologyRequirement requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > , topoSegToDatastoresMap map[zone-1:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-205, datastore URL: ds:///vmfs/volumes/d3cec85f-c18d869d/] zone-2:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-203, datastore URL: ds:///vmfs/volumes/d1377884-6e1032bb/] zone-3:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-204, datastore URL: ds:///vmfs/volumes/6f7b8796-8da795e6/]]   {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}

2025-08-10T19:59:58.940Z        INFO    wcp/controller.go:588   Volume pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb is created from snapshot 098c1e2a-9bc3-468e-8cbd-a1daad1131a8+b7f11da0-310d-456f-84e1-2b8e4a8ee339, get the datastore accessible topology from the snapshot     {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}

2025-08-10T19:59:58.942Z        DEBUG   wcp/controller.go:1069  getDatastoreAccessibleTopologyForSnapshot: contentSourceSnapshotID: 098c1e2a-9bc3-468e-8cbd-a1daad1131a8+b7f11da0-310d-456f-84e1-2b8e4a8ee339, storageTopologyType: Zonal, topologyRequirement requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > , topoSegToDatastoresMap map[zone-1:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-205, datastore URL: ds:///vmfs/volumes/d3cec85f-c18d869d/] zone-2:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-203, datastore URL: ds:///vmfs/volumes/d1377884-6e1032bb/] zone-3:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-204, datastore URL: ds:///vmfs/volumes/6f7b8796-8da795e6/]] {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}

2025-08-10T19:59:58.989Z        DEBUG   wcp/controller.go:1104  getDatastoreAccessibleTopologyForSnapshot: selectedDatastore: ds:///vmfs/volumes/d3cec85f-c18d869d/     {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}
2025-08-10T19:59:58.990Z        INFO    k8sorchestrator/topology.go:1774        Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:zone-1]]        {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}
2025-08-10T19:59:58.990Z        INFO    wcp/controller.go:1134  getDatastoreAccessibleTopologyForSnapshot: returning topology [segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > ]   {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}
2025-08-10T19:59:58.990Z        INFO    wcp/controller.go:602   Replaced with topologyRequirement requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > >  for creating volume pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb from snapshot 098c1e2a-9bc3-468e-8cbd-a1daad1131a8+b7f11da0-310d-456f-84e1-2b8e4a8ee339     {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}
2025-08-10T19:59:58.990Z        DEBUG   wcp/controller.go:605   Calling GetSharedDatastoresInTopology again for create volume from snapshot: snapshotID: 098c1e2a-9bc3-468e-8cbd-a1daad1131a8+b7f11da0-310d-456f-84e1-2b8e4a8ee339, storageTopologyType: Zonal, topologyRequirement requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > , topoSegToDatastoresMap map[zone-1:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-205, datastore URL: ds:///vmfs/volumes/d3cec85f-c18d869d/] zone-2:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-203, datastore URL: ds:///vmfs/volumes/d1377884-6e1032bb/] zone-3:[Datastore: Datastore:datastore-114, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: Datastore:datastore-204, datastore URL: ds:///vmfs/volumes/6f7b8796-8da795e6/]]    {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}
2025-08-10T19:59:59.205Z        INFO    common/vsphereutil.go:366       Overwrite the datatstores field in create spec [Datastore:datastore-114 Datastore:datastore-205] with the compatible datastore Datastore:datastore-205 when create volume from snapshot 098c1e2a-9bc3-468e-8cbd-a1daad1131a8+b7f11da0-310d-456f-84e1-2b8e4a8ee339       {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}
2025-08-10T20:00:04.681Z        INFO    wcp/controller.go:1679  Volume created successfully. Volume Handle: "0728c923-f32f-48e1-b8f9-966438d722b6", PV Name: "pvc-8029cb78-2e6c-4baa-97a3-7816f12a65fb" {"TraceId": "78fc2408-a542-4cc5-9ea4-02f44d4e3047"}
```

Tested on a regulat testbed.
```
root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl create -f my-pvc.yaml
persistentvolumeclaim/test-pvc created

root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get pvc -n test-ns
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-pvc   Bound    pvc-a11ab903-3b53-41a7-9cd5-f535ba

root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl create -f my-snapshot.yaml
volumesnapshot.snapshot.storage.k8s.io/test-snapshot created
root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get volumesnapshot -n test-ns
NAME            READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
test-snapshot   true         test-pvc                            1Gi           volumesnapshotclass-delete   snapcontent-03739c77-c7ff-46ba-b40d-f283d803359c   <invalid>      8s

root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl create -f my-restore.yaml
persistentvolumeclaim/test-restore created
root@4212c70cc858f2019b374d2841863006 [ ~ ]# kubectl get pvc -n test-ns
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-pvc       Bound    pvc-a11ab903-3b53-41a7-9cd5-f535ba1ac615   1Gi        RWO            wcpglobal-storage-profile   <unset>                 10m
test-restore   Bound    pvc-0c7363fa-e8c4-48a2-a5ea-d886fdd429ed   1Gi        RWO            wcpglobal-storage-profile   <unset>                 5s
```

Unit tests passed:
```
xy036828broadcom.net@KWH0FXLFYR vsphere-csi-driver % go test -v ./pkg/csi/service/common/commonco/k8sorchestrator -run TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Single_cluster_per_AZ_-_isPodVMOnStretchedSupervisorEnabled_false
{"level":"info","time":"2025-08-12T11:14:21.374716-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-3\" are [domain-c139]"}
{"level":"info","time":"2025-08-12T11:14:21.375393-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c117]"}
{"level":"info","time":"2025-08-12T11:14:21.375404-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-2\" are [domain-c128]"}
{"level":"info","time":"2025-08-12T11:14:21.375833-04:00","caller":"k8sorchestrator/topology.go:1564","msg":"Shared datastores [Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6f7b8796-8da795e6/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/d3cec85f-c18d869d/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/d1377884-6e1032bb/] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > "}
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Multiple_clusters_per_AZ_-_isPodVMOnStretchedSupervisorEnabled_true
{"level":"info","time":"2025-08-12T11:14:21.375895-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-3\" are [domain-c139]"}
{"level":"info","time":"2025-08-12T11:14:21.375907-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c117]"}
{"level":"info","time":"2025-08-12T11:14:21.375914-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-2\" are [domain-c128]"}
{"level":"info","time":"2025-08-12T11:14:21.375951-04:00","caller":"k8sorchestrator/topology.go:1564","msg":"Shared datastores [Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6f7b8796-8da795e6/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/d3cec85f-c18d869d/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/d1377884-6e1032bb/] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > "}
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Multiple_clusters_per_AZ_-_isPodVMOnStretchedSupervisorEnabled_false
{"level":"info","time":"2025-08-12T11:14:21.376061-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-3\" are [domain-c139]"}
{"level":"info","time":"2025-08-12T11:14:21.376289-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c117]"}
{"level":"info","time":"2025-08-12T11:14:21.376342-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-2\" are [domain-c128]"}
{"level":"info","time":"2025-08-12T11:14:21.376557-04:00","caller":"k8sorchestrator/topology.go:1564","msg":"Shared datastores [Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6f7b8796-8da795e6/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/d3cec85f-c18d869d/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/d1377884-6e1032bb/] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > "}
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Nil_preferred_topology_requirement
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Zone_not_found_in_azClusterMap
{"level":"info","time":"2025-08-12T11:14:21.376644-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-unknown\" are [domain-c999]"}
{"level":"info","time":"2025-08-12T11:14:21.376651-04:00","caller":"k8sorchestrator/topology.go:1564","msg":"Shared datastores [] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-unknown\" > > "}
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Single_zone_with_multiple_datastores_-_isPodVMOnStretchedSupervisorEnabled_false
{"level":"info","time":"2025-08-12T11:14:21.376723-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c117]"}
{"level":"info","time":"2025-08-12T11:14:21.376753-04:00","caller":"k8sorchestrator/topology.go:1564","msg":"Shared datastores [Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/d3cec85f-c18d869d/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/d1377884-6e1032bb/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6f7b8796-8da795e6/] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > "}
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Empty_topology_requirement
{"level":"info","time":"2025-08-12T11:14:21.376792-04:00","caller":"k8sorchestrator/topology.go:1564","msg":"Shared datastores [] for topologyRequirement: "}
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Zone_with_no_datastores
{"level":"info","time":"2025-08-12T11:14:21.376863-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c117]"}
{"level":"info","time":"2025-08-12T11:14:21.37687-04:00","caller":"k8sorchestrator/topology.go:1564","msg":"Shared datastores [] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > "}
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Multiple_clusters_with_no_shared_datastores
{"level":"info","time":"2025-08-12T11:14:21.376895-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c117 domain-c118]"}
{"level":"info","time":"2025-08-12T11:14:21.376905-04:00","caller":"k8sorchestrator/topology.go:1564","msg":"Shared datastores [] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > "}
=== RUN   TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Multiple_zones_with_mixed_results
{"level":"info","time":"2025-08-12T11:14:21.377194-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c117]"}
{"level":"info","time":"2025-08-12T11:14:21.377213-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-2\" are [domain-c128]"}
{"level":"info","time":"2025-08-12T11:14:21.377229-04:00","caller":"k8sorchestrator/topology.go:1590","msg":"Clusters matching topology requirement \"zone-unknown\" are [domain-c999]"}
{"level":"info","time":"2025-08-12T11:14:21.377372-04:00","caller":"k8sorchestrator/topology.go:1564","msg":"Shared datastores [Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/ Datastore: <nil>, datastore URL: ds:///vmfs/volumes/6895f0bb-1ffe619b-574b-020053013de8/] for topologyRequirement: preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-unknown\" > > "}
--- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Single_cluster_per_AZ_-_isPodVMOnStretchedSupervisorEnabled_false (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Multiple_clusters_per_AZ_-_isPodVMOnStretchedSupervisorEnabled_true (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Multiple_clusters_per_AZ_-_isPodVMOnStretchedSupervisorEnabled_false (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Nil_preferred_topology_requirement (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Zone_not_found_in_azClusterMap (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Single_zone_with_multiple_datastores_-_isPodVMOnStretchedSupervisorEnabled_false (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Empty_topology_requirement (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Zone_with_no_datastores (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Multiple_clusters_with_no_shared_datastores (0.00s)
    --- PASS: TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology/Multiple_zones_with_mixed_results (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed a problem populating topology segments to datastores map for create volume from snapshot.
```
