### PR TITLE
set max back off duration for reconcilers

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -854,7 +854,8 @@ func recordEvent(ctx context.Context, r *ReconcileCnsFileAccessConfig,
 	case v1.EventTypeWarning:
 		// Double backOff duration.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = backOffDuration[namespacedName] * 2
+		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
+			cnsoperatortypes.MaxBackOffDurationForReconciler)
 		r.recorder.Event(instance, v1.EventTypeWarning, "CnsFileAccessConfigFailed", msg)
 		backOffDurationMapMutex.Unlock()
 	case v1.EventTypeNormal:

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -928,7 +928,8 @@ func recordEvent(ctx context.Context, r *ReconcileCnsNodeVMAttachment,
 	case v1.EventTypeWarning:
 		// Double backOff duration.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = backOffDuration[namespacedName] * 2
+		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
+			cnsoperatortypes.MaxBackOffDurationForReconciler)
 		backOffDurationMapMutex.Unlock()
 		r.recorder.Event(instance, v1.EventTypeWarning, "NodeVMAttachFailed", msg)
 		log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -529,7 +529,8 @@ func recordEvent(ctx context.Context, r *Reconciler,
 	case v1.EventTypeWarning:
 		// Double backOff duration.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = backOffDuration[namespacedName] * 2
+		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
+			cnsoperatortypes.MaxBackOffDurationForReconciler)
 		backOffDurationMapMutex.Unlock()
 		r.recorder.Event(instance, v1.EventTypeWarning, "NodeVmBatchAttachFailed", msg)
 		log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 
 	clientConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -1010,7 +1011,8 @@ func recordEvent(ctx context.Context, r *ReconcileCnsRegisterVolume,
 	case v1.EventTypeWarning:
 		// Double backOff duration.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = backOffDuration[namespacedName] * 2
+		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
+			cnsoperatortypes.MaxBackOffDurationForReconciler)
 		r.recorder.Event(instance, v1.EventTypeWarning, "CnsRegisterVolumeFailed", msg)
 		backOffDurationMapMutex.Unlock()
 	case v1.EventTypeNormal:

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/controller.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	v1a1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsunregistervolume/v1alpha1"
@@ -50,7 +51,6 @@ import (
 
 const (
 	defaultMaxWorkerThreads = 10
-	maxBackOffDuration      = 5 * time.Minute
 )
 
 var (
@@ -332,7 +332,8 @@ func recordEvent(ctx context.Context, r *Reconciler,
 	case v1.EventTypeWarning:
 		// Double backOff duration.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2, maxBackOffDuration)
+		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
+			cnsoperatortypes.MaxBackOffDurationForReconciler)
 		r.recorder.Event(instance, v1.EventTypeWarning, "CnsUnregisterVolumeFailed", msg)
 		backOffDurationMapMutex.Unlock()
 	case v1.EventTypeNormal:

--- a/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
@@ -507,7 +507,8 @@ func recordEvent(ctx context.Context, r *ReconcileCnsVolumeMetadata,
 	case v1.EventTypeWarning:
 		// Double backOff duration.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = backOffDuration[namespacedName] * 2
+		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
+			cnsoperatortypes.MaxBackOffDurationForReconciler)
 		backOffDurationMapMutex.Unlock()
 		r.recorder.Event(instance, v1.EventTypeWarning, "UpdateFailed", msg)
 		log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -466,7 +467,8 @@ func updateCRStatus(ctx context.Context, r *ReconcileCSINodeTopology, instance *
 	case csinodetopologyv1alpha1.CSINodeTopologyError:
 		// Increase backoff duration for the instance.
 		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = backOffDuration[namespacedName] * 2
+		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
+			cnsoperatortypes.MaxBackOffDurationForReconciler)
 		backOffDurationMapMutex.Unlock()
 
 		// Record an event on the CR.

--- a/pkg/syncer/cnsoperator/types/types.go
+++ b/pkg/syncer/cnsoperator/types/types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package types
 
+import "time"
+
 const (
 	// CNSFinalizer is the finalizer on CNSNodeVmAttachment and CnsVolumeMetadata controllers
 	CNSFinalizer = "cns.vmware.com"
@@ -41,4 +43,6 @@ const (
 	LabelVirtualMachineName = "vm.consumer.storage.com/name"
 	// Label that points to a StoragePolicyReservation CR name. This is added to CNSRegisterVolume CR and PVC.
 	LabelStoragePolicyReservationName = "quota.storage.vmware.com/storagepolicyreservation-name"
+	// MaxBackOffDurationForReconciler for supervisor APIs is set to 5 minutes
+	MaxBackOffDurationForReconciler = 5 * time.Minute
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
set max back off duration for reconcilers.

Currently, the reconcile failure backoff starts at 1 second and doubles after every failure without any upper limit. This behavior does not align well with PVCSI operations. For example, PVCSI attach/detach operations have a maximum backoff capped at 5 minutes.

If the PVCSI attach operation retries after 5 minutes, but the reconcile backoff in the supervisor has already grown beyond 5 minutes, the overall operation can take significantly longer to complete—even if the underlying failure condition has already been resolved. This accumulated backoff delay in the reconciler negatively impacts operation completion time and requires manual restart of syncer container in the supervisor.

We need to make sure following Reconciler has max back off set for failure retry.

- csinodetopology
- cnsunregistervolume
- cnsvolumemetadata
- virtualmachinesnapshot
- cnsnodevmbatchattachment
- cnsregistervolume
- cnsfileaccessconfig
- cnsnodevmattachment


**Testing done**:
Verified max back off is set to 5 minutes.

Logs

```
{"level":"info","time":"2025-08-28T23:09:29.358170591Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:225","msg":"Reconciling CnsNodeVmAttachment with Request.Name: \"pvc-attachment\" Namespace \"test-ns\" timeout \"4m16s\" seconds","TraceId":"e473a9ec-0279-4cf5-85b0-ad3ba0bce60f"}

.
.
{"level":"info","time":"2025-08-28T23:13:45.397895101Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:225","msg":"Reconciling CnsNodeVmAttachment with Request.Name: \"pvc-attachment\" Namespace \"test-ns\" timeout \"5m0s\" seconds","TraceId":"d804fac5-8e0b-431f-96c3-8fd153f6b640"}
.
.
{"level":"info","time":"2025-08-28T23:18:45.459889375Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:225","msg":"Reconciling CnsNodeVmAttachment with Request.Name: \"pvc-attachment\" Namespace \"test-ns\" timeout \"5m0s\" seconds","TraceId":"ee456b50-29e9-4828-8f3c-7d50e51a22bb"}

```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set max back off duration for reconcilers
```
