### PR TITLE
Improve capabilities check for case when TKR is newer than supervisor

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1126,7 +1126,7 @@ func (c *K8sOrchestrator) HandleLateEnablementOfCapability(ctx context.Context,
 			_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Get(ctx,
 				"capabilities.iaas.vmware.com", metav1.GetOptions{})
 			if err != nil {
-				if apierrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 					// If capabilities CR is not registered on supervisor, then sleep for some time and check
 					// again if CR has been registered on supervisor. If TKR is new, but supervisor is old, then
 					// it could happen that capabilities CR is not registered on the supervisor cluster.
@@ -1342,6 +1342,32 @@ func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) 
 					}
 					// Get rest client config for supervisor.
 					restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx, cfg.GC.Endpoint, cfg.GC.Port)
+					// Check if CRD for capabilities exists
+					// If CRD does not exist on supervisor then skip further capability check
+					// this is case when tkr is newer and supervisor is older where capabilities CRD does not exist.
+					apiextensionsClientSet, err := apiextensionsclientset.NewForConfig(restClientConfig)
+					if err != nil {
+						log.Errorf("failed to create apiextension clientset using config. Err: %+v", err)
+						return false
+					}
+					_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Get(ctx,
+						"capabilities.iaas.vmware.com", metav1.GetOptions{})
+					if err != nil {
+						if featureName == common.WorkloadDomainIsolationFSS {
+							// prefer CSI internal feature-state configmap for workload-domain-isolation feature
+							// in case capabilities CRD is not registred on supervisor
+							log.Info("CSI workload-domain-isolation is set to true in pvcsi fss configmap. " +
+								"check if it is enabled in cns-csi fss")
+							return c.IsCNSCSIFSSEnabled(ctx, featureName)
+						}
+						if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
+							log.Info("CR instance capabilities.iaas.vmware.com is not registered on supervisor, " +
+								"considering feature to be false")
+							return false
+						}
+						log.Errorf("failed to check if Capabilities CR is registered. Err: %v", err)
+						return false
+					}
 					wcpCapabilityApiClient, err := k8s.NewClientForGroup(ctx, restClientConfig, wcpcapapis.GroupName)
 					if err != nil {
 						log.Errorf("failed to create wcpCapabilityApi client. Err: %+v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Improve capabilities-check compatibility for new TKr versions with older supervisor.
With fix added with this PR, Along with Notfound error for Capabilities CRD we will check for  Forbidden error to access the CRD. Forbidden error returned when supervisor version is older and CRD and Rbacs for CRD not available on supervisor. when notfound and forbidden error for capabilities CRD, We will consider capability is not set on supervisor.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing
tested on setup with tkr is latest and supervisor is 8.x, pods are up and running.
```
root@42374236eb305dc8fbcec8610988e06a [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml
root@42374236eb305dc8fbcec8610988e06a [ ~ ]# kubectl patch pkgi wl-antrea-vsphere-pv-csi -n vmware-system-tkg -p '{"spec":{"paused":true}}' --type=merge
packageinstall.packaging.carvel.dev/wl-antrea-vsphere-pv-csi patched
root@42374236eb305dc8fbcec8610988e06a [ ~ ]# k edit deploy -n vmware-system-csi
Warning: spec.template.spec.containers[2].ports[0]: duplicate port name "prometheus" with spec.template.spec.containers[1].ports[0], services and probes that select ports by name will use spec.template.spec.containers[1].ports[0]
deployment.apps/vsphere-csi-controller edited
root@42374236eb305dc8fbcec8610988e06a [ ~ ]# k get pod -n vmware-system-csi
NAME                                      READY   STATUS              RESTARTS          AGE
vsphere-csi-controller-68db4d7474-2pkl6   1/7     CrashLoopBackOff    55 (98s ago)      28m
vsphere-csi-controller-7d84c8dd58-cpfz6   0/7     ContainerCreating   0                 9s
vsphere-csi-node-7p4xk                    2/3     CrashLoopBackOff    130 (3m14s ago)   12h
vsphere-csi-node-d22pn                    2/3     CrashLoopBackOff    129 (37s ago)     12h
vsphere-csi-node-kbrrf                    2/3     CrashLoopBackOff    129 (2m51s ago)   12h
vsphere-csi-node-ktx8j                    2/3     CrashLoopBackOff    128 (4m48s ago)   12h
vsphere-csi-node-l5qtl                    2/3     CrashLoopBackOff    129 (11s ago)     12h
vsphere-csi-node-vzwz5                    2/3     CrashLoopBackOff    129 (75s ago)     12h
root@42374236eb305dc8fbcec8610988e06a [ ~ ]# k get pod -n vmware-system-csi -w
NAME                                      READY   STATUS             RESTARTS          AGE
vsphere-csi-controller-7d84c8dd58-cpfz6   7/7     Running            0                 38s
vsphere-csi-node-7p4xk                    2/3     CrashLoopBackOff   130 (3m43s ago)   12h
vsphere-csi-node-d22pn                    2/3     CrashLoopBackOff   129 (66s ago)     12h
vsphere-csi-node-kbrrf                    2/3     CrashLoopBackOff   129 (3m20s ago)   12h
vsphere-csi-node-ktx8j                    3/3     Running            129 (5m17s ago)   12h
vsphere-csi-node-l5qtl                    2/3     CrashLoopBackOff   129 (40s ago)     12h
vsphere-csi-node-vzwz5                    2/3     CrashLoopBackOff   129 (104s ago)    12h
^Croot@42374236eb305dc8fbcec8610988e06a [ ~ ]# k delete pod vsphere-csi-node-7p4xk  vsphere-csi-node-d22pn vsphere-csi-node-kbrrf  vsphere-csi-node-ktx8j vsphere-csi-node-l5qtl  vsphere-csi-node-vzwz5 -n vmware-system-csi
pod "vsphere-csi-node-7p4xk" deleted
pod "vsphere-csi-node-d22pn" deleted
pod "vsphere-csi-node-kbrrf" deleted
pod "vsphere-csi-node-ktx8j" deleted
pod "vsphere-csi-node-l5qtl" deleted
pod "vsphere-csi-node-vzwz5" deleted
root@42374236eb305dc8fbcec8610988e06a [ ~ ]# k get pod -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-7d84c8dd58-cpfz6   7/7     Running   0             3m16s
vsphere-csi-node-6lfhv                    3/3     Running   1 (38s ago)   102s
vsphere-csi-node-7r2km                    3/3     Running   1 (38s ago)   102s
vsphere-csi-node-9gskr                    3/3     Running   1 (38s ago)   102s
vsphere-csi-node-dv5dl                    3/3     Running   1 (38s ago)   102s
vsphere-csi-node-j4hg2                    3/3     Running   1 (38s ago)   102s
vsphere-csi-node-l75m9                    3/3     Running   1 (39s ago)   103s
root@42374236eb305dc8fbcec8610988e06a [ ~ ]# 
```
CSI Controller Logs:
```
{"level":"info","time":"2025-08-29T07:13:31.478115046Z","caller":"k8sorchestrator/k8sorchestrator.go:1135","msg":"CR instance capabilities.iaas.vmware.com is not registered on supervisor, sleep for some time and check again if the CR instance is registered on the supervisor cluster.","TraceId":"3a77a30e-5642-4935-a191-f6313733131c"}
{"level":"info","time":"2025-08-29T07:13:31.478187168Z","caller":"k8sorchestrator/k8sorchestrator.go:1135","msg":"CR instance capabilities.iaas.vmware.com is not registered on supervisor, sleep for some time and check again if the CR instance is registered on the supervisor cluster.","TraceId":"3a77a30e-5642-4935-a191-f6313733131c"}


"level":"info","time":"2025-08-29T09:49:09.042057164Z","caller":"kubernetes/kubernetes.go:348","msg":"adding scheme for vm-operator versions v1alpha1, v1alpha2, v1alpha3, v1alpha4","TraceId":"273829f8-0e1a-4ac5-8304-b6901dd70f7c"}
{"level":"info","time":"2025-08-29T09:49:09.07024842Z","caller":"k8sorchestrator/k8sorchestrator.go:1367","msg":"CSI workload-domain-isolation is set to true in pvcsi fss configmap. check if it is enabled in cns-csi fss","TraceId":"273829f8-0e1a-4ac5-8304-b6901dd70f7c"}
{"level":"info","time":"2025-08-29T09:49:09.070330446Z","caller":"k8sorchestrator/k8sorchestrator.go:1448","msg":"linked-clone-support feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap","TraceId":"273829f8-0e1a-4ac5-8304-b6901dd70f7c"}
```
[csi-controller-tkr_capability_check.log](https://github.com/user-attachments/files/22042987/csi-controller-tkr_capability_check.log)

[vsphere-syncer-tkr-capability-check.log](https://github.com/user-attachments/files/22039223/vsphere-syncer-tkr-capability-check.log)

[csi-controller-tkr_capabilities_available_on_supervisor.log](https://github.com/user-attachments/files/22039345/csi-controller-tkr_capabilities_available_on_supervisor.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Improve capabilities-check compatibility for new TKr versions with older supervisor.
```
