### PR TITLE
Fix backward compatibility for workload-domain-isolation FSS in Guest Clusters

### DIFF
--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -10,8 +10,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -10,8 +10,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -10,8 +10,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -10,8 +10,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -10,8 +10,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -47,6 +47,12 @@ type FakeK8SOrchestrator struct {
 	featureStates     map[string]string
 }
 
+func (c *FakeK8SOrchestrator) HandleLateEnablementOfCapability(
+	ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, capability, gcPort, gcEndpoint string) {
+	//TODO implement me
+	panic("implement me")
+}
+
 // volumeMigration holds mocked migrated volume information
 type mockVolumeMigration struct {
 	// volumePath to volumeId map

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -58,33 +58,33 @@ var mapVolumePathToID map[string]map[string]string
 // GetFakeContainerOrchestratorInterface returns a dummy CO interface based on the CO type
 func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCommonInterface, error) {
 	if orchestratorType == common.Kubernetes {
+		defaultFSS := map[string]string{
+			"csi-migration":                     "true",
+			"file-volume":                       "true",
+			"block-volume-snapshot":             "true",
+			"tkgs-ha":                           "true",
+			"list-volumes":                      "true",
+			"csi-internal-generated-cluster-id": "true",
+			"online-volume-extend":              "true",
+			"csi-windows-support":               "true",
+			"use-csinode-id":                    "true",
+			"pv-to-backingdiskobjectid-mapping": "false",
+			"cnsmgr-suspend-create-volume":      "true",
+			"multi-vcenter-csi-topology":        "true",
+			"listview-tasks":                    "true",
+			"storage-quota-m2":                  "false",
+			"workload-domain-isolation":         "true",
+			// From `wcp-cluster-capabilities` configmap in supervisor
+			"Workload_Domain_Isolation_Supported": "false",
+		}
+
 		fakeCO := &FakeK8SOrchestrator{
 			featureStatesLock: &sync.RWMutex{},
-			featureStates: map[string]string{
-				"csi-migration":                     "true",
-				"file-volume":                       "true",
-				"block-volume-snapshot":             "true",
-				"tkgs-ha":                           "true",
-				"list-volumes":                      "true",
-				"csi-internal-generated-cluster-id": "true",
-				"online-volume-extend":              "true",
-				"csi-windows-support":               "true",
-				"use-csinode-id":                    "true",
-				"pv-to-backingdiskobjectid-mapping": "false",
-				"cnsmgr-suspend-create-volume":      "true",
-				"multi-vcenter-csi-topology":        "true",
-				"listview-tasks":                    "true",
-				"storage-quota-m2":                  "false",
-				"workload-domain-isolation":         "true",
-				// Adding FSS from `wcp-cluster-capabilities` configmap in supervisor here for simplicity.
-				// TODO: Enable FSS for unit tests after mockControllerVolumeTopology interfaces are implemented
-				"Workload_Domain_Isolation_Supported": "false",
-			},
+			featureStates:     defaultFSS,
 		}
 		return fakeCO, nil
 	}
 	return nil, fmt.Errorf("unrecognized CO type")
-
 }
 
 // IsFSSEnabled returns the FSS values for a given feature

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -123,6 +123,8 @@ type COCommonInterface interface {
 	GetActiveClustersForNamespaceInRequestedZones(ctx context.Context, ns string, zones []string) ([]string, error)
 	// GetPvcObjectByName return PVC object for the given PVC name
 	GetPvcObjectByName(ctx context.Context, pvcName string, namespace string) (*v1.PersistentVolumeClaim, error)
+	HandleLateEnablementOfCapability(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, capability,
+		gcPort, gcEndpoint string)
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -51,7 +51,6 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
@@ -159,7 +158,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	IsMultipleClustersPerVsphereZoneFSSEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.MultipleClustersPerVsphereZone)
 	if !IsMultipleClustersPerVsphereZoneFSSEnabled {
-		go k8sorchestrator.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
+		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
 			common.MultipleClustersPerVsphereZone, "", "")
 	} else {
 		err := commonco.ContainerOrchestratorUtility.StartZonesInformer(ctx, nil, metav1.NamespaceAll)

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -151,7 +151,6 @@ func getControllerTest(t *testing.T) *controllerTest {
 // TestWCPCreateVolumeWithStoragePolicy creates volume with storage policy.
 func TestWCPCreateVolumeWithStoragePolicy(t *testing.T) {
 	ct := getControllerTest(t)
-
 	// Create.
 	params := make(map[string]string)
 
@@ -262,20 +261,6 @@ func TestWCPCreateVolumeWithStoragePolicy(t *testing.T) {
 // but not storage topology type. It is a negative case.
 func TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType(t *testing.T) {
 	ct := getControllerTest(t)
-	// TODO: Add following code back when FSS for Workload_Domain_Isolation_Supported is enabled for unit tests
-	/*
-		err := commonco.ContainerOrchestratorUtility.DisableFSS(ctx, "Workload_Domain_Isolation_Supported")
-		if err != nil {
-			t.Fatal("failed to disable Workload_Domain_Isolation_Supported FSS")
-		}
-		defer func() {
-			err := commonco.ContainerOrchestratorUtility.EnableFSS(ctx, "Workload_Domain_Isolation_Supported")
-			if err != nil {
-				t.Fatal("failed to enable Workload_Domain_Isolation_Supported FSS back to true")
-			}
-		}()
-	*/
-
 	// Create.
 	params := make(map[string]string)
 

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -61,7 +61,6 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
@@ -158,11 +157,11 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 	isLinkedCloneSupported := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.LinkedCloneSupportFSS)
 	if !isWorkloadDomainIsolationSupported {
-		go k8sorchestrator.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
+		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 			common.WorkloadDomainIsolation, config.GC.Port, config.GC.Endpoint)
 	}
 	if !isLinkedCloneSupported {
-		go k8sorchestrator.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
+		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 			common.LinkedCloneSupport, config.GC.Port, config.GC.Endpoint)
 	}
 	if isWorkloadDomainIsolationSupported {

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -25,8 +25,6 @@ import (
 	"net/http"
 	"os"
 
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator"
-
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/zapr"
 	cnstypes "github.com/vmware/govmomi/cns/types"
@@ -154,7 +152,7 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 			common.FileVolumesWithVmService)
 		featureIsLinkedCloneSupportEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupport)
 		if !featureIsLinkedCloneSupportEnabled {
-			go k8sorchestrator.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
+			go containerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
 				common.LinkedCloneSupport, "", "")
 		}
 		if err := startCNSCSIWebhookManager(ctx, enableWebhookClientCertVerification,
@@ -169,7 +167,7 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 			if configErr != nil {
 				return fmt.Errorf("failed to read config. Error: %+v", err)
 			}
-			go k8sorchestrator.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
+			go containerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 				common.LinkedCloneSupport, gcConfig.GC.Port, gcConfig.GC.Endpoint)
 		}
 		startPVCSIWebhookManager(ctx)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -215,6 +215,22 @@ func (m *mockVolumeManager) CreateVolume(ctx context.Context, spec *cnstypes.Cns
 
 type mockCOCommon struct{}
 
+func (m *mockCOCommon) EnableFSS(ctx context.Context, featureName string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) DisableFSS(ctx context.Context, featureName string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockCOCommon) HandleLateEnablementOfCapability(ctx context.Context,
+	clusterFlavor cnstypes.CnsClusterFlavor, capability, gcPort, gcEndpoint string) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockCOCommon) IsFSSEnabled(ctx context.Context, featureName string) bool {
 	return true
 }
