### PR TITLE
Timeout fixes for PV and VSC deletion

### DIFF
--- a/tests/e2e/csi_snapshot_utils.go
+++ b/tests/e2e/csi_snapshot_utils.go
@@ -184,7 +184,7 @@ func deleteVolumeSnapshotContentWithPandoraWait(ctx context.Context, snapc *snap
 func waitForVolumeSnapshotContentToBeDeletedWithPandoraWait(ctx context.Context, snapc *snapclient.Clientset,
 	name string, pandoraSyncWaitTime int) error {
 	var err error
-	waitErr := wait.PollUntilContextTimeout(ctx, poll, 2*pollTimeout, true,
+	waitErr := wait.PollUntilContextTimeout(ctx, poll, vscDeleteTimeout, true,
 		func(ctx context.Context) (bool, error) {
 			_, err = snapc.SnapshotV1().VolumeSnapshotContents().Get(ctx, name, metav1.GetOptions{})
 			if err != nil {

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -179,7 +179,7 @@ const (
 	regionKey                                 = "topology.csi.vmware.com/k8s-region"
 	resizePollInterval                        = 2 * time.Second
 	restartOperation                          = "restart"
-	rqLimit                                   = "200Gi"
+	rqLimit                                   = "500Gi"
 	rqLimitScaleTest                          = "900Gi"
 	rootUser                                  = "root"
 	defaultrqLimit                            = "20Gi"
@@ -275,6 +275,8 @@ const (
 	devopsKubeConf                           = "DEV_OPS_USER_KUBECONFIG"
 	quotaSupportedVCVersion                  = "9.0.0"
 	lateBinding                              = "-latebinding"
+	cnsVolumeDeleteTimeout                   = 5 * time.Minute
+	vscDeleteTimeout                         = 5 * time.Minute
 )
 
 /*

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -467,7 +467,7 @@ func (vs *vSphere) waitForMetadataToBeDeleted(volumeID string, entityType string
 // waitForCNSVolumeToBeDeleted executes QueryVolume API on vCenter and verifies
 // volume entries are deleted from vCenter Database
 func (vs *vSphere) waitForCNSVolumeToBeDeleted(volumeID string) error {
-	err := wait.PollUntilContextTimeout(context.Background(), poll, 2*pollTimeout, true,
+	err := wait.PollUntilContextTimeout(context.Background(), poll, cnsVolumeDeleteTimeout, true,
 		func(ctx context.Context) (bool, error) {
 			queryResult, err := vs.queryCNSVolumeWithResult(volumeID)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now in current code, PV deletion and VSC deletion is waiting for 20 minutes to get deleted. This PR is taking care of reducing timeout from 20 minutes to 5 minutes.

**Testing done**:
Not required as I have just changed timings from 20 minutes to default wait time of 5 minutes


