### PR TITLE
Enhancement - Improve CNSUnregisterVolume reconciliation logic

### DIFF
--- a/pkg/apis/cnsoperator/config/cnsunregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsunregistervolume_crd.yaml
@@ -62,6 +62,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -156,6 +156,9 @@ type Manager interface {
 	// BatchAttachVolumes attaches multiple volumes to a virtual machine.
 	BatchAttachVolumes(ctx context.Context,
 		vm *cnsvsphere.VirtualMachine, batchAttachRequest []BatchAttachRequest) ([]BatchAttachResult, string, error)
+	// UnregisterVolume unregisters a volume from CNS.
+	// If unregisterDisk is true, it will also unregister the disk from FCD.
+	UnregisterVolume(ctx context.Context, volumeID string, unregisterDisk bool) *Error
 }
 
 // CnsVolumeInfo hold information related to volume created by CNS.
@@ -213,6 +216,22 @@ type ExpandVolumeExtraParams struct {
 	// Capacity stores the original volume size which is from CNSVolumeInfo
 	Capacity                             *resource.Quantity
 	IsPodVMOnStretchSupervisorFSSEnabled bool
+}
+
+// Error is a custom error type that wraps an error and adds a transient flag.
+// This is used to indicate whether the error is transient or not, which can be
+// useful for retry logic in the context of volume operations.
+// More fields can be added to this struct in the future if needed.
+type Error struct {
+	error
+	IsTransient bool
+}
+
+func newError(err error, isTransient bool) *Error {
+	return &Error{
+		error:       err,
+		IsTransient: isTransient,
+	}
 }
 
 var (
@@ -3614,4 +3633,104 @@ func (m *defaultManager) SetListViewNotReady(ctx context.Context) {
 	if m.listViewIf != nil {
 		m.listViewIf.SetListViewNotReady(ctx)
 	}
+}
+
+// UnregisterVolume unregisters a volume from CNS.
+// If unregisterDisk is true, it will also unregister the disk from FCD.
+func (m *defaultManager) UnregisterVolume(ctx context.Context, volumeID string, unregisterDisk bool) *Error {
+	ctx, cancelFunc := ensureOperationContextHasATimeout(ctx)
+	defer cancelFunc()
+	start := time.Now()
+	e := m.unregisterVolume(ctx, volumeID, unregisterDisk)
+	if e != nil {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusUnregisterVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+		return e
+	}
+
+	prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusUnregisterVolumeOpType,
+		prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+	return nil
+}
+
+func (m *defaultManager) unregisterVolume(ctx context.Context, volumeID string, unregisterDisk bool) *Error {
+	log := logger.GetLogger(ctx)
+
+	if m.virtualCenter == nil {
+		return newError(errors.New("invalid manager instance"), true)
+	}
+
+	err := m.virtualCenter.ConnectCns(ctx)
+	if err != nil {
+		log.Errorf("ConnectCns failed with err: %+v", err)
+		return newError(err, true)
+	}
+
+	targetVolumeType := "FCD"
+	if unregisterDisk {
+		targetVolumeType = "LEGACY_DISK"
+	}
+	spec := []cnstypes.CnsUnregisterVolumeSpec{
+		{
+			VolumeId:         cnstypes.CnsVolumeId{Id: volumeID},
+			TargetVolumeType: targetVolumeType,
+		},
+	}
+	task, err := m.virtualCenter.CnsClient.UnregisterVolume(ctx, spec)
+	if err != nil {
+		log.Errorf("CNS UnregisterVolume failed from the vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+		return handleUnregisterError(ctx, err)
+	}
+
+	taskInfo, err := m.waitOnTask(ctx, task.Reference())
+	if err != nil {
+		log.Errorf("failed to get UnregisterVolume taskInfo from vCenter %q with err: %v",
+			m.virtualCenter.Config.Host, err)
+		// TODO: check if there could be non-transient errors here.
+		return newError(err, true)
+	}
+
+	if taskInfo == nil {
+		log.Errorf("failed to get UnregisterVolume taskInfo from vCenter %q",
+			m.virtualCenter.Config.Host)
+		return newError(errors.New("taskInfo is empty for UnregisterVolume task"), true)
+	}
+
+	log.Infof("UnregisterVolume: volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
+	res, err := getTaskResultFromTaskInfo(ctx, taskInfo)
+	if err != nil {
+		log.Errorf("failed to get UnregisterVolume task result with error: %v", err)
+		return newError(err, true)
+	}
+
+	if res == nil {
+		log.Errorf("failed to get UnregisterVolume task result from vCenter %q. taskID: %q, opId: %q",
+			m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId)
+		return newError(errors.New("task result is empty for UnregisterVolume task"), true)
+	}
+
+	volOpRes := res.GetCnsVolumeOperationResult()
+	if volOpRes.Fault != nil {
+		log.Errorf("failed to unregister volume: %q, fault: %q, opID: %q",
+			volumeID, ExtractFaultTypeFromVolumeResponseResult(ctx, volOpRes), taskInfo.ActivationId)
+		return newError(errors.New("observed a fault in UnregisterVolume result"), true)
+	}
+
+	log.Infof("UnregisterVolume: volume unregistered successfully. volumeID: %q, opId: %q",
+		volumeID, taskInfo.ActivationId)
+	return nil
+}
+
+func handleUnregisterError(ctx context.Context, err error) *Error {
+	faultType := ExtractFaultTypeFromErr(ctx, err)
+	e := Error{err, true}
+	if faultType == csifault.VimFaultNotFound ||
+		faultType == csifault.VimFaultInvalidState ||
+		faultType == csifault.VimFaultInvalidDatastore ||
+		faultType == csifault.VimFaultInvalidArgument {
+		// If the fault type is NotFound, InvalidState, InvalidDatastore, or InvalidArgument,
+		// retry won't help.
+		e.IsTransient = false
+	}
+	return &e
 }

--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -78,4 +78,20 @@ const (
 	VimFaultInvalidHostState = VimFaultPrefix + "InvalidHostState"
 	// VimFaultHostNotConnected is the fault returned from CNS when host is not connected.
 	VimFaultHostNotConnected = VimFaultPrefix + "HostNotConnected"
+	// VimFaultNotFound is the fault returned from CNS when the object is not found.
+	VimFaultNotFound = VimFaultPrefix + "NotFound"
+	// VimFaultInvalidState is the fault returned from CNS
+	// when the operation is not valid in the current state of the object.
+	VimFaultInvalidState = VimFaultPrefix + "InvalidState"
+	// VimFaultInvalidDatastore is the fault returned from CNS
+	// when the datastore is not valid for the operation being performed.
+	VimFaultInvalidDatastore = VimFaultPrefix + "InvalidDatastore"
+	// VimFaultTaskInProgress is the fault returned from CNS
+	// when the task is already in progress for the object.
+	VimFaultTaskInProgress = VimFaultPrefix + "TaskInProgress"
+	// VimFaultInvalidArgument is the fault returned from CNS
+	// when the argument provided is not valid for the operation being performed.
+	VimFaultInvalidArgument = VimFaultPrefix + "InvalidArgument"
+	// VimFaultCNSFault is the fault returned from CNS when a generic CNS fault occurs.
+	VimFaultCNSFault = VimFaultPrefix + "CnsFault"
 )

--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -88,6 +88,8 @@ const (
 	PrometheusAccessibleVolumes = "accessible-volumes"
 	// PrometheusInaccessibleVolumes represents inaccessible volumes.
 	PrometheusInaccessibleVolumes = "inaccessible-volumes"
+	// PrometheusUnregisterVolumeOpType represents UnregisterVolume operation.
+	PrometheusUnregisterVolumeOpType = "unregister-volume"
 
 	// PrometheusPassStatus represents a successful API run.
 	PrometheusPassStatus = "pass"

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -106,6 +106,12 @@ type MockVolumeManager struct {
 		extraParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error)
 }
 
+func (m *MockVolumeManager) UnregisterVolume(ctx context.Context, volumeID string,
+	unregisterDisk bool) *cnsvolume.Error {
+	//TODO implement me
+	return nil
+}
+
 func (m *MockVolumeManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
 	extraParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
 	if m.createVolumeFunc != nil {

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -25,6 +25,12 @@ type mockVolumeManager struct {
 		extraParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error)
 }
 
+func (m *mockVolumeManager) UnregisterVolume(ctx context.Context, volumeID string,
+	unregisterDisk bool) *cnsvolume.Error {
+	//TODO implement me
+	return nil
+}
+
 func (m *mockVolumeManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
 	extraParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
 	if m.createVolumeFunc != nil {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -694,3 +694,19 @@ func PatchFinalizers(ctx context.Context, c client.Client, obj client.Object, fi
 	patch := client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})
 	return c.Patch(ctx, obj, patch)
 }
+
+// UpdateStatus updates the status subresource of the given Kubernetes object.
+// If the object is a Custom Resource, make sure that the `subresources` field in the
+// CustomResourceDefinition includes `status` to enable status subresource updates.
+func UpdateStatus(ctx context.Context, c client.Client, obj client.Object) error {
+	log := logger.GetLogger(ctx)
+	if err := c.Status().Update(ctx, obj); err != nil {
+		log.Errorf("Failed to update status for %s %s/%s: %v", obj.GetObjectKind().GroupVersionKind().Kind,
+			obj.GetNamespace(), obj.GetName(), err)
+		return err
+	}
+
+	log.Infof("Successfully updated status for %s %s/%s", obj.GetObjectKind().GroupVersionKind().Kind,
+		obj.GetNamespace(), obj.GetName())
+	return nil
+}

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -55,6 +55,12 @@ type mockVolumeManager struct {
 		ctxParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error)
 }
 
+func (m *mockVolumeManager) UnregisterVolume(ctx context.Context, volumeID string,
+	unregisterDisk bool) *cnsvolume.Error {
+	//TODO implement me
+	return nil
+}
+
 func (m *mockVolumeManager) AttachVolume(ctx context.Context, vm *cnsvsphere.VirtualMachine,
 	volumeID string, checkNVMeController bool) (string, string, error) {
 	//TODO implement me


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates CNSUnregisterVolume reconciler to use the status subresource while updating the status of CNSUnregisterVolume instances which avoids unnecessary generation increments.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Created 3 volumes in a namespace and attached 2 of them to a PodVM and a VM Service VM. 
Invoked unregister API on all 3 volumes. As expected, the unused volume(`vol-unused`) got unregistered successfully whereas the other two(`vol-used-by-pod` and `vol-used-by-vm`) failed with appropriate error. Also verified that all the instances remained at `generation 1`.

<details><summary>Details</summary>
<p>

```yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsUnregisterVolume
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsUnregisterVolume","metadata":{"annotations":{},"name":"non-existent-volume","namespace":"cns-unregister-volume"},"spec":{"volumeID":"00000000-0000-0000-0000-000"}}
    creationTimestamp: "2025-08-15T11:12:20Z"
    generation: 1
    name: non-existent-volume
    namespace: cns-unregister-volume
    resourceVersion: "2398842"
    uid: 500a357e-94d4-472a-b3b3-c4156350e59a
  spec:
    volumeID: 00000000-0000-0000-0000-000
  status:
    error: 'Failed to unregister volume "00000000-0000-0000-0000-000" with error:
      ServerFaultCode: The object or item referred to could not be found.'
    unregistered: false
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsUnregisterVolume
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsUnregisterVolume","metadata":{"annotations":{},"name":"vol-unused","namespace":"cns-unregister-volume"},"spec":{"volumeID":"6d018c3c-17bd-4c05-a5c6-9443b2f1b989"}}
    creationTimestamp: "2025-08-15T11:01:33Z"
    generation: 1
    name: vol-unused
    namespace: cns-unregister-volume
    resourceVersion: "2391840"
    uid: 2a7f3252-44b2-4d93-b1bb-4ec3bc7c2971
  spec:
    volumeID: 6d018c3c-17bd-4c05-a5c6-9443b2f1b989
  status:
    unregistered: true
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsUnregisterVolume
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsUnregisterVolume","metadata":{"annotations":{},"name":"vol-used-by-pod","namespace":"cns-unregister-volume"},"spec":{"volumeID":"9a8a718c-b688-40c8-b21e-3d57dceff9f6"}}
    creationTimestamp: "2025-08-15T11:01:32Z"
    generation: 1
    name: vol-used-by-pod
    namespace: cns-unregister-volume
    resourceVersion: "2391794"
    uid: 4687d68e-d01e-41e1-8cdf-52f351ab9ca6
  spec:
    volumeID: 9a8a718c-b688-40c8-b21e-3d57dceff9f6
  status:
    error: cannot unregister the volume 9a8a718c-b688-40c8-b21e-3d57dceff9f6 as it's
      in use by pod pod in namespace cns-unregister-volume
    unregistered: false
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsUnregisterVolume
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsUnregisterVolume","metadata":{"annotations":{},"name":"vol-used-by-vm","namespace":"cns-unregister-volume"},"spec":{"volumeID":"11932d6a-27a6-486d-a685-ce77a8bbf0da"}}
    creationTimestamp: "2025-08-15T11:01:33Z"
    generation: 1
    name: vol-used-by-vm
    namespace: cns-unregister-volume
    resourceVersion: "2391811"
    uid: 30c53de2-ccbc-446b-a9d7-bf95fc157fdf
  spec:
    volumeID: 11932d6a-27a6-486d-a685-ce77a8bbf0da
  status:
    error: cannot unregister the volume 11932d6a-27a6-486d-a685-ce77a8bbf0da as it's
      in use by VirtualMachine vm in namespace cns-unregister-volume
    unregistered: false
kind: List
metadata:
  resourceVersion: ""
```

</p>
</details> 



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Optimise performance of CNSUnregisterVolume reconciler by leveraging subresource
```
