### PR TITLE
Revert "[Cherry-pick]Fix the LinkedClone FSS check and capability checks for pvcsi webhook(#3524)"

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -155,15 +155,13 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 	// some init() function which can initialize required things when capability value changes from false to true.
 	isWorkloadDomainIsolationSupported := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.WorkloadDomainIsolationFSS)
-	linkedClonePVCSIFSS := commonco.ContainerOrchestratorUtility.IsPVCSIFSSEnabled(ctx, common.LinkedCloneSupportFSS)
-	linkedCloneCapability := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS)
+	isLinkedCloneSupported := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.LinkedCloneSupportFSS)
 	if !isWorkloadDomainIsolationSupported {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 			common.WorkloadDomainIsolation, config.GC.Port, config.GC.Endpoint)
 	}
-	// Start the late enablement watcher only if the PVCSI internal FSS is enabled, but the current supervisor
-	// capability is disabled.
-	if linkedClonePVCSIFSS && !linkedCloneCapability {
+	if !isLinkedCloneSupported {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 			common.LinkedCloneSupport, config.GC.Port, config.GC.Endpoint)
 	}

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -24,15 +24,13 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
-
-	admissionv1 "k8s.io/api/admission/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/zapr"
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	cr_log "sigs.k8s.io/controller-runtime/pkg/log"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -162,66 +160,15 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 			return fmt.Errorf("unable to run the webhook manager: %w", err)
 		}
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
-		linkedCloneCapability := false
-		linkedClonePVCSIFSS := containerOrchestratorUtility.IsPVCSIFSSEnabled(ctx, common.LinkedCloneSupportFSS)
-		if linkedClonePVCSIFSS {
-			// Check the linked clone capability only if the internal fss is enabled.
-			linkedCloneCapability = containerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS)
-		}
-		featureIsLinkedCloneSupportEnabled = linkedClonePVCSIFSS && linkedCloneCapability
+		featureIsLinkedCloneSupportEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupport)
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
-		// Start the late enablement watcher only if the PVCSI internal FSS is enabled, but the current supervisor
-		// capability is disabled.
-		if linkedClonePVCSIFSS && !linkedCloneCapability {
+		if !featureIsLinkedCloneSupportEnabled {
 			gcConfig, configErr := cnsconfig.GetConfig(ctx)
 			if configErr != nil {
 				return fmt.Errorf("failed to read config. Error: %+v", err)
 			}
 			go containerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 				common.LinkedCloneSupport, gcConfig.GC.Port, gcConfig.GC.Endpoint)
-		}
-		if featureIsLinkedCloneSupportEnabled {
-			pvcsiConfigPath := cnsconfig.GetConfigPath(ctx)
-			watcher, err := fsnotify.NewWatcher()
-			if err != nil {
-				log.Errorf("failed to create fsnotify watcher. err=%v", err)
-				return err
-			}
-			go func() {
-				for {
-					log.Debugf("Waiting for event on fsnotify watcher")
-					select {
-					case event, ok := <-watcher.Events:
-						if !ok {
-							return
-						}
-						log.Debugf("fsnotify event: %q", event.String())
-						if event.Op&fsnotify.Remove == fsnotify.Remove {
-							// restart the webhook
-							os.Exit(1)
-						}
-					case err, ok := <-watcher.Errors:
-						if !ok {
-							return
-						}
-						log.Errorf("fsnotify error: %+v", err)
-					}
-					log.Debugf("fsnotify event processed")
-				}
-			}()
-			cfgDirPath := filepath.Dir(pvcsiConfigPath)
-			log.Infof("Adding watch on path: %q", cfgDirPath)
-			err = watcher.Add(cfgDirPath)
-			if err != nil {
-				log.Errorf("failed to watch on path: %q. err=%v", cfgDirPath, err)
-				return err
-			}
-			log.Infof("Adding watch on path: %q", cnsconfig.DefaultpvCSIProviderPath)
-			err = watcher.Add(cnsconfig.DefaultpvCSIProviderPath)
-			if err != nil {
-				log.Errorf("failed to watch on path: %q. err=%v", cnsconfig.DefaultpvCSIProviderPath, err)
-				return err
-			}
 		}
 		startPVCSIWebhookManager(ctx)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -363,12 +363,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				common.WorkloadDomainIsolation,
 				metadataSyncer.configInfo.Cfg.GC.Port, metadataSyncer.configInfo.Cfg.GC.Endpoint)
 		}
-		linkedClonePVCSIFSS := commonco.ContainerOrchestratorUtility.IsPVCSIFSSEnabled(ctx, common.LinkedCloneSupportFSS)
-		linkedCloneCapability := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS)
-		IsLinkedCloneSupportFSSEnabled = linkedClonePVCSIFSS && linkedCloneCapability
-		// Start the late enablement watcher only if the PVCSI internal FSS is enabled, but the current supervisor
-		// capability is disabled.
-		if linkedClonePVCSIFSS && !linkedCloneCapability {
+		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS) {
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
 				clusterFlavor, common.LinkedCloneSupport,
 				metadataSyncer.configInfo.Cfg.GC.Port, metadataSyncer.configInfo.Cfg.GC.Endpoint)


### PR DESCRIPTION
Reverts kubernetes-sigs/vsphere-csi-driver#3536 to maintain the same commit order for release-3.6 branch as we are planning to do batch cherry-pick of master