### PR TITLE
Change batch attach validation to not allow DiskMode and SharingMode for RWO volumes

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -3585,7 +3585,7 @@ func (m *defaultManager) BatchAttachVolumes(ctx context.Context,
 		var errMsg string
 		if len(volumesThatFailedToAttach) != 0 {
 			errMsg = strings.Join(volumesThatFailedToAttach, ",")
-			overallError = errors.New(errMsg)
+			overallError = errors.New("failed to attach volumes: " + errMsg)
 			return batchAttachResult, csifault.CSIBatchAttachFault, overallError
 		}
 		log.Infof("BatchAttach: all volumes attached successfully with opID %s", taskInfo.ActivationId)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -376,7 +376,7 @@ func TestValidateBatchAttachRequestWithRwoPvc(t *testing.T) {
 		}
 
 		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
-		err := validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-1")
+		_, err := validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-1")
 		expectedEr := fmt.Errorf("incorrect input for PVC pvc-1 in namespace test-ns with accessMode ReadWriteOnce. " +
 			"DiskMode cannot be IndependentPersistent")
 		assert.EqualError(t, expectedEr, err.Error())
@@ -386,10 +386,19 @@ func TestValidateBatchAttachRequestWithRwoPvc(t *testing.T) {
 		}
 
 		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
-		err = validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-1")
+		_, err = validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-1")
 		expectedEr = fmt.Errorf("incorrect input for PVC pvc-1 in namespace test-ns with accessMode ReadWriteOnce. " +
 			"SharingMode cannot be sharingMultiWriter")
 		assert.EqualError(t, expectedEr, err.Error())
+
+		batchAttachRequest = volumes.BatchAttachRequest{
+			SharingMode: "",
+		}
+
+		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+		_, err = validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-1")
+		assert.NoError(t, err)
+
 	})
 }
 
@@ -404,7 +413,7 @@ func TestValidateBatchAttachRequestWithRwxPvc(t *testing.T) {
 		}
 
 		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
-		err := validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-rwx")
+		_, err := validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-rwx")
 		expectedErr := fmt.Errorf("incorrect input for PVC pvc-rwx in namespace test-ns with accessMode ReadWriteMany. " +
 			"DiskMode cannot be persistent")
 		assert.EqualError(t, expectedErr, err.Error())
@@ -416,10 +425,22 @@ func TestValidateBatchAttachRequestWithRwxPvc(t *testing.T) {
 		}
 
 		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
-		err = validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-rwx")
+		_, err = validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-rwx")
 		expectedErr = fmt.Errorf("incorrect input for PVC pvc-rwx in namespace test-ns with accessMode ReadWriteMany. " +
 			"ControllerKey cannot be empty")
 		assert.EqualError(t, expectedErr, err.Error())
+
+		batchAttachRequest = volumes.BatchAttachRequest{
+			ControllerKey: "1001",
+			UnitNumber:    "12",
+			DiskMode:      "",
+			SharingMode:   "None",
+		}
+
+		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+		attacheReq, err := validateBatchAttachRequest(context.TODO(), batchAttachRequest, testNamespace, "pvc-rwx")
+		assert.NoError(t, err)
+		assert.Equal(t, "independent_persistent", attacheReq.DiskMode)
 	})
 }
 


### PR DESCRIPTION
For RWO volumes, diskMode and sharingMode should not be allowed so that the behaviour can default to the original one (single attach). This way, it becomes much cleaner for CNS also to handle different cases.

These are the valid values for each accessMode:

| AccessMode | SharingMode | DiskMode | ControllerKey | UnitNumber 
|---|:---|:---:|---:|---:|
| RWX | Empty or Independent Persistent | Multiwriter or None | Required | Required
| RWO | Empty | Empty | Empty | Empty

**Testing done**:

Validated different combinations on batch attach and updated unit tests accordingly.

Here are the various combinations for RWX volume:
```
  Type     Reason                   Age                   From            Message
  ----     ------                   ----                  ----            -------
  Warning  NodeVmBatchAttachFailed  20m (x6 over 20m)     cns.vmware.com  incorrect input for PVC rwm-pvc-block in namespace test with accessMode ReadWriteMany. DiskMode cannot be persistent
  Warning  NodeVmBatchAttachFailed  17m (x3 over 20m)     cns.vmware.com  incorrect input for PVC rwm-pvc-block in namespace test with accessMode ReadWriteMany. ControllerKey cannot be empty
  Warning  NodeVmBatchAttachFailed  16m                   cns.vmware.com  incorrect input for PVC rwm-pvc-block in namespace test with accessMode ReadWriteMany.  UnitNumber cannot be empty
```

Here are the various combinations for RWO volume:
```
  Warning  NodeVmBatchAttachFailed  15m (x2 over 16m)     cns.vmware.com  incorrect input for PVC rwo-pvc in 
namespace test with accessMode ReadWriteOnce. DiskMode cannot be independentPersistent
  Warning  NodeVmBatchAttachFailed  3m7s (x8 over 5m14s)  cns.vmware.com  incorrect input for PVC rwo-pvc in namespace test with accessMode ReadWriteOnce. DiskMode cannot be persistent
  Warning  NodeVmBatchAttachFailed  2m24s                 cns.vmware.com  incorrect input for PVC rwo-pvc in namespace test with accessMode ReadWriteOnce. SharingMode cannot be none
  Warning  NodeVmBatchAttachFailed  25s (x4 over 2m4s)    cns.vmware.com  incorrect input for PVC rwo-pvc in namespace test with accessMode ReadWriteOnce. ControllerNumber and UnitNumber must not be provided with RWO accessMode
```

Both TKG and WCP pipelines have passed.