### PR TITLE
Enable "sv-pvc-snapshot-protection-finalizer" FSS

### DIFF
--- a/manifests/guestcluster/1.29/pvcsi.yaml
+++ b/manifests/guestcluster/1.29/pvcsi.yaml
@@ -547,7 +547,7 @@ data:
   "tkgs-ha": "true"
   "cnsmgr-suspend-create-volume": "true"
   "workload-domain-isolation": "false"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.30/pvcsi.yaml
+++ b/manifests/guestcluster/1.30/pvcsi.yaml
@@ -547,7 +547,7 @@ data:
   "tkgs-ha": "true"
   "cnsmgr-suspend-create-volume": "true"
   "workload-domain-isolation": "false"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.31/pvcsi.yaml
+++ b/manifests/guestcluster/1.31/pvcsi.yaml
@@ -689,7 +689,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/guestcluster/1.32/pvcsi.yaml
+++ b/manifests/guestcluster/1.32/pvcsi.yaml
@@ -687,7 +687,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/guestcluster/1.33/pvcsi.yaml
+++ b/manifests/guestcluster/1.33/pvcsi.yaml
@@ -668,7 +668,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/guestcluster/1.34/pvcsi.yaml
+++ b/manifests/guestcluster/1.34/pvcsi.yaml
@@ -744,7 +744,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "csi-windows-support": "true"
   "workload-domain-isolation": "true"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -578,7 +578,7 @@ data:
   "vdpp-on-stretched-supervisor": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
   "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -580,7 +580,7 @@ data:
   "storage-quota-m2": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
   "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -580,7 +580,7 @@ data:
   "storage-quota-m2": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
   "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -580,7 +580,7 @@ data:
   "storage-quota-m2": "true"
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
-  "sv-pvc-snapshot-protection-finalizer": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
   "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR enables local CSI level "sv-pvc-snapshot-protection-finalizer" FSS to enable changes to protect supervisor PVC/Snapshot from getting deleted without getting associated guest cluster objects deleted.
Original changes merged via https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3238, https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3242, https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3275

**Testing done**:

WCP CSI regression pipeline run with FSS enabled manually by Raj from FVT team: https://jenkins-vcf-csifvt.devops.broadcom.net/job/WCP_VDS_createTestbed_withFSS/32/

Testlogs covering scenarios - (old supervisor + new TKR with FSS enabled) & (new supervisor with FSS enable + old KTR)
[pvc_finalizer_fss_enable_upgrade.log](https://github.com/user-attachments/files/22273241/pvc_finalizer_fss_enable_upgrade.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enable "sv-pvc-snapshot-protection-finalizer" FSS
```
