### PR TITLE
Ensure that an RWO volume is not attached to a VM via CnsNodeVmAttachment CR (before upgrade).

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,7 +23,7 @@ set -o nounset
 set -o pipefail
 set -x
 
-DO_WINDOWS_BUILD=${DO_WINDOWS_BUILD_ENV:-false}
+DO_WINDOWS_BUILD=${DO_WINDOWS_BUILD_ENV:-true}
 
 # BASE_REPO is the root path of the image repository
 readonly BASE_IMAGE_REPO=us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,7 +23,7 @@ set -o nounset
 set -o pipefail
 set -x
 
-DO_WINDOWS_BUILD=${DO_WINDOWS_BUILD_ENV:-true}
+DO_WINDOWS_BUILD=${DO_WINDOWS_BUILD_ENV:-false}
 
 # BASE_REPO is the root path of the image repository
 readonly BASE_IMAGE_REPO=us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -123,8 +123,9 @@ func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 	volumeManager volumes.Manager, vmOperatorClient client.Client,
 	recorder record.EventRecorder) reconcile.Reconciler {
 	return &Reconciler{client: mgr.GetClient(),
-		scheme:     mgr.GetScheme(),
-		configInfo: *configInfo, volumeManager: volumeManager,
+		scheme:           mgr.GetScheme(),
+		configInfo:       *configInfo,
+		volumeManager:    volumeManager,
 		vmOperatorClient: vmOperatorClient,
 		recorder:         recorder, instanceLock: sync.Map{}}
 }

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/vmware/govmomi/object"
 	v1 "k8s.io/api/core/v1"
@@ -59,6 +60,16 @@ var namespaceNetworkInfoGVR = schema.GroupVersionResource{
 	Version:  "v1alpha1",
 	Resource: "namespacenetworkinfos",
 }
+
+var (
+	// VolumesAtatchedBeforeUpgrade contains the volumeIDs which have been attached to a VM
+	// via the CnsNodeVmAttachment CR.
+	// From 9.1 onwards, new attachements will happen only via CnsNodeVmBatchAttachment CR.
+	VolumesAtatchedBeforeUpgrade map[string]bool
+	// This is the lock to which is acquired before doing any read/write operation
+	// on VolumesAtatchedBeforeUpgrade map.
+	MapLock *sync.Mutex
+)
 
 const (
 	snatIPAnnotation = "ncp/snat_ip"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Ensure that an RWO volume is not attached to a VM via CnsNodeVmAttachment CR (before upgrade) while finding out if a volume needs to be detached or not. It is possible that there was a volume which was attached to a VM before upgrade and this its attachment happened via CnsNodeVmAttachment CR.


**Testing done**:

Created a VM and attached it to a PVC using CnsNodeVmAttachment CR.

Then attached the same VM to multiple volumes using CnsNodeVmBatchAttachment CR.

Detached 1 volume from the VM using CnsNodeVmBatchAttachment CR.
Ensured the the volume attached via CnsNodeVmAttachment CR did not get detached by checking the VM on the mob.
