### PR TITLE
Labels added for vmsvc, Thick-thin and stretched-svc to run in UTS

### DIFF
--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -3596,7 +3596,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		8. cleanup the snapshots, restore-pvc and source-pvc
 	*/
 
-	ginkgo.It("[ef-wcp-snapshot][block-vanilla-snapshot][supervisor-snapshot] Snapshot restore while the Host "+
+	ginkgo.It("[pq-wcp-neg-snpt][block-vanilla-snapshot][supervisor-snapshot] Snapshot restore while the Host "+
 		"is Down", ginkgo.Label(p2, block, vanilla, snapshot, disruptive, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -4887,7 +4887,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		2. Create Snapshot class and take a snapshot of the volume
 		3. Cleanup of snapshot, pvc and sc
 	*/
-	ginkgo.It("[ef-wcp-snapshot][block-vanilla-snapshot][tkg-snapshot][supervisor-snapshot] Volume provision and "+
+	ginkgo.It("[pq-wcp-snpt][block-vanilla-snapshot][tkg-snapshot][supervisor-snapshot] Volume provision and "+
 		"snapshot creation/restore on VVOL Datastore", ginkgo.Label(p0, block, vanilla, snapshot,
 		tkg, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -4903,7 +4903,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		2. Create Snapshot class and take a snapshot of the volume
 		3. Cleanup of snapshot, pvc and sc
 	*/
-	ginkgo.It("[ef-wcp-snapshot][block-vanilla-snapshot][tkg-snapshot] [supervisor-snapshot] Volume provision and "+
+	ginkgo.It("[pq-wcp-snpt][block-vanilla-snapshot][tkg-snapshot] [supervisor-snapshot] Volume provision and "+
 		"snapshot creation/restore on VMFS Datastore", ginkgo.Label(p0, block, vanilla, snapshot,
 		tkg, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -4931,7 +4931,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		2. Create Snapshot class and take a snapshot of the volume
 		3. Cleanup of snapshot, pvc and sc
 	*/
-	ginkgo.It("[ef-wcp-snapshot] [tkg-snapshot] [supervisor-snapshot] Volume provision and snapshot creation/restore "+
+	ginkgo.It("[pq-wcp-snpt] [tkg-snapshot] [supervisor-snapshot] Volume provision and snapshot creation/restore "+
 		"on VSAN2 Datastore", ginkgo.Label(p0, snapshot, tkg, newTest, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/policy_driven_vol_allocation.go
+++ b/tests/e2e/policy_driven_vol_allocation.go
@@ -159,9 +159,8 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 			9	Delete the SCs created in step 2
 			10	Deleted the SPBM polices created in step 1
 	*/
-	ginkgo.It("[csi-block-vanilla][csi-block-vanilla-parallelized][csi-guest][csi-supervisor]"+
-		"[csi-wcp-vsan-direct][ef-vks-thickthin][cf-vanilla-block] Verify Thin,"+
-		"EZT, LZT volume creation via SPBM "+
+	ginkgo.It("[ef-svc-volallowcation][csi-block-vanilla][csi-block-vanilla-parallelized][csi-guest][csi-supervisor]"+
+		"[csi-wcp-vsan-direct][ef-vks-thickthin][cf-vanilla-block] Verify Thin, EZT, LZT volume creation via SPBM "+
 		"policies", ginkgo.Label(p0, vanilla, block, thickThin, wcp, tkg, windows, stable, vsanDirect, vc70), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -417,9 +416,9 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		9. Delete the SCs created in step 2
 		10. Deleted the SPBM policies created in step 1
 	*/
-	ginkgo.It("[csi-block-vanilla][csi-guest][csi-supervisor][csi-wcp-vsan-direct]"+
-		" Fill LZT/EZT "+
-		"volume", ginkgo.Label(p0, vanilla, block, thickThin, wcp, tkg, windows, stable, vsanDirect, vc70), func() {
+	ginkgo.It("[ef-svc-volallowcation][csi-block-vanilla][csi-guest][csi-supervisor][csi-wcp-vsan-direct] Fill "+
+		"LZT/EZT volume", ginkgo.Label(p0, vanilla, block, thickThin, wcp, tkg, windows, stable, vsanDirect,
+		vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		sharedvmfsURL, vsanDDatstoreURL := "", ""
@@ -672,9 +671,9 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		7. Delete the SC created in step 2
 		8. Deleted the SPBM policy created in step 1
 	*/
-	ginkgo.It("[csi-block-vanilla][csi-guest][csi-supervisor]"+
-		"[csi-wcp-vsan-direct] Verify large EZT volume creation which takes longer than vpxd "+
-		"timeout", ginkgo.Label(p0, vanilla, block, thickThin, wcp, tkg, windows, stable, vsanDirect, vc70), func() {
+	ginkgo.It("[pq-svc-volallowcation-neg][csi-block-vanilla][csi-guest][csi-supervisor][csi-wcp-vsan-direct] Verify "+
+		"large EZT volume creation which takes longer than vpxd timeout", ginkgo.Label(p0, vanilla, block, thickThin,
+		wcp, tkg, windows, stable, vsanDirect, vc70), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -880,9 +879,9 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		10	Delete the SC created in step 2
 		11	Deleted the SPBM policy created in step 1
 	*/
-	ginkgo.It("[csi-block-vanilla][csi-guest][csi-supervisor]"+
-		"[csi-wcp-vsan-direct] Verify EZT online volume expansion to a large size which takes longer than vpxd "+
-		"timeout", ginkgo.Label(p0, vanilla, block, thickThin, wcp, windows, tkg, stable, vsanDirect, vc70), func() {
+	ginkgo.It("[pq-svc-volallowcation-neg][csi-block-vanilla][csi-guest][csi-supervisor][csi-wcp-vsan-direct] Verify "+
+		"EZT online volume expansion to a large size which takes longer than vpxd timeout", ginkgo.Label(p0, vanilla,
+		block, thickThin, wcp, windows, tkg, stable, vsanDirect, vc70), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1157,7 +1156,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		11	Delete the SC created in step 2
 		12	Deleted the SPBM policy created in step 1
 	*/
-	ginkgo.It("[csi-block-vanilla][csi-guest][csi-supervisor][ef-vks-thickthin]"+
+	ginkgo.It("[ef-svc-volallowcation][csi-block-vanilla][csi-guest][csi-supervisor][ef-vks-thickthin]"+
 		"[csi-wcp-vsan-direct] Verify online LZT/EZT volume expansion of attached volumes with "+
 		"IO", ginkgo.Label(p0, vanilla, block, thickThin, wcp, tkg, stable, vsanDirect, vc70), func() {
 
@@ -1481,9 +1480,9 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		9	Delete pod1
 		10	Delete pvc, sc and SPBM policy created for this test
 	*/
-	ginkgo.It("[cflater-wcp][csi-supervisor][csi-block-vanilla][csi-block-vanilla-parallelized][csi-guest]"+
-		"[csi-wcp-vsan-direct] Relocate volume to another same type "+
-		"datastore", ginkgo.Label(p0, vanilla, block, thickThin, wcp, tkg, stable, vsanDirect, vc70), func() {
+	ginkgo.It("[ef-svc-volallowcation][cflater-wcp][csi-supervisor][csi-block-vanilla][csi-block-vanilla-parallelized]"+
+		"[csi-guest][csi-wcp-vsan-direct] Relocate volume to another same type datastore", ginkgo.Label(p0, vanilla, block,
+		thickThin, wcp, tkg, stable, vsanDirect, vc70), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1802,9 +1801,9 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		12.	Delete the SC created in step 2
 		13.	Deleted the SPBM policy created in step 1
 	*/
-	ginkgo.It("[csi-guest][csi-supervisor][csi-block-vanilla][csi-wcp-vsan-direct] [ef-vks-thickthin] Verify "+
-		"EZT offline volume "+
-		"expansion", ginkgo.Label(p0, vanilla, block, thickThin, wcp, tkg, windows, stable, vsanDirect, vc70), func() {
+	ginkgo.It("[ef-svc-volallowcation][csi-guest][csi-supervisor][csi-block-vanilla][csi-wcp-vsan-direct] "+
+		"[ef-vks-thickthin] Verify EZT offline volume expansion", ginkgo.Label(p0, vanilla, block, thickThin,
+		wcp, tkg, windows, stable, vsanDirect, vc70), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2378,9 +2377,9 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		11	Delete the SCs created in step 2
 		12	Deleted the SPBM policies created in step 1
 	*/
-	ginkgo.It("[csi-block-vanilla][csi-guest][csi-supervisor] Verify expansion during Thin -> EZT, LZT -> EZT"+
-		" conversion (should take >vpxd task timeout)", ginkgo.Label(p0, vanilla, block, thickThin, wcp, tkg,
-		windows, stable, vc70), func() {
+	ginkgo.It("[pq-svc-volallowcation-neg][csi-block-vanilla][csi-guest][csi-supervisor] Verify expansion during "+
+		"Thin -> EZT, LZT -> EZT conversion (should take >vpxd task timeout)", ginkgo.Label(p0, vanilla, block,
+		thickThin, wcp, tkg, windows, stable, vc70), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/snapshot_vmservice_vm.go
+++ b/tests/e2e/snapshot_vmservice_vm.go
@@ -322,7 +322,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   12. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("Taking snapshot of a vm service vm attached to a static "+
+	ginkgo.It("[ef-vmsvc] Taking snapshot of a vm service vm attached to a static "+
 		"volume", ginkgo.Label(p0, block, wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -461,7 +461,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("Restoring snapshot and attaching it to a vm service "+
+	ginkgo.It("[ef-vmsvc] Restoring snapshot and attaching it to a vm service "+
 		"vm", ginkgo.Label(p0, block, wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -638,7 +638,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 		17. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("Restoring multiple snapshots and attaching it to a single vm service "+
+	ginkgo.It("[ef-vmsvc] Restoring multiple snapshots and attaching it to a single vm service "+
 		"vm", ginkgo.Label(p1, block, wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -846,7 +846,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   19. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("Offline volume expansion and later attaching it to a vm service "+
+	ginkgo.It("[ef-vmsvc] Offline volume expansion and later attaching it to a vm service "+
 		"vm", ginkgo.Label(p1, block, wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1089,7 +1089,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   17. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("Attaching new restore snapshots to vm service vms", ginkgo.Label(p1, block,
+	ginkgo.It("[ef-vmsvc] Attaching new restore snapshots to vm service vms", ginkgo.Label(p1, block,
 		wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1398,7 +1398,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	  Confirm that the Pod reaches the running state and that read and write operations can be performed on the volume.
 	  Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
-	ginkgo.It("Attaching same volume to a pod and vm service vm", ginkgo.Label(p1, block, wcp, snapshot,
+	ginkgo.It("[ef-vmsvc] Attaching same volume to a pod and vm service vm", ginkgo.Label(p1, block, wcp, snapshot,
 		vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1600,7 +1600,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   18. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("Power on and off operation on a vm service vm with snapshot", ginkgo.Label(p0, block,
+	ginkgo.It("[pq-neg-vmsvc] Power on and off operation on a vm service vm with snapshot", ginkgo.Label(p0, block,
 		wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1819,8 +1819,8 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   25. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("vCenter services down operation during snapshot creation and restoration taken for a vm service"+
-		"vm", ginkgo.Label(p1, block, wcp, snapshot, vmServiceVm, negative, vc80), func() {
+	ginkgo.It("pq-neg-vmsvc] vCenter services down operation during snapshot creation and restoration taken for "+
+		"a vm service vm", ginkgo.Label(p1, block, wcp, snapshot, vmServiceVm, negative, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -2066,7 +2066,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("Storage vmotion of a vm from one datastore to another with "+
+	ginkgo.It("[pq-neg-vmsvc] Storage vmotion of a vm from one datastore to another with "+
 		"snapshot", ginkgo.Label(p1, block, wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -2314,8 +2314,8 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   14. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("Creation of multiple vm service vms and attaching it to restore snapshots", ginkgo.Label(p1, block, wcp,
-		snapshot, vmServiceVm, vc80), func() {
+	ginkgo.It("[ef-vmsvc] Creation of multiple vm service vms and attaching it to restore snapshots", ginkgo.Label(p1,
+		block, wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2598,7 +2598,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   21. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("Recurring taking snapshots of a vm service vm", ginkgo.Label(p1, block, wcp,
+	ginkgo.It("[ef-vmsvc] Recurring taking snapshots of a vm service vm", ginkgo.Label(p1, block, wcp,
 		vmServiceVm, snapshot, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/vmservice_vm.go
+++ b/tests/e2e/vmservice_vm.go
@@ -349,7 +349,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 	   8   delete pvcs from step2
 	   9   Remove spbm policy attached to test namespace
 	*/
-	ginkgo.It("hot detach and attach pvc to vmservice vms", ginkgo.Label(p0,
+	ginkgo.It("[ef-vmsvc] hot detach and attach pvc to vmservice vms", ginkgo.Label(p0,
 		vmServiceVm, block, wcp, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -553,7 +553,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 	   9   Delete pvc1
 	   10   Remove spbm policy attached to test namespace
 	*/
-	ginkgo.It("attach PVC used by one VM to another VM while in use", ginkgo.Label(p1,
+	ginkgo.It("[ef-vmsvc] attach PVC used by one VM to another VM while in use", ginkgo.Label(p1,
 		vmServiceVm, block, wcp, negative, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -745,7 +745,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 	   8   delete pvc1, pvc2
 	   9   Remove spbm policy attached to test namespace in step1
 	*/
-	ginkgo.It("[vmsvc-stretched] VM and PVC both belong to same zone", ginkgo.Label(p0,
+	ginkgo.It("[stretched-svc] VM and PVC both belong to same zone", ginkgo.Label(p0,
 		vmServiceVm, block, wcp, stretchedSvc, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -860,7 +860,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 	   9	delete pvc1
 	   10   Remove spbm policy attached to test namespace in step1
 	*/
-	ginkgo.It("[vmsvc-stretched] VM and PVC both belong to same zone", ginkgo.Label(p0,
+	ginkgo.It("[stretched-svc] VM and PVC both belong to same zone", ginkgo.Label(p0,
 		vmServiceVm, block, wcp, stretchedSvc, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -997,7 +997,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 	   10	Delete pvc1 and pvc2
 	   11	Remove spbm policy attached to test namespace
 	*/
-	ginkgo.It("attach a PVC attached to a pod to VM", ginkgo.Label(p1,
+	ginkgo.It("[ef-vmsvc] attach a PVC attached to a pod to VM", ginkgo.Label(p1,
 		vmServiceVm, block, wcp, negative, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1144,7 +1144,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		10	Delete pvc1 and pvc2
 		11	Remove spbm policy attached to test namespace
 	*/
-	ginkgo.It("Create VM or attach/detach PVC to VM when vsan-health is down", ginkgo.Label(p1,
+	ginkgo.It("[pq-wcp-snpt] Create VM or attach/detach PVC to VM when vsan-health is down", ginkgo.Label(p1,
 		vmServiceVm, block, wcp, negative, disruptive, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1365,7 +1365,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 		10	Delete pvc1
 		11	Remove spbm policy attached to test namespace
 	*/
-	ginkgo.It("create VM with pvc when sps is down", ginkgo.Label(p1,
+	ginkgo.It("[pq-wcp-snpt] create VM with pvc when sps is down", ginkgo.Label(p1,
 		vmServiceVm, block, wcp, negative, disruptive, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1494,7 +1494,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 	   8   delete pvcs
 	   9   Remove spbm policy attached to test namespace
 	*/
-	ginkgo.It("static-vm and verify vm creation and validate storagequota", ginkgo.Label(p0,
+	ginkgo.It("[ef-vmsvc] static-vm and verify vm creation and validate storagequota", ginkgo.Label(p0,
 		vmServiceVm, block, wcp, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**: Labels added for vmsvc and stretched-svc to run in UTS

**Testing done**:
Not required only label update

**Special notes for your reviewer**:
[ef-vmsvc] -> All vmservice tests to run in ef
[pq-neg-vmsvc]  -> Negetice / service down tests to run in pq
[stretched-svc]  -> stretched-supervisor tests
[pq-wcp-neg-snpt] -> negetive snapshot  which runs in pq
[pq-wcp-snpt] ->  positive snapshot which runs in pq
[ef-svc-volallowcation] -> Thick/Thin tests to run in EF
[pq-svc-volallowcation-neg] -> Thick/Thin tests to run in PQ




