### PR TITLE
Update CSI spec dependency to v1.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.2
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/akutz/gofsutil v0.1.2
-	github.com/container-storage-interface/spec v1.9.0
+	github.com/container-storage-interface/spec v1.11.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/fsnotify/fsnotify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNSjIRk=
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
-github.com/container-storage-interface/spec v1.9.0 h1:zKtX4STsq31Knz3gciCYCi1SXtO2HJDecIjDVboYavY=
-github.com/container-storage-interface/spec v1.9.0/go.mod h1:ZfDu+3ZRyeVqxZM0Ds19MVLkN2d1XJ5MAfi1L3VjlT0=
+github.com/container-storage-interface/spec v1.11.0 h1:H/YKTOeUZwHtyPOr9raR+HgFmGluGCklulxDYxSdVNM=
+github.com/container-storage-interface/spec v1.11.0/go.mod h1:DtUvaQszPml1YJfIK7c00mlv6/g4wNMLanLgiUbKFRI=
 github.com/containerd/containerd/api v1.8.0 h1:hVTNJKR8fMc/2Tiw60ZRijntNMd1U+JVMyTRdsD2bS0=
 github.com/containerd/containerd/api v1.8.0/go.mod h1:dFv4lt6S20wTu/hMcP4350RL87qPWLVa/OHOwmmdnYc=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/pkg/csi/service/common/types.go
