### PR TITLE
Enhancement - Optimise CNSNodeVMAttachment reconciliation workflow

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -49,7 +49,7 @@ rules:
     resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status"]
+    resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnscsisvfeaturestates"]

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -49,7 +49,7 @@ rules:
     resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status"]
+    resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnscsisvfeaturestates"]

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -49,7 +49,7 @@ rules:
     resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status"]
+    resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnscsisvfeaturestates"]

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -49,7 +49,7 @@ rules:
     resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status"]
+    resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnscsisvfeaturestates"]

--- a/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmattachments.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmattachments.yaml
@@ -77,6 +77,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
## What this PR does / why we need it:
Enhances CNSNodeVMAttachment reconciler to use subresource endpoint to update the status to avoid unnecessary generation increments.
Enhances CNSNodeVMAttachment reconciler to ignore update events that do not change the generation of the CR to avoid unnecessary reconciliations.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
N/A

**Testing done**:

Tested the changes with an attachment request for a WFFC volume for a VM. Since the attachment request will be retried till the volume is actually provisioned, there will be multiple reconciliations. Below are the results with and without my fix -

Without the fix, the instance's generation increased to 3 due to status updates.

```
apiVersion: cns.vmware.com/v1alpha1
kind: CnsNodeVmAttachment
metadata:
  creationTimestamp: "2025-09-12T08:24:05Z"
  finalizers:
  - cns.vmware.com
  generation: 3
  name: vm1-pvc
  namespace: vm-svc-vm
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha5
    blockOwnerDeletion: true
    controller: true
    kind: VirtualMachine
    name: vm1
    uid: 842411f2-ef00-4f72-a4f5-60aeaf03cb6e
  resourceVersion: "6915737"
  uid: d449c40c-313b-48cd-9aa2-5ccfd5c9c834
spec:
  nodeuuid: c36bbbd5-a07d-4b17-92fa-a33fc71dcb6d
  volumename: pvc
status:
  attached: true
  metadata:
    cnsVolumeId: 1b331163-7e86-489a-bb01-862a00630014
    diskUUID: 6000C29d-0382-9f10-20fe-b02b487e930e

``` 

With the fix, the instance's generation remained at 1.

```
apiVersion: cns.vmware.com/v1alpha1
kind: CnsNodeVmAttachment
metadata:
  creationTimestamp: "2025-09-12T10:57:49Z"
  finalizers:
  - cns.vmware.com
  generation: 1
  name: vm1-pvc
  namespace: vm-svc-vm
  ownerReferences:
  - apiVersion: v1
    blockOwnerDeletion: false
    controller: false
    kind: PersistentVolumeClaim
    name: pvc
    uid: 517fa7e0-41de-44bf-aef4-6ff028ea655c
  - apiVersion: vmoperator.vmware.com/v1alpha5
    blockOwnerDeletion: true
    controller: true
    kind: VirtualMachine
    name: vm1
    uid: 3afa98d8-66e2-481b-b5f9-e428038208f2
  resourceVersion: "7016024"
  uid: 2aff0d26-c1a4-4019-981e-d9e2871e2e60
spec:
  nodeuuid: 6e003bab-58a0-436f-b05b-e45f3e7bf394
  volumename: pvc
status:
  attached: true
  metadata:
    cnsVolumeId: 34fc56ca-6070-46e1-a1ed-d1dbb529b90e
    diskUUID: 6000C29f-c76e-9961-715a-14a26fc5d7e5
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Optimise CNSNodeVMAttachment reconciliation workflow
```
