### PR TITLE
Fix nil pointer panic in CreateSnapshot with transaction support

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -2856,8 +2856,8 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 		}
 	}()
 	volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, quotaInfo,
-		volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
-		createSnapshotsTask.Reference().Value, "", "", taskInvocationStatusInProgress, "")
+		metav1.Now(),
+		"", "", "", taskInvocationStatusInProgress, "")
 	if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
 		// Don't return if CreateSnapshot details can't be stored.
 		log.Warnf("failed to store CreateSnapshot details with error: %v", err)
@@ -2875,7 +2875,7 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 	var faultType string
 	createSnapshotsTaskInfo, err = m.waitOnTask(ctx, createSnapshotsTask.Reference())
 	if err != nil {
-		if IsNotSupportedFault(ctx, createSnapshotsTaskInfo.Error) {
+		if createSnapshotsTaskInfo != nil && IsNotSupportedFault(ctx, createSnapshotsTaskInfo.Error) {
 			faultType = "vim25:NotSupported"
 			err = fmt.Errorf("failed to create snapshot with fault: %q", faultType)
 		} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes a nil pointer panic observed during CreateSnapshot when transaction support is enabled.
The panic occurred in two scenarios:

- volumeOperationDetails was not initialized before dereferencing OperationDetails.TaskInvocationTimestamp.
- createSnapshotsTaskInfo was nil when accessing its Error field after waitOnTask returned an error. 

Changes in this PR

- Always initialize volumeOperationDetails with metav1.Now() before invoking CNS, ensuring it is never nil.
- Add a nil check around createSnapshotsTaskInfo.Error to avoid dereferencing a nil task info.




**Testing done**:
Before this fix

```
# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-5d549d87df-lkg97   4/7     CrashLoopBackOff   75 (79s ago)   107m
```


```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x235799c]

goroutine 197 [running]:
sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume.(*defaultManager).createSnapshotWithTransaction(0xc000996000, {0x34e1228, 0xc000150820}, {0xc000995680, 0x24}, {0xc0009956b0, 0x2d}, {0x26ef780, 0xc000e73f00})
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/common/cns-lib/volume/manager.go:2860 +0x4fc
sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume.(*defaultManager).CreateSnapshot.func1(...)
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/common/cns-lib/volume/manager.go:2951
sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume.(*defaultManager).CreateSnapshot(0xc000996000, {0x34e11f0?, 0xc000e6eae0?}, {0xc000995680, 0x24}, {0xc0009956b0, 0x2d}, {0x26ef780, 0xc000e73f00})
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/common/cns-lib/volume/manager.go:2968 +0x2ab
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common.CreateSnapshotUtil({0x34e11f0, 0xc000e6eae0}, {0x350ab50, 0xc000996000}, {0xc000995680, 0x24}, {0xc0009956b0, 0x2d}, {0x26ef780, 0xc000e73f00})
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/common/vsphereutil.go:1208 +0x14d
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateSnapshot.func1()
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/wcp/controller.go:2451 +0x6a5
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateSnapshot(0xc000766ed0, {0x34e11f0?, 0xc000e6e360?}, 0xc0000aa550)
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/wcp/controller.go:2524 +0x1b8
github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateSnapshot_Handler({0x2f83260, 0xc000766ed0}, {0x34e11f0, 0xc000e6e360}, 0xc0001d4d00, 0x0)
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/github.com/container-storage-interface/spec@v1.9.0/lib/go/csi/csi.pb.go:6724 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000e65800, {0x34e11f0, 0xc000e6e2d0}, {0x34ee800, 0xc0001489c0}, 0xc000d78120, 0xc0008494a0, 0x5095c60, 0x0)
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/google.golang.org/grpc@v1.68.1/server.go:1394 +0xe24
google.golang.org/grpc.(*Server).handleStream(0xc000e65800, {0x34ee800, 0xc0001489c0}, 0xc000d78120)
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/google.golang.org/grpc@v1.68.1/server.go:1805 +0xe8a
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/google.golang.org/grpc@v1.68.1/server.go:1029 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 158
	/build/mts/release/bora-24928087/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/google.golang.org/grpc@v1.68.1/server.go:1040 +0x11d
```

After this fix

```
{"level":"info","time":"2025-09-08T23:50:38.761355899Z","caller":"volume/util.go:439","msg":"Calling CnsClient.CreateSnapshots: VolumeID [\"30a46280-51c6-425e-9691-88b226c70e74\"] Description [\"snapshot-178a43ec-e716-4e9c-83c6-a3ae5c4a0ff4-30a46280-51c6-425e-9691-88b226c70e74\"] cnsSnapshotCreateSpecList [[]types.CnsSnapshotCreateSpec{types.CnsSnapshotCreateSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"30a46280-51c6-425e-9691-88b226c70e74\"}, Description:\"snapshot-178a43ec-e716-4e9c-83c6-a3ae5c4a0ff4-30a46280-51c6-425e-9691-88b226c70e74\", SnapshotId:(*types.CnsSnapshotId)(nil)}}]","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:38.804992994Z","caller":"volume/listview.go:200","msg":"AddTask called for Task:task-473","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:38.816489518Z","caller":"volume/listview.go:218","msg":"client is valid. trying to add task to listview object","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:38.824746828Z","caller":"volume/listview.go:241","msg":"task Task:task-473 added to listView","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:38.829206002Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-473 Task:Task:task-473 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createsnapshot Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc0005a6d10 QueueTime:2025-09-08 23:50:40.641294 +0000 UTC StartTime:2025-09-08 23:50:40.662757 +0000 UTC CompleteTime:<nil> EventChainId:15998 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:1b9ffd37}}","TraceId":"2a879c10-94ba-4520-88b8-47b2d0a63228"}
{"level":"info","time":"2025-09-08T23:50:39.239144724Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-473 Task:Task:task-473 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createsnapshot Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc0005a6eb0 QueueTime:2025-09-08 23:50:40.641294 +0000 UTC StartTime:2025-09-08 23:50:40.662757 +0000 UTC CompleteTime:<nil> EventChainId:15998 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:1b9ffd37}}","TraceId":"2a879c10-94ba-4520-88b8-47b2d0a63228"}
{"level":"info","time":"2025-09-08T23:50:39.246821563Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-473 Task:Task:task-473 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createsnapshot Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc0005a6140 QueueTime:2025-09-08 23:50:40.641294 +0000 UTC StartTime:2025-09-08 23:50:40.662757 +0000 UTC CompleteTime:<nil> EventChainId:15998 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:1b9ffd37}}","TraceId":"2a879c10-94ba-4520-88b8-47b2d0a63228"}
{"level":"info","time":"2025-09-08T23:50:39.482306289Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-473 Task:Task:task-473 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createsnapshot Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:success Cancelled:false Cancelable:false Error:<nil> Result:{DynamicData:{} VolumeResults:[0xc0003f4150]} Progress:0 ProgressDetails:[] Reason:0xc000db4040 QueueTime:2025-09-08 23:50:40.641294 +0000 UTC StartTime:2025-09-08 23:50:40.662757 +0000 UTC CompleteTime:2025-09-08 23:50:41.34638 +0000 UTC EventChainId:15998 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:1b9ffd37}}","TraceId":"2a879c10-94ba-4520-88b8-47b2d0a63228"}
{"level":"info","time":"2025-09-08T23:50:39.486537056Z","caller":"volume/listview.go:267","msg":"client is valid. trying to remove task from listview object","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.489911013Z","caller":"volume/listview.go:273","msg":"task Task:task-473 removed from listView","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.490000521Z","caller":"volume/manager.go:2707","msg":"CreateSnapshots: VolumeID: \"30a46280-51c6-425e-9691-88b226c70e74\", opId: \"1b9ffd37\"","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.490050435Z","caller":"volume/manager.go:2768","msg":"For volumeID \"30a46280-51c6-425e-9691-88b226c70e74\" new AggregatedSnapshotSize is 10241 and SnapshotLatestOperationCompleteTime is \"2025-09-08 23:50:41.34638 +0000 UTC\"","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.49014187Z","caller":"volume/manager.go:2775","msg":"Update quotainfo on successful snapshot \"adbc033d-d5c7-4723-b7eb-1493cdcecb87\" creation for volume \"30a46280-51c6-425e-9691-88b226c70e74\": {Reserved:10Gi StoragePolicyId:dea5f154-886f-46e6-a7f9-ce74a6bc2c3d StorageClassName:transaction-support-profile-large Namespace:transaction-support-ns AggregatedSnapshotSize:10241Mi SnapshotLatestOperationCompleteTime:2025-09-08 23:50:41.34638 +0000 UTC}","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.490296266Z","caller":"volume/manager.go:2786","msg":"CreateSnapshot: Snapshot created successfully. VolumeID: \"30a46280-51c6-425e-9691-88b226c70e74\", SnapshotID: \"adbc033d-d5c7-4723-b7eb-1493cdcecb87\", SnapshotCreateTime: \"2025-09-08 23:50:41.34638 +0000 UTC\", opId: \"1b9ffd37\"","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.490448157Z","caller":"volume/manager.go:2602","msg":"Setting the reserved field for VolumeOperationDetails instance snapshot-178a43ec-e716-4e9c-83c6-a3ae5c4a0ff4-30a46280-51c6-425e-9691-88b226c70e74 to 0","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.507433433Z","caller":"common/util.go:472","msg":"retrieved aggregated snapshot capacity 10241 for volume \"30a46280-51c6-425e-9691-88b226c70e74\"","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.516732005Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:305","msg":"attempt: 1, Successfully patched the cnsvolumeinfo \"30a46280-51c6-425e-9691-88b226c70e74\" namespace \"vmware-system-csi\"","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.516937631Z","caller":"wcp/controller.go:2480","msg":"successfully updated aggregated snapshot capacity: 10241 for volume \"30a46280-51c6-425e-9691-88b226c70e74\" and snapshot \"30a46280-51c6-425e-9691-88b226c70e74+adbc033d-d5c7-4723-b7eb-1493cdcecb87\"","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.518504332Z","caller":"wcp/controller.go:2501","msg":"CreateSnapshot succeeded for snapshot 30a46280-51c6-425e-9691-88b226c70e74+adbc033d-d5c7-4723-b7eb-1493cdcecb87 on volume 30a46280-51c6-425e-9691-88b226c70e74 size 10737418240 Time proto seconds:1757375441  nanos:346380000 Timestamp 2025-09-08 23:50:41.34638 +0000 UTC Response: snapshot:{size_bytes:10737418240  snapshot_id:\"30a46280-51c6-425e-9691-88b226c70e74+adbc033d-d5c7-4723-b7eb-1493cdcecb87\"  source_volume_id:\"30a46280-51c6-425e-9691-88b226c70e74\"  creation_time:{seconds:1757375441  nanos:346380000}  ready_to_use:true}","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.51861976Z","caller":"wcp/controller.go:2508","msg":"Attempting to annotate volumesnapshot transaction-support-ns/test-snapshot-divyen with annotation csi.vsphere.volume/snapshot:30a46280-51c6-425e-9691-88b226c70e74+adbc033d-d5c7-4723-b7eb-1493cdcecb87","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.541195281Z","caller":"k8sorchestrator/k8sorchestrator_helper.go:189","msg":"attempt: 1, Successfully patched volumesnapshot transaction-support-ns/test-snapshot-divyen with latest annotations map[csi.vsphere.volume/snapshot:30a46280-51c6-425e-9691-88b226c70e74+adbc033d-d5c7-4723-b7eb-1493cdcecb87]","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
{"level":"info","time":"2025-09-08T23:50:39.541548307Z","caller":"wcp/controller.go:2526","msg":"Snapshot for volume \"30a46280-51c6-425e-9691-88b226c70e74\" created successfully.","TraceId":"5ec906e7-a8f2-4dae-a6f8-d30d13411f4d"}
```

Verified creating volumesnapshot with transaction support

```
# kubectl get volumesnapshot test-snapshot-divyen -n transaction-support-ns -o yaml
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  annotations:
    csi.vsphere.volume/snapshot: 30a46280-51c6-425e-9691-88b226c70e74+adbc033d-d5c7-4723-b7eb-1493cdcecb87
  creationTimestamp: "2025-09-08T23:50:37Z"
  finalizers:
  - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
  - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
  generation: 1
  name: test-snapshot-divyen
  namespace: transaction-support-ns
  resourceVersion: "4160058"
  uid: 178a43ec-e716-4e9c-83c6-a3ae5c4a0ff4
spec:
  source:
    persistentVolumeClaimName: pvc-clkdw
  volumeSnapshotClassName: volumesnapshotclass-delete
status:
  boundVolumeSnapshotContentName: snapcontent-178a43ec-e716-4e9c-83c6-a3ae5c4a0ff4
  creationTime: "2025-09-08T23:50:41Z"
  readyToUse: true
  restoreSize: 10Gi
```


```
# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-65d86bd858-dd92g   7/7     Running   0          22m
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix nil pointer panic in CreateSnapshot with transaction support
```
