### PR TITLE
fix GetActiveClustersForNamespaceInRequestedZones to not skip zone not marked for deletion

### DIFF
--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -341,6 +341,7 @@ func getCnsVolumeInfoFromTaskResult(ctx context.Context, virtualCenter *cnsvsphe
 			if len(placementResult.PlacementFaults) == 0 {
 				if len(placementResult.Clusters) != 0 {
 					placementClusters = placementResult.Clusters
+					log.Debugf("placementClusters:%v for volume:%q", placementClusters, volumeID)
 				} else {
 					datastoreMoRef = &placementResult.Datastore
 					var dsMo mo.Datastore
@@ -352,6 +353,7 @@ func getCnsVolumeInfoFromTaskResult(ctx context.Context, virtualCenter *cnsvsphe
 						return nil, faultType, logger.LogNewErrorf(log, "failed to retrieve datastore summary property: %v", err)
 					}
 					datastoreURL = dsMo.Summary.Url
+					log.Debugf("datastoreURL: %q for volume:%q", datastoreURL, volumeID)
 				}
 				break
 			}
@@ -359,8 +361,6 @@ func getCnsVolumeInfoFromTaskResult(ctx context.Context, virtualCenter *cnsvsphe
 	}
 	log.Infof("Volume created successfully. VolumeName: %q, volumeID: %q",
 		volumeName, volumeID.Id)
-	log.Debugf("CreateVolume volumeId %q is placed on datastore %q",
-		volumeID, datastoreURL)
 	return &CnsVolumeInfo{
 		DatastoreURL: datastoreURL,
 		VolumeID:     volumeID,

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1721,7 +1721,7 @@ func (c *K8sOrchestrator) GetActiveClustersForNamespaceInRequestedZones(ctx cont
 		// Only consider zones in targetNS.
 		zoneObjUnstructured := zoneObj.(*unstructured.Unstructured)
 		// Only get active clusters from zones without a deletion timestamp.
-		if zoneObjUnstructured.GetDeletionTimestamp() == nil {
+		if zoneObjUnstructured.GetDeletionTimestamp() != nil {
 			log.Debugf("skipping zone:%q as it is being deleted", zoneObjUnstructured.GetName())
 			continue
 		}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is fixing `GetActiveClustersForNamespaceInRequestedZones` to consider zones which are not marked for removal.

Along with this fix, adding debug logs in `getCnsVolumeInfoFromTaskResult` to print `placementResult.Clusters` and `datastoreURL`.

**Testing done**:
Verified Creating volume on the zone with multiple clusters.

```
# kubectl get az zone-3 -o json
{
    "apiVersion": "topology.tanzu.vmware.com/v1alpha1",
    "kind": "AvailabilityZone",
    "metadata": {
        "creationTimestamp": "2025-09-03T00:54:46Z",
        "finalizers": [
            "tanzu-topology.vmware.com/zone"
        ],
        "generation": 11,
        "labels": {
            "tanzu-topology.vmware.com/type": "WORKLOAD"
        },
        "name": "zone-3",
        "resourceVersion": "1505774",
        "uid": "c9dc6af8-7667-49e7-918d-854982ff602c"
    },
    "spec": {
        "clusterComputeResourceMoIDs": [
            "domain-c1003",
            "domain-c1001"
        ],
        "clusterComputeResourceMoId": "domain-c1003",
        "namespaces": {
            "test-ns": {
                "folderMoId": "group-v1055"
            }
        },
        "systemInfo": {
            "folderMoID": "group-v1024",
            "poolMoIDs": [
                "resgroup-1035",
                "resgroup-1054"
            ]
        }
    }
}


# kubectl get pvc -n test-ns
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       VOLUMEATTRIBUTESCLASS   AGE
test-pvc   Bound    pvc-e764c451-a851-49f1-88c1-20efa48b0a3d   5Gi        RWO            non-zonal-policy   <unset>                 17m

```




**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix GetActiveClustersForNamespaceInRequestedZones to not skip zone not marked for deletion
```
