### PR TITLE
Disable CGO_ENABLED in CSI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,11 +106,11 @@ CSI_BIN_SRCS += $(addsuffix /*.go,$(shell go list -f '{{ join .Deps "\n" }}' ./c
 export CSI_BIN_SRCS
 endif
 $(CSI_BIN): $(CSI_BIN_SRCS)
-	CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags '$(LDFLAGS_CSI)' -o $(CSI_BIN_LINUX) $<
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags '$(LDFLAGS_CSI)' -o $(CSI_BIN_LINUX) $<
 	@touch $@
 
 $(CSI_BIN_WINDOWS): $(CSI_BIN_SRCS)
-	CGO_ENABLED=1 GOOS=windows GOARCH=$(GOARCH) go build -ldflags '$(LDFLAGS_CSI)' -o $(CSI_BIN_WINDOWS) $<
+	CGO_ENABLED=0 GOOS=windows GOARCH=$(GOARCH) go build -ldflags '$(LDFLAGS_CSI)' -o $(CSI_BIN_WINDOWS) $<
 	@touch $@
 
 
@@ -144,7 +144,7 @@ CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
 $(SYNCER_BIN): $(SYNCER_BIN_SRCS) syncer_manifest
-	CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags '$(LDFLAGS_SYNCER)' -o $(abspath $@) $<
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags '$(LDFLAGS_SYNCER)' -o $(abspath $@) $<
 	@touch $@
 
 # The default build target.

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -50,7 +50,7 @@ COPY cmd ./cmd/
 ARG GOOS
 ARG GOARCH
 ARG GOPROXY
-ENV CGO_ENABLED=1 GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64}
+ENV CGO_ENABLED=0 GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64}
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
 RUN LDFLAGS=$(cat ldflags.txt) && \
     go build -ldflags "${LDFLAGS}" ./cmd/vsphere-csi

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /build
 COPY go.mod go.sum ./
 COPY pkg/    pkg/
 COPY cmd/    cmd/
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 ENV GOFIPS=1
 ENV GOEXPERIMENT="boringcrypto"
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -37,7 +37,7 @@ COPY pkg/    pkg/
 
 COPY cmd/    cmd/
 
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
 

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /build
 COPY go.mod go.sum ./
 COPY pkg/    pkg/
 COPY cmd/    cmd/
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 ENV GOFIPS=1
 ENV GOEXPERIMENT="boringcrypto"
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -543,6 +543,7 @@ func (vc *VirtualCenter) getDatacenters(ctx context.Context, dcPaths []string) (
 // GetActiveUser returns the current logged in user. It is fetched from govmomi.Session
 // to reflect the real current user being used
 func (vc *VirtualCenter) GetActiveUser(ctx context.Context) (string, error) {
+	log := logger.GetLogger(ctx)
 	if vc.Client == nil || vc.Client.SessionManager == nil {
 		return "", fmt.Errorf("client or sessionmanager are null")
 	}
@@ -551,6 +552,7 @@ func (vc *VirtualCenter) GetActiveUser(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error getting current user: %w", err)
 	}
+	log.Infof("UserName from the session object : %s", userSession.UserName)
 	return userSession.UserName, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Disable CGO_ENABLED in CSI build as k8s prow infra does not support this. 
As part of the FIPS TLS enforcement CGO was enabled - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3506, hence we are observing this issue now.

The internal builds for WCP & GC works as expected for CGO enabled builds as we use internal infra.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes the csi driver build issue on k8s prow, refer - https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-vsphere-csi-driver-push-images/1963011866309431296

**Testing done**:

[pull-vsphere-csi-driver-build](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_vsphere-csi-driver/3522/pull-vsphere-csi-driver-build/1963616910671089664) has passed

build command does not return any error:
```
 CGO_ENABLED=0 GOFIPS=1 GOEXPERIMENT="boringcrypto" GOOS=linux GOARCH=amd64 go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.Version=unknown" -o ./bin/vsphere-syncer ./cmd/syncer
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Disable CGO_ENABLED in CSI build as k8s prow infra does not support this
```