@@ -225,16 +241,6 @@ func (m *mockCOCommon) IsCNSCSIFSSEnabled(ctx context.Context, featureName strin
 }
 
 func (m *mockCOCommon) IsPVCSIFSSEnabled(ctx context.Context, featureName string) bool {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (m *mockCOCommon) EnableFSS(ctx context.Context, featureName string) error {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (m *mockCOCommon) DisableFSS(ctx context.Context, featureName string) error {
 	//TODO implement me
 	panic("implement me")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR addresses a regression introduced by [#3279](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3279).

When the supervisor cluster is deployed with the changes from [#3279](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3279) PR, but the Guest Cluster is still running older code, the guest cluster interprets the workload-domain-isolation feature as disabled, even when the corresponding WCP capability for workload-domain-isolation is actually enabled. 

This PR updates the ConfigMap in the Supervisor to set the workload-domain-isolation FSS to true, ensuring backward compatibility with older Guest Cluster versions that do not check the capability in the Supervisor.


**Testing done**:
Verified deploying cluster with capability enabled but FSS disabled.

```
# kubectl get capabilities.iaas.vmware.com supervisor-capabilities -o  yaml
.
.

     Workload_Domain_Isolation_Supported:
      activated: true
.
.

# kubectl get configmap csi-feature-states -n vmware-system-csi -o yaml
.
.
  workload-domain-isolation: "false"
.
.
```


Patched Image and Updated RBAC rules on the service accout.
and verified Config-map is updated with FSS set to true


```
# kubectl get configmap csi-feature-states -n vmware-system-csi -o yaml
.
.
  workload-domain-isolation: "false"
.
.
```





Logs

{"level":"info","time":"2025-08-19T18:41:54.103158725Z","caller":"k8sorchestrator/k8sorchestrator.go:1246","msg":"Feature \"Workload_Domain_Isolation_Supported\" is a WCP defined feature state. Reading the capabilities CR \"supervisor-capabilities\".","TraceId":"d2c06115-8bef-426c-8309-7870e83010bc"}
{"level":"info","time":"2025-08-19T18:41:54.103221228Z","caller":"k8sorchestrator/k8sorchestrator.go:1268","msg":"Supervisor capability \"Workload_Domain_Isolation_Supported\" is set to true","TraceId":"d2c06115-8bef-426c-8309-7870e83010bc"}
{"level":"warn","time":"2025-08-19T18:42:05.704375029Z","caller":"k8sorchestrator/k8sorchestrator.go:775","msg":"configMapUpdated: Supervisor feature state values from \"csi-feature-states\" stored successfully: map[WCP_VMService_BYOK:false async-query-volume:true block-volume-snapshot:true cns-unregister-volume:false cnsmgr-suspend-create-volume:true csi-sv-feature-states-replication:true csi-transaction-support:false fake-attach:true file-volume:true file-volume-with-vm-service:false improved-csi-idempotency:true linked-clone-support:false list-volumes:true online-volume-extend:true sibling-replica-bound-pvc-check:true storage-quota-m2:true sv-pvc-snapshot-protection-finalizer:false tkgs-ha:true trigger-csi-fullsync:false vdpp-on-stretched-supervisor:true vol-from-snapshot-on-target-ds:false volume-extend:true volume-health:true workload-domain-isolation:true]","TraceId":"0f18f437-7b88-47d5-b976-ca31a165d8c1"}



**Special notes for your reviewer**:
Due to this issue file volume created in the guest cluster were not publishing node affinity rules on the PV.

Verified creating file volume in the guest cluster. Node Affinity rules are correctly set

```
# kubectl describe pv
Name:              pvc-fdb0b68a-cb30-4f57-92e8-b4d5b5865a62
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name:
                   volume.kubernetes.io/provisioner-deletion-secret-namespace:
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      vsanmax-policy
Status:            Bound
Claim:             default/file-pvc-tkc
Reclaim Policy:    Delete
Access Modes:      RWX
VolumeMode:        Filesystem
Capacity:          5Gi
Node Affinity:
  Required Terms:
    Term 0:        topology.kubernetes.io/zone in [az4]
    Term 1:        topology.kubernetes.io/zone in [az1]
    Term 2:        topology.kubernetes.io/zone in [az2]
    Term 3:        topology.kubernetes.io/zone in [az3]
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      0462ee94-788b-476c-b346-f2eecc2251ea-fdb0b68a-cb30-4f57-92e8-b4d5b5865a62
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1755634363058-2776-csi.vsphere.vmware.com
                           type=vSphere CNS File Volume
Events:                <none>
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix backward compatibility for workload-domain-isolation FSS in Guest Clusters
```
