### PR TITLE
Session Manager updates - Refactors tag manager & implements session manager in CSI

### DIFF
--- a/docs/book/vc_shared_sessions.md
+++ b/docs/book/vc_shared_sessions.md
@@ -1,0 +1,115 @@
+# vSphere Shared Session capability
+
+One problem that can be found when provisioning a large amount of clusters using
+vSphere CSI is vCenter session exhaustion. This happens because every
+workload cluster needs to request a new session to vSphere to do proper reconciliation.
+
+vSphere 8.0U3 and up uses a new approach of session management, that allows the
+creation and sharing of the sessions among different clusters.
+
+A cluster admin can implement a rest API that, once called, requests a new vCenter
+session and shares with CSI. This session will not count on the total generated
+sessions of vSphere, and instead will be a child derived session.
+
+This configuration can be applied on vSphere CSI with the usage of
+the following CSI configuration:
+
+```shell
+[Global]
+ca-file = "/etc/ssl/certs/trusted-certificates.crt"
+[VirtualCenter "your-vcenter-host"]
+datacenters = "datacenter1"
+vc-session-manager-url = "https://some-session-manager/session"
+vc-session-manager-token = "a-secret-token"
+```
+
+The configuration above will make CSI call the shared session rest API and use the
+provided token to authenticate against vSphere, instead of using a username/password.
+
+The parameter provider at `vc-session-manager-token` is sent as a `Authorization: Bearer` token
+to the session manager, and in case this directive is not configured CSI will send the
+Pod Service Account token instead.
+
+Below is an example implementation of a shared session manager rest API. Starting the
+program below and calling `http://127.0.0.1:18080/session` should return a JSON that is expected
+by CSI using session manager to work:
+
+```shell
+$ curl 127.0.0.1:18080/session
+{"token":"cst-VCT-52f8d061-aace-4506-f4e6-fca78293a93f-....."}
+```
+
+**NOTE**: Below implementation is **NOT PRODUCTION READY** and does not implement
+any kind of authentication!
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "log"
+    "net/http"
+    "net/url"
+
+    "github.com/vmware/govmomi"
+    "github.com/vmware/govmomi/session"
+    "github.com/vmware/govmomi/vim25"
+    "github.com/vmware/govmomi/vim25/soap"
+)
+
+const (
+    vcURL      = "https://my-vc.tld"
+    vcUsername = "Administrator@vsphere.local"
+    vcPassword = "somepassword"
+)
+
+var (
+    userPassword = url.UserPassword(vcUsername, vcPassword)
+)
+
+// SharedSessionResponse is the expected response of CPI when using Shared session manager
+type SharedSessionResponse struct {
+    Token string `json:"token"`
+}
+
+func main() {
+    ctx := context.Background()
+    vcURL, err := soap.ParseURL(vcURL)
+    if err != nil {
+        panic(err)
+    }
+    soapClient := soap.NewClient(vcURL, false)
+    c, err := vim25.NewClient(ctx, soapClient)
+    if err != nil {
+        panic(err)
+    }
+    client := &govmomi.Client{
+        Client:         c,
+        SessionManager: session.NewManager(c),
+    }
+    if err := client.SessionManager.Login(ctx, userPassword); err != nil {
+        panic(err)
+    }
+
+    vcsession := func(w http.ResponseWriter, r *http.Request) {
+        clonedtoken, err := client.SessionManager.AcquireCloneTicket(ctx)
+        if err != nil {
+            w.WriteHeader(http.StatusForbidden)
+            return
+        }
+        token := &SharedSessionResponse{Token: clonedtoken}
+        jsonT, err := json.Marshal(token)
+        if err != nil {
+            w.WriteHeader(http.StatusInternalServerError)
+            return
+        }
+        w.WriteHeader(http.StatusOK)
+        w.Write(jsonT)
+    }
+
+    http.HandleFunc("/session", vcsession)
+    log.Printf("starting webserver on port 18080")
+    http.ListenAndServe(":18080", nil)
+}
+```

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -147,7 +147,9 @@ function build_driver_images_linux() {
 
 function build_syncer_image_linux() {
   echo "building ${SYNCER_IMAGE_NAME}:${VERSION} for linux"
-  docker buildx build --platform "linux/$ARCH"\
+  docker buildx build \
+      --platform "linux/$ARCH" \
+      --output "${LINUX_IMAGE_OUTPUT}" \
       -f images/syncer/Dockerfile \
       -t "${SYNCER_IMAGE_NAME}":"${VERSION}" \
       --build-arg "VERSION=${VERSION}" \

--- a/pkg/common/cns-lib/vsphere/tagmanager.go
+++ b/pkg/common/cns-lib/vsphere/tagmanager.go
@@ -1,0 +1,29 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/vapi/tags"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// GetTagManager returns tagManager connected to given VirtualCenter.
+func (vc *VirtualCenter) GetTagManager(ctx context.Context) (*tags.Manager, error) {
+	log := logger.GetLogger(ctx)
+	// Validate input.
+	if vc == nil || vc.Client == nil || vc.Client.Client == nil {
+		return nil, fmt.Errorf("vCenter not initialized")
+	}
+
+	if err := vc.Connect(ctx); err != nil {
+		return nil, fmt.Errorf("error connecting to VC: %w", err)
+	}
+
+	vc.tagManager = tags.NewManager(vc.RestClient)
+	if vc.tagManager == nil {
+		return nil, fmt.Errorf("failed to create a tagManager")
+	}
+	log.Infof("New tag manager with useragent '%s'", vc.tagManager.UserAgent)
+	return vc.tagManager, nil
+}

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -2,11 +2,8 @@ package vsphere
 
 import (
 	"context"
-	"crypto/tls"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -14,10 +11,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
-	"github.com/vmware/govmomi/sts"
-	"github.com/vmware/govmomi/vapi/rest"
-	"github.com/vmware/govmomi/vapi/tags"
-	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -201,6 +194,12 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 		ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
 		MigrationDataStoreURL:       cfg.VirtualCenter[host].MigrationDataStoreURL,
 		FileVolumeActivated:         cfg.VirtualCenter[host].FileVolumeActivated,
+		VCSessionManagerURL:         cfg.VirtualCenter[host].VCSessionManagerURL,
+		VCSessionManagerToken:       cfg.VirtualCenter[host].VCSessionManagerToken,
+	}
+
+	if vcConfig.VCSessionManagerURL != "" {
+		log.Infof("Using Shared Session Manager: %s", vcConfig.VCSessionManagerURL)
 	}
 
 	log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
@@ -247,6 +246,8 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			QueryLimit:                  cfg.Global.QueryLimit,
 			ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
 			FileVolumeActivated:         cfg.VirtualCenter[vCenterIP].FileVolumeActivated,
+			VCSessionManagerURL:         cfg.VirtualCenter[vCenterIP].VCSessionManagerURL,
+			VCSessionManagerToken:       cfg.VirtualCenter[vCenterIP].VCSessionManagerToken,
 		}
 		if vcConfig.CAFile == "" {
 			vcConfig.CAFile = cfg.Global.CAFile
@@ -305,62 +306,6 @@ func CompareKubernetesMetadata(ctx context.Context, k8sMetaData *cnstypes.CnsKub
 		labelsMatch, spew.Sdump(GetLabelsMapFromKeyValue(k8sMetaData.Labels)),
 		spew.Sdump(GetLabelsMapFromKeyValue(cnsMetaData.Labels)))
 	return labelsMatch
-}
-
-// Signer decodes the certificate and private key and returns SAML token needed
-// for authentication.
-func signer(ctx context.Context, client *vim25.Client, username string, password string) (*sts.Signer, error) {
-	pemBlock, _ := pem.Decode([]byte(username))
-	if pemBlock == nil {
-		return nil, nil
-	}
-	certificate, err := tls.X509KeyPair([]byte(username), []byte(password))
-	if err != nil {
-		return nil, fmt.Errorf("failed to load X509 key pair. Error: %+v", err)
-	}
-	tokens, err := sts.NewClient(ctx, client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create STS client. err: %+v", err)
-	}
-	req := sts.TokenRequest{
-		Certificate: &certificate,
-		Delegatable: true,
-	}
-	signer, err := tokens.Issue(ctx, req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to issue SAML token. err: %+v", err)
-	}
-	return signer, nil
-}
-
-// GetTagManager returns tagManager connected to given VirtualCenter.
-func GetTagManager(ctx context.Context, vc *VirtualCenter) (*tags.Manager, error) {
-	log := logger.GetLogger(ctx)
-	// Validate input.
-	if vc == nil || vc.Client == nil || vc.Client.Client == nil {
-		return nil, fmt.Errorf("vCenter not initialized")
-	}
-
-	restClient := rest.NewClient(vc.Client.Client)
-	signer, err := signer(ctx, vc.Client.Client, vc.Config.Username, vc.Config.Password)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the Signer. Error: %v", err)
-	}
-	if signer == nil {
-		user := url.UserPassword(vc.Config.Username, vc.Config.Password)
-		err = restClient.Login(ctx, user)
-	} else {
-		err = restClient.LoginByToken(restClient.WithSigner(ctx, signer))
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to login for the rest client. Error: %v", err)
-	}
-	tagManager := tags.NewManager(restClient)
-	if tagManager == nil {
-		return nil, fmt.Errorf("failed to create a tagManager")
-	}
-	log.Infof("New tag manager with useragent '%s'", tagManager.UserAgent)
-	return tagManager, nil
 }
 
 // GetCandidateDatastoresInClusters gets the shared datastores and vSAN-direct

--- a/pkg/common/cns-lib/vsphere/vc_session_manager.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_manager.go
@@ -1,0 +1,104 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	saFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
+// SharedSessionResponse is the expected structure for a session manager valid
+// token response
+type SharedSessionResponse struct {
+	Token string `json:"token"`
+}
+
+// SharedTokenOptions represents the options that can be used when calling vc session manager
+type SharedTokenOptions struct {
+	// URL is the session manager URL. Eg.: https://my-session-manager/session)
+	URL string
+	// Token is the authorization token that should be passed to session manager
+	Token string
+	// TrustedCertificates contains the certpool of certificates trusted by the client
+	TrustedCertificates *x509.CertPool
+	// InsecureSkipVerify defines if bad certificates requests should be ignored
+	InsecureSkipVerify bool
+	// Timeout defines the client timeout. Defaults to 5 seconds
+	Timeout time.Duration
+	// TokenFile defines a file with token content. Defaults to Kubernetes Service Account file
+	TokenFile string
+}
+
+// GetSharedToken executes an http request on session manager and gets the session manager
+// token that can be reused on govmomi sessions
+func GetSharedToken(ctx context.Context, options SharedTokenOptions) (string, error) {
+	if options.URL == "" {
+		return "", fmt.Errorf("URL of session manager cannot be empty")
+	}
+
+	if options.TokenFile == "" {
+		options.TokenFile = saFile
+	}
+
+	// If the token is empty, we should use service account from the Pod instead
+	if options.Token == "" {
+		saValue, err := os.ReadFile(options.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("failed reading token from service account: %w", err)
+		}
+		options.Token = string(saValue)
+	}
+
+	timeout := 5 * time.Second
+	if options.Timeout != 0 {
+		timeout = options.Timeout
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:            options.TrustedCertificates,
+			InsecureSkipVerify: options.InsecureSkipVerify,
+		},
+	}
+
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+
+	request, err := http.NewRequest(http.MethodGet, options.URL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed creating new http client: %w", err)
+	}
+	authToken := fmt.Sprintf("Bearer %s", options.Token)
+	request.Header.Add("Authorization", authToken)
+
+	resp, err := client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("failed calling vc session manager: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("invalid vc session manager response: %s", resp.Status)
+	}
+
+	token := &SharedSessionResponse{}
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(token); err != nil {
+		return "", fmt.Errorf("failed decoding vc session manager response: %w", err)
+	}
+
+	if token.Token == "" {
+		return "", fmt.Errorf("returned vc session token is empty")
+	}
+	return token.Token, nil
+}

--- a/pkg/common/cns-lib/vsphere/vc_session_manager_test.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_manager_test.go
@@ -1,0 +1,189 @@
+package vsphere_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vclib "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+)
+
+const (
+	validToken    = "validtoken"
+	validResponse = "a-valid-response"
+)
+
+var (
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authZHdr := r.Header.Get("Authorization")
+		if authZHdr != fmt.Sprintf("Bearer %s", validToken) {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if r.URL.Path == "/timeout" {
+			time.Sleep(15 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/invalid-token" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not a json"))
+			return
+		}
+		if r.URL.Path == "/session" {
+			token := vclib.SharedSessionResponse{
+				Token: validResponse,
+			}
+			response, err := json.Marshal(&token)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(response)
+			return
+		}
+		if r.URL.Path == "/empty" {
+			token := vclib.SharedSessionResponse{
+				Token: "",
+			}
+			response, err := json.Marshal(&token)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(response)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+)
+
+func TestGetSharedToken(t *testing.T) {
+	ctx := context.Background()
+	t.Run("when options are invalid", func(t *testing.T) {
+		t.Run("should fail when no URL is sent", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{})
+			assert.ErrorContains(t, err, "URL of session manager cannot be empty")
+		})
+
+		t.Run("should fail when no token is passed and SA token cannot be read", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL: "http://something.tld/lala",
+			})
+			assert.ErrorContains(t, err, "failed reading token from service account: "+
+				"open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory")
+		})
+
+		t.Run("should fail when passed URL is invalid", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:   "https://some-session-manager.tld:xxxxx/session",
+				Token: "anything",
+			})
+			assert.ErrorContains(t, err, "invalid port")
+		})
+	})
+
+	t.Run("when using a valid session manager", func(t *testing.T) {
+		server := httptest.NewTLSServer(handler)
+
+		certpool := x509.NewCertPool()
+		certpool.AddCert(server.Certificate())
+		t.Cleanup(server.Close)
+
+		t.Run("should respect the timeout", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/timeout", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+				Timeout:             5 * time.Millisecond,
+			})
+			assert.ErrorContains(t, err, "context deadline exceeded")
+		})
+		t.Run("should fail when calling an invalid path", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 server.URL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "404 Not Found")
+		})
+		t.Run("should fail when an empty token is returned", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/empty", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "returned vc session token is empty")
+		})
+
+		t.Run("should fail when an invalid json is returned", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/invalid-token", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "failed decoding vc session manager response")
+		})
+
+		t.Run("should fail when no cert is passed and insecureskipverify is false", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:   reqURL,
+				Token: validToken,
+			})
+			assert.ErrorContains(t, err, "tls: failed to verify certificate: x509")
+		})
+
+		t.Run("should return a valid token for the right request and insecureskip=true", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                reqURL,
+				InsecureSkipVerify: true,
+				Token:              validToken,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+
+		t.Run("should return a valid token for the right request and cert", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+
+		t.Run("should return a valid token when using a file as a token", func(t *testing.T) {
+			tokenFile, err := os.CreateTemp("", "")
+			require.NoError(t, err)
+			require.NoError(t, tokenFile.Close())
+			require.NoError(t, os.WriteFile(tokenFile.Name(), []byte(validToken), 0755))
+
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				TokenFile:           tokenFile.Name(),
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+	})
+
+}

--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -211,7 +211,7 @@ func (vm *VirtualMachine) GetTagManager(ctx context.Context) (*tags.Manager, err
 		log.Errorf("failed to get virtualCenter. Error: %v", err)
 		return nil, err
 	}
-	return GetTagManager(ctx, virtualCenter)
+	return virtualCenter.GetTagManager(ctx)
 }
 
 // GetAncestors returns ancestors of VM.

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -111,7 +111,7 @@ const (
 // Errors
 var (
 	// ErrUsernameMissing is returned when the provided username is empty.
-	ErrUsernameMissing = errors.New("username is missing")
+	ErrUsernameMissing = errors.New("username or session manager configuration are missing")
 
 	// ErrInvalidUsername is returned when vCenter username provided in vSphere config
 	// secret is invalid. e.g. If username is not a fully qualified domain name, then
@@ -119,7 +119,7 @@ var (
 	ErrInvalidUsername = errors.New("username is invalid, make sure it is a fully qualified domain username")
 
 	// ErrPasswordMissing is returned when the provided password is empty.
-	ErrPasswordMissing = errors.New("password is missing")
+	ErrPasswordMissing = errors.New("password or session manager configuration are missing")
 
 	// ErrInvalidVCenterIP is returned when the provided vCenter IP address is
 	// missing from the provided configuration.
@@ -382,15 +382,15 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 
 		if vcConfig.User == "" {
 			vcConfig.User = cfg.Global.User
-			if vcConfig.User == "" {
-				log.Errorf("vcConfig.User is empty for vc %s!", vcServer)
+			if vcConfig.User == "" && vcConfig.VCSessionManagerURL == "" {
+				log.Errorf("vcConfig.User or vcConfig.VCSessionManagerURL should be configured for vc %s!", vcServer)
 				return ErrUsernameMissing
 			}
 		}
 
 		// vCenter server username provided in vSphere config secret should contain domain name,
 		// CSI driver will crash if username doesn't contain domain name.
-		if !isValidvCenterUsernameWithDomain(vcConfig.User) {
+		if !isValidvCenterUsernameWithDomain(vcConfig.User) && vcConfig.VCSessionManagerURL == "" {
 			log.Errorf("username %v specified in vSphere config secret is invalid, "+
 				"make sure that username is a fully qualified domain name.", vcConfig.User)
 			return ErrInvalidUsername
@@ -398,8 +398,8 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 
 		if vcConfig.Password == "" {
 			vcConfig.Password = cfg.Global.Password
-			if vcConfig.Password == "" {
-				log.Errorf("vcConfig.Password is empty for vc %s!", vcServer)
+			if vcConfig.Password == "" && vcConfig.VCSessionManagerURL == "" {
+				log.Errorf("vcConfig.Password or vcConfig.VCSessionManagerURL should be configured for vc %s!", vcServer)
 				return ErrPasswordMissing
 			}
 		}

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -201,6 +201,25 @@ func TestValidateConfigWithValidUsername1(t *testing.T) {
 	}
 }
 
+func TestValidateConfigWithSessionManager(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			VCenterPort:         "443",
+			Datacenters:         "dc1",
+			InsecureFlag:        true,
+			VCSessionManagerURL: "http://xxx.yyy.com/tld",
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as valid session manager was used. Config given - %+v", *cfg)
+	}
+}
+
 func TestValidateConfigWithValidUsername2(t *testing.T) {
 	vcConfigValidUsername := map[string]*VirtualCenterConfig{
 		"1.1.1.1": {

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -157,6 +157,12 @@ type VirtualCenterConfig struct {
 	MigrationDataStoreURL string `gcfg:"migration-datastore-url"`
 	// FileVolumeActivated indicates whether file service has been enabled on any vSAN cluster or not
 	FileVolumeActivated bool
+	// VCSessionManagerURL is the path of a rest api capable of generating vCenter Cloned tokens
+	// to be reused by clients. When this is used, Username and Password configuration are ignored
+	VCSessionManagerURL string `gcfg:"vc-session-manager-url"`
+	// VCSessionManagerToken is the token that should be passed to authenticate against the session manager
+	// If empty, the Pod service account will be used
+	VCSessionManagerToken string `gcfg:"vc-session-manager-token"`
 }
 
 // GCConfig contains information used by guest cluster to access a supervisor

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -337,7 +337,11 @@ func getDatastoresWithBlockVolumePrivs(ctx context.Context, vc *cnsvsphere.Virtu
 	authMgr := object.NewAuthorizationManager(vc.Client.Client)
 	privIds := []string{DsPriv, SysReadPriv}
 
-	userName := vc.Config.Username
+	userName, err := vc.GetActiveUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Invoke authMgr function HasUserPrivilegeOnEntities.
 	result, err := authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds) // entities empty -> error
 	if err != nil {
@@ -440,10 +444,14 @@ func getFSEnabledClustersWithPriv(ctx context.Context, vc *cnsvsphere.VirtualCen
 		clusterComputeResources = append(clusterComputeResources, clusterComputeResource...)
 	}
 
+	userName, err := vc.GetActiveUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Get Clusters with HostConfigStoragePriv.
 	authMgr := object.NewAuthorizationManager(vc.Client.Client)
 	privIds := []string{HostConfigStoragePriv}
-	userName := vc.Config.Username
 	var entities []vim25types.ManagedObjectReference
 	clusterComputeResourcesMap := make(map[string]*object.ClusterComputeResource)
 	for _, cluster := range clusterComputeResources {

--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -82,16 +82,10 @@ func DiscoverTagEntities(ctx context.Context) error {
 				vcenterCfg.Host, err)
 		}
 		// Get tag manager instance.
-		tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+		tagManager, err := vcenter.GetTagManager(ctx)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create tagManager. Error: %v", err)
 		}
-		defer func() {
-			err := tagManager.Logout(ctx)
-			if err != nil {
-				log.Errorf("failed to logout tagManager. Error: %v", err)
-			}
-		}()
 		for _, cat := range categories {
 			topoTags, err := tagManager.GetTagsForCategory(ctx, cat)
 			if err != nil {
@@ -439,17 +433,11 @@ func RefreshPreferentialDatastoresForMultiVCenter(ctx context.Context) error {
 				vcConfig.Host, err)
 		}
 		// Get tag manager instance.
-		tagMgr, err := cnsvsphere.GetTagManager(ctx, vc)
+		tagMgr, err := vc.GetTagManager(ctx)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create tag manager for vCenter %q. Error: %+v",
 				vcConfig.Host, err)
 		}
-		defer func() {
-			err := tagMgr.Logout(ctx)
-			if err != nil {
-				log.Errorf("failed to logout tagManager for vCenter %q. Error: %v", vcConfig.Host, err)
-			}
-		}()
 		// Get tags for category reserved for preferred datastore tagging.
 		tagIds, err := tagMgr.ListTagsForCategory(ctx, PreferredDatastoresCategory)
 		if err != nil {

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -94,6 +94,11 @@ func CreateBlockVolumeUtil(
 		}
 	}
 
+	username, err := vc.GetActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
+
 	var clusterMorefs []vim25types.ManagedObjectReference
 	var datastoreInfoList []*vsphere.DatastoreInfo
 
@@ -103,7 +108,7 @@ func CreateBlockVolumeUtil(
 		clusterID = manager.CnsConfig.Global.SupervisorID
 	}
 	containerCluster := vsphere.GetContainerCluster(clusterID,
-		manager.CnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor,
+		username, clusterFlavor,
 		manager.CnsConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
@@ -455,10 +460,15 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{},
 		datastores = append(datastores, ds.Reference())
 	}
 
+	username, err := params.Vcenter.GetActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
+
 	var containerClusterArray []cnstypes.CnsContainerCluster
 	clusterID := params.CNSConfig.Global.ClusterID
 	containerCluster := vsphere.GetContainerCluster(clusterID,
-		params.CNSConfig.VirtualCenter[params.Vcenter.Config.Host].User, params.ClusterFlavor,
+		username, params.ClusterFlavor,
 		params.CNSConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
@@ -648,9 +658,14 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 	if useSupervisorId {
 		clusterID = cnsConfig.Global.SupervisorID
 	}
+
+	username, err := vc.GetActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
 	var containerClusterArray []cnstypes.CnsContainerCluster
 	containerCluster := vsphere.GetContainerCluster(clusterID,
-		cnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor,
+		username, clusterFlavor,
 		cnsConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25/types"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
@@ -313,12 +316,27 @@ func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Mock getVCenterInternal to return a mock VirtualCenter
 			originalGetVCenter := getVCenterInternal
+
+			// Create a new vcsim instance for use against govmomi client
+			model := simulator.VPX()
+			defer model.Remove()
+			err := model.Create()
+			require.NoError(t, err, "failed to create virtual VC for govmomi client")
+
+			// Create a vcsim server
+			s := model.Service.NewServer()
+
+			// Create a new client
+			client, err := govmomi.NewClient(context.Background(), s.URL, true)
+			require.NoError(t, err, "ailed to create new govmomi client")
+
 			getVCenterInternal = func(_ context.Context, _ *Manager) (*vsphere.VirtualCenter, error) {
 				return &vsphere.VirtualCenter{
 					Config: &vsphere.VirtualCenterConfig{
 						Host:            "test-vc",
 						DatacenterPaths: []string{},
 					},
+					Client: client,
 				}, nil
 			}
 			defer func() { getVCenterInternal = originalGetVCenter }()
@@ -381,7 +399,7 @@ func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
 			// Call the actual CreateBlockVolumeUtil function
 			// Note that the cluster flavor does not have a significance for this test
 			// because it depends on the VolFromSnapshotOnTargetDs flag.
-			_, _, err := CreateBlockVolumeUtil(context.Background(), cnstypes.CnsClusterFlavorWorkload,
+			_, _, err = CreateBlockVolumeUtil(context.Background(), cnstypes.CnsClusterFlavorWorkload,
 				manager, spec, sharedDatastores, []string{}, opts, nil)
 
 			// Verify no error occurred

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -508,17 +508,11 @@ func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine,
 	}
 
 	// Get tag manager instance.
-	tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+	tagManager, err := vcenter.GetTagManager(ctx)
 	if err != nil {
 		log.Errorf("failed to create tagManager. Error: %v", err)
 		return nil, err
 	}
-	defer func() {
-		err := tagManager.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout tagManager. Error: %v", err)
-		}
-	}()
 
 	// Create a map of TopologyCategories with category as key and value as empty string.
 	var isZoneRegion bool

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2328,9 +2328,12 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 		if newVCConfig != nil {
 			var vcenter *cnsvsphere.VirtualCenter
 			newVCConfig.ReloadVCConfigForNewClient = true
+			vcConfig := metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host]
 			if metadataSyncer.host != newVCConfig.Host ||
-				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User != newVCConfig.Username ||
-				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].Password != newVCConfig.Password ||
+				vcConfig.User != newVCConfig.Username ||
+				vcConfig.Password != newVCConfig.Password ||
+				vcConfig.VCSessionManagerURL != newVCConfig.VCSessionManagerURL ||
+				vcConfig.VCSessionManagerToken != newVCConfig.VCSessionManagerToken ||
 				reconnectToVCFromNewConfig {
 				// Verify if new configuration has valid credentials by connecting
 				// to vCenter. Proceed only if the connection succeeds, else return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Return error when attempts to create user session & rest session fails, so that a re-login is attempted by all volume operations.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. Replace CSI images with the changes from this PR
2. Create Volume
3. Restart VPXD
4. Delete Volume
5. Create another volume
6.  Delete volume

```
kubectl get pvc -A
NAMESPACE            NAME              STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                   VOLUMEATTRIBUTESCLASS   AGE
e2e-test-namespace   example-rwo-pvc   Bound     pvc-1d1b9b40-d4e7-4596-b78d-b4b840cae422   10Mi       RWO            shared-ds-policy               <unset>                 32h
```

```
# vmon-cli -r vpxd

Completed Restart service request.
```

```
kubectl delete -f pvc.yaml -n e2e-test-namespace
```

```
kubectl create -f pvc.yaml -n e2e-test-namespace
 kubectl get pvc -n e2e-test-namespace
NAME              STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                   VOLUMEATTRIBUTESCLASS   AGE
example-rwo-pvc   Bound     pvc-39d820e4-28bf-4285-a87b-3ee0048519e7   10Mi       RWO            shared-ds-policy               <unset>                 29s
```
```
kubectl delete -f pvc.yaml -n e2e-test-namespace
```

NotAuthenticated errors were not observed

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
8. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Return error when attempts to create user session & rest session fails
```
