### PR TITLE
Use capability for file volumes with VM service VMs feature

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -581,7 +581,6 @@ data:
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
-  "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -583,7 +583,6 @@ data:
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
-  "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -583,7 +583,6 @@ data:
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
-  "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -583,7 +583,6 @@ data:
   "cns-unregister-volume": "false"
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
-  "file-volume-with-vm-service": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -439,7 +439,7 @@ const (
 	// CNS finalizer on supervisor PVC/Snapshots from PVCSI
 	SVPVCSnapshotProtectionFinalizer = "sv-pvc-snapshot-protection-finalizer"
 	// FileVolumesWithVmService is an FSS to support file volumes with VM service VMs.
-	FileVolumesWithVmService = "file-volume-with-vm-service"
+	FileVolumesWithVmService = "supports_file_volumes_with_VM_service_VMs"
 	// SharedDiskFss is an FSS that tells whether shared disks are supported or not
 	SharedDiskFss = "supports_shared_disks_with_VM_service_VMs"
 	// FCDTransactionSupport is the wcp capability that tells whether transaction is supported in CSI
@@ -474,6 +474,7 @@ var WCPFeatureStates = map[string]struct{}{
 	BYOKEncryption:                  {},
 	FCDTransactionSupport:           {},
 	MultipleClustersPerVsphereZone:  {},
+	FileVolumesWithVmService:        {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
@@ -486,6 +487,8 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 	MultipleClustersPerVsphereZone: {},
 	WCPVMServiceVMSnapshots:        {},
 	BYOKEncryption:                 {},
+	SharedDiskFss:                  {},
+	FileVolumesWithVmService:       {},
 }
 
 // WCPFeatureAssociatedWithPVCSI contains FSS name used in PVCSI and associated WCP Capability name on a


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Start using capability for file volumes instead of FSS in configmap.

**Testing done**:
Enabled the capability on a cluster and created CFC CR. Observed that the CR got labels on it which are added only when the capability is enabled:
```
Name:         rwm-vm-3
Namespace:    test
Labels:       cns.vmware.com/pvc-name=rwm-pvc-2
              cns.vmware.com/user-created=true
              cns.vmware.com/vm-name=vm-1
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2025-09-16T07:08:44Z
  Generation:          2
  Resource Version:    122897
  UID:                 0e455dc7-9d63-4acb-8812-dfebcf69ef2a
Spec:
  Pvc Name:  rwm-pvc-2
  Vm Name:   vm-1

```

VKS pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/387/
WCP pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/351/