+++ b/pkg/csi/service/common/types.go
@@ -30,10 +30,8 @@ var (
 	// BlockVolumeCaps represents how the block volume could be accessed.
 	// CNS block volumes support only SINGLE_NODE_WRITER where the volume is
 	// attached to a single node at any given time.
-	BlockVolumeCaps = []csi.VolumeCapability_AccessMode{
-		{
-			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-		},
+	BlockVolumeCaps = []csi.VolumeCapability_AccessMode_Mode{
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 	}
 
 	// MultiNodeVolumeCaps represents how the file volume or shared raw block volume
@@ -41,16 +39,10 @@ var (
 	// CNS file volumes or shared raw block volumes support
 	//  MULTI_NODE_READER_ONLY, MULTI_NODE_SINGLE_WRITER
 	// and MULTI_NODE_MULTI_WRITER
-	MultiNodeVolumeCaps = []csi.VolumeCapability_AccessMode{
-		{
-			Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
-		},
-		{
-			Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER,
-		},
-		{
-			Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
-		},
+	MultiNodeVolumeCaps = []csi.VolumeCapability_AccessMode_Mode{
+		csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 	}
 
 	// ErrNotFound represents not found error

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -185,12 +185,12 @@ func IsVolumeReadOnly(capability *csi.VolumeCapability) bool {
 // validateVolumeCapabilities validates the access mode in given volume
 // capabilities in validAccessModes.
 func validateVolumeCapabilities(volCaps []*csi.VolumeCapability,
-	validAccessModes []csi.VolumeCapability_AccessMode, volumeType string) error {
+	validAccessModes []csi.VolumeCapability_AccessMode_Mode, volumeType string) error {
 	// Validate if all capabilities of the volume are supported.
 	for _, volCap := range volCaps {
 		found := false
 		for _, validAccessMode := range validAccessModes {
-			if volCap.AccessMode.GetMode() == validAccessMode.GetMode() {
+			if volCap.AccessMode.GetMode() == validAccessMode {
 				found = true
 				break
 			}

--- a/pkg/csi/service/driver.go
+++ b/pkg/csi/service/driver.go
@@ -67,6 +67,8 @@ type vsphereCSIDriver struct {
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID) return an Aborted error
 	volumeLocks *node.VolumeLocks
+	csi.UnimplementedNodeServer
+	csi.UnimplementedIdentityServer
 }
 
 // If k8s node died unexpectedly in an earlier run, the unix socket is left

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -51,7 +51,7 @@ func (driver *vsphereCSIDriver) NodeStageVolume(
 	*csi.NodeStageVolumeResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("NodeStageVolume: called with args %+v", *req)
+	log.Infof("NodeStageVolume: called with args %+v", req)
 
 	volumeID := req.GetVolumeId()
 	volCap := req.GetVolumeCapability()
@@ -112,7 +112,7 @@ func (driver *vsphereCSIDriver) NodeUnstageVolume(
 	*csi.NodeUnstageVolumeResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("NodeUnstageVolume: called with args %+v", *req)
+	log.Infof("NodeUnstageVolume: called with args %+v", req)
 
 	// Validate arguments
 	volumeID := req.GetVolumeId()
@@ -177,7 +177,7 @@ func (driver *vsphereCSIDriver) NodePublishVolume(
 	*csi.NodePublishVolumeResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("NodePublishVolume: called with args %+v", *req)
+	log.Infof("NodePublishVolume: called with args %+v", req)
 	var err error
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -245,7 +245,7 @@ func (driver *vsphereCSIDriver) NodeUnpublishVolume(
 	*csi.NodeUnpublishVolumeResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("NodeUnpublishVolume: called with args %+v", *req)
+	log.Infof("NodeUnpublishVolume: called with args %+v", req)
 
 	volID := req.GetVolumeId()
 	target := req.GetTargetPath()
@@ -275,7 +275,7 @@ func (driver *vsphereCSIDriver) NodeGetVolumeStats(
 	*csi.NodeGetVolumeStatsResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("NodeGetVolumeStats: called with args %+v", *req)
+	log.Infof("NodeGetVolumeStats: called with args %+v", req)
 
 	var err error
 	targetPath := req.GetVolumePath()
@@ -377,7 +377,7 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 	*csi.NodeGetInfoResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("NodeGetInfo: called with args %+v", *req)
+	log.Infof("NodeGetInfo: called with args %+v", req)
 
 	driver.osUtils.ShouldContinue(ctx)
 
@@ -508,7 +508,7 @@ func (driver *vsphereCSIDriver) NodeExpandVolume(
 	*csi.NodeExpandVolumeResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("NodeExpandVolume: called with args %+v", *req)
+	log.Infof("NodeExpandVolume: called with args %+v", req)
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/prototext"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	clientset "k8s.io/client-go/kubernetes"
@@ -772,7 +773,7 @@ func TestExtendVolume(t *testing.T) {
 		},
 		VolumeCapability: capabilities[0],
 	}
-	t.Logf("ControllerExpandVolume will be called with req +%v", *reqExpand)
+	t.Logf("ControllerExpandVolume will be called with req +%v", prototext.Format(reqExpand))
 	respExpand, err := ct.controller.ControllerExpandVolume(ctx, reqExpand)
 	if err != nil {
 		t.Fatal(err)
@@ -830,7 +831,7 @@ func TestMigratedExtendVolume(t *testing.T) {
 			RequiredBytes: 1024,
 		},
 	}
-	t.Logf("ControllerExpandVolume will be called with req +%v", *reqExpand)
+	t.Logf("ControllerExpandVolume will be called with req +%v", prototext.Format(reqExpand))
 	_, err := ct.controller.ControllerExpandVolume(ctx, reqExpand)
 	if err != nil {
 		t.Logf("Expected error received. migrated volume with VMDK path can not be expanded")
@@ -923,7 +924,7 @@ func TestCompleteControllerFlow(t *testing.T) {
 		VolumeCapability: capabilities[0],
 		Readonly:         false,
 	}
-	t.Logf("ControllerPublishVolume will be called with req +%v", *reqControllerPublishVolume)
+	t.Logf("ControllerPublishVolume will be called with req +%v", prototext.Format(reqControllerPublishVolume))
 	respControllerPublishVolume, err := ct.controller.ControllerPublishVolume(ctx, reqControllerPublishVolume)
 	if err != nil {
 		t.Fatal(err)
@@ -936,7 +937,8 @@ func TestCompleteControllerFlow(t *testing.T) {
 		VolumeId: volID,
 		NodeId:   NodeID,
 	}
-	t.Logf("ControllerUnpublishVolume will be called with req +%v", *reqControllerUnpublishVolume)
+	t.Logf("ControllerUnpublishVolume will be called with req +%v",
+		prototext.Format(reqControllerUnpublishVolume))
 	_, err = ct.controller.ControllerUnpublishVolume(ctx, reqControllerUnpublishVolume)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -763,7 +763,7 @@ func isValidVolumeCapabilitiesInWcp(ctx context.Context, volCaps []*csi.VolumeCa
 // validateVolumeCapabilitiesInWcp validates the access mode in given volume
 // capabilities in validAccessModes for WCP cluster.
 func validateVolumeCapabilitiesInWcp(ctx context.Context, volCaps []*csi.VolumeCapability,
-	validAccessModes []csi.VolumeCapability_AccessMode, volumeType string) error {
+	validAccessModes []csi.VolumeCapability_AccessMode_Mode, volumeType string) error {
 
 	log := logger.GetLogger(ctx)
 	isSharedDiskEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SharedDiskFss)
@@ -772,7 +772,7 @@ func validateVolumeCapabilitiesInWcp(ctx context.Context, volCaps []*csi.VolumeC
 	for _, volCap := range volCaps {
 		found := false
 		for _, validAccessMode := range validAccessModes {
-			if volCap.AccessMode.GetMode() == validAccessMode.GetMode() {
+			if volCap.AccessMode.GetMode() == validAccessMode {
 				found = true
 				break
 			}

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -91,6 +91,7 @@ type controller struct {
 	tanzukubernetesClusterUID   string
 	tanzukubernetesClusterName  string
 	guestClusterDist            string
+	csi.UnimplementedControllerServer
 }
 
 // New creates a CNS controller
@@ -301,7 +302,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			pvcNamespace         string
 			isLinkedCloneRequest bool
 		)
-		log.Infof("CreateVolume: called with args %+v", *req)
+		log.Infof("CreateVolume: called with args %+v", req)
 		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
@@ -310,7 +311,8 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		// Later we may need to define different csi faults.
 		err := validateGuestClusterCreateVolumeRequest(ctx, req)
 		if err != nil {
-			log.Errorf("validation for CreateVolume Request: %+v has failed. Error: %+v", *req, err)
+			log.Errorf("validation for CreateVolume Request: %+v has failed. Error: %+v",
+				req, err)
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
 		isFileVolumeRequest := common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities())
@@ -576,7 +578,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 
 	deleteVolumeInternal := func() (
 		*csi.DeleteVolumeResponse, string, error) {
-		log.Infof("DeleteVolume: called with args: %+v", *req)
+		log.Infof("DeleteVolume: called with args: %+v", req)
 		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
@@ -586,7 +588,8 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		var err error
 		err = validateGuestClusterDeleteVolumeRequest(ctx, req)
 		if err != nil {
-			msg := fmt.Sprintf("Validation for Delete Volume Request: %+v has failed. Error: %+v", *req, err)
+			msg := fmt.Sprintf("Validation for Delete Volume Request: %+v has failed. Error: %+v",
+				req, err)
 			log.Error(msg)
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
@@ -636,10 +639,11 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 			ctx, req.VolumeId, *metav1.NewDeleteOptions(0))
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.Debugf("PVC: %q not found in the Supervisor cluster. Assuming this volume to be deleted.", req.VolumeId)
+				log.Debugf("PVC: %q not found in the Supervisor cluster. Assuming this volume to be deleted.",
+					req.VolumeId)
 				return &csi.DeleteVolumeResponse{}, "", nil
 			}
-			msg := fmt.Sprintf("DeleteVolume Request: %+v has failed. Error: %+v", *req, err)
+			msg := fmt.Sprintf("DeleteVolume Request: %+v has failed. Error: %+v", req, err)
 			log.Error(msg)
 			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
 		}
@@ -687,7 +691,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 
 	controllerPublishVolumeInternal := func() (
 		*csi.ControllerPublishVolumeResponse, string, error) {
-		log.Infof("ControllerPublishVolume: called with args %+v", *req)
+		log.Infof("ControllerPublishVolume: called with args %+v", req)
 		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
@@ -700,7 +704,8 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 
 		err := validateGuestClusterControllerPublishVolumeRequest(ctx, req)
 		if err != nil {
-			msg := fmt.Sprintf("Validation for PublishVolume Request: %+v has failed. Error: %v", *req, err)
+			msg := fmt.Sprintf("Validation for PublishVolume Request: %+v has failed. Error: %v",
+				req, err)
 			log.Error(msg)
 			return nil, csifault.CSIInvalidArgumentFault, status.Error(codes.Internal, msg)
 		}
@@ -1064,7 +1069,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 
 	controllerUnpublishVolumeInternal := func() (
 		*csi.ControllerUnpublishVolumeResponse, string, error) {
-		log.Infof("ControllerUnpublishVolume: called with args %+v", *req)
+		log.Infof("ControllerUnpublishVolume: called with args %+v", req)
 		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
@@ -1074,7 +1079,8 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 
 		err := validateGuestClusterControllerUnpublishVolumeRequest(ctx, req)
 		if err != nil {
-			msg := fmt.Sprintf("Validation for UnpublishVolume Request: %+v has failed. Error: %v", *req, err)
+			msg := fmt.Sprintf("Validation for UnpublishVolume Request: %+v has failed. Error: %v",
+				req, err)
 			log.Error(msg)
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
@@ -1382,7 +1388,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 
 	controllerExpandVolumeInternal := func() (
 		*csi.ControllerExpandVolumeResponse, string, error) {
-		log.Infof("ControllerExpandVolume: called with args %+v", *req)
+		log.Infof("ControllerExpandVolume: called with args %+v", req)
 		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
@@ -1526,7 +1532,7 @@ func (c *controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 	*csi.ValidateVolumeCapabilitiesResponse, error) {
 
 	log := logger.GetLogger(ctx)
-	log.Infof("ValidateVolumeCapabilities: called with args %+v", *req)
+	log.Infof("ValidateVolumeCapabilities: called with args %+v", req)
 	volCaps := req.GetVolumeCapabilities()
 	var confirmed *csi.ValidateVolumeCapabilitiesResponse_Confirmed
 	if err := common.IsValidVolumeCapabilities(ctx, volCaps); err == nil {
@@ -1542,7 +1548,7 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("ListVolumes: called with args %+v", *req)
+	log.Infof("ListVolumes: called with args %+v", req)
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
@@ -1550,7 +1556,7 @@ func (c *controller) GetCapacity(ctx context.Context, req *csi.GetCapacityReques
 	*csi.GetCapacityResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("GetCapacity: called with args %+v", *req)
+	log.Infof("GetCapacity: called with args %+v", req)
 
 	// Setting capacity to MaxInt64 for all topologies except for those which have been marked for deletion by VI Admin.
 	totalcapacity := int64(math.MaxInt64)
@@ -1587,7 +1593,7 @@ func (c *controller) ControllerGetCapabilities(ctx context.Context, req *csi.Con
 
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	log.Infof("ControllerGetCapabilities: called with args %+v", *req)
+	log.Infof("ControllerGetCapabilities: called with args %+v", req)
 	var caps []*csi.ControllerServiceCapability
 	for _, cap := range controllerCaps {
 		c := &csi.ControllerServiceCapability{
@@ -1608,7 +1614,7 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 	log := logger.GetLogger(ctx)
 	start := time.Now()
 	volumeType := prometheus.PrometheusBlockVolumeType
-	log.Infof("CreateSnapshot: called with args %+v", *req)
+	log.Infof("CreateSnapshot: called with args %+v", req)
 	isBlockVolumeSnapshotWCPEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.BlockVolumeSnapshot)
 	if !isBlockVolumeSnapshotWCPEnabled {
@@ -1740,7 +1746,7 @@ func (c *controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshot
 	log := logger.GetLogger(ctx)
 	start := time.Now()
 	volumeType := prometheus.PrometheusBlockVolumeType
-	log.Infof("DeleteSnapshot: called with args %+v", *req)
+	log.Infof("DeleteSnapshot: called with args %+v", req)
 	isBlockVolumeSnapshotWCPEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 	if !isBlockVolumeSnapshotWCPEnabled {
 		return nil, logger.LogNewErrorCode(log, codes.Unimplemented, "deleteSnapshot")
@@ -1833,13 +1839,13 @@ func (c *controller) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRe
 	log := logger.GetLogger(ctx)
 	start := time.Now()
 	volumeType := prometheus.PrometheusBlockVolumeType
-	log.Infof("ListSnapshots: called with args %+v", *req)
+	log.Infof("ListSnapshots: called with args %+v", req)
 	isBlockVolumeSnapshotEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 	if !isBlockVolumeSnapshotEnabled {
 		return nil, logger.LogNewErrorCode(log, codes.Unimplemented, "listSnapshot")
 	}
 	listSnapshotsInternal := func() (*csi.ListSnapshotsResponse, error) {
-		log.Infof("ListSnapshots: called with args %+v", *req)
+		log.Infof("ListSnapshots: called with args %+v", req)
 		maxEntries := common.QuerySnapshotLimit
 		if req.MaxEntries != 0 {
 			log.Warnf("Specifying MaxEntries in ListSnapshotRequest is not supported,"+


### PR DESCRIPTION
**What this PR does / why we need it**:
This change updatesthe  CSI Spec Dependency to v1.11

Updated CSI driver server implementation to embed UnimplementedControllerServer in vanilla, supervisor and guest

CSI v1.11 updates the gRPC-generated interfaces to require mustEmbedUnimplementedControllerServer, ensuring drivers explicitly embed csi.UnimplementedControllerServer. This improves forward compatibility by providing default stubs for new RPCs and prevents silent breakage during future spec upgrades.

Additionally, changes to logging of the protobuf request.
Changed it from "*req" to "req" because "*req" dereferenced the req, which contains lock state, which causes lint errors.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Pre-checkins: 

WCP: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/216/
VKS: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/326/

Tested Create PVC:

```
{"level":"info","time":"2025-08-26T21:58:31.257624556Z","caller":"wcp/controller.go:1603","msg":"CreateVolume: called with args name:\"pvc-66b7d9ef-63f5-4bcf-b6f5-e52b9c0ea8b5\"  capacity_range:{required_bytes:1073741824}  volume_capabilities:{mount:{fs_type:\"ext4\"}  access_mode:{mode:SINGLE_NODE_WRITER}}  parameters:{key:\"csi.storage.k8s.io/pv/name\"  value:\"pvc-66b7d9ef-63f5-4bcf-b6f5-e52b9c0ea8b5\"}  parameters:{key:\"csi.storage.k8s.io/pvc/name\"  value:\"src-pvc\"}  parameters:{key:\"csi.storage.k8s.io/pvc/namespace\"  value:\"testns\"}  parameters:{key:\"csi.storage.k8s.io/sc/name\"  value:\"wcpglobal-storage-profile\"}  parameters:{key:\"csi.vsphere.k8s.io/linked-clone\"  value:\"false\"}  parameters:{key:\"storagePolicyID\"  value:\"f542d232-3246-4ec0-9202-858f695db549\"}  accessibility_requirements:{requisite:{segments:{key:\"topology.kubernetes.io/zone\"  value:\"domain-c36\"}}  preferred:{segments:{key:\"topology.kubernetes.io/zone\"  value:\"domain-c36\"}}}","TraceId":"8ae37e0f-f19d-4a8a-bc80-6446720ba34e"}

```

**Special notes for your reviewer**:

**Release note**:
```release-note
CSI Spec Dependency to v1.11
```
