### PR TITLE
Enhancement - Introduce pvcName input param in CNSUnregisterVolume spec

### DIFF
--- a/pkg/apis/cnsoperator/cnsunregistervolume/v1alpha1/cnsunregistervolume_types.go
+++ b/pkg/apis/cnsoperator/cnsunregistervolume/v1alpha1/cnsunregistervolume_types.go
@@ -24,7 +24,10 @@ import (
 // +k8s:openapi-gen=true
 type CnsUnregisterVolumeSpec struct {
 	// VolumeID indicates the volume handle of CNS volume to be unregistered
-	VolumeID string `json:"volumeID"`
+	VolumeID string `json:"volumeID,omitempty"`
+
+	// PVCName indicates the name of the PVC to be unregistered.
+	PVCName string `json:"pvcName,omitempty"`
 
 	// RetainFCD indicates if the volume should be retained as an FCD.
 	// If set to false or not specified, the volume will be retained as a VMDK.

--- a/pkg/apis/cnsoperator/config/cnsunregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsunregistervolume_crd.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -16,66 +15,73 @@ spec:
     singular: cnsunregistervolume
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: CnsUnregisterVolume is the Schema for the cnsunregistervolumes API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: CnsUnregisterVolume is the Schema for the cnsunregistervolumes API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: CnsUnregisterVolumeSpec defines the desired state of CnsUnregisterVolume
-            properties:
-              volumeID:
-                description: VolumeID indicates the volume handle of CNS volume to be unregistered.
-                type: string
-                pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
-              retainFCD:
-                description: RetainFCD indicates if the volume should be retained as an FCD. 
-                  If set to false or not specified, the volume will be retained as a VMDK.
-                type: boolean
-              forceUnregister:
-                description: ForceUnregister indicates if the volume should be forcefully unregistered.
-                  If set to true, the volume will be unregistered even if it is still in use by any VM.
-                  This should be used with caution as it may lead to data loss.
-                type: boolean
-            required:
-            - volumeID
-            type: object
-          status:
-            description: CnsUnregisterVolumeStatus defines the observed state of CnsUnregisterVolume
-            properties:
-              error:
-                description: The last error encountered during export operation, if
-                  any. This field must only be set by the entity completing the export
-                  operation, i.e. the CNS Operator.
-                type: string
-              unregistered:
-                description: Indicates the volume is successfully unregistered. 
-                  This field must only be set by the entity completing the unregister 
-                  operation, i.e. the CNS Operator.
-                type: boolean
-            required:
-            - unregistered
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CnsUnregisterVolumeSpec defines the desired state of CnsUnregisterVolume
+              properties:
+                volumeID:
+                  description: VolumeID indicates the volume handle of CNS volume to be unregistered.
+                  type: string
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                pvcName:
+                  description: PVCName indicates the name of the PVC to be unregistered.
+                  type: string
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                retainFCD:
+                  description: RetainFCD indicates if the volume should be retained as an FCD.
+                    If set to false or not specified, the volume will be retained as a VMDK.
+                  type: boolean
+                forceUnregister:
+                  description: ForceUnregister indicates if the volume should be forcefully unregistered.
+                    If set to true, the volume will be unregistered even if it is still in use by any VM.
+                    This should be used with caution as it may lead to data loss.
+                  type: boolean
+              type: object
+              x-kubernetes-validations:
+                - rule: "has(self.volumeID) || has(self.pvcName)"
+                  message: "Either 'volumeID' or 'pvcName' must be specified, but not both"
+                - rule: "!(has(self.volumeID) && has(self.pvcName))"
+                  message: "Cannot specify both 'volumeID' and 'pvcName' at the same time. Please specify only one of them"
+            status:
+              description: CnsUnregisterVolumeStatus defines the observed state of CnsUnregisterVolume
+              properties:
+                error:
+                  description: The last error encountered during export operation, if
+                    any. This field must only be set by the entity completing the export
+                    operation, i.e. the CNS Operator.
+                  type: string
+                unregistered:
+                  description: Indicates the volume is successfully unregistered.
+                    This field must only be set by the entity completing the unregister
+                    operation, i.e. the CNS Operator.
+                  type: boolean
+              required:
+                - unregistered
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: { }
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: [ ]
+  storedVersions: [ ]

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -3766,6 +3766,11 @@ func (m *defaultManager) UnregisterVolume(ctx context.Context, volumeID string, 
 func (m *defaultManager) unregisterVolume(ctx context.Context, volumeID string, unregisterDisk bool) error {
 	log := logger.GetLogger(ctx)
 
+	if volumeID == "" {
+		log.Debugf("UnregisterVolume: volumeID is empty, nothing to unregister")
+		return nil
+	}
+
 	if m.virtualCenter == nil {
 		return errors.New("invalid manager instance")
 	}

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -431,7 +431,7 @@ func (c *FakeK8SOrchestrator) GetPVCNameFromCSIVolumeID(volumeID string) (string
 }
 
 // GetVolumeIDFromPVCName simlates an invalid case when pvcName contains "invalid".
-func (c *FakeK8SOrchestrator) GetVolumeIDFromPVCName(pvcName string) (string, bool) {
+func (c *FakeK8SOrchestrator) GetVolumeIDFromPVCName(namespace string, pvcName string) (string, bool) {
 	if strings.Contains(pvcName, "invalid") {
 		// Simulate a case where the volumeID is invalid and does not correspond to any PVC.
 		return "", false

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -98,9 +98,8 @@ type COCommonInterface interface {
 	GetPVNameFromCSIVolumeID(volumeID string) (string, bool)
 	// GetPVCNameFromCSIVolumeID returns `pvc name` and `pvc namespace` for the given volumeID using volumeIDToPvcMap.
 	GetPVCNameFromCSIVolumeID(volumeID string) (string, string, bool)
-	// GetVolumeIDFromPVCName returns volumeID the given pvcName using pvcToVolumeIDMap.
-	// PVC name is its namespaced name.
-	GetVolumeIDFromPVCName(pvcName string) (string, bool)
+	// GetVolumeIDFromPVCName returns volumeID for the given pvc name and namespace.
+	GetVolumeIDFromPVCName(namespace string, pvcName string) (string, bool)
 	// InitializeCSINodes creates CSINode instances for each K8s node with the appropriate topology keys.
 	InitializeCSINodes(ctx context.Context) error
 	// StartZonesInformer starts a dynamic informer which listens on Zones CR in

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -2016,8 +2016,8 @@ func (c *K8sOrchestrator) GetPVCNameFromCSIVolumeID(volumeID string) (
 
 // GetVolumeIDFromPVCName returns volumeID the given pvcName using pvcToVolumeIDMap.
 // PVC name is its namespaced name.
-func (c *K8sOrchestrator) GetVolumeIDFromPVCName(pvcName string) (string, bool) {
-	return c.pvcToVolumeIDMap.get(pvcName)
+func (c *K8sOrchestrator) GetVolumeIDFromPVCName(namespace string, pvcName string) (string, bool) {
+	return c.pvcToVolumeIDMap.get(fmt.Sprintf("%s/%s", namespace, pvcName))
 }
 
 // IsLinkedCloneRequest checks if the pvc is a linked clone request

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -188,7 +188,7 @@ func (m *MockCOCommonInterface) GetPVCNameFromCSIVolumeID(volumeID string) (stri
 	return args.String(0), args.String(1), args.Bool(2)
 }
 
-func (m *MockCOCommonInterface) GetVolumeIDFromPVCName(pvcName string) (string, bool) {
+func (m *MockCOCommonInterface) GetVolumeIDFromPVCName(namespace, pvcName string) (string, bool) {
 	args := m.Called(pvcName)
 	return args.String(0), args.Bool(1)
 }

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -24,7 +24,7 @@ import (
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	v1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -59,11 +59,6 @@ func removeFinalizerFromCRDInstance(ctx context.Context,
 		}
 	}
 	return k8s.PatchFinalizers(ctx, c, instance, finalizersOnInstance)
-}
-
-// getNamespacedPvcName take namespace and pvcName sends back namespace + "/" + pvcName.
-func getNamespacedPvcName(namespace string, pvcName string) string {
-	return namespace + "/" + pvcName
 }
 
 // getVolumesToDetachFromInstance finds out which are the volumes to detach by finding out which are
@@ -281,8 +276,8 @@ func getVolumeNameVolumeIdMapsInSpec(ctx context.Context,
 	volumeIdsInSpec = make(map[string]string)
 	volumeNamesInSpec = make(map[string]string)
 	for _, volume := range instance.Spec.Volumes {
-		namespacedPvcName := getNamespacedPvcName(instance.Namespace, volume.PersistentVolumeClaim.ClaimName)
-		volumeId, ok := commonco.ContainerOrchestratorUtility.GetVolumeIDFromPVCName(namespacedPvcName)
+		volumeId, ok := commonco.ContainerOrchestratorUtility.GetVolumeIDFromPVCName(
+			instance.Namespace, volume.PersistentVolumeClaim.ClaimName)
 		if !ok {
 			msg := fmt.Sprintf("failed to find volumeID for PVC %s", volume.PersistentVolumeClaim.ClaimName)
 			log.Errorf(msg)
@@ -299,8 +294,8 @@ func getVolumeNameVolumeIdMapsInSpec(ctx context.Context,
 func getPvcsInSpec(instance *v1alpha1.CnsNodeVmBatchAttachment) (map[string]string, error) {
 	pvcsInSpec := make(map[string]string)
 	for _, volume := range instance.Spec.Volumes {
-		namespacedPvcName := getNamespacedPvcName(instance.Namespace, volume.PersistentVolumeClaim.ClaimName)
-		volumeId, ok := commonco.ContainerOrchestratorUtility.GetVolumeIDFromPVCName(namespacedPvcName)
+		volumeId, ok := commonco.ContainerOrchestratorUtility.GetVolumeIDFromPVCName(
+			instance.Namespace, volume.PersistentVolumeClaim.ClaimName)
 		if !ok {
 			return pvcsInSpec, fmt.Errorf("failed to find volumeID for PVC %s", volume.PersistentVolumeClaim.ClaimName)
 		}
@@ -369,8 +364,7 @@ func constructBatchAttachRequest(ctx context.Context,
 		volumeName := volume.Name
 
 		// Find volumeID for PVC.
-		namespacedPvcName := getNamespacedPvcName(instance.Namespace, pvcName)
-		attachVolumeId, ok := commonco.ContainerOrchestratorUtility.GetVolumeIDFromPVCName(namespacedPvcName)
+		attachVolumeId, ok := commonco.ContainerOrchestratorUtility.GetVolumeIDFromPVCName(instance.Namespace, pvcName)
 		if !ok {
 			err := fmt.Errorf("failed to find volumeID for PVC %s", pvcName)
 			log.Error(err)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -397,7 +397,7 @@ func (m *mockCOCommon) GetPvcObjectByName(ctx context.Context, pvcName string,
 	return nil, nil
 }
 
-func (m *mockCOCommon) GetVolumeIDFromPVCName(pvcName string) (string, bool) {
+func (m *mockCOCommon) GetVolumeIDFromPVCName(namespace string, pvcName string) (string, bool) {
 	return "vol-1", true
 }
 

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/controller_test.go
@@ -19,6 +19,7 @@ package cnsunregistervolume
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -39,27 +40,84 @@ import (
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	v1a1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsunregistervolume/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	cnsoptypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
 
 func TestReconciler_Reconcile(t *testing.T) {
+	// function overrides
 	newK8sClientOriginal := newK8sClient
-	getPVNameOriginal := getPVName
-	getPVCNameOriginal := getPVCName
+	getValidatedParamsOriginal := getValidatedParams
 	getVolumeUsageInfoOriginal := getVolumeUsageInfo
-	retainPVOriginal := retainPV
+	protectPVCOriginal := protectPVC
 	deletePVCOriginal := deletePVC
-	deletePVOriginal := deletePV
+	removeFinalizerFromPVCOriginal := removeFinalizerFromPVC
+	backOffDurationOriginal := backOffDuration
 	defer func() {
 		newK8sClient = newK8sClientOriginal
-		getPVName = getPVNameOriginal
-		getPVCName = getPVCNameOriginal
+		getValidatedParams = getValidatedParamsOriginal
 		getVolumeUsageInfo = getVolumeUsageInfoOriginal
-		retainPV = retainPVOriginal
+		protectPVC = protectPVCOriginal
 		deletePVC = deletePVCOriginal
-		deletePV = deletePVOriginal
+		removeFinalizerFromPVC = removeFinalizerFromPVCOriginal
+		backOffDuration = backOffDurationOriginal
 	}()
+
+	setup := func(t *testing.T, runtimeObjs []client.Object, interceptorFuncs interceptor.Funcs,
+		volumeManager volume.Manager) *Reconciler {
+		t.Helper()
+		c := newClient(t, runtimeObjs, interceptorFuncs)
+		backOffDuration = make(map[types.NamespacedName]time.Duration)
+		return &Reconciler{
+			client:        c,
+			recorder:      record.NewFakeRecorder(10),
+			volumeManager: volumeManager,
+		}
+	}
+	assertUtil := func(t *testing.T, r *Reconciler, req reconcile.Request, res reconcile.Result, err error,
+		expRequeue bool, expRequeueAfter time.Duration, expBackoff bool, expErr, expEvent, expStatus string) {
+		t.Helper()
+
+		if expErr == "" {
+			assert.Nil(t, err, "Expected no error")
+		} else {
+			assert.NotNil(t, err, "Expected an error")
+		}
+
+		if expRequeue {
+			assert.Equal(t, expRequeueAfter, res.RequeueAfter, "Expected requeue after duration")
+		} else {
+			assert.True(t, res.IsZero(), "Expected no requeue")
+		}
+
+		if expBackoff {
+			assert.Equal(t, expRequeueAfter*2, backOffDuration[req.NamespacedName], "Expected backoff duration to be doubled")
+		} else {
+			assert.NotContains(t, backOffDuration, req.NamespacedName, "Expected no backoff duration")
+		}
+
+		if expEvent != "" {
+			if r.recorder == nil {
+				t.Fatal("Expected recorder to be initialized")
+			}
+
+			event, ok := <-r.recorder.(*record.FakeRecorder).Events
+			if !ok {
+				t.Fatal("Expected an event but none found")
+			}
+
+			assert.Contains(t, event, expEvent)
+		}
+
+		if expStatus != "" {
+			var updatedInstance v1a1.CnsUnregisterVolume
+			err := r.client.Get(context.Background(), req.NamespacedName, &updatedInstance)
+			if err != nil {
+				t.Fatalf("Failed to get updated instance: %v", err)
+			}
+
+			assert.Equal(t, expStatus, updatedInstance.Status.Error, "Expected status error to match")
+		}
+	}
 
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -67,151 +125,150 @@ func TestReconciler_Reconcile(t *testing.T) {
 			Namespace: "mock-namespace",
 		},
 	}
+
 	t.Run("WhenGettingInstanceFails", func(tt *testing.T) {
 		tt.Run("WhenNotFound", func(tt *testing.T) {
-			cb := fake.NewClientBuilder().WithInterceptorFuncs(
-				interceptor.Funcs{
-					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey,
-						obj client.Object, opts ...client.GetOption) error {
-						return apierrors.NewNotFound(
-							schema.GroupResource{
-								Group:    "cns.vmware.com",
-								Resource: "cnsunregistervolume",
-							}, key.Name)
-					},
+			// Setup
+			reconciler := setup(tt, nil, interceptor.Funcs{
+				Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey,
+					obj client.Object, opts ...client.GetOption) error {
+					return apierrors.NewNotFound(
+						schema.GroupResource{
+							Group:    "cns.vmware.com",
+							Resource: "cnsunregistervolume",
+						}, key.Name)
 				},
-			)
-			reconciler := &Reconciler{
-				client: cb.Build(),
-			}
-			ctx := context.Background()
-			res, err := reconciler.Reconcile(ctx, request)
-			assert.Nil(tt, err)
-			assert.True(tt, res.IsZero(), "Expected no requeue")
+			}, nil)
+
+			// Execute
+			res, err := reconciler.Reconcile(context.Background(), request)
+
+			// Assert
+			assertUtil(tt, reconciler, request, res, err, false, 0, false, "", "", "")
 		})
 		tt.Run("WhenOtherError", func(tt *testing.T) {
-			cb := fake.NewClientBuilder().WithInterceptorFuncs(
-				interceptor.Funcs{
-					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey,
-						obj client.Object, opts ...client.GetOption) error {
-						return apierrors.NewInternalError(errors.New("other error"))
-					},
+			// Setup
+			reconciler := setup(tt, nil, interceptor.Funcs{
+				Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey,
+					obj client.Object, opts ...client.GetOption) error {
+					return apierrors.NewInternalError(errors.New("other error"))
 				},
-			)
-			reconciler := &Reconciler{
-				client: cb.Build(),
-			}
-			ctx := context.Background()
-			res, err := reconciler.Reconcile(ctx, request)
-			assert.NotNil(tt, err)
-			assert.True(tt, res.IsZero(), "Expected no requeue")
+			}, nil)
+
+			// Execute
+			res, err := reconciler.Reconcile(context.Background(), request)
+
+			// Assert
+			assertUtil(tt, reconciler, request, res, err, false, time.Second, false, "other error", "", "")
+		})
+	})
+
+	t.Run("WhenInstanceIsBeingDeleted", func(tt *testing.T) {
+		tt.Run("WhenRemovingFinalizerFails", func(tt *testing.T) {
+			// Setup
+			errMsg := "failed to remove finalizer"
+			instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+				[]string{cnsoptypes.CNSUnregisterVolumeFinalizer}, true, false, false, true)
+			reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{
+				Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					return apierrors.NewInternalError(errors.New("failed to remove finalizer"))
+				},
+			}, nil)
+
+			// Execute
+			res, err := reconciler.Reconcile(context.Background(), request)
+
+			// Assert
+			assertUtil(tt, reconciler, request, res, err, false, time.Second,
+				false, errMsg, "", "")
+		})
+		tt.Run("WhenRemovingFinalizerSucceeds", func(tt *testing.T) {
+			// Setup
+			instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+				[]string{cnsoptypes.CNSUnregisterVolumeFinalizer}, false, false, false, true)
+			reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, nil)
+
+			// Execute
+			res, err := reconciler.Reconcile(context.Background(), request)
+
+			// Assert
+			assertUtil(tt, reconciler, request, res, err, false, 0, false, "", "", "")
 		})
 	})
 
 	t.Run("WhenInstanceIsUnregistered", func(tt *testing.T) {
 		// Setup
-		cb := fake.NewClientBuilder()
-		registerSchemes(tt, cb)
-		ctx := context.Background()
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
-		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id",
-			false, false, true, "")
-		registerRuntimeObjects(tt, cb, instance)
-		reconciler := &Reconciler{
-			client: cb.Build(),
-		}
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, true, false)
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, nil)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.True(tt, res.IsZero(), "Expected no requeue")
-		assert.NotContains(tt, backOffDuration, request, "Expected no backoff duration for unregistered instance")
+		assertUtil(tt, reconciler, request, res, err, false, 0, false, "", "", "")
 	})
 
-	cb := fake.NewClientBuilder()
-	registerSchemes(t, cb)
-	ctx := context.Background()
-	instance := newInstance(t, "mock-instance", "mock-namespace", "mock-volume-id",
-		false, false, false, "")
-	registerRuntimeObjects(t, cb, instance)
-
-	t.Run("WhenGettingPVNameFails", func(tt *testing.T) {
+	t.Run("WhenAddingFinalizerFails", func(tt *testing.T) {
 		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
-		reconciler := &Reconciler{
-			client:   cb.Build(),
-			recorder: record.NewFakeRecorder(10),
-		}
-		getPVName = func(ctx context.Context, volumeID string) (string, error) {
-			return "", errors.New("failed to get PV name")
-		}
+		instance := newInstance(t, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{
+			Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return apierrors.NewInternalError(errors.New("failed to add finalizer"))
+			},
+		}, nil)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
-		assert.Equal(tt, 2*time.Second, backOffDuration[request.NamespacedName], "Expected backoff duration to be 2 seconds")
+		assertUtil(tt, reconciler, request, res, err, false, 0, false, "failed to add finalizer", "", "")
 	})
 
-	getPVName = func(ctx context.Context, volumeID string) (string, error) {
-		return "mock-pv-name", nil
-	}
-
-	t.Run("WhenGettingPVCNameFails", func(tt *testing.T) {
+	t.Run("WhenParamsAreInvalid", func(tt *testing.T) {
 		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
-		reconciler := &Reconciler{
-			client:   cb.Build(),
-			recorder: record.NewFakeRecorder(10),
+		errMsg := "invalid parameters"
+		instance := newInstance(t, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
+		getValidatedParams = func(ctx context.Context, instance v1a1.CnsUnregisterVolume) (*params, error) {
+			return nil, errors.New(errMsg)
 		}
-		getPVCName = func(ctx context.Context, volumeID string) (string, string, error) {
-			return "", "", errors.New("failed to get PVC name")
-		}
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, nil)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
-		assert.Equal(tt, 2*time.Second, backOffDuration[request.NamespacedName], "Expected backoff duration to be 2 seconds")
-
+		assertUtil(tt, reconciler, request, res, err, true, time.Second, true, "", errMsg, errMsg)
 	})
 
-	getPVCName = func(ctx context.Context, volumeID string) (string, string, error) {
-		return "mock-pvc-name", "mock-pvc-namespace", nil
+	getValidatedParams = func(ctx context.Context, instance v1a1.CnsUnregisterVolume) (*params, error) {
+		return &params{
+			retainFCD: false,
+			force:     false,
+			namespace: "mock-namespace",
+			volumeID:  "mock-volume-id",
+			pvcName:   "mock-pvc-name",
+			pvName:    "mock-pv-name",
+		}, nil
 	}
 
 	t.Run("WhenCreatingK8sClientFails", func(tt *testing.T) {
 		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
+		errMsg := "failed to init K8s client for volume unregistration"
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
 		newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
-			return nil, errors.New("failed to create k8s client")
+			return nil, errors.New(errMsg)
 		}
-		reconciler := &Reconciler{
-			client:   cb.Build(),
-			recorder: record.NewFakeRecorder(10),
-		}
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, nil)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      "mock-instance",
-				Namespace: "mock-namespace",
-			},
-		})
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
-		assert.Equal(tt, 2*time.Second, backOffDuration[types.NamespacedName{
-			Name:      "mock-instance",
-			Namespace: "mock-namespace",
-		}], "Expected backoff duration to be 2 seconds")
+		assertUtil(tt, reconciler, request, res, err, true, time.Second, true, "", errMsg, errMsg)
 	})
 
 	newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
@@ -220,18 +277,17 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 	t.Run("WhenGettingVolumeUsageInfoFails", func(tt *testing.T) {
 		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
+		errMsg := "failed to get volume usage info"
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
 		getVolumeUsageInfo = func(ctx context.Context, k8sClient kubernetes.Interface, pvcName string,
 			pvcNamespace string, ignoreVMUsage bool) (*volumeUsageInfo, error) {
-			return nil, errors.New("failed to get volume usage info")
+			return nil, errors.New(errMsg)
 		}
-		reconciler := &Reconciler{
-			client:   cb.Build(),
-			recorder: record.NewFakeRecorder(10),
-		}
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, nil)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, reconcile.Request{
+		res, err := reconciler.Reconcile(context.Background(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      "mock-instance",
 				Namespace: "mock-namespace",
@@ -239,95 +295,82 @@ func TestReconciler_Reconcile(t *testing.T) {
 		})
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
-		assert.Equal(tt, 2*time.Second, backOffDuration[types.NamespacedName{
-			Name:      "mock-instance",
-			Namespace: "mock-namespace",
-		}], "Expected backoff duration to be 2 seconds")
+		assertUtil(tt, reconciler, request, res, err, true, time.Second, true, "", errMsg, errMsg)
 	})
 
 	t.Run("WhenVolumeIsInUse", func(tt *testing.T) {
 		// Setup
+		usageInfo := &volumeUsageInfo{
+			isInUse: true,
+			pods:    []string{"pod1", "pod2"},
+		}
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
 		getVolumeUsageInfo = func(ctx context.Context, k8sClient kubernetes.Interface, pvcName string,
 			pvcNamespace string, ignoreVMUsage bool) (*volumeUsageInfo, error) {
-			return &volumeUsageInfo{
-				isInUse: true,
-				pods:    []string{"pod1", "pod2"},
-			}, nil
+			return usageInfo, nil
 		}
 		newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
 			return fakeclientset.NewClientset(), nil
 		}
-		reconciler := &Reconciler{
-			client:   cb.Build(),
-			recorder: record.NewFakeRecorder(10),
-		}
-		ctx := context.Background()
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
-		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, nil)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
-		assert.Equal(tt, 2*time.Second, backOffDuration[request.NamespacedName],
-			"Expected backoff duration to be 2 seconds")
+		expStatus := fmt.Sprintf("volume %s cannot be unregistered because %s", instance.Spec.VolumeID, usageInfo)
+		assertUtil(tt, reconciler, request, res, err, true, time.Second, true, "", usageInfo.String(), expStatus)
 	})
 
 	getVolumeUsageInfo = func(ctx context.Context, k8sClient kubernetes.Interface, pvcName string,
 		pvcNamespace string, ignoreVMUsage bool) (*volumeUsageInfo, error) {
-		return &volumeUsageInfo{
-			isInUse: false,
-		}, nil
+		return &volumeUsageInfo{}, nil
 	}
 
-	t.Run("WhenRetainingPVFails", func(tt *testing.T) {
+	t.Run("WhenAddingFinalizerOnPVCFails", func(tt *testing.T) {
 		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
-		retainPV = func(ctx context.Context, k8sClient kubernetes.Interface, pvName string) error {
-			return errors.New("failed to retain PV")
+		errMsg := "failed to add finalizer on PVC"
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
+		protectPVC = func(ctx context.Context, k8sClient kubernetes.Interface, pvcName, pvcNamespace,
+			finalizer string) error {
+			return errors.New("failed to add finalizer on PVC")
 		}
-		reconciler := &Reconciler{
-			client:   cb.Build(),
-			recorder: record.NewFakeRecorder(10),
-		}
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, nil)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
-		assert.Equal(tt, 2*time.Second, backOffDuration[request.NamespacedName],
-			"Expected backoff duration to be 2 seconds")
+		assertUtil(tt, reconciler, request, res, err, true, time.Second,
+			true, "", errMsg, errMsg)
 	})
 
-	retainPV = func(ctx context.Context, k8sClient kubernetes.Interface, pvName string) error {
+	protectPVC = func(ctx context.Context, k8sClient kubernetes.Interface, pvcName, pvcNamespace, finalizer string) error {
 		return nil
 	}
 
 	t.Run("WhenDeletingPVCFails", func(tt *testing.T) {
 		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
+		errMsg := "failed to delete PVC"
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
 		deletePVC = func(ctx context.Context, k8sClient kubernetes.Interface, pvcName string, pvcNamespace string) error {
-			return errors.New("failed to delete PVC")
+			return errors.New(errMsg)
 		}
-		reconciler := &Reconciler{
-			client:   cb.Build(),
-			recorder: record.NewFakeRecorder(10),
-		}
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, nil)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
 		assert.Nil(tt, err, "Expected no error")
 		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
 		assert.Equal(tt, 2*time.Second, backOffDuration[request.NamespacedName],
 			"Expected backoff duration to be 2 seconds")
+
+		assertUtil(tt, reconciler, request, res, err, true, time.Second, true, "", errMsg, errMsg)
 	})
 
 	deletePVC = func(ctx context.Context, k8sClient kubernetes.Interface, pvcName string, pvcNamespace string) error {
@@ -336,23 +379,19 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 	t.Run("WhenDeletingPVFails", func(tt *testing.T) {
 		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
+		errMsg := "failed to delete PV"
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
 		deletePV = func(ctx context.Context, k8sClient kubernetes.Interface, pvName string) error {
-			return errors.New("failed to delete PV")
+			return errors.New(errMsg)
 		}
-		reconciler := &Reconciler{
-			client:   cb.Build(),
-			recorder: record.NewFakeRecorder(10),
-		}
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, nil)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
-		assert.Equal(tt, 2*time.Second, backOffDuration[request.NamespacedName],
-			"Expected backoff duration to be 2 seconds")
+		assertUtil(tt, reconciler, request, res, err, true, time.Second, true, "", errMsg, errMsg)
 	})
 
 	deletePV = func(ctx context.Context, k8sClient kubernetes.Interface, pvName string) error {
@@ -361,80 +400,239 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 	t.Run("WhenUnregisteringVolumeFails", func(tt *testing.T) {
 		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
-		mockVolManager := volume.NewMockManager(true, errors.New("failed to unregister volume"))
-		reconciler := &Reconciler{
-			client:        cb.Build(),
-			recorder:      record.NewFakeRecorder(10),
-			volumeManager: mockVolManager,
-		}
+		errMsg := "failed to unregister volume"
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
+		mockVolManager := volume.NewMockManager(true, errors.New(errMsg))
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, mockVolManager)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
-		assert.Equal(tt, 2*time.Second, backOffDuration[request.NamespacedName],
-			"Expected backoff duration to be 2 seconds")
+		assertUtil(tt, reconciler, request, res, err, true, time.Second, true, "", errMsg, errMsg)
 	})
 
 	mockVolManager := volume.NewMockManager(false, nil)
 
-	t.Run("WhenUpdatingStatusFails", func(tt *testing.T) {
+	t.Run("WhenRemovingFinalizerFromPVCFails", func(tt *testing.T) {
 		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
-		cb.WithInterceptorFuncs(
-			interceptor.Funcs{
-				SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string,
-					obj client.Object, opts ...client.SubResourceUpdateOption) error {
-					return apierrors.NewInternalError(errors.New("failed to update status"))
-				},
-			},
-		)
-		reconciler := &Reconciler{
-			client:        cb.Build(),
-			recorder:      record.NewFakeRecorder(10),
-			volumeManager: mockVolManager,
+		errMsg := "failed to remove finalizer from PVC"
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
+		removeFinalizerFromPVC = func(ctx context.Context, k8sClient kubernetes.Interface, pvcName, pvcNamespace,
+			finalizer string) error {
+			return errors.New(errMsg)
 		}
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{}, mockVolManager)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.Equal(tt, res.RequeueAfter, time.Second, "Expected requeue after 1 second")
-		assert.Equal(tt, 2*time.Second, backOffDuration[request.NamespacedName],
-			"Expected backoff duration to be 2 seconds")
+		assertUtil(tt, reconciler, request, res, err, true, time.Second,
+			true, "", errMsg, errMsg)
 	})
 
-	cb.WithInterceptorFuncs(
-		interceptor.Funcs{
+	removeFinalizerFromPVC = func(ctx context.Context, k8sClient kubernetes.Interface, pvcName, pvcNamespace,
+		finalizer string) error {
+		return nil
+	}
+
+	t.Run("WhenUpdatingStatusFails", func(tt *testing.T) {
+		// Setup
+		errMsg := "failed to update status"
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string,
+				obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				return apierrors.NewInternalError(errors.New(errMsg))
+			},
+		}, mockVolManager)
+
+		// Execute
+		res, err := reconciler.Reconcile(context.Background(), request)
+
+		// Assert
+		assertUtil(tt, reconciler, request, res, err, true, time.Second, true, "", "", "")
+	})
+
+	t.Run("WhenReconcileSucceeds", func(tt *testing.T) {
+		// Setup
+		instance := newInstance(tt, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+			nil, false, false, false, false)
+		reconciler := setup(tt, []client.Object{instance}, interceptor.Funcs{
 			SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string,
 				obj client.Object, opts ...client.SubResourceUpdateOption) error {
 				return nil // Simulate successful update
 			},
-		},
-	)
-
-	t.Run("WhenReconcileSucceeds", func(tt *testing.T) {
-		// Setup
-		backOffDuration = make(map[types.NamespacedName]time.Duration)
-		reconciler := &Reconciler{
-			client:        cb.Build(),
-			recorder:      record.NewFakeRecorder(10),
-			volumeManager: mockVolManager,
-		}
+		}, mockVolManager)
 
 		// Execute
-		res, err := reconciler.Reconcile(ctx, request)
+		res, err := reconciler.Reconcile(context.Background(), request)
 
 		// Assert
-		assert.Nil(tt, err, "Expected no error")
-		assert.True(tt, res.IsZero(), "Expected no requeue")
-		assert.NotContains(tt, backOffDuration, request.NamespacedName,
-			"Expected no backoff duration for successful reconciliation")
+		assertUtil(tt, reconciler, request, res, err, false, 0, false, "", "", "")
 	})
+}
+
+func TestGetValidatedParams(t *testing.T) {
+	getPVCNameOriginal := getPVCName
+	getPVNameOriginal := getPVName
+	getVolumeIDOriginal := getVolumeID
+	defer func() {
+		getPVCName = getPVCNameOriginal
+		getPVName = getPVNameOriginal
+		getVolumeID = getVolumeIDOriginal
+	}()
+
+	t.Run("WhenVolumeIDAndPVCNameAreEmpty", func(t *testing.T) {
+		// Setup
+		instance := newInstance(t, "mock-instance", "mock-namespace", "", "", "",
+			nil, false, false, false, false)
+
+		// Execute
+		params, err := getValidatedParams(context.Background(), *instance)
+
+		// Assert
+		assert.Nil(t, params, "Expected params to be nil")
+		assert.NotNil(t, err, "Expected an error")
+	})
+
+	t.Run("WhenVolumeIDAndPVCNameAreBothSet", func(t *testing.T) {
+		// Setup
+		instance := newInstance(t, "mock-instance", "mock-namespace", "mock-volume-id", "", "mock-pvc-name",
+			nil, false, false, false, false)
+
+		// Execute
+		params, err := getValidatedParams(context.Background(), *instance)
+
+		// Assert
+		assert.Nil(t, params, "Expected params to be nil")
+		assert.NotNil(t, err, "Expected an error")
+	})
+
+	t.Run("WhenVolumeIDIsSet", func(t *testing.T) {
+		t.Run("WhenPVCNotFound", func(t *testing.T) {
+			// Setup
+			getPVCName = func(ctx context.Context, volumeID string) (string, string, error) {
+				return "", "", errors.New("PVC not found")
+			}
+			getPVName = func(ctx context.Context, volumeID string) (string, error) {
+				return "mock-pv", nil
+			}
+			instance := newInstance(t, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+				nil, false, false, false, false)
+			expParams := params{
+				retainFCD: false,
+				force:     false,
+				namespace: "mock-namespace",
+				volumeID:  "mock-volume-id",
+				pvcName:   "",
+				pvName:    "mock-pv",
+			}
+
+			// Execute
+			params, err := getValidatedParams(context.Background(), *instance)
+
+			// Assert
+			assert.Nil(t, err, "Expected no error")
+			assert.Equal(t, expParams, *params, "Expected params to match")
+		})
+		t.Run("WhenPVNotFound", func(t *testing.T) {
+			// Setup
+			cb := fake.NewClientBuilder()
+			registerSchemes(t, cb)
+			getPVCName = func(ctx context.Context, volumeID string) (string, string, error) {
+				return "mock-pvc", "mock-namespace", nil
+			}
+			getPVName = func(ctx context.Context, volumeID string) (string, error) {
+				return "", errors.New("PV not found")
+			}
+			instance := newInstance(t, "mock-instance", "mock-namespace", "mock-volume-id", "", "",
+				nil, false, false, false, false)
+			expParams := params{
+				retainFCD: false,
+				force:     false,
+				namespace: "mock-namespace",
+				volumeID:  "mock-volume-id",
+				pvcName:   "mock-pvc",
+				pvName:    "",
+			}
+
+			// Execute
+			params, err := getValidatedParams(context.Background(), *instance)
+
+			// Assert
+			assert.Nil(t, err, "Expected no error")
+			assert.Equal(t, expParams, *params, "Expected params to match")
+		})
+	})
+
+	t.Run("WhenPVCNameIsSet", func(t *testing.T) {
+		t.Run("WhenVolumeIDNotFound", func(t *testing.T) {
+			// Setup
+			getVolumeID = func(ctx context.Context, pvcName, namespace string) (string, error) {
+				return "", errors.New("VolumeID not found")
+			}
+			getPVName = func(ctx context.Context, volumeID string) (string, error) {
+				return "mock-pv", nil
+			}
+			instance := newInstance(t, "mock-instance", "mock-namespace", "", "", "mock-pvc-name",
+				nil, false, false, false, false)
+			expParams := params{
+				retainFCD: false,
+				force:     false,
+				namespace: "mock-namespace",
+				volumeID:  "",
+				pvcName:   "mock-pvc-name",
+				pvName:    "mock-pv",
+			}
+
+			// Execute
+			params, err := getValidatedParams(context.Background(), *instance)
+
+			// Assert
+			assert.Nil(t, err, "Expected no error")
+			assert.Equal(t, expParams, *params, "Expected params to match")
+		})
+		t.Run("WhenPVNotFound", func(t *testing.T) {
+			// Setup
+			getVolumeID = func(ctx context.Context, pvcName, namespace string) (string, error) {
+				return "mock-volume-id", nil
+			}
+			getPVName = func(ctx context.Context, volumeID string) (string, error) {
+				return "", errors.New("PV not found")
+			}
+			instance := newInstance(t, "mock-instance", "mock-namespace", "", "", "mock-pvc-name",
+				nil, false, false, false, false)
+			expParams := params{
+				retainFCD: false,
+				force:     false,
+				namespace: "mock-namespace",
+				volumeID:  "mock-volume-id",
+				pvcName:   "mock-pvc-name",
+				pvName:    "",
+			}
+
+			// Execute
+			params, err := getValidatedParams(context.Background(), *instance)
+
+			// Assert
+			assert.Nil(t, err, "Expected no error")
+			assert.Equal(t, expParams, *params, "Expected params to match")
+		})
+	})
+}
+
+func newClient(t *testing.T, runtimeObjs []client.Object, interceptorFuncs interceptor.Funcs) client.Client {
+	t.Helper()
+	cb := fake.NewClientBuilder()
+	registerSchemes(t, cb)
+	registerRuntimeObjects(t, cb, runtimeObjs...)
+	cb.WithInterceptorFuncs(interceptorFuncs)
+	return cb.Build()
 }
 
 func registerSchemes(t *testing.T, cb *fake.ClientBuilder) {
@@ -458,22 +656,30 @@ func registerRuntimeObjects(t *testing.T, cb *fake.ClientBuilder, objs ...client
 	cb.WithStatusSubresource(objs...)
 }
 
-func newInstance(t *testing.T, name, namespace, volumeID string,
-	retainFCD, forceUnregister, unregistered bool, err string) *v1a1.CnsUnregisterVolume {
+func newInstance(t *testing.T, name, namespace, volumeID, errMsg, pvcName string, finalizers []string,
+	retainFCD, forceUnregister, unregistered, withDeletionTS bool) *v1a1.CnsUnregisterVolume {
 	t.Helper()
-	return &v1a1.CnsUnregisterVolume{
+	instance := &v1a1.CnsUnregisterVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:       name,
+			Namespace:  namespace,
+			Finalizers: finalizers,
 		},
 		Spec: v1a1.CnsUnregisterVolumeSpec{
 			VolumeID:        volumeID,
+			PVCName:         pvcName,
 			RetainFCD:       retainFCD,
 			ForceUnregister: forceUnregister,
 		},
 		Status: v1a1.CnsUnregisterVolumeStatus{
 			Unregistered: unregistered,
-			Error:        err,
+			Error:        errMsg,
 		},
 	}
+
+	if withDeletionTS {
+		instance.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	}
+
+	return instance
 }

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/util.go
@@ -68,6 +68,7 @@ func (v volumeUsageInfo) String() string {
 var getVolumeUsageInfo = _getVolumeUsageInfo
 
 // getVolumeUsageInfo checks if the PVC is in use by any resources in the specified namespace.
+// For the sake of efficiency, the function returns as soon as it finds that the volume is in use by any resource.
 // If ignoreVMUsage is set to true, the function skips checking if the volume is in use by any virtual machines.
 func _getVolumeUsageInfo(ctx context.Context, k8sClient clientset.Interface, pvcName string, pvcNamespace string,
 	ignoreVMUsage bool) (*volumeUsageInfo, error) {
@@ -79,34 +80,39 @@ func _getVolumeUsageInfo(ctx context.Context, k8sClient clientset.Interface, pvc
 		return &volumeUsageInfo, nil
 	}
 
-	pods, isInUse, err := getPodsForPVC(ctx, pvcName, pvcNamespace, k8sClient)
+	var err error
+	volumeUsageInfo.pods, volumeUsageInfo.isInUse, err = getPodsForPVC(ctx, pvcName, pvcNamespace, k8sClient)
 	if err != nil {
 		return nil, err
 	}
 
-	volumeUsageInfo.pods = pods
-	volumeUsageInfo.isInUse = volumeUsageInfo.isInUse || isInUse
+	if volumeUsageInfo.isInUse {
+		return &volumeUsageInfo, nil
+	}
 
 	cfg, err := k8s.GetKubeConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	guestClusters, isInUse, err := getGuestClustersForPVC(ctx, pvcName, pvcNamespace, *cfg)
+	volumeUsageInfo.guestClusters, volumeUsageInfo.isInUse, err = getGuestClustersForPVC(
+		ctx, pvcName, pvcNamespace, *cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	volumeUsageInfo.guestClusters = guestClusters
-	volumeUsageInfo.isInUse = volumeUsageInfo.isInUse || isInUse
+	if volumeUsageInfo.isInUse {
+		return &volumeUsageInfo, nil
+	}
 
-	snapshots, isInUse, err := getSnapshotsForPVC(ctx, pvcName, pvcNamespace, *cfg)
+	volumeUsageInfo.snapshots, volumeUsageInfo.isInUse, err = getSnapshotsForPVC(ctx, pvcName, pvcNamespace, *cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	volumeUsageInfo.snapshots = snapshots
-	volumeUsageInfo.isInUse = volumeUsageInfo.isInUse || isInUse
+	if volumeUsageInfo.isInUse {
+		return &volumeUsageInfo, nil
+	}
 
 	if ignoreVMUsage {
 		log.Debugf("Skipping check for virtual machines using PVC %q in namespace %q as ignoreVMUsage is set to true",
@@ -114,13 +120,11 @@ func _getVolumeUsageInfo(ctx context.Context, k8sClient clientset.Interface, pvc
 		return &volumeUsageInfo, nil
 	}
 
-	vms, isInUse, err := getVMsForPVC(ctx, pvcName, pvcNamespace, *cfg)
+	volumeUsageInfo.virtualMachines, volumeUsageInfo.isInUse, err = getVMsForPVC(ctx, pvcName, pvcNamespace, *cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	volumeUsageInfo.virtualMachines = vms
-	volumeUsageInfo.isInUse = volumeUsageInfo.isInUse || isInUse
 	return &volumeUsageInfo, nil
 }
 
@@ -162,6 +166,25 @@ func _getPVCName(ctx context.Context, volumeID string) (string, string, error) {
 	return pvc, ns, nil
 }
 
+var getVolumeID = _getVolumeID
+
+func _getVolumeID(ctx context.Context, pvcName, namespace string) (string, error) {
+	log := logger.GetLogger(ctx)
+	if commonco.ContainerOrchestratorUtility == nil {
+		err := errors.New("ContainerOrchestratorUtility is not initialized")
+		log.Warn(err)
+		return "", err
+	}
+
+	volID, ok := commonco.ContainerOrchestratorUtility.GetVolumeIDFromPVCName(namespace, pvcName)
+	if !ok {
+		log.Infof("no volumeID found for PVC %q", pvcName)
+	} else {
+		log.Infof("volumeID %q found for PVC %q", volID, pvcName)
+	}
+	return volID, nil
+}
+
 // getPodsForPVC returns a list of pods that are using the specified PVC.
 func getPodsForPVC(ctx context.Context, pvcName string, pvcNamespace string,
 	k8sClient clientset.Interface) ([]string, bool, error) {
@@ -169,8 +192,9 @@ func getPodsForPVC(ctx context.Context, pvcName string, pvcNamespace string,
 	// TODO: check if we can use informer cache
 	list, err := k8sClient.CoreV1().Pods(pvcNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, false, logger.LogNewErrorf(log, "Failed to list pods in namespace %q for PVC %q. Error: %q",
+		log.Warnf("Failed to list pods in namespace %q for PVC %q. Error: %q",
 			pvcNamespace, pvcName, err.Error())
+		return nil, false, errors.New("failed to list pods")
 	}
 
 	var pods []string
@@ -197,17 +221,17 @@ func getSnapshotsForPVC(ctx context.Context, pvcName string, pvcNamespace string
 	log := logger.GetLogger(ctx)
 	c, err := snapshotclient.NewForConfig(&cfg)
 	if err != nil {
-		return nil, false, logger.LogNewErrorf(log,
-			"Failed to initialize snapshot client for PVC %q in namespace %q. Error: %q",
+		log.Warnf("Failed to create snapshot client for PVC %q in namespace %q. Error: %q",
 			pvcName, pvcNamespace, err.Error())
+		return nil, false, errors.New("failed to create snapshot client")
 	}
 
 	// TODO: check if we can use informer cache
 	list, err := c.SnapshotV1().VolumeSnapshots(pvcNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, false, logger.LogNewErrorf(log,
-			"Failed to list VolumeSnapshots in namespace %q for PVC %q. Error: %q",
+		log.Warnf("Failed to list VolumeSnapshots in namespace %q for PVC %q. Error: %q",
 			pvcNamespace, pvcName, err.Error())
+		return nil, false, errors.New("failed to list VolumeSnapshots")
 	}
 
 	var snapshots []string
@@ -243,9 +267,9 @@ func getGuestClustersForPVC(ctx context.Context, pvcName, pvcNamespace string,
 			return nil, false, nil
 		}
 
-		return nil, false, logger.LogNewErrorf(log,
-			"Failed to get CnsVolumeMetadata %q in namespace %q. Error: %q",
+		log.Warnf("Failed to get CnsVolumeMetadata %q in namespace %q. Error: %q",
 			pvcName, pvcNamespace, err.Error())
+		return nil, false, errors.New("failed to get CnsVolumeMetadata")
 	}
 
 	var gcs []string
@@ -264,13 +288,13 @@ func getVMsForPVC(ctx context.Context, pvcName string, pvcNamespace string,
 	cfg rest.Config) ([]string, bool, error) {
 	c, err := k8s.NewClientForGroup(ctx, &cfg, vmoperatortypes.GroupName)
 	if err != nil {
-		return nil, false, err
+		return nil, false, errors.New("failed to create client for virtual machine group")
 	}
 
 	// TODO: check if we can use informer cache
 	list, err := utils.ListVirtualMachines(ctx, c, pvcNamespace)
 	if err != nil {
-		return nil, false, err
+		return nil, false, errors.New("failed to list virtual machines")
 	}
 
 	var vms []string

--- a/pkg/syncer/cnsoperator/types/types.go
+++ b/pkg/syncer/cnsoperator/types/types.go
@@ -36,6 +36,14 @@ const (
 	// This finalizer is added to avoid deletion of such VolumeSnapshots directly from Supervisor.
 	CNSSnapshotFinalizer = "cns.vmware.com/volumesnapshot-protection"
 
+	// CNSUnregisterVolumeFinalizer is the finalizer added to CNSUnregisterVolume CRs
+	// to handle deletion gracefully.
+	CNSUnregisterVolumeFinalizer = "cns.vmware.com/unregister-volume"
+
+	// CNSUnregisterProtectionFinalizer is the finalizer on Supervisor PVC
+	// to avoid deletion of PVCs which are in the process of UnregisterVolume operation.
+	CNSUnregisterProtectionFinalizer = "cns.vmware.com/unregister-protection"
+
 	// VSphereCSIDriverName is the vsphere CSI driver name
 	VSphereCSIDriverName = "csi.vsphere.vmware.com"
 


### PR DESCRIPTION
## What this PR does / why we need it

- Introduces a new field called `pvcName` as part of the CNS Unregister Volume spec. As the users are inclined to refer to the volumes using the PVCs rather than the volume handles, this would improve the UX.
- Adds validation rules using `x-kubernetes-validations` to ensure that only one of the `volumeID` or `pvcName` is specified to avoid ambiguity.
- Updates the reconciler to use the informer cache to find out the PV and VolumeID when the PVC Name is supplied.
- Optimises the reconciler logic to ignore all such events that do not increment the generation.
- Optimises the usage calculation logic by failing fast when usages are detected.
- Updates the reconciler to add a finalizer to the CR before reconciling to have control over deletion process
- Updates the reconciler to process the delete events and remove the finalizer for graceful deletion.
- Updates the reconciler to protect the PVC using a finalizer to gracefully reconciler in case of retries
- Removes the code that retains the persistent volume as it's no longer required
- Updates the reconciler to remove the finalizer on the PVC once unregistration is successful for graceful deletion of the PVC.
- Adds/updates unit tests wherever necessary and applicable.

## Testing done
### Input Validation
<details><summary>When input is invalid</summary>
<p>

```yaml
---
apiVersion: cns.vmware.com/v1alpha1
kind: CnsUnregisterVolume
metadata:
  name: unreg-with-volume-id-and-pvc
spec:
  pvcName: my-pvc
  volumeID: 123e4567-e89b-12d3-a456-426614174000
  retainFCD: true
  forceUnregister: false
---
apiVersion: cns.vmware.com/v1alpha1
kind: CnsUnregisterVolume
metadata:
  name: unreg-with-neither-pvc-nor-volume-id
spec:
  retainFCD: true
  forceUnregister: false
```

</p>
</details> 

**Result:** CR admission was rejected with the expected errors - 

```
Error from server (Invalid): error when creating "invalid_spec.yaml": CnsUnregisterVolume.cns.vmware.com "unreg-with-volume-id-and-pvc" is invalid: spec: Invalid value: "object": Cannot specify both 'volumeID' and 'pvcName' at the same time. Please specify only one of them
Error from server (Invalid): error when creating "invalid_spec.yaml": CnsUnregisterVolume.cns.vmware.com "unreg-with-neither-pvc-nor-volume-id" is invalid: spec: Invalid value: "object": Either 'volumeID' or 'pvcName' must be specified, but not both
```

### Workflow validation

1. Created 3 PVCs `vol-used-by-pod`, `vol-used-by-vm` and `vol-unused`
2. Invoked unregistration on `vol-unused` with the Volume ID
3. Invoked unregistration on `vol-used-by-pod` with the PVC Name
4. Invoked unregistration on `vol-used-by-vm` with the PVC Name and `forceUnregister` set to true

<details><summary>Input</summary>
<p>

```yaml
---
apiVersion: cns.vmware.com/v1alpha1
kind: CnsUnregisterVolume
metadata:
  name: vol-used-by-pod
  namespace: cns-unregister-volume
spec:
  pvcName: vol-used-by-pod
---
apiVersion: cns.vmware.com/v1alpha1
kind: CnsUnregisterVolume
metadata:
  name: vol-used-by-vm
  namespace: cns-unregister-volume
spec:
  pvcName: vol-used-by-vm
  forceUnregister: true
---
apiVersion: cns.vmware.com/v1alpha1
kind: CnsUnregisterVolume
metadata:
  name: vol-unused
  namespace: cns-unregister-volume
spec:
  volumeID: 77983527-0b74-44ef-926c-eaff27f9e9f3
```

</p>
</details> 

<details><summary>Output</summary>
<p>

```yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsUnregisterVolume
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsUnregisterVolume","metadata":{"annotations":{},"name":"vol-unused","namespace":"cns-unregister-volume"},"spec":{"volumeID":"77983527-0b74-44ef-926c-eaff27f9e9f3"}}
    creationTimestamp: "2025-09-30T09:22:32Z"
    finalizers:
    - cns.vmware.com/unregister-volume
    generation: 1
    name: vol-unused
    namespace: cns-unregister-volume
    resourceVersion: "5901789"
    uid: 17520557-cae7-402a-9f8d-7d7f92f5d99c
  spec:
    volumeID: 77983527-0b74-44ef-926c-eaff27f9e9f3
  status:
    unregistered: true
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsUnregisterVolume
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsUnregisterVolume","metadata":{"annotations":{},"name":"vol-used-by-pod","namespace":"cns-unregister-volume"},"spec":{"pvcName":"vol-used-by-pod"}}
    creationTimestamp: "2025-09-30T09:22:30Z"
    finalizers:
    - cns.vmware.com/unregister-volume
    generation: 1
    name: vol-used-by-pod
    namespace: cns-unregister-volume
    resourceVersion: "5901750"
    uid: 664edba0-73be-4e0a-8efb-66c09c31d709
  spec:
    pvcName: vol-used-by-pod
  status:
    error: |-
      volume 369f3388-2a68-4ed9-8c89-0ff85a87b337 cannot be unregistered because volume is in use by the following resources:
       Pods: pod
    unregistered: false
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsUnregisterVolume
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsUnregisterVolume","metadata":{"annotations":{},"name":"vol-used-by-vm","namespace":"cns-unregister-volume"},"spec":{"forceUnregister":true,"pvcName":"vol-used-by-vm"}}
    creationTimestamp: "2025-09-30T09:22:31Z"
    finalizers:
    - cns.vmware.com/unregister-volume
    generation: 1
    name: vol-used-by-vm
    namespace: cns-unregister-volume
    resourceVersion: "5901800"
    uid: 5467d868-c7d1-4967-a2c2-6cd352361147
  spec:
    forceUnregister: true
    pvcName: vol-used-by-vm
  status:
    unregistered: true
kind: List
metadata:
  resourceVersion: ""
```

</p>
</details> 

**Observations:**

1. As expected, unregistration of `vol-used-by-pod` failed with appropriate error - 
```
      volume 369f3388-2a68-4ed9-8c89-0ff85a87b337 cannot be unregistered because volume is in use by the following resources:
       Pods: pod
```
2. As expected, unregistration of `vol-used-by-vm` succeeded due to application of force and the PVC/PV are in terminating state(_it will be garbage collected once the VM is deleted_) - 
```
NAME             STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
vol-used-by-vm   Terminating   pvc-3e01c03c-fc2a-4fad-946e-c13b58429b95   4Gi        RWO            wcpglobal-storage-profile   <unset>                 9m31s
```

3. As expected, unregistration of `vol-unused` was successful.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Introduce pvcName input param in CNSUnregisterVolume spec
Optimize CNSUnregisterVolume reconcile workflow
```
