### PR TITLE
TKG fixes for tests failures

### DIFF
--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -200,12 +200,14 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		if guestCluster {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+		if guestCluster && svcClient != nil && svcNamespace != "" {
 			framework.Logf("Collecting supervisor PVC events before performing PV/PVC cleanup")
 			eventList, err := svcClient.CoreV1().Events(svcNamespace).List(ctx, metav1.ListOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			if err != nil {
+				framework.Logf("Failed to list events in namespace %q: %v", svcNamespace, err)
+				return
+			}
+
 			for _, item := range eventList.Items {
 				framework.Logf("%q", item.Message)
 			}

--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -72,7 +72,6 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
-		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In this PR, I addressed GC test failures caused by missing svcClient or svcNamespace, which previously led to log collection failures in the Supervisor Cluster. With this fix, such cases are handled gracefully, ensuring that test execution does not fail in the AfterEach block.


**Testing done**:
Yes



