### PR TITLE
Fix the LinkedClone FSS check and capability checks for pvcsi webhook

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -155,13 +155,15 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 	// some init() function which can initialize required things when capability value changes from false to true.
 	isWorkloadDomainIsolationSupported := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.WorkloadDomainIsolationFSS)
-	isLinkedCloneSupported := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
-		common.LinkedCloneSupportFSS)
+	linkedClonePVCSIFSS := commonco.ContainerOrchestratorUtility.IsPVCSIFSSEnabled(ctx, common.LinkedCloneSupportFSS)
+	linkedCloneCapability := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS)
 	if !isWorkloadDomainIsolationSupported {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 			common.WorkloadDomainIsolation, config.GC.Port, config.GC.Endpoint)
 	}
-	if !isLinkedCloneSupported {
+	// Start the late enablement watcher only if the PVCSI internal FSS is enabled, but the current supervisor
+	// capability is disabled.
+	if linkedClonePVCSIFSS && !linkedCloneCapability {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 			common.LinkedCloneSupport, config.GC.Port, config.GC.Endpoint)
 	}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -359,7 +359,12 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				common.WorkloadDomainIsolation,
 				metadataSyncer.configInfo.Cfg.GC.Port, metadataSyncer.configInfo.Cfg.GC.Endpoint)
 		}
-		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS) {
+		linkedClonePVCSIFSS := commonco.ContainerOrchestratorUtility.IsPVCSIFSSEnabled(ctx, common.LinkedCloneSupportFSS)
+		linkedCloneCapability := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS)
+		IsLinkedCloneSupportFSSEnabled = linkedClonePVCSIFSS && linkedCloneCapability
+		// Start the late enablement watcher only if the PVCSI internal FSS is enabled, but the current supervisor
+		// capability is disabled.
+		if linkedClonePVCSIFSS && !linkedCloneCapability {
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
 				clusterFlavor, common.LinkedCloneSupport,
 				metadataSyncer.configInfo.Cfg.GC.Port, metadataSyncer.configInfo.Cfg.GC.Endpoint)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Update the FSS name to the internal fss name for pvcsi
2. pvcsi webhook now needs to read the supervisor capability to support late enablement of linkedclone capability, to support this, we need to have pvcsi credential volume mounted 
4. It also needs to watch for change in pvcsi configuration and restart the webhook if the credentials change for some reason.
5. Check PVCSI fss state before attempting to launch a goroutine to check if capability is enabled.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

pvcsi webhook startup

**Testing done**:
Pre-Checkins: 

WCP:
TKG: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/344/


Verified that the pvcsi webhook starts up.


