### PR TITLE
Change Diskmode to the correct independent_persistent value

### DIFF
--- a/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
+++ b/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
@@ -24,11 +24,11 @@ import (
 type DiskMode string
 
 const (
-	// By setting DiskMode to IndependentPersistent, a virtual machine's disk is not captured in snapshots and
+	// By setting DiskMode to independent_persistent, a virtual machine's disk is not captured in snapshots and
 	// changes are permanently written to the disk, regardless of snapshot operations.
-	IndependentPersistent DiskMode = "IndependentPersistent"
+	IndependentPersistent DiskMode = "independent_persistent"
 	// Changes are immediately and permanently written to the virtual disk.
-	Persistent DiskMode = "Persistent"
+	Persistent DiskMode = "persistent"
 )
 
 // The sharing mode of the virtual disk.

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -398,7 +398,7 @@ func TestValidateBatchAttachRequestWithRwxPvc(t *testing.T) {
 	t.Run("TestValidateBatchAttachRequestWithRwxPvc", func(t *testing.T) {
 
 		batchAttachRequest := volumes.BatchAttachRequest{
-			DiskMode:      "Persistent",
+			DiskMode:      "persistent",
 			ControllerKey: "12345",
 			UnitNumber:    "9",
 		}
@@ -406,13 +406,13 @@ func TestValidateBatchAttachRequestWithRwxPvc(t *testing.T) {
 		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
 		err := validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-rwx")
 		expectedErr := fmt.Errorf("incorrect input for PVC pvc-rwx in namespace test-ns with accessMode ReadWriteMany. " +
-			"DiskMode cannot be Persistent")
+			"DiskMode cannot be persistent")
 		assert.EqualError(t, expectedErr, err.Error())
 
 		batchAttachRequest = volumes.BatchAttachRequest{
 			ControllerKey: "",
 			UnitNumber:    "12",
-			DiskMode:      "IndependentPersistent",
+			DiskMode:      "independent_persistent",
 		}
 
 		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}


### PR DESCRIPTION
**What this PR does / why we need it**:
VM configure takes diskMode parameter as independent_persistent and persistent instead of IndependentPersistent and Persistent respectively.
So it is important to change these values so that CNS can understand the correct diskMode.

**Testing done**:
CNS API for batch attach are not yet ready. So, I cannot really call this API and test.


Ran make images command.
I have updated the unit tests.

Precheckin: Precheckin passed