### PR TITLE
pvCSI - add resourceQuota for vmware-system-csi namespace

### DIFF
--- a/manifests/guestcluster/1.34/pvcsi.yaml
+++ b/manifests/guestcluster/1.34/pvcsi.yaml
@@ -6,6 +6,18 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
 ---
 apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: system-priorityclass-resourcequota
+  namespace: {{ .PVCSINamespace }}
+spec:
+  scopeSelector:
+    matchExpressions:
+      - operator : In
+        scopeName: PriorityClass
+        values: ["system-node-critical", "system-cluster-critical"] 
+---
+apiVersion: v1
 kind: LimitRange
 metadata:
   name: vsphere-csi-limit-range


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add resourceQuota for pvCSI vmware-system-csi namespace.

Limiting PriorityClass consumption by[ default ](https://kubernetes.io/docs/concepts/policy/resource-quotas/#limit-priority-class-consumption-by-default) introduces a safeguard to restrict the usage of high-priority classes like system-node-critical and/or system-cluster-critical to only a few, well-defined namespaces.

This ensures that critical resources remain reserved for truly essential workloads, preventing accidental or intentional overuse, and improving overall cluster stability. It ensures that no single team or service can monopolize critical priority levels, enabling fair usage and preventing resource overcommitment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing 
```
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]#  kubectl get secret  wl-antrea-kubeconfig  -n test-ns -o jsonpath="{.data.value}" | base64 -d > gc-cluster.yaml
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]# ls
gc-cluster.yaml
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]# k get deploy -n vmware-system-csi 
NAME                     READY   UP-TO-DATE   AVAILABLE   AGE
vsphere-csi-controller   1/1     1            1           6h22m
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]# k get pod -n  vmware-system-csi
NAME                                      READY   STATUS    RESTARTS        AGE
vsphere-csi-controller-5c44b4fdf9-s7dnv   7/7     Running   0               6h22m
vsphere-csi-node-mt2mz                    3/3     Running   0               6h21m
vsphere-csi-node-p27m4                    3/3     Running   1 (6h17m ago)   6h17m
vsphere-csi-node-th5bh                    3/3     Running   2 (6h22m ago)   6h22m
vsphere-csi-node-vtgck                    3/3     Running   2 (6h12m ago)   6h12m
vsphere-csi-node-zngfb                    3/3     Running   0               6h21m
vsphere-csi-node-znzwn                    3/3     Running   0               6h21m
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]# cat resourcequota.yaml 
apiVersion: v1
kind: ResourceQuota
metadata:
  name: system-priorityclass-resourcequota
  namespace: vmware-system-csi
spec:
  scopeSelector:
    matchExpressions:
      - operator : In
        scopeName: PriorityClass
        values: ["system-node-critical", "system-cluster-critical"] 
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]# k apply -f resourcequota.yaml
resourcequota/system-priorityclass-resourcequota created
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]#  k get ResourceQuota -n vmware-system-csi
NAME                                 AGE   REQUEST   LIMIT
system-priorityclass-resourcequota   42s             
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]#  k get ResourceQuota -n vmware-system-csi -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: ResourceQuota
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"v1","kind":"ResourceQuota","metadata":{"annotations":{},"name":"system-priorityclass-resourcequota","namespace":"vmware-system-csi"},"spec":{"scopeSelector":{"matchExpressions":[{"operator":"In","scopeName":"PriorityClass","values":["system-node-critical","system-cluster-critical"]}]}}}
    creationTimestamp: "2025-08-24T15:04:19Z"
    name: system-priorityclass-resourcequota
    namespace: vmware-system-csi
    resourceVersion: "76963"
    uid: 041d1f38-daf8-402c-89b6-78de02e78f5a
  spec:
    scopeSelector:
      matchExpressions:
      - operator: In
        scopeName: PriorityClass
        values:
        - system-node-critical
        - system-cluster-critical
  status: {}
kind: List
metadata:
  resourceVersion: ""
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]# k delete pod -n  vmware-system-csi vsphere-csi-controller-5c44b4fdf9-s7dnv
pod "vsphere-csi-controller-5c44b4fdf9-s7dnv" deleted
root@423255eb0fc1bb4d32fe2c59f3a61901 [ ~ ]# k get pod -n  vmware-system-csi
NAME                                      READY   STATUS    RESTARTS        AGE
vsphere-csi-controller-5c44b4fdf9-kgbd9   7/7     Running   0               9s
vsphere-csi-node-mt2mz                    3/3     Running   0               6h33m
vsphere-csi-node-p27m4                    3/3     Running   1 (6h29m ago)   6h29m
vsphere-csi-node-th5bh                    3/3     Running   2 (6h34m ago)   6h34m
vsphere-csi-node-vtgck                    3/3     Running   2 (6h24m ago)   6h24m
vsphere-csi-node-zngfb                    3/3     Running   0               6h33m
vsphere-csi-node-znzwn                    3/3     Running   0               6h33m
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add resourceQuota for vmware-system-csi namespace (pvCSI)
```
