### PR TITLE
Upgrade CSI Attacher to 4.9.0

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -241,7 +241,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Upgrade CSI Attacher to 4.9.0 to consume the fix related to duplicate detach volume calls.
Refer https://github.com/kubernetes-csi/external-attacher/pull/624 & https://github.com/kubernetes-csi/external-attacher/issues/587 for more details.


**Testing done**:
TBA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade CSI Attacher to 4.9.0
```