```
root@localhost [ ~ ]# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-86946b4bb9-mc4pm   7/7     Running   0             26h
vsphere-csi-node-4c2rb                    3/3     Running   0             26h
vsphere-csi-node-8nnzt                    3/3     Running   0             26h
vsphere-csi-node-w9vb7                    3/3     Running   3 (26h ago)   26h
vsphere-csi-webhook-6dfc64f558-cbjrn      1/1     Running   0             2m38s
root@localhost [ ~ ]# kubectl -n vmware-system-csi logs vsphere-csi-webhook-6dfc64f558-cbjrn
{"level":"info","time":"2025-09-03T07:56:33.280987487Z","caller":"logger/logger.go:41","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2025-09-03T07:56:33.281536729Z","caller":"syncer/main.go:102","msg":"Version : v2.1.0-rc.1-2342-g71a166e7","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.281635692Z","caller":"commonco/utils.go:75","msg":"Defaulting supervisor feature states configmap name to \"csi-feature-states\"","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.281700356Z","caller":"commonco/utils.go:80","msg":"Defaulting supervisor feature states configmap namespace to \"vmware-system-csi\"","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.28210663Z","caller":"syncer/main.go:145","msg":"Starting container with operation mode: WEBHOOK_SERVER","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.2822923Z","caller":"k8sorchestrator/k8sorchestrator.go:300","msg":"Initializing k8sOrchestratorInstance","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.286203066Z","caller":"kubernetes/informers.go:86","msg":"Created new informer factory for in-cluster client","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.323641172Z","caller":"k8sorchestrator/k8sorchestrator.go:483","msg":"New internal feature states values stored successfully: map[block-volume-snapshot:true cnsmgr-suspend-create-volume:true csi-sv-feature-states-replication:false csi-windows-support:true file-volume:true linked-clone-support:true online-volume-extend:true tkgs-ha:true volume-extend:true volume-health:true workload-domain-isolation:true]","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.329023741Z","caller":"k8sorchestrator/k8sorchestrator.go:627","msg":"New supervisor feature states values stored successfully: map[block-volume-snapshot:true cns-unregister-volume:false cnsmgr-suspend-create-volume:true csi-sv-feature-states-replication:true fake-attach:true file-volume:true file-volume-with-vm-service:false improved-csi-idempotency:true list-volumes:true online-volume-extend:true storage-quota-m2:true sv-pvc-snapshot-protection-finalizer:false tkgs-ha:true trigger-csi-fullsync:false workload-domain-isolation:true]","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.32915016Z","caller":"k8sorchestrator/k8sorchestrator.go:384","msg":"k8sOrchestratorInstance initialized","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.342569949Z","caller":"k8sorchestrator/k8sorchestrator.go:724","msg":"configMapAdded: Supervisor feature state values from \"csi-feature-states\" stored successfully: map[block-volume-snapshot:true cns-unregister-volume:false cnsmgr-suspend-create-volume:true csi-sv-feature-states-replication:true fake-attach:true file-volume:true file-volume-with-vm-service:false improved-csi-idempotency:true list-volumes:true online-volume-extend:true storage-quota-m2:true sv-pvc-snapshot-protection-finalizer:false tkgs-ha:true trigger-csi-fullsync:false workload-domain-isolation:true]","TraceId":"4d345432-1b69-4e07-8276-2962dd5c29d5"}
{"level":"info","time":"2025-09-03T07:56:33.34296213Z","caller":"k8sorchestrator/k8sorchestrator.go:732","msg":"configMapAdded: Internal feature state values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[block-volume-snapshot:true cnsmgr-suspend-create-volume:true csi-sv-feature-states-replication:false csi-windows-support:true file-volume:true linked-clone-support:true online-volume-extend:true tkgs-ha:true volume-extend:true volume-health:true workload-domain-isolation:true]","TraceId":"4456591b-0f21-4882-8a0f-57ee29e1c991"}
{"level":"info","time":"2025-09-03T07:56:33.552895702Z","caller":"k8sorchestrator/k8sorchestrator.go:1382","msg":"WCP cluster capabilities map - map[Add_NSX_Day2_M1_Supported:false CSI_Detach_Supported:true Control_Plane_Backup_Restore_Supported:true Foundation_Load_Balancer_Supported:true Fronting_CPVM_Services_Via_LB_Supported:false Import_OVF_In_Namespace_CL_Supported:true Load_Balancer_Supported:true MultipleCL_For_TKG_Supported:true Only_Generate_Http_Proxy_Secret:true PodVM_On_DHCP_VDS_Supported:true PodVM_On_Stretched_Supervisor_Supported:true PodVM_On_VDS_Supported:true Resume_Failed_Supervisor_Upgrade_Supported:true Supervisor_New_Folder_Hierarchy_Supported:true TKG_SupervisorService_Supported:true Tanzu_Topology_CR_Supported:true User_Pods_On_VDS_Supported:true VMImage_ResourceNamingStrategy_Supported:true VPC_Supported:false Vdpp_On_Stretched_Supervisor:true Workload_Domain_Isolation_Supported:true supports_AVIVCF_integration:false supports_BYOK_encryption:true supports_FCD_linked_clone:true supports_FCD_transaction:false supports_LocalConsumptionInterface_CoreService:true supports_Supervisor_Service_allow_list:true supports_Supervisor_Service_namespace_generation:true supports_VIDB_authentication:false supports_VM_service_ISO_deployment:true supports_VM_service_VM_groups:false supports_VM_service_VM_placement_policies:false supports_VM_service_VM_snapshots:false supports_VM_service_WFFC_PVC:false supports_VM_service_immutable_VM_classes:false supports_VM_service_mutable_networks:false supports_VM_service_register_VM_subnet_mappings:false supports_VM_service_resize_CPU_memory:true supports_ako_vks_integration:false supports_apiserver_to_webhook_authentication:true supports_automated_VKS_monitoring:false supports_easy_sv_wldi:true supports_embedded_Supervisor_Service_ConfigMap:true supports_gatewayapi_in_supervisor:false supports_go_authproxy:false supports_inventory_content_library:false supports_log_agent_configuration:false supports_max_concurrent_dns_forwards:true supports_mobility_non_disruptive_import:false supports_monitoring_config_improvements:false supports_multiple_clusters_per_zone:false supports_namespace_API_fairness:true supports_namespace_zone_rp_crud:false supports_pinniped_identity_transformation:true supports_resource_utilization_monitoring:true supports_secure_Supervisor_Service_platform:true supports_shared_disks_with_VM_service_VMs:false supports_shared_subnets_with_namespace:false supports_supervisor_FIPS_modules_report:false supports_supervisor_VCFOps_integration:true supports_supervisor_async_upgrade:true supports_supervisor_certs_custom_key_size:false supports_supervisor_clientip_preservation:false supports_supervisor_management_proxy:false supports_supervisor_privileged_labels:false supports_vc_events:false supports_vds_networks_without_ipam:false supports_vks_multi_networks:false supports_vol_from_snapshot_on_target_ds:false supports_vpc_namespace_no_lb_no_nat_configuration:false supports_workload_CLI:true]","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.553054802Z","caller":"admissionhandler/admissionhandler.go:202","msg":"Adding watch on path: \"/etc/cloud/pvcsi-config\"","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.553604801Z","caller":"admissionhandler/admissionhandler.go:208","msg":"Adding watch on path: \"/etc/cloud/pvcsi-provider\"","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.553735579Z","caller":"admissionhandler/pvcsi_admissionhandler.go:66","msg":"setting up webhook manager with webhookPort 9883 and metricsBindAddress 0","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.554128249Z","caller":"admissionhandler/pvcsi_admissionhandler.go:87","msg":"registering validating webhook with the endpoint /validate","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.554434187Z","logger":"controller-runtime.webhook","caller":"webhook/server.go:183","msg":"Registering webhook","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00","path":"/validate"}
{"level":"info","time":"2025-09-03T07:56:33.554464456Z","caller":"admissionhandler/pvcsi_admissionhandler.go:94","msg":"registering mutating webhook with the endpoint /mutate","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.554557764Z","logger":"controller-runtime.webhook","caller":"webhook/server.go:183","msg":"Registering webhook","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00","path":"/mutate"}
{"level":"info","time":"2025-09-03T07:56:33.554564966Z","caller":"admissionhandler/pvcsi_admissionhandler.go:101","msg":"registering webhooks complete","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.554770792Z","logger":"controller-runtime.webhook","caller":"webhook/server.go:191","msg":"Starting webhook server","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.555453233Z","logger":"controller-runtime.certwatcher","caller":"certwatcher/certwatcher.go:161","msg":"Updated current TLS certificate","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.556098712Z","logger":"controller-runtime.certwatcher","caller":"certwatcher/certwatcher.go:115","msg":"Starting certificate watcher","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00"}
{"level":"info","time":"2025-09-03T07:56:33.561013848Z","logger":"controller-runtime.webhook","caller":"webhook/server.go:242","msg":"Serving webhook server","TraceId":"b31edd67-a101-419f-ad94-19eb2c8d9c00","host":"","port":9883}

```


Verified by creating PVC, VolumeSnapshot and LinkedClones
Attempted to delete the volumesnapshto from which a LinkedClone was created.

```
root@localhost [ ~ ]# kubectl -n testns get pvc
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
src-pvc    Bound    pvc-8ed8ef3e-b04d-460b-bb3b-d07ec649ae60   1Gi        RWO            wcpglobal-storage-profile   <unset>                 8h
vs1-lc-2   Bound    pvc-47ed73b6-5df5-4881-91dd-a432b05a787b   1Gi        RWO            wcpglobal-storage-profile   <unset>                 9m40s


root@localhost [ ~ ]# kubectl -n testns get vs
NAME   READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
vs-1   true         src-pvc                             1Gi           volumesnapshotclass-delete   snapcontent-6c6fe53f-8c7c-4e3b-9122-693c875ea6ff   104s           3m41s
root@localhost [ ~ ]# kubectl -n testns delete vs vs-1
Error from server (Forbidden): admission webhook "validation.csi.vsphere.vmware.com" denied the request: deleting volumesnapshot from which linked clones are created is not allowed. There are 1 linked clones created from this volumesnapshot

```


**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
