### PR TITLE
Code changes to support running vm service vm tests with Immediate and LateBinding storage policies

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -274,6 +274,7 @@ const (
 	envStoragePolicyNameForVsanNfsDatastores = "STORAGE_POLICY_FOR_VSAN_NFS_DATASTORES"
 	devopsKubeConf                           = "DEV_OPS_USER_KUBECONFIG"
 	quotaSupportedVCVersion                  = "9.0.0"
+	lateBinding                              = "-latebinding"
 )
 
 /*
@@ -365,6 +366,7 @@ var (
 	multipleSvc          bool
 	multivc              bool
 	stretchedSVC         bool
+	latebinding          bool
 )
 
 // For busybox pod image
@@ -639,6 +641,12 @@ func setClusterFlavor(clusterFlavor cnstypes.CnsClusterFlavor) {
 	testbedType := os.Getenv("STRETCHED_SVC")
 	if strings.TrimSpace(string(testbedType)) == "1" {
 		stretchedSVC = true
+	}
+
+	//Check if policy given is latebinding
+	bindingModeType := os.Getenv("BINDING_MODE_TYPE")
+	if strings.TrimSpace(string(bindingModeType)) == "WFFC" {
+		latebinding = true
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR includes updates to the existing VM Service VM regression suite to ensure compatibility with both Immediate and LateBinding storage policies, while verifying that no regressions are introduced and that the suite runs smoothly with the new changes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Running existing regression with LateBinding mode storage policy

**Testing done**:
Yes
[test-logs-old.txt](https://github.com/user-attachments/files/22088819/test-logs-old.txt)

[test-logs-new.txt](https://github.com/user-attachments/files/22088830/test-logs-new.txt)

**Special notes for your reviewer**:

