### PR TITLE
Upgrade to vm operator api version v1alpha5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/sftp v1.13.6
 	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
-	github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250729185616-b3910fb93c83
+	github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250820184450-53a697d52f9c
 	github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa
 	github.com/vmware/govmomi v0.52.0-alpha.0.0.20250807230438-0eee109f1f2c
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/thecodeteam/gofsutil v0.1.2 h1:FL87mBzZeeuDMZm8hpYLFcYylQdq6bbm8UQ1oc
 github.com/thecodeteam/gofsutil v0.1.2/go.mod h1:7bDOpr2aMnmdm9RTdxBEeqdOr+8RpnQhsB/VUEI3DgM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
-github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250729185616-b3910fb93c83 h1:EvjDjVpO5x4W/ITTjkfzdABa0NHxaqXGaasvOQfCJ2g=
-github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250729185616-b3910fb93c83/go.mod h1:f2zOJg30nPEsBBF0SlSw5hin1cZs2L5lDdB1t0gzqnc=
+github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250820184450-53a697d52f9c h1:+lECoxyxQcMsxU2CJ53YvaLEwqfGduS/3yQaLLRDYDo=
+github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250820184450-53a697d52f9c/go.mod h1:hkc/QZCSHcosWWMPS6VWWR12WenZcNE3BaTJ/8A8sNE=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa h1:4MKu14YJ7J54O6QKmT4ds5EUpysWLLtQRMff73cVkmU=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa/go.mod h1:8tiuyYslzjLIUmOlXZuGKQdQP2ZgWGCVhVeyptmZYnk=
 github.com/vmware/govmomi v0.52.0-alpha.0.0.20250807230438-0eee109f1f2c h1:1nMVFr1CBMSNLLjsfx3QPfZ5k0R1/O29QX/A2X0w3RQ=

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -26,6 +26,7 @@ import (
 	vmoperatorv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatorv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"google.golang.org/grpc/codes"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,7 +54,7 @@ var getLatestCRDVersion = kubernetes.GetLatestCRDVersion
 // Since, VM Operator converts all the older API versions to the latest version,
 // this function determines the latest API version of the VirtualMachine CRD and lists the resources.
 func ListVirtualMachines(ctx context.Context, clt client.Client,
-	namespace string) (*vmoperatorv1alpha4.VirtualMachineList, error) {
+	namespace string) (*vmoperatorv1alpha5.VirtualMachineList, error) {
 	log := logger.GetLogger(ctx)
 
 	version, err := getLatestCRDVersion(ctx, virtualMachineCRDName)
@@ -62,7 +63,7 @@ func ListVirtualMachines(ctx context.Context, clt client.Client,
 		return nil, err
 	}
 
-	vmList := &vmoperatorv1alpha4.VirtualMachineList{}
+	vmList := &vmoperatorv1alpha5.VirtualMachineList{}
 	log.Info("Attempting to list virtual machines with the latest API version ", version)
 	switch version {
 	case "v1alpha1":
@@ -73,10 +74,10 @@ func ListVirtualMachines(ctx context.Context, clt client.Client,
 			return nil, err
 		}
 
-		err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachineList_To_v1alpha4_VirtualMachineList(
+		err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachineList_To_v1alpha5_VirtualMachineList(
 			vmAlpha1List, vmList, nil)
 		if err != nil {
-			log.Fatal("Error converting v1alpha1 virtual machines to v1alpha4: ", err)
+			log.Fatal("Error converting v1alpha1 virtual machines to v1alpha5: ", err)
 			return nil, err
 		}
 	case "v1alpha2":
@@ -87,10 +88,10 @@ func ListVirtualMachines(ctx context.Context, clt client.Client,
 			return nil, err
 		}
 
-		err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachineList_To_v1alpha4_VirtualMachineList(
+		err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachineList_To_v1alpha5_VirtualMachineList(
 			vmAlpha2List, vmList, nil)
 		if err != nil {
-			log.Fatal("Error converting v1alpha2 virtual machines to v1alpha4: ", err)
+			log.Fatal("Error converting v1alpha2 virtual machines to v1alpha5: ", err)
 			return nil, err
 		}
 	case "v1alpha3":
@@ -101,10 +102,23 @@ func ListVirtualMachines(ctx context.Context, clt client.Client,
 			return nil, err
 		}
 
-		err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachineList_To_v1alpha4_VirtualMachineList(
+		err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachineList_To_v1alpha5_VirtualMachineList(
 			vmAlpha3List, vmList, nil)
 		if err != nil {
-			log.Error("Error converting v1alpha3 virtual machines to v1alpha4: ", err)
+			log.Error("Error converting v1alpha3 virtual machines to v1alpha5: ", err)
+			return nil, err
+		}
+	case "v1alpha4":
+		vmAlpha4List := &vmoperatorv1alpha4.VirtualMachineList{}
+		err := clt.List(ctx, vmAlpha4List, client.InNamespace(namespace))
+		if err != nil {
+			log.Error("failed listing virtual machines for v1alpha4: ", err)
+			return nil, err
+		}
+		err = vmoperatorv1alpha4.Convert_v1alpha4_VirtualMachineList_To_v1alpha5_VirtualMachineList(
+			vmAlpha4List, vmList, nil)
+		if err != nil {
+			log.Error("Error converting v1alpha4 virtual machines to v1alpha5: ", err)
 			return nil, err
 		}
 	default:
@@ -351,54 +365,67 @@ func QueryAllVolumesForCluster(ctx context.Context, m cnsvolume.Manager, cluster
 }
 
 func GetVirtualMachineAllApiVersions(ctx context.Context, vmKey types.NamespacedName,
-	vmOperatorClient client.Client) (*vmoperatorv1alpha4.VirtualMachine, string, error) {
+	vmOperatorClient client.Client) (*vmoperatorv1alpha5.VirtualMachine, string, error) {
 	log := logger.GetLogger(ctx)
-	apiVersion := vmOperatorApiVersionPrefix + "/v1alpha4"
 	vmV1alpha1 := &vmoperatorv1alpha1.VirtualMachine{}
 	vmV1alpha2 := &vmoperatorv1alpha2.VirtualMachine{}
 	vmV1alpha3 := &vmoperatorv1alpha3.VirtualMachine{}
 	vmV1alpha4 := &vmoperatorv1alpha4.VirtualMachine{}
+	vm := &vmoperatorv1alpha5.VirtualMachine{}
 	var err error
-	log.Infof("get machine with vm-operator api version v1alpha4 name: %s, namespace: %s",
+	log.Infof("get machine with vm-operator api version v1alpha5 name: %s, namespace: %s",
 		vmKey.Name, vmKey.Namespace)
-	err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha4)
+	apiVersion := vmOperatorApiVersionPrefix + "/v1alpha5"
+	err = vmOperatorClient.Get(ctx, vmKey, vm)
 	if err != nil && isKindNotFound(err.Error()) {
-		log.Warnf("failed to get VirtualMachines. %s", err.Error())
-		err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha3)
+		err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha4)
 		if err != nil && isKindNotFound(err.Error()) {
 			log.Warnf("failed to get VirtualMachines. %s", err.Error())
-			err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha2)
+			err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha3)
 			if err != nil && isKindNotFound(err.Error()) {
 				log.Warnf("failed to get VirtualMachines. %s", err.Error())
-				err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha1)
+				err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha2)
 				if err != nil && isKindNotFound(err.Error()) {
 					log.Warnf("failed to get VirtualMachines. %s", err.Error())
+					err = vmOperatorClient.Get(ctx, vmKey, vmV1alpha1)
+					if err != nil && isKindNotFound(err.Error()) {
+						log.Warnf("failed to get VirtualMachines. %s", err.Error())
+					} else if err == nil {
+						log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha1 VirtualMachine "+
+							"to v1alpha5 VirtualMachine, name %s", vmV1alpha1.Name)
+						apiVersion = vmOperatorApiVersionPrefix + "/v1alpha1"
+						err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachine_To_v1alpha5_VirtualMachine(
+							vmV1alpha1, vm, nil)
+						if err != nil {
+							return nil, apiVersion, err
+						}
+					}
 				} else if err == nil {
-					log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha1 VirtualMachine "+
-						"to v1alpha4 VirtualMachine, name %s", vmV1alpha1.Name)
-					apiVersion = vmOperatorApiVersionPrefix + "/v1alpha1"
-					err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachine_To_v1alpha4_VirtualMachine(
-						vmV1alpha1, vmV1alpha4, nil)
+					log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha2 VirtualMachine "+
+						"to v1alpha5 VirtualMachine, name %s", vmV1alpha2.Name)
+					apiVersion = vmOperatorApiVersionPrefix + "/v1alpha2"
+					err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachine_To_v1alpha5_VirtualMachine(
+						vmV1alpha2, vm, nil)
 					if err != nil {
 						return nil, apiVersion, err
 					}
 				}
 			} else if err == nil {
-				log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha2 VirtualMachine "+
-					"to v1alpha4 VirtualMachine, name %s", vmV1alpha2.Name)
-				apiVersion = vmOperatorApiVersionPrefix + "/v1alpha2"
-				err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachine_To_v1alpha4_VirtualMachine(
-					vmV1alpha2, vmV1alpha4, nil)
+				log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha3 VirtualMachine "+
+					"to v1alpha5 VirtualMachine, name %s", vmV1alpha3.Name)
+				apiVersion = vmOperatorApiVersionPrefix + "/v1alpha3"
+				err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachine_To_v1alpha5_VirtualMachine(
+					vmV1alpha3, vm, nil)
 				if err != nil {
 					return nil, apiVersion, err
 				}
 			}
 		} else if err == nil {
-			log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha3 VirtualMachine "+
-				"to v1alpha4 VirtualMachine, name %s", vmV1alpha3.Name)
-			apiVersion = vmOperatorApiVersionPrefix + "/v1alpha3"
-			err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachine_To_v1alpha4_VirtualMachine(
-				vmV1alpha3, vmV1alpha4, nil)
+			log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha4 VirtualMachine "+
+				"to v1alpha5 VirtualMachine, name %s", vmV1alpha4.Name)
+			apiVersion = vmOperatorApiVersionPrefix + "/v1alpha4"
+			err = vmoperatorv1alpha4.Convert_v1alpha5_VirtualMachine_To_v1alpha4_VirtualMachine(
+				vm, vmV1alpha4, nil)
 			if err != nil {
 				return nil, apiVersion, err
 			}
