### PR TITLE
Use dedicated service account for vSphere CSI webhook and update RBAC bindings

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -4,6 +4,12 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: vmware-system-csi
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -732,7 +738,7 @@ metadata:
   name: vsphere-csi-webhook-cluster-role-binding
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-webhook
     namespace: vmware-system-csi
 roleRef:
   kind: ClusterRole
@@ -756,7 +762,7 @@ metadata:
   namespace: vmware-system-csi
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-webhook
     namespace: vmware-system-csi
 roleRef:
   kind: Role
@@ -796,6 +802,7 @@ spec:
                       - vsphere-csi-webhook
               topologyKey: kubernetes.io/hostname
       hostNetwork: true
+      serviceAccount: vsphere-csi-webhook
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -4,6 +4,12 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: vmware-system-csi
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -731,7 +737,7 @@ metadata:
   name: vsphere-csi-webhook-cluster-role-binding
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-webhook
     namespace: vmware-system-csi
 roleRef:
   kind: ClusterRole
@@ -755,7 +761,7 @@ metadata:
   namespace: vmware-system-csi
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-webhook
     namespace: vmware-system-csi
 roleRef:
   kind: Role
@@ -795,6 +801,7 @@ spec:
                       - vsphere-csi-webhook
               topologyKey: kubernetes.io/hostname
       hostNetwork: true
+      serviceAccount: vsphere-csi-webhook
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -4,6 +4,12 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: vmware-system-csi
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -731,7 +737,7 @@ metadata:
   name: vsphere-csi-webhook-cluster-role-binding
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-webhook
     namespace: vmware-system-csi
 roleRef:
   kind: ClusterRole
@@ -755,7 +761,7 @@ metadata:
   namespace: vmware-system-csi
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-webhook
     namespace: vmware-system-csi
 roleRef:
   kind: Role
@@ -795,6 +801,7 @@ spec:
                       - vsphere-csi-webhook
               topologyKey: kubernetes.io/hostname
       hostNetwork: true
+      serviceAccount: vsphere-csi-webhook
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -4,6 +4,12 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: vmware-system-csi
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -734,7 +740,7 @@ metadata:
   name: vsphere-csi-webhook-cluster-role-binding
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-webhook
     namespace: vmware-system-csi
 roleRef:
   kind: ClusterRole
@@ -758,7 +764,7 @@ metadata:
   namespace: vmware-system-csi
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-webhook
     namespace: vmware-system-csi
 roleRef:
   kind: Role
@@ -798,6 +804,7 @@ spec:
                       - vsphere-csi-webhook
               topologyKey: kubernetes.io/hostname
       hostNetwork: true
+      serviceAccount: vsphere-csi-webhook
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:

Switch vSphere CSI webhook to use a dedicated service account

- Created a new ServiceAccount `vsphere-csi-webhook` in `vmware-system-csi` namespace.
- Updated `vsphere-csi-webhook-cluster-role-binding` ClusterRoleBinding and `vsphere-csi-webhook-role-binding` RoleBinding to use the new service account `vsphere-csi-webhook` instead of `default`.
- Updated the vSphere CSI webhook Deployment to use new service account `vsphere-csi-webhook`.

This is required for VKS and Supervisor address DSA STIG, NIST 800-53, CIS and PCI DSS requirements  to ensure security and least privilege.

**Testing done**:
Verified deploying webhook with changes made in this PR. No issue observed.
Webhook pod is running without any issue.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Switch vSphere CSI webhook to use a dedicated service account
```
