### PR TITLE
Enhancement - Keep active VC session alive

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -194,6 +194,10 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 		log.Errorf("failed to create new client with err: %v", err)
 		return nil, nil, err
 	}
+
+	// Invoke KeepAlive on the vimClient RoundTripper to keep the connection alive
+	// every 10 minutes.
+	vimClient.RoundTripper = session.KeepAlive(vimClient.RoundTripper, 10*time.Minute)
 	err = vimClient.UseServiceVersion("vsan")
 	if err != nil && vc.Config.Host != "127.0.0.1" {
 		// Skipping error for simulator connection for unit tests.


### PR DESCRIPTION
**What this PR does / why we need it**:

We have noticed in both customer environments and in internal testing, that some times a VC session which is actively in use is terminated abruptly. This causes the CSI Driver to reload the configuration and establish a new session which is inefficient. Ideally, a session should remain active as long as it's in active use.

This PR introduces a one-liner that essentially adds the Keep Alive functionality to the session to ensure that an active session isn't terminated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Successful regression run - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3479#issuecomment-3178289332

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enhance VC client to keep session active
```
