### PR TITLE
Improvement in reconciling logic for vmsnapshot and rbacs

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -129,6 +129,9 @@ rules:
   - apiGroups: ["nsx.vmware.com"]
     resources: ["namespacenetworkinfos"]
     verbs: ["get", "list"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachinesnapshots"]
+    verbs: ["get", "list", "patch", "update", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -129,6 +129,9 @@ rules:
   - apiGroups: ["nsx.vmware.com"]
     resources: ["namespacenetworkinfos"]
     verbs: ["get", "list"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachinesnapshots"]
+    verbs: ["get", "list", "patch", "update", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Improvement in reconciling logic for VMSnapshot and Rbacs for n-2 versions

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing
exponential back-off duration added on error
```
{"level":"error","time":"2025-08-28T19:42:36.912185146Z","caller":"virtualmachinesnapshot/virtualmachinesnapshot_controller.go:242","msg":"error while processing virtualmachinesnapshot test-ns/my-cluster-np-1-vcqpj-92r29-hpw5c-snapshot-err set backOffDuration: 2s. error: virtualmachines.vmoperator.vmware.com \"my-cluster-np-1-vcqpj-92r29-hpw5c-err\" not found","TraceId":"bbd8dd6e-09a9-4a2b-a499-a3bce71ae662",
.
.
{"level":"error","time":"2025-08-28T19:42:51.970451742Z","caller":"virtualmachinesnapshot/virtualmachinesnapshot_controller.go:242","msg":"error while processing virtualmachinesnapshot test-ns/my-cluster-np-1-vcqpj-92r29-hpw5c-snapshot-err set backOffDuration: 32s. error: virtualmachines.vmoperator.vmware.com \"my-cluster-np-1-vcqpj-92r29-hpw5c-err\" not found","TraceId":"112ab9db-dfb5-4f35-9a48-936eff81baba",
.
.
{"level":"error","time":"2025-08-28T19:43:40.10219297Z","caller":"virtualmachinesnapshot/virtualmachinesnapshot_controller.go:242","msg":"error while processing virtualmachinesnapshot test-ns/my-cluster-np-1-vcqpj-92r29-hpw5c-snapshot-err set backOffDuration: 2m8s. error: virtualmachines.vmoperator.vmware.com \"my-cluster-np-1-vcqpj-92r29-hpw5c-err\" not found","TraceId":"35a777c5-e851-4de7-866f-02d6136c59cb"
```

[vmsnapshot_update_successful.log](https://github.com/user-attachments/files/22032235/vmsnapshot_update_successful.log)
[vmsnpshot_err_backoffduration.log](https://github.com/user-attachments/files/22032237/vmsnpshot_err_backoffduration.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Improvement in reconciling logic for VMSnapshot 
```
