### PR TITLE
Change service type to ClusterIP for vsphere-csi-controller service

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -598,7 +598,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -597,7 +597,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -597,7 +597,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -600,7 +600,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR updates the vsphere-csi-controller service to use ClusterIP instead of LoadBalancer.

LoadBalancer exposes metrics outside the cluster, which can be considered overexposure in a VCFA tenancy environment.
ClusterIP restricts the service to internal cluster access, improving security.

Telegraf collects metrics using the service endpoint. Switching to ClusterIP will not affect Telegraf’s configuration or metric collection, provided the service URL (DNS name) remains unchanged.


**Testing done**:
Verified re-creating service with yaml changes

```
# kubectl describe service vmware-system-csi-webhook-service -n vmware-system-csi
Name:                     vmware-system-csi-webhook-service
Namespace:                vmware-system-csi
Labels:                   app=vsphere-csi-webhook
Annotations:              <none>
Selector:                 app=vsphere-csi-webhook
Type:                     ClusterIP
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       172.24.150.172
IPs:                      172.24.150.172
Port:                     <unset>  443/TCP
TargetPort:               9883/TCP
Endpoints:                192.168.128.0:9883
Session Affinity:         None
Internal Traffic Policy:  Cluster
Events:                   <none>
```

there is no impact during upgrade, as during upgrade we are deleting existing service and re-creating new service.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Change service type to ClusterIP for vsphere-csi-controller service
```
