### PR TITLE
Enable vDPP volume creation and storage pool service in multi-cluster zones

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -559,11 +559,6 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		// keys as topology requirement during volume provisioning.
 		hostnameLabelPresent, zoneLabelPresent = checkTopologyKeysFromAccessibilityReqs(topologyRequirement)
 		if zoneLabelPresent && hostnameLabelPresent {
-			if IsMultipleClustersPerVsphereZoneFSSEnabled && c.topologyMgr.ZonesWithMultipleClustersExist(ctx) {
-				return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal,
-					"Creating volume with both zone and hostname in topology requirement is not "+
-						"supported on deployment with multiple vSphere Clusters per zone")
-			}
 			log.Infof("Host Local volume provisioning with requirement: %+v", topologyRequirement)
 		} else if zoneLabelPresent {
 			if !isWorkloadDomainIsolationEnabled {

--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -56,7 +56,7 @@ func InitStoragePoolService(ctx context.Context,
 	log := logger.GetLogger(ctx)
 	clusterIDs := []string{configInfo.Cfg.Global.ClusterID}
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
-		clusterComputeResourceMoIds, multipleClustersPerAZ, err := common.GetClusterComputeResourceMoIds(ctx)
+		clusterComputeResourceMoIds, _, err := common.GetClusterComputeResourceMoIds(ctx)
 		if err != nil {
 			log.Errorf("failed to get clusterComputeResourceMoIds. err: %v", err)
 			return err
@@ -68,16 +68,8 @@ func InitStoragePoolService(ctx context.Context,
 				common.PodVMOnStretchedSupervisor)
 			return nil
 		}
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.MultipleClustersPerVsphereZone) {
-			if multipleClustersPerAZ {
-				// vDPP workload is not supported on the deployment with multiple zones per clusters
-				log.Info("AZ has multiple vSphere Clusters. Skip starting storage pool service.")
-				return nil
-			}
-		}
 	}
 	log.Infof("Initializing Storage Pool Service")
-
 	// Create StoragePool CRD.
 	err := k8s.CreateCustomResourceDefinitionFromManifest(ctx, storagepoolconfig.EmbedStoragePoolCRFile,
 		storagepoolconfig.EmbedStoragePoolCRFileName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Allow vDPP volumes to be created when both host and zone topology labels are present, and enable storage pool service startup on the deployment with zones having multiple clusters.

**Testing done**:
Verified storagepool service is started and CRD is registered.

```
# kubectl get crd storagepools.cns.vmware.com
NAME                          CREATED AT
storagepools.cns.vmware.com   2025-09-03T00:36:32Z
```

storagepool instances are created for datastores

```
# kubectl get storagepools.cns.vmware.com
NAME                       AGE
storagepool-local-0        82s
storagepool-local-0-1      81s
storagepool-local-0-2      81s
storagepool-sharedvmfs-0   83s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enable vDPP volume creation and storage pool service in multi-cluster zones
```
