### PR TITLE
support for late enablement of supports_multiple_clusters_per_zone capability on supervisor

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -112,6 +112,8 @@ var (
 	IsPodVMOnStretchSupervisorFSSEnabled bool
 	// IsLinkedCloneSupportFSSEnabled is true when linked-clone-support FSS is enabled.
 	IsLinkedCloneSupportFSSEnabled bool
+	// IsMultipleClustersPerVsphereZoneFSSEnabled is true when supports_multiple_clusters_per_zone FSS is enabled
+	IsMultipleClustersPerVsphereZoneFSSEnabled bool
 	// ResourceAPIgroupPVC is an empty string as PVC belongs to the core resource group denoted by `""`.
 	ResourceAPIgroupPVC = ""
 
@@ -315,6 +317,12 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			common.LinkedCloneSupport)
 		if !IsLinkedCloneSupportFSSEnabled {
 			go k8sorchestrator.HandleLateEnablementOfCapability(ctx, clusterFlavor, common.LinkedCloneSupport, "", "")
+		}
+		IsMultipleClustersPerVsphereZoneFSSEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+			common.MultipleClustersPerVsphereZone)
+		if !IsMultipleClustersPerVsphereZoneFSSEnabled {
+			go k8sorchestrator.HandleLateEnablementOfCapability(ctx, clusterFlavor,
+				common.MultipleClustersPerVsphereZone, "", "")
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

If supervisor is upgraded first and then VC is upgraded with support for multiple cluster per zone, wcp capability `supports_multiple_clusters_per_zone` will be enabled late after CSI controller/syncer starts.

We need to start zone informer when capability for supports_multiple_clusters_per_zone is enabled. This PR is calling k8sorchestrator.HandleLateEnablementOfCapability to ensure WCP controller and Syncer container gets restarted when capability is enabled late after they are initialized.

**Testing done**:
Pipeline passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/123/

```
Ran 10 of 1080 Specs in 1230.271 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 1070 Skipped
PASS
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
support for late enablement of supports_multiple_clusters_per_zone capability on supervisor
```