@@ -411,141 +438,280 @@ func GetVirtualMachineAllApiVersions(ctx context.Context, vmKey types.Namespaced
 	}
 	log.Infof("successfully fetched the virtual machines with name %s and namespace %s",
 		vmKey.Name, vmKey.Namespace)
-	return vmV1alpha4, apiVersion, nil
+	return vm, apiVersion, nil
 }
 func isKindNotFound(errMsg string) bool {
 	return strings.Contains(errMsg, "no matches for kind") || strings.Contains(errMsg, "no kind is registered")
 }
 
 func PatchVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
-	vmV1alpha4, old_vmV1alpha4 *vmoperatorv1alpha4.VirtualMachine) error {
+	vm, old_vm *vmoperatorv1alpha5.VirtualMachine) error {
 	log := logger.GetLogger(ctx)
 	vmV1alpha1, old_vmV1alpha1 := &vmoperatorv1alpha1.VirtualMachine{}, &vmoperatorv1alpha1.VirtualMachine{}
 	vmV1alpha2, old_vmV1alpha2 := &vmoperatorv1alpha2.VirtualMachine{}, &vmoperatorv1alpha2.VirtualMachine{}
 	vmV1alpha3, old_vmV1alpha3 := &vmoperatorv1alpha3.VirtualMachine{}, &vmoperatorv1alpha3.VirtualMachine{}
-	vmPatch4 := client.MergeFromWithOptions(
-		old_vmV1alpha4.DeepCopy(),
-		client.MergeFromWithOptimisticLock{})
+	vmV1alpha4, old_vmV1alpha4 := &vmoperatorv1alpha4.VirtualMachine{}, &vmoperatorv1alpha4.VirtualMachine{}
 	log.Infof("PatchVirtualMachine: patch virtualmachine name: %s", vmV1alpha4.Name)
-	// try patch virtualmachine with api version v1alpha4
-	err := vmOperatorClient.Patch(ctx, vmV1alpha4, vmPatch4)
+	// try patch virtualmachine with latest api version
+	vmPatch := client.MergeFromWithOptions(
+		old_vm.DeepCopy(),
+		client.MergeFromWithOptimisticLock{})
+	err := vmOperatorClient.Patch(ctx, vm, vmPatch)
 	if err != nil && isKindNotFound(err.Error()) {
-		log.Infof("PatchVirtualMachine: converting v1alpha4 VirtualMachine to "+
-			"v1alpha3 VirtualMachine, name: %s", vmV1alpha4.Name)
-		err = vmoperatorv1alpha3.Convert_v1alpha4_VirtualMachine_To_v1alpha3_VirtualMachine(
-			vmV1alpha4, vmV1alpha3, nil)
+		log.Infof("PatchVirtualMachine: converting VirtualMachine to "+
+			"v1alpha4 VirtualMachine, name: %s", vm.Name)
+		err = vmoperatorv1alpha4.Convert_v1alpha5_VirtualMachine_To_v1alpha4_VirtualMachine(
+			vm, vmV1alpha4, nil)
 		if err != nil {
 			return err
 		}
-		err = vmoperatorv1alpha3.Convert_v1alpha4_VirtualMachine_To_v1alpha3_VirtualMachine(
-			old_vmV1alpha4, old_vmV1alpha3, nil)
+		err = vmoperatorv1alpha4.Convert_v1alpha5_VirtualMachine_To_v1alpha4_VirtualMachine(
+			old_vm, old_vmV1alpha4, nil)
 		if err != nil {
 			return err
 		}
-		vmPatch3 := client.MergeFromWithOptions(
-			old_vmV1alpha3.DeepCopy(),
+		vmPatch4 := client.MergeFromWithOptions(old_vmV1alpha4.DeepCopy(),
 			client.MergeFromWithOptimisticLock{})
-		err = vmOperatorClient.Patch(ctx, vmV1alpha3, vmPatch3)
+		err := vmOperatorClient.Patch(ctx, vmV1alpha4, vmPatch4)
 		if err != nil && isKindNotFound(err.Error()) {
-			log.Infof("PatchVirtualMachine: converting v1alpha4 VirtualMachine to "+
-				"v1alpha2 VirtualMachine, name: %s", vmV1alpha4.Name)
-			err = vmoperatorv1alpha2.Convert_v1alpha4_VirtualMachine_To_v1alpha2_VirtualMachine(
-				vmV1alpha4, vmV1alpha2, nil)
+			log.Infof("PatchVirtualMachine: converting VirtualMachine to "+
+				"v1alpha3 VirtualMachine, name: %s", vm.Name)
+			err = vmoperatorv1alpha3.Convert_v1alpha5_VirtualMachine_To_v1alpha3_VirtualMachine(
+				vm, vmV1alpha3, nil)
 			if err != nil {
 				return err
 			}
-			err = vmoperatorv1alpha2.Convert_v1alpha4_VirtualMachine_To_v1alpha2_VirtualMachine(
-				old_vmV1alpha4, old_vmV1alpha2, nil)
+			err = vmoperatorv1alpha3.Convert_v1alpha5_VirtualMachine_To_v1alpha3_VirtualMachine(
+				old_vm, old_vmV1alpha3, nil)
 			if err != nil {
 				return err
 			}
-			vmPatch2 := client.MergeFromWithOptions(
-				old_vmV1alpha2.DeepCopy(),
+			vmPatch3 := client.MergeFromWithOptions(old_vmV1alpha3.DeepCopy(),
 				client.MergeFromWithOptimisticLock{})
-			// try patch virtualmachine with api version v1alpha2
-			err := vmOperatorClient.Patch(ctx, vmV1alpha2, vmPatch2)
+			err = vmOperatorClient.Patch(ctx, vmV1alpha3, vmPatch3)
 			if err != nil && isKindNotFound(err.Error()) {
-				log.Infof("PatchVirtualMachine: converting v1alpha4 VirtualMachine to "+
-					"v1alpha1 VirtualMachine, name: %s", vmV1alpha4.Name)
-				err = vmoperatorv1alpha1.Convert_v1alpha4_VirtualMachine_To_v1alpha1_VirtualMachine(
-					vmV1alpha4, vmV1alpha1, nil)
+				log.Infof("PatchVirtualMachine: converting VirtualMachine to "+
+					"v1alpha2 VirtualMachine, name: %s", vm.Name)
+				err = vmoperatorv1alpha2.Convert_v1alpha5_VirtualMachine_To_v1alpha2_VirtualMachine(
+					vm, vmV1alpha2, nil)
 				if err != nil {
 					return err
 				}
-				err = vmoperatorv1alpha1.Convert_v1alpha4_VirtualMachine_To_v1alpha1_VirtualMachine(
-					old_vmV1alpha4, old_vmV1alpha1, nil)
+				err = vmoperatorv1alpha2.Convert_v1alpha5_VirtualMachine_To_v1alpha2_VirtualMachine(
+					old_vm, old_vmV1alpha2, nil)
 				if err != nil {
 					return err
 				}
-				vmPatch1 := client.MergeFromWithOptions(
-					old_vmV1alpha1.DeepCopy(),
+				vmPatch2 := client.MergeFromWithOptions(old_vmV1alpha2.DeepCopy(),
 					client.MergeFromWithOptimisticLock{})
-				// try patch virtualmachine with api version v1alpha1
-				err := vmOperatorClient.Patch(ctx, vmV1alpha1, vmPatch1)
-				if err != nil {
-					return err
+				// try patch virtualmachine with api version v1alpha2
+				err := vmOperatorClient.Patch(ctx, vmV1alpha2, vmPatch2)
+				if err != nil && isKindNotFound(err.Error()) {
+					log.Infof("PatchVirtualMachine: converting VirtualMachine to "+
+						"v1alpha1 VirtualMachine, name: %s", vm.Name)
+					err = vmoperatorv1alpha1.Convert_v1alpha5_VirtualMachine_To_v1alpha1_VirtualMachine(
+						vm, vmV1alpha1, nil)
+					if err != nil {
+						return err
+					}
+					err = vmoperatorv1alpha1.Convert_v1alpha5_VirtualMachine_To_v1alpha1_VirtualMachine(
+						old_vm, old_vmV1alpha1, nil)
+					if err != nil {
+						return err
+					}
+					vmPatch1 := client.MergeFromWithOptions(old_vmV1alpha1.DeepCopy(),
+						client.MergeFromWithOptimisticLock{})
+					// try patch virtualmachine with api version v1alpha1
+					err := vmOperatorClient.Patch(ctx, vmV1alpha1, vmPatch1)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}
 	}
 	if err != nil {
 		log.Errorf("PatchVirtualMachine: error while patching virtualmachine name: %s, err %v",
-			vmV1alpha4.Name, err)
+			vm.Name, err)
 		return err
 	}
-	log.Infof("PatchVirtualMachine: successfully patched the virtualmachine, name: %s", vmV1alpha4.Name)
+	log.Infof("PatchVirtualMachine: successfully patched the virtualmachine, name: %s", vm.Name)
 	return nil
 }
 
 func UpdateVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
-	vmV1alpha4 *vmoperatorv1alpha4.VirtualMachine) error {
+	vm *vmoperatorv1alpha5.VirtualMachine) error {
 	vmV1alpha1 := &vmoperatorv1alpha1.VirtualMachine{}
 	vmV1alpha2 := &vmoperatorv1alpha2.VirtualMachine{}
 	vmV1alpha3 := &vmoperatorv1alpha3.VirtualMachine{}
+	vmV1alpha4 := &vmoperatorv1alpha4.VirtualMachine{}
 	log := logger.GetLogger(ctx)
-	log.Infof("UpdateVirtualMachine: update virtualmachine name: %s", vmV1alpha4.Name)
+	log.Infof("UpdateVirtualMachine: update virtualmachine name: %s", vm.Name)
 	// try update virtualmachine with api version v1alpha4
-	err := vmOperatorClient.Update(ctx, vmV1alpha4)
+	err := vmOperatorClient.Update(ctx, vm)
 	if err != nil && isKindNotFound(err.Error()) {
-		log.Infof("UpdateVirtualMachine: converting v1alpha4 VirtualMachine to "+
-			"v1alpha3 VirtualMachine, name: %s", vmV1alpha4.Name)
-		err = vmoperatorv1alpha3.Convert_v1alpha4_VirtualMachine_To_v1alpha3_VirtualMachine(
-			vmV1alpha4, vmV1alpha3, nil)
+		log.Infof("UpdateVirtualMachine: converting VirtualMachine to "+
+			"v1alpha4 VirtualMachine, name: %s", vm.Name)
+		err = vmoperatorv1alpha4.Convert_v1alpha5_VirtualMachine_To_v1alpha4_VirtualMachine(
+			vm, vmV1alpha4, nil)
 		if err != nil {
 			return err
 		}
-		err := vmOperatorClient.Update(ctx, vmV1alpha3)
+		err = vmOperatorClient.Update(ctx, vmV1alpha4)
 		if err != nil && isKindNotFound(err.Error()) {
-			log.Infof("UpdateVirtualMachine: converting v1alpha4 VirtualMachine to "+
-				"v1alpha2 VirtualMachine, name: %s", vmV1alpha4.Name)
-			err = vmoperatorv1alpha2.Convert_v1alpha4_VirtualMachine_To_v1alpha2_VirtualMachine(
-				vmV1alpha4, vmV1alpha2, nil)
+			log.Infof("UpdateVirtualMachine: converting VirtualMachine to "+
+				"v1alpha3 VirtualMachine, name: %s", vm.Name)
+			err = vmoperatorv1alpha3.Convert_v1alpha5_VirtualMachine_To_v1alpha3_VirtualMachine(
+				vm, vmV1alpha3, nil)
 			if err != nil {
 				return err
 			}
-			// try update virtualmachine with api version v1alpha2
-			err := vmOperatorClient.Update(ctx, vmV1alpha2)
+			err := vmOperatorClient.Update(ctx, vmV1alpha3)
 			if err != nil && isKindNotFound(err.Error()) {
-				log.Infof("UpdateVirtualMachine: converting v1alpha4 VirtualMachine to "+
-					"v1alpha1 VirtualMachine, name: %s", vmV1alpha4.Name)
-				err = vmoperatorv1alpha1.Convert_v1alpha4_VirtualMachine_To_v1alpha1_VirtualMachine(
-					vmV1alpha4, vmV1alpha1, nil)
+				log.Infof("UpdateVirtualMachine: converting VirtualMachine to "+
+					"v1alpha2 VirtualMachine, name: %s", vm.Name)
+				err = vmoperatorv1alpha2.Convert_v1alpha5_VirtualMachine_To_v1alpha2_VirtualMachine(
+					vm, vmV1alpha2, nil)
 				if err != nil {
 					return err
 				}
-				// try update virtualmachine with api version v1alpha1
-				err := vmOperatorClient.Update(ctx, vmV1alpha1)
-				if err != nil {
-					return err
+				// try update virtualmachine with api version v1alpha2
+				err := vmOperatorClient.Update(ctx, vmV1alpha2)
+				if err != nil && isKindNotFound(err.Error()) {
+					log.Infof("UpdateVirtualMachine: converting VirtualMachine to "+
+						"v1alpha1 VirtualMachine, name: %s", vm.Name)
+					err = vmoperatorv1alpha1.Convert_v1alpha5_VirtualMachine_To_v1alpha1_VirtualMachine(
+						vm, vmV1alpha1, nil)
+					if err != nil {
+						return err
+					}
+					// try update virtualmachine with api version v1alpha1
+					err := vmOperatorClient.Update(ctx, vmV1alpha1)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}
 	}
 	if err != nil {
 		log.Errorf("UpdateVirtualMachine: error while updating virtualmachine name: %s, err %v",
-			vmV1alpha4.Name, err)
+			vm.Name, err)
 		return err
 	}
-	log.Infof("UpdateVirtualMachine: successfully updated the virtualmachine, name: %s", vmV1alpha4.Name)
+	log.Infof("UpdateVirtualMachine: successfully updated the virtualmachine, name: %s", vm.Name)
 	return nil
+}
+
+// GetVirtualMachineListAllApiVersions get lists of all the virtual machines
+func GetVirtualMachineListAllApiVersions(ctx context.Context, namespace string,
+	vmOperatorClient client.Client) (*vmoperatorv1alpha5.VirtualMachineList, error) {
+	log := logger.GetLogger(ctx)
+	vmListV1alpha1 := &vmoperatorv1alpha1.VirtualMachineList{}
+	vmListV1alpha2 := &vmoperatorv1alpha2.VirtualMachineList{}
+	vmListV1alpha3 := &vmoperatorv1alpha3.VirtualMachineList{}
+	vmListV1alpha4 := &vmoperatorv1alpha4.VirtualMachineList{}
+	vmListV1alpha5 := &vmoperatorv1alpha5.VirtualMachineList{}
+	var err error
+	if namespace != "" {
+		// get list of virtualmachine for specific namespace
+		log.Infof("list virtualmachines for namespace %s", namespace)
+		err = vmOperatorClient.List(ctx, vmListV1alpha5, client.InNamespace(namespace))
+		if err != nil && isKindNotFound(err.Error()) {
+			err = vmOperatorClient.List(ctx, vmListV1alpha4, client.InNamespace(namespace))
+			if err != nil && isKindNotFound(err.Error()) {
+				err = vmOperatorClient.List(ctx, vmListV1alpha3, client.InNamespace(namespace))
+				if err != nil && isKindNotFound(err.Error()) {
+					err := vmOperatorClient.List(ctx, vmListV1alpha2, client.InNamespace(namespace))
+					if err != nil && isKindNotFound(err.Error()) {
+						err := vmOperatorClient.List(ctx, vmListV1alpha1, client.InNamespace(namespace))
+						if err != nil {
+							return nil, err
+						} else {
+							log.Info("converting v1alpha1 VirtualMachineList to v1alpha5 VirtualMachineList")
+							err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachineList_To_v1alpha5_VirtualMachineList(
+								vmListV1alpha1, vmListV1alpha5, nil)
+							if err != nil {
+								return nil, err
+							}
+						}
+					} else if err == nil {
+						log.Info("converting v1alpha2 VirtualMachineList to v1alpha5 VirtualMachineList")
+						err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachineList_To_v1alpha5_VirtualMachineList(
+							vmListV1alpha2, vmListV1alpha5, nil)
+						if err != nil {
+							return nil, err
+						}
+					}
+				} else if err == nil {
+					log.Info("converting v1alpha3 VirtualMachineList to v1alpha5 VirtualMachineList")
+					err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachineList_To_v1alpha5_VirtualMachineList(
+						vmListV1alpha3, vmListV1alpha5, nil)
+					if err != nil {
+						return nil, err
+					}
+				}
+			} else if err != nil {
+				log.Info("converting v1alpha4 VirtualMachineList to v1alpha5 VirtualMachineList")
+				err = vmoperatorv1alpha4.Convert_v1alpha4_VirtualMachineList_To_v1alpha5_VirtualMachineList(
+					vmListV1alpha4, vmListV1alpha5, nil)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	} else {
+		// get list of virtualmachine without providing namespace (all)
+		log.Info("list all virtualmachines")
+		err = vmOperatorClient.List(ctx, vmListV1alpha5)
+		if err != nil && isKindNotFound(err.Error()) {
+			err = vmOperatorClient.List(ctx, vmListV1alpha4)
+			if err != nil && isKindNotFound(err.Error()) {
+				err = vmOperatorClient.List(ctx, vmListV1alpha3)
+				if err != nil && isKindNotFound(err.Error()) {
+					err := vmOperatorClient.List(ctx, vmListV1alpha2)
+					if err != nil && isKindNotFound(err.Error()) {
+						err := vmOperatorClient.List(ctx, vmListV1alpha1)
+						if err != nil {
+							return nil, err
+						} else {
+							log.Info("converting v1alpha1 VirtualMachineList to v1alpha5 VirtualMachineList")
+							err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachineList_To_v1alpha5_VirtualMachineList(
+								vmListV1alpha1, vmListV1alpha5, nil)
+							if err != nil {
+								return nil, err
+							}
+						}
+					} else if err == nil {
+						log.Info("converting v1alpha2 VirtualMachineList to v1alpha5 VirtualMachineList")
+						err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachineList_To_v1alpha5_VirtualMachineList(
+							vmListV1alpha2, vmListV1alpha5, nil)
+						if err != nil {
+							return nil, err
+						}
+					}
+				} else if err == nil {
+					log.Info("converting v1alpha3 VirtualMachineList to v1alpha5 VirtualMachineList")
+					err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachineList_To_v1alpha5_VirtualMachineList(
+						vmListV1alpha3, vmListV1alpha5, nil)
+					if err != nil {
+						return nil, err
+					}
+				}
+			} else if err == nil {
+				log.Info("converting v1alpha4 VirtualMachineList to v1alpha5 VirtualMachineList")
+				err = vmoperatorv1alpha4.Convert_v1alpha4_VirtualMachineList_To_v1alpha5_VirtualMachineList(
+					vmListV1alpha4, vmListV1alpha5, nil)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+	}
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("successfully fetched the virtual machines for namespace %s", namespace)
+	return vmListV1alpha5, nil
 }

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -15,6 +15,7 @@ import (
 	vmoperatorv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatorv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnssim "github.com/vmware/govmomi/cns/simulator"
 	"github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/simulator"
@@ -298,22 +299,22 @@ func TestListVirtualMachines(t *testing.T) {
 				vmoperatorv1alpha1.AddToScheme,
 			})
 			clientBuilder.WithRuntimeObjects(namespace, otherNamespace, vm1, vm2, vm3)
-			v1Alpha4VM1 := vmoperatorv1alpha4.VirtualMachine{
+			v1Alpha4VM1 := vmoperatorv1alpha5.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vm1",
 					Namespace: namespace.Name,
 				},
 			}
-			v1Alpha4VM2 := vmoperatorv1alpha4.VirtualMachine{
+			v1Alpha4VM2 := vmoperatorv1alpha5.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vm2",
 					Namespace: namespace.Name,
 				},
 			}
-			exp := vmoperatorv1alpha4.VirtualMachineList{
+			exp := vmoperatorv1alpha5.VirtualMachineList{
 				TypeMeta: metav1.TypeMeta{},
 				ListMeta: metav1.ListMeta{},
-				Items: []vmoperatorv1alpha4.VirtualMachine{
+				Items: []vmoperatorv1alpha5.VirtualMachine{
 					v1Alpha4VM1,
 					v1Alpha4VM2,
 				},
@@ -394,22 +395,22 @@ func TestListVirtualMachines(t *testing.T) {
 				vmoperatorv1alpha2.AddToScheme,
 			})
 			clientBuilder.WithRuntimeObjects(namespace, vm1, vm2)
-			v1Alpha4VM1 := vmoperatorv1alpha4.VirtualMachine{
+			v1Alpha4VM1 := vmoperatorv1alpha5.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vm1",
 					Namespace: namespace.Name,
 				},
 			}
-			v1Alpha4VM2 := vmoperatorv1alpha4.VirtualMachine{
+			v1Alpha4VM2 := vmoperatorv1alpha5.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vm2",
 					Namespace: namespace.Name,
 				},
 			}
-			exp := vmoperatorv1alpha4.VirtualMachineList{
+			exp := vmoperatorv1alpha5.VirtualMachineList{
 				TypeMeta: metav1.TypeMeta{},
 				ListMeta: metav1.ListMeta{},
-				Items: []vmoperatorv1alpha4.VirtualMachine{
+				Items: []vmoperatorv1alpha5.VirtualMachine{
 					v1Alpha4VM1,
 					v1Alpha4VM2,
 				},
@@ -490,22 +491,22 @@ func TestListVirtualMachines(t *testing.T) {
 				vmoperatorv1alpha3.AddToScheme,
 			})
 			clientBuilder.WithRuntimeObjects(namespace, vm1, vm2)
-			v1Alpha4VM1 := vmoperatorv1alpha4.VirtualMachine{
+			v1Alpha4VM1 := vmoperatorv1alpha5.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vm1",
 					Namespace: namespace.Name,
 				},
 			}
-			v1Alpha4VM2 := vmoperatorv1alpha4.VirtualMachine{
+			v1Alpha4VM2 := vmoperatorv1alpha5.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vm2",
 					Namespace: namespace.Name,
 				},
 			}
-			exp := vmoperatorv1alpha4.VirtualMachineList{
+			exp := vmoperatorv1alpha5.VirtualMachineList{
 				TypeMeta: metav1.TypeMeta{},
 				ListMeta: metav1.ListMeta{},
-				Items: []vmoperatorv1alpha4.VirtualMachine{
+				Items: []vmoperatorv1alpha5.VirtualMachine{
 					v1Alpha4VM1,
 					v1Alpha4VM2,
 				},
@@ -520,8 +521,7 @@ func TestListVirtualMachines(t *testing.T) {
 			assert.True(tt, compareVirtualMachineLists(exp, *actual))
 		})
 	})
-
-	t.Run("WhenLatestCRDVersionIsV1Alpha4OrAbove", func(tt *testing.T) {
+	t.Run("WhenLatestCRDVersionIsV1Alpha4", func(tt *testing.T) {
 		getLatestCRDVersion = func(ctx context.Context, crdName string) (string, error) {
 			return "v1alpha4", nil
 		}
@@ -586,10 +586,105 @@ func TestListVirtualMachines(t *testing.T) {
 				vmoperatorv1alpha4.AddToScheme,
 			})
 			clientBuilder.WithRuntimeObjects(namespace, vm1, vm2)
-			exp := vmoperatorv1alpha4.VirtualMachineList{
+			v1Alpha4VM1 := vmoperatorv1alpha5.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1",
+					Namespace: namespace.Name,
+				},
+			}
+			v1Alpha4VM2 := vmoperatorv1alpha5.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm2",
+					Namespace: namespace.Name,
+				},
+			}
+			exp := vmoperatorv1alpha5.VirtualMachineList{
 				TypeMeta: metav1.TypeMeta{},
 				ListMeta: metav1.ListMeta{},
-				Items: []vmoperatorv1alpha4.VirtualMachine{
+				Items: []vmoperatorv1alpha5.VirtualMachine{
+					v1Alpha4VM1,
+					v1Alpha4VM2,
+				},
+			}
+
+			// Execute
+			actual, err := ListVirtualMachines(context.Background(), clientBuilder.Build(), namespace.Name)
+
+			// Assert
+			assert.Nil(tt, err)
+			assert.NotNil(tt, actual)
+			assert.True(tt, compareVirtualMachineLists(exp, *actual))
+		})
+	})
+	t.Run("WhenLatestCRDVersionIsV1Alpha5OrAbove", func(tt *testing.T) {
+		getLatestCRDVersion = func(ctx context.Context, crdName string) (string, error) {
+			return "v1alpha5", nil
+		}
+		tt.Run("WhenListFails", func(ttt *testing.T) {
+			// Setup
+			clientBuilder := fake.NewClientBuilder()
+			clientBuilder.WithInterceptorFuncs(
+				interceptor.Funcs{
+					List: func(ctx context.Context, client client.WithWatch, list client.ObjectList,
+						opts ...client.ListOption) error {
+						return fmt.Errorf("failing list for testing purposes")
+					}})
+
+			// Execute
+			_, err := ListVirtualMachines(context.Background(), clientBuilder.Build(), "")
+
+			// Assert
+			assert.NotNil(ttt, err)
+		})
+		tt.Run("WhenListSucceeds", func(ttt *testing.T) {
+			// Setup
+			namespace := &v1.Namespace{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Namespace",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "namespace",
+				},
+				Spec: v1.NamespaceSpec{
+					Finalizers: []v1.FinalizerName{
+						v1.FinalizerKubernetes,
+					},
+				},
+				Status: v1.NamespaceStatus{
+					Phase: v1.NamespaceActive,
+				},
+			}
+			vm1 := &vmoperatorv1alpha5.VirtualMachine{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VirtualMachine",
+					APIVersion: "vmoperator.vmware.com/v1alpha5",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1",
+					Namespace: namespace.Name,
+				},
+			}
+			vm2 := &vmoperatorv1alpha5.VirtualMachine{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VirtualMachine",
+					APIVersion: "vmoperator.vmware.com/v1alpha5",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm2",
+					Namespace: namespace.Name,
+				},
+			}
+			clientBuilder := fake.NewClientBuilder()
+			scheme := runtime.NewScheme()
+			clientBuilder = registerSchemes(context.Background(), clientBuilder, scheme, runtime.SchemeBuilder{
+				v1.AddToScheme,
+				vmoperatorv1alpha5.AddToScheme,
+			})
+			clientBuilder.WithRuntimeObjects(namespace, vm1, vm2)
+			exp := vmoperatorv1alpha5.VirtualMachineList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []vmoperatorv1alpha5.VirtualMachine{
 					*vm1,
 					*vm2,
 				},
@@ -617,7 +712,7 @@ func registerSchemes(ctx context.Context, clientBuilder *fake.ClientBuilder, sch
 	return clientBuilder
 }
 
-func compareVirtualMachineLists(exp, actual vmoperatorv1alpha4.VirtualMachineList) bool {
+func compareVirtualMachineLists(exp, actual vmoperatorv1alpha5.VirtualMachineList) bool {
 	// since the list output may not be in the same order, we will compare the items
 	// using brute force.
 	if len(exp.Items) != len(actual.Items) {

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatorv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -215,10 +215,10 @@ func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.Cont
 			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to get config with error: %+v", err)
 		}
-		vmOperatorClient, err := k8s.NewClientForGroup(ctx, cfg, vmoperatorv1alpha4.GroupName)
+		vmOperatorClient, err := k8s.NewClientForGroup(ctx, cfg, vmoperatorv1alpha5.GroupName)
 		if err != nil {
 			return logger.LogNewErrorCodef(log, codes.Internal,
-				"failed to get client for group %s with error: %+v", vmoperatorv1alpha4.GroupName, err)
+				"failed to get client for group %s with error: %+v", vmoperatorv1alpha5.GroupName, err)
 		}
 		vmList, err := utils.ListVirtualMachines(ctx, vmOperatorClient, "")
 		if err != nil {

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -36,6 +36,7 @@ import (
 	vmoperatorv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatorv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -129,7 +130,7 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 		return err
 	}
 
-	c.vmOperatorClient, err = k8s.NewClientForGroup(ctx, c.restClientConfig, vmoperatorv1alpha4.GroupName)
+	c.vmOperatorClient, err = k8s.NewClientForGroup(ctx, c.restClientConfig, vmoperatorv1alpha5.GroupName)
 	if err != nil {
 		log.Errorf("failed to create vmOperatorClient. Error: %+v", err)
 		return err
@@ -267,7 +268,7 @@ func (c *controller) ReloadConfiguration() error {
 			return err
 		}
 		log.Infof("successfully re-created supervisorClient using updated configuration")
-		c.vmOperatorClient, err = k8s.NewClientForGroup(ctx, c.restClientConfig, vmoperatorv1alpha4.GroupName)
+		c.vmOperatorClient, err = k8s.NewClientForGroup(ctx, c.restClientConfig, vmoperatorv1alpha5.GroupName)
 		if err != nil {
 			log.Errorf("failed to create vmOperatorClient. Error: %+v", err)
 			return err
@@ -755,7 +756,7 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 	var diskUUID string
 	var err error
 
-	virtualMachine := &vmoperatorv1alpha4.VirtualMachine{}
+	virtualMachine := &vmoperatorv1alpha5.VirtualMachine{}
 	vmKey := types.NamespacedName{
 		Namespace: c.supervisorNamespace,
 		Name:      req.NodeId,
@@ -786,10 +787,10 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 		old_virtualMachine := virtualMachine.DeepCopy()
 		// Volume is not present in the virtualMachine.Spec.Volumes, so adding
 		// volume in the spec and patching virtualMachine instance.
-		vmvolumes := vmoperatorv1alpha4.VirtualMachineVolume{
+		vmvolumes := vmoperatorv1alpha5.VirtualMachineVolume{
 			Name: req.VolumeId,
-			VirtualMachineVolumeSource: vmoperatorv1alpha4.VirtualMachineVolumeSource{
-				PersistentVolumeClaim: &vmoperatorv1alpha4.PersistentVolumeClaimVolumeSource{
+			VirtualMachineVolumeSource: vmoperatorv1alpha5.VirtualMachineVolumeSource{
+				PersistentVolumeClaim: &vmoperatorv1alpha5.PersistentVolumeClaimVolumeSource{
 					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: req.VolumeId,
 					},
@@ -808,7 +809,7 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 			log.Error(msg)
 			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
 		}
-		virtualMachine = &vmoperatorv1alpha4.VirtualMachine{}
+		virtualMachine = &vmoperatorv1alpha5.VirtualMachine{}
 	}
 
 	for _, volume := range virtualMachine.Status.Volumes {
@@ -838,44 +839,54 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 			// blocking wait for update event
 			log.Debugf("waiting for update on virtualmachine: %q", virtualMachine.Name)
 			event := <-watchVirtualMachine.ResultChan()
-			vm := &vmoperatorv1alpha4.VirtualMachine{}
-			vm4, ok := event.Object.(*vmoperatorv1alpha4.VirtualMachine)
+			vm := &vmoperatorv1alpha5.VirtualMachine{}
+			vm5, ok := event.Object.(*vmoperatorv1alpha5.VirtualMachine)
 			if !ok {
-				vm3, ok := event.Object.(*vmoperatorv1alpha3.VirtualMachine)
+				vm4, ok := event.Object.(*vmoperatorv1alpha4.VirtualMachine)
 				if !ok {
-					vm2, ok := event.Object.(*vmoperatorv1alpha2.VirtualMachine)
+					vm3, ok := event.Object.(*vmoperatorv1alpha3.VirtualMachine)
 					if !ok {
-						vm1, ok := event.Object.(*vmoperatorv1alpha1.VirtualMachine)
+						vm2, ok := event.Object.(*vmoperatorv1alpha2.VirtualMachine)
 						if !ok {
-							msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
-							log.Error(msg)
-							return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+							vm1, ok := event.Object.(*vmoperatorv1alpha1.VirtualMachine)
+							if !ok {
+								msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
+								log.Error(msg)
+								return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+							} else {
+								log.Infof("converting v1alpha1 VirtualMachine to v1alpha5 VirtualMachine, name %s", vm1.Name)
+								err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachine_To_v1alpha5_VirtualMachine(
+									vm1, vm, nil)
+								if err != nil {
+									return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
+								}
+							}
 						} else {
-							log.Infof("converting v1alpha1 VirtualMachine to v1alpha4 VirtualMachine, name %s", vm1.Name)
-							err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachine_To_v1alpha4_VirtualMachine(
-								vm1, vm, nil)
+							log.Infof("converting v1alpha2 VirtualMachine to v1alpha5 VirtualMachine, name %s", vm2.Name)
+							err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachine_To_v1alpha5_VirtualMachine(
+								vm2, vm, nil)
 							if err != nil {
 								return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 							}
 						}
 					} else {
-						log.Infof("converting v1alpha2 VirtualMachine to v1alpha4 VirtualMachine, name %s", vm2.Name)
-						err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachine_To_v1alpha4_VirtualMachine(
-							vm2, vm, nil)
+						log.Infof("converting v1alpha3 VirtualMachine to v1alpha5 VirtualMachine, name %s", vm3.Name)
+						err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachine_To_v1alpha5_VirtualMachine(
+							vm3, vm, nil)
 						if err != nil {
 							return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 						}
 					}
 				} else {
-					log.Infof("converting v1alpha2 VirtualMachine to v1alpha4 VirtualMachine, name %s", vm3.Name)
-					err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachine_To_v1alpha4_VirtualMachine(
-						vm3, vm, nil)
+					log.Infof("converting v1alpha4 VirtualMachine to v1alpha5 VirtualMachine, name %s", vm4.Name)
+					err = vmoperatorv1alpha4.Convert_v1alpha4_VirtualMachine_To_v1alpha5_VirtualMachine(
+						vm4, vm, nil)
 					if err != nil {
 						return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 					}
 				}
 			} else {
-				vm = vm4
+				vm = vm5
 			}
 			if vm.Name != virtualMachine.Name {
 				log.Debugf("Observed vm name: %q, expecting vm name: %q, volumeID: %q",
@@ -1136,7 +1147,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest, c *controller) (
 	*csi.ControllerUnpublishVolumeResponse, string, error) {
 	log := logger.GetLogger(ctx)
-	virtualMachine := &vmoperatorv1alpha4.VirtualMachine{}
+	virtualMachine := &vmoperatorv1alpha5.VirtualMachine{}
 	vmKey := types.NamespacedName{
 		Namespace: c.supervisorNamespace,
 		Name:      req.NodeId,
@@ -1178,7 +1189,7 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 			log.Error(msg)
 			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
 		}
-		virtualMachine = &vmoperatorv1alpha4.VirtualMachine{}
+		virtualMachine = &vmoperatorv1alpha5.VirtualMachine{}
 	}
 	isVolumePresentInVMStatus := false
 	for _, volume := range virtualMachine.Status.Volumes {
@@ -1214,42 +1225,52 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 			log.Debugf("Waiting for update on VirtualMachine: %q", virtualMachine.Name)
 			// Block on update events
 			event := <-watchVirtualMachine.ResultChan()
-			vm := &vmoperatorv1alpha4.VirtualMachine{}
-			vm4, ok := event.Object.(*vmoperatorv1alpha4.VirtualMachine)
+			vm := &vmoperatorv1alpha5.VirtualMachine{}
+			vm5, ok := event.Object.(*vmoperatorv1alpha5.VirtualMachine)
 			if !ok {
-				vm3, ok := event.Object.(*vmoperatorv1alpha3.VirtualMachine)
+				vm4, ok := event.Object.(*vmoperatorv1alpha4.VirtualMachine)
 				if !ok {
-					vm2, ok := event.Object.(*vmoperatorv1alpha2.VirtualMachine)
+					vm3, ok := event.Object.(*vmoperatorv1alpha3.VirtualMachine)
 					if !ok {
-						vm1, ok := event.Object.(*vmoperatorv1alpha1.VirtualMachine)
+						vm2, ok := event.Object.(*vmoperatorv1alpha2.VirtualMachine)
 						if !ok {
-							msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
-							log.Error(msg)
-							return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+							vm1, ok := event.Object.(*vmoperatorv1alpha1.VirtualMachine)
+							if !ok {
+								msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
+								log.Error(msg)
+								return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+							} else {
+								err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachine_To_v1alpha5_VirtualMachine(
+									vm1, vm, nil)
+								if err != nil {
+									return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
+								}
+							}
 						} else {
-							err = vmoperatorv1alpha1.Convert_v1alpha1_VirtualMachine_To_v1alpha4_VirtualMachine(
-								vm1, vm, nil)
+							err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachine_To_v1alpha5_VirtualMachine(
+								vm2, vm, nil)
 							if err != nil {
 								return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 							}
 						}
 					} else {
-						err = vmoperatorv1alpha2.Convert_v1alpha2_VirtualMachine_To_v1alpha4_VirtualMachine(
-							vm2, vm, nil)
+						err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachine_To_v1alpha5_VirtualMachine(
+							vm3, vm, nil)
 						if err != nil {
 							return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 						}
 					}
 				} else {
-					err = vmoperatorv1alpha3.Convert_v1alpha3_VirtualMachine_To_v1alpha4_VirtualMachine(
-						vm3, vm, nil)
+					err = vmoperatorv1alpha4.Convert_v1alpha4_VirtualMachine_To_v1alpha5_VirtualMachine(
+						vm4, vm, nil)
 					if err != nil {
 						return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 					}
 				}
 			} else {
-				vm = vm4
+				vm = vm5
 			}
+
 			if vm.Name != virtualMachine.Name {
 				log.Debugf("Observed vm name: %q, expecting vm name: %q, volumeID: %q",
 					vm.Name, virtualMachine.Name, req.VolumeId)
@@ -1409,7 +1430,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 
 		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
-			vmList, err := utils.ListVirtualMachines(ctx, c.vmOperatorClient, c.supervisorNamespace)
+			vmList, err := utils.GetVirtualMachineListAllApiVersions(ctx, c.supervisorNamespace, c.vmOperatorClient)
 			if err != nil {
 				msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
 				log.Error(msg)

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -30,6 +30,7 @@ import (
 	vmoperatorv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmoperatorv1alpha3 "github.com/vmware-tanzu/vm-operator/api/v1alpha3"
 	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatorv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -231,7 +232,7 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 			log.Errorf("failed to add to scheme with err: %+v", err)
 			return nil, err
 		}
-	case vmoperatorv1alpha4.GroupName:
+	case vmoperatorv1alpha5.GroupName:
 		log.Info("adding scheme for vm-operator version v1alpha1")
 		err = vmoperatorv1alpha1.AddToScheme(scheme)
 		if err != nil {
@@ -252,6 +253,12 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 		}
 		log.Info("adding scheme for vm-operator version v1alpha4")
 		err = vmoperatorv1alpha4.AddToScheme(scheme)
+		if err != nil {
+			log.Errorf("failed to add to scheme with err: %+v", err)
+			return nil, err
+		}
+		log.Info("adding scheme for vm-operator version v1alpha5")
+		err = vmoperatorv1alpha5.AddToScheme(scheme)
 		if err != nil {
 			log.Errorf("failed to add to scheme with err: %+v", err)
 			return nil, err
@@ -345,7 +352,11 @@ func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config,
 	log := logger.GetLogger(ctx)
 
 	scheme := runtime.NewScheme()
-	log.Info("adding scheme for vm-operator versions v1alpha1, v1alpha2, v1alpha3, v1alpha4")
+	log.Info("adding scheme for vm-operator versions v1alpha1, v1alpha2, v1alpha3, v1alpha4, v1alpha5")
+	err = vmoperatorv1alpha5.AddToScheme(scheme)
+	if err != nil {
+		log.Errorf("failed to add to scheme with err: %+v", err)
+	}
 	err = vmoperatorv1alpha4.AddToScheme(scheme)
 	if err != nil {
 		log.Errorf("failed to add to scheme with err: %+v", err)

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -138,7 +138,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
-	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatorv1alpha4.GroupName)
+	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatortypes.GroupName)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to initialize vmOperatorClient. Error: %+v", err)
 		log.Error(msg)
@@ -419,7 +419,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 	vmOwnerRefExists := false
 	if len(instance.OwnerReferences) != 0 {
 		for _, ownerRef := range instance.OwnerReferences {
-			if ownerRef.Kind == reflect.TypeOf(vmoperatorv1alpha4.VirtualMachine{}).Name() &&
+			if ownerRef.Kind == reflect.TypeOf(vmoperatortypes.VirtualMachine{}).Name() &&
 				ownerRef.Name == instance.Spec.VMName && ownerRef.UID == vm.UID {
 				vmOwnerRefExists = true
 				break
@@ -685,7 +685,7 @@ func (r *ReconcileCnsFileAccessConfig) removePermissionsForFileVolume(ctx contex
 // permissions by setting the parameter removePermission to true or false
 // respectively. Returns error if any operation fails.
 func (r *ReconcileCnsFileAccessConfig) configureNetPermissionsForFileVolume(ctx context.Context,
-	volumeID string, vm *vmoperatorv1alpha4.VirtualMachine, instance *cnsfileaccessconfigv1alpha1.CnsFileAccessConfig,
+	volumeID string, vm *vmoperatortypes.VirtualMachine, instance *cnsfileaccessconfigv1alpha1.CnsFileAccessConfig,
 	removePermission bool) error {
 	log := logger.GetLogger(ctx)
 	volumePermissionLock, _ := volumePermissionLockMap.LoadOrStore(volumeID, &sync.Mutex{})
@@ -781,7 +781,7 @@ func (r *ReconcileCnsFileAccessConfig) configureVolumeACLs(ctx context.Context,
 
 // getVMExternalIP helps to fetch the external facing IP for a given TKG VM.
 func (r *ReconcileCnsFileAccessConfig) getVMExternalIP(ctx context.Context,
-	vm *vmoperatorv1alpha4.VirtualMachine) (string, error) {
+	vm *vmoperatortypes.VirtualMachine) (string, error) {
 	log := logger.GetLogger(ctx)
 	networkProvider, err := cnsoperatorutil.GetNetworkProvider(ctx)
 	if err != nil {
@@ -829,7 +829,7 @@ func (r *ReconcileCnsFileAccessConfig) getVMExternalIP(ctx context.Context,
 // The VM does not have a label applied by CAPV - example capv.vmware.com/cluster.name.
 // The PVC does not have a label applied by CAPV - example <TKG cluster namespace>/TKGService
 func validateVmAndPvc(ctx context.Context, instanceLabels map[string]string, instanceName string, pvcName string,
-	namespace string, client client.Client, vm *vmoperatorv1alpha4.VirtualMachine) error {
+	namespace string, client client.Client, vm *vmoperatortypes.VirtualMachine) error {
 	log := logger.GetLogger(ctx)
 
 	if instanceLabels == nil {

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller_test.go
@@ -8,14 +8,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestValidateVmAndPvc(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = v1.AddToScheme(scheme)
-	_ = vmoperatorv1alpha4.AddToScheme(scheme)
+	_ = vmoperatortypes.AddToScheme(scheme)
 
 	ctx := context.TODO()
 
@@ -62,7 +62,7 @@ func TestValidateVmAndPvc(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var objects []runtime.Object
 
-			vm := &vmoperatorv1alpha4.VirtualMachine{
+			vm := &vmoperatortypes.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "my-vm",
 					Labels: test.vmLabels,

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/util.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"strconv"
 
-	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 
@@ -36,7 +36,7 @@ import (
 // getVirtualMachine gets the virtual machine instance with a name on a SV
 // namespace.
 func getVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
-	vmName string, namespace string) (*vmoperatorv1alpha4.VirtualMachine, string, error) {
+	vmName string, namespace string) (*vmoperatortypes.VirtualMachine, string, error) {
 	log := logger.GetLogger(ctx)
 	vmKey := apitypes.NamespacedName{
 		Namespace: namespace,
@@ -58,7 +58,7 @@ func setInstanceOwnerRef(instance *cnsfileaccessconfigv1alpha1.CnsFileAccessConf
 	vmUID apitypes.UID, apiVersion string) {
 	bController := true
 	bOwnerDeletion := true
-	kind := reflect.TypeOf(vmoperatorv1alpha4.VirtualMachine{}).Name()
+	kind := reflect.TypeOf(vmoperatortypes.VirtualMachine{}).Name()
 	instance.OwnerReferences = []metav1.OwnerReference{
 		{
 			APIVersion:         apiVersion,

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -107,7 +107,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
-	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatorv1alpha4.GroupName)
+	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatortypes.GroupName)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to initialize vmOperatorClient. Error: %+v", err)
 		log.Error(msg)
@@ -764,7 +764,7 @@ func updateSVPVC(ctx context.Context, client client.Client,
 // isVmCrPresent checks whether VM CR is present in SV namespace
 // with given vmuuid and returns the VirtualMachine CR object if it is found
 func isVmCrPresent(ctx context.Context, vmOperatorClient client.Client,
-	vmuuid string, namespace string) (*vmoperatorv1alpha4.VirtualMachine, error) {
+	vmuuid string, namespace string) (*vmoperatortypes.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	vmList, err := utils.ListVirtualMachines(ctx, vmOperatorClient, namespace)
 	if err != nil {

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 
-	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -108,7 +108,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
-	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatorv1alpha4.GroupName)
+	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatortypes.GroupName)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to initialize vmOperatorClient. Error: %+v", err)
 		log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/util.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	snapshotclient "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
-	vmv1a4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -298,7 +298,7 @@ func getGuestClustersForPVC(ctx context.Context, pvcName, pvcNamespace string,
 // getVMsForPVC returns a list of virtual machines that are using the specified PVC.
 func getVMsForPVC(ctx context.Context, pvcName string, pvcNamespace string,
 	cfg rest.Config) ([]string, bool, error) {
-	c, err := k8s.NewClientForGroup(ctx, &cfg, vmv1a4.GroupName)
+	c, err := k8s.NewClientForGroup(ctx, &cfg, vmoperatortypes.GroupName)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -98,7 +98,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		log.Infof("The %s FSS is enabled in %s", common.TKGsHA, cnstypes.CnsClusterFlavorGuest)
 		restClientConfigForSupervisor :=
 			k8s.GetRestClientConfigForSupervisor(ctx, configInfo.Cfg.GC.Endpoint, configInfo.Cfg.GC.Port)
-		vmOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfigForSupervisor, vmoperatorv1alpha4.GroupName)
+		vmOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfigForSupervisor, vmoperatortypes.GroupName)
 		if err != nil {
 			log.Errorf("failed to create vmOperatorClient. Error: %+v", err)
 			return err

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	vmoperatorv1alpha4 "github.com/vmware-tanzu/vm-operator/api/v1alpha4"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
@@ -300,7 +300,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		log.Errorf("failed to set the scheme for Cns operator. Err: %+v", err)
 		return err
 	}
-	if err := vmoperatorv1alpha4.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := vmoperatortypes.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Errorf("failed to set the scheme for vm operator. Err: %+v", err)
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Upgrading to vm-operator api version to v1alpha5

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing performed



Scenario 1: New vsphere-csi on guest with old supervisor have virtualmachines with v1alpha2 version.
```
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get vm -A
NAMESPACE   NAME                                      POWER-STATE   AGE
test-ns     wl-antrea-node-pool-1-jc9jl-x5fx9-2mf7n   PoweredOn     4h55m
test-ns     wl-antrea-node-pool-1-jc9jl-x5fx9-642cv   PoweredOn     4h55m
test-ns     wl-antrea-node-pool-1-jc9jl-x5fx9-92trt   PoweredOn     4h55m
test-ns     wl-antrea-vxpx2-6fl27                     PoweredOn     5h2m
test-ns     wl-antrea-vxpx2-nlfh9                     PoweredOn     4h51m
test-ns     wl-antrea-vxpx2-sc7kt                     PoweredOn     4h46m
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get vm -A -o yaml | grep apiVersion
apiVersion: v1
- apiVersion: vmoperator.vmware.com/v1alpha2
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
          apiVersion: netoperator.vmware.com/v1alpha1
      apiVersion: vmoperator.vmware.com/v1alpha2
      apiVersion: vmoperator.vmware.com/v1alpha2
- apiVersion: vmoperator.vmware.com/v1alpha2
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
          apiVersion: netoperator.vmware.com/v1alpha1
      apiVersion: vmoperator.vmware.com/v1alpha2
      apiVersion: vmoperator.vmware.com/v1alpha2
- apiVersion: vmoperator.vmware.com/v1alpha2
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
          apiVersion: netoperator.vmware.com/v1alpha1
      apiVersion: vmoperator.vmware.com/v1alpha2
      apiVersion: vmoperator.vmware.com/v1alpha2
- apiVersion: vmoperator.vmware.com/v1alpha2
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
          apiVersion: netoperator.vmware.com/v1alpha1
      apiVersion: vmoperator.vmware.com/v1alpha2
      apiVersion: vmoperator.vmware.com/v1alpha2
- apiVersion: vmoperator.vmware.com/v1alpha2
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
          apiVersion: netoperator.vmware.com/v1alpha1
      apiVersion: vmoperator.vmware.com/v1alpha2
      apiVersion: vmoperator.vmware.com/v1alpha2
- apiVersion: vmoperator.vmware.com/v1alpha2
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
          apiVersion: netoperator.vmware.com/v1alpha1
      apiVersion: vmoperator.vmware.com/v1alpha2
      apiVersion: vmoperator.vmware.com/v1alpha2
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k apply -f pvc.yaml 
persistentvolumeclaim/example-raw-block-pvc created
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get pvc  -w
NAME                    STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc   Pending                                      wcpglobal-storage-profile   <unset>                 17s
example-raw-block-pvc   Pending   pvc-07e6e338-566f-4eaa-b623-99b63e7e1e7c   0                         wcpglobal-storage-profile   <unset>                 73s
example-raw-block-pvc   Bound     pvc-07e6e338-566f-4eaa-b623-99b63e7e1e7c   5Gi        RWO            wcpglobal-storage-profile   <unset>                 73s
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k apply -f pod.yaml
pod/example-raw-block-pod created
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get pod  -o wide
NAME                    READY   STATUS    RESTARTS   AGE   IP           NODE                                      NOMINATED NODE   READINESS GATES
example-raw-block-pod   1/1     Running   0          6s    100.96.2.3   wl-antrea-node-pool-1-jc9jl-x5fx9-92trt   <none>           <none>
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# export KUBECONFIG=
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get vm -n test-ns wl-antrea-node-pool-1-jc9jl-x5fx9-92trt
NAME                                      POWER-STATE   AGE
wl-antrea-node-pool-1-jc9jl-x5fx9-92trt   PoweredOn     4h58m
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get vm -n test-ns wl-antrea-node-pool-1-jc9jl-x5fx9-92trt -o yaml
apiVersion: vmoperator.vmware.com/v1alpha2
kind: VirtualMachine
metadata:
 ...
  name: wl-antrea-node-pool-1-jc9jl-x5fx9-92trt
  namespace: test-ns
  ownerReferences:
  - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: VSphereMachine
    name: wl-antrea-node-pool-1-jc9jl-x5fx9-92trt
    uid: e26cec22-6985-464e-abe4-970924f07c00
  resourceVersion: "3422646"
  uid: c09c19b6-89b1-4b16-ad0c-11d806b317da
spec:
 ...
  storageClass: worker-storagepolicy
  suspendMode: TrySoft
  volumes:
  - name: 3a2f5f64-992e-47f2-9bc0-c9742492db64-07e6e338-566f-4eaa-b623-99b63e7e1e7c
    persistentVolumeClaim:
      claimName: 3a2f5f64-992e-47f2-9bc0-c9742492db64-07e6e338-566f-4eaa-b623-99b63e7e1e7c
status:
  biosUUID: 4202db5c-c448-c01a-adb7-0669295b9e24
  ...
  powerState: PoweredOn
  uniqueID: vm-84
  volumes:
  - attached: true
    diskUUID: 6000C290-3776-2b3b-f95b-6267180ec363
    name: 3a2f5f64-992e-47f2-9bc0-c9742492db64-07e6e338-566f-4eaa-b623-99b63e7e1e7c
  zone: domain-c9
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get pvc -n test-ns
NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
3a2f5f64-992e-47f2-9bc0-c9742492db64-07e6e338-566f-4eaa-b623-99b63e7e1e7c   Bound    pvc-e9d493f8-4825-4588-abd4-0f8360b6ae41   5Gi        RWO            wcpglobal-storage-profile   <unset>                 60s
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get pv 
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                               STORAGECLASS                VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-e9d493f8-4825-4588-abd4-0f8360b6ae41   5Gi        RWO            Delete           Bound    test-ns/3a2f5f64-992e-47f2-9bc0-c9742492db64-07e6e338-566f-4eaa-b623-99b63e7e1e7c   wcpglobal-storage-profile   <unset>                          66s
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k delete -f pod.yaml
pod "example-raw-block-pod" deleted
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get pod  -o wide
No resources found in default namespace.
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k delete -f pvc.yaml
persistentvolumeclaim "example-raw-block-pvc" deleted
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# k get pvc  
No resources found in default namespace.
root@42020eb1cf97f1aa8f00b2b324ead5fa [ ~ ]# 

```
[v1alpha5_testing_with_new_gc_old_supervisor.log](https://github.com/user-attachments/files/22351353/v1alpha5_testing_with_new_gc_old_supervisor.log)
[v1alpha5_gc_container_logs_new_gc_old_supervisor.log](https://github.com/user-attachments/files/22351355/v1alpha5_gc_container_logs_new_gc_old_supervisor.log)
[v1alpha5_supervisor_container_logs_new_gc_old_supervisor.log](https://github.com/user-attachments/files/22351356/v1alpha5_supervisor_container_logs_new_gc_old_supervisor.log)

Scenario 2: New vsphere-csi on guest with new supervisor have virtualmachines with v1alpha5 version.
```
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k get vm -A -o yaml | grep  apiVersion:
apiVersion: v1
- apiVersion: vmoperator.vmware.com/v1alpha5
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
          apiVersion: vmware.com/v1alpha1
      apiVersion: vmoperator.vmware.com/v1alpha5
- apiVersion: vmoperator.vmware.com/v1alpha5
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
          apiVersion: vmware.com/v1alpha1
      apiVersion: vmoperator.vmware.com/v1alpha5
- apiVersion: vmoperator.vmware.com/v1alpha5
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
          apiVersion: vmware.com/v1alpha1
      apiVersion: vmoperator.vmware.com/v1alpha5
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml 
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k apply -f pvc.yaml
persistentvolumeclaim/example-raw-block-pvc created
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k get pvc -w
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc   Bound    pvc-0e3be6b9-aa26-49e6-b1d4-c9513bc15092   5Gi        RWO            wcpglobal-storage-profile   <unset>                 10s
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k apply -f pod.yaml
pod/example-raw-block-pod created
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k get pod -o wide
NAME                    READY   STATUS    RESTARTS   AGE   IP          NODE                                NOMINATED NODE   READINESS GATES
example-raw-block-pod   1/1     Running   0          29s   192.0.1.2   my-cluster-np-1-87g82-qdd4c-bkrg9   <none>           <none>
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# export KUBECONFIG=
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k get vm my-cluster-np-1-87g82-qdd4c-bkrg9 -n test-ns -o yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachine
metadata:
 ...
  name: my-cluster-np-1-87g82-qdd4c-bkrg9
  namespace: test-ns
  ...
  resourceVersion: "867225"
  uid: 2a9c6b57-223a-4cda-8909-dfc9d25425d3
spec:
  biosUUID: 3de3a85f-6dfb-4b6d-baea-8b840bb21f12
  ...
  storageClass: wcpglobal-storage-profile
  suspendMode: TrySoft
  volumes:
  - name: 5273e8b3-735e-4d45-b252-6c36b24de44e-0e3be6b9-aa26-49e6-b1d4-c9513bc15092
    persistentVolumeClaim:
      claimName: 5273e8b3-735e-4d45-b252-6c36b24de44e-0e3be6b9-aa26-49e6-b1d4-c9513bc15092
      controllerType: SCSI
      diskMode: Persistent
status:
  biosUUID: 3de3a85f-6dfb-4b6d-baea-8b840bb21f12
    ...
  powerState: PoweredOn
  uniqueID: vm-69
  volumes:
  - attached: true
    diskUUID: 6000C291-338d-0419-f05b-cdf9cd21ec7a
    limit: 5Gi
    name: 5273e8b3-735e-4d45-b252-6c36b24de44e-0e3be6b9-aa26-49e6-b1d4-c9513bc15092
    requested: 5Gi
    type: Managed
    used: 36Mi
  - attached: true
    diskUUID: 6000C292-e862-88ad-d6b1-c7bc9cc979fe
    limit: 20Gi
    name: my-cluster-np-1-87g82-qdd4c-bkrg9
    requested: 20Gi
    type: Classic
    used: "17980981248"
  zone: domain-c10
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k get pvc -n test-ns
NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
5273e8b3-735e-4d45-b252-6c36b24de44e-0e3be6b9-aa26-49e6-b1d4-c9513bc15092   Bound    pvc-907bbf60-0bbc-42c1-a9a6-6c30fa001798   5Gi        RWO            wcpglobal-storage-profile   <unset>                 72s
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                               STORAGECLASS                VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-907bbf60-0bbc-42c1-a9a6-6c30fa001798   5Gi        RWO            Delete           Bound    test-ns/5273e8b3-735e-4d45-b252-6c36b24de44e-0e3be6b9-aa26-49e6-b1d4-c9513bc15092   wcpglobal-storage-profile   <unset>                          75s
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml 
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k delete pod example-raw-block-pod
pod "example-raw-block-pod" deleted
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k get pod
No resources found in default namespace.
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k delete pvc example-raw-block-pvc 
persistentvolumeclaim "example-raw-block-pvc" deleted
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# k get pvc
No resources found in default namespace.
root@42394facf864b7bdb9aacc7b4943870f [ ~ ]# 

```

[v1alpha5_testing_with_new_gc_new_supervisor.log](https://github.com/user-attachments/files/22351377/v1alpha5_testing_with_new_gc_new_supervisor.log)
[v1alpha5_gc_csi_container_new_gc_new_supervisor.log](https://github.com/user-attachments/files/22351379/v1alpha5_gc_csi_container_new_gc_new_supervisor.log)
[v1alpha5_supervisor_container_logs_new_gc_new_supervisor.log](https://github.com/user-attachments/files/22351380/v1alpha5_supervisor_container_logs_new_gc_new_supervisor.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrading to vm-operator api version to v1alpha5
```
