### PR TITLE
Fix - Grant privilege to update CNSUnregisterVolume/Status to the ClusterRole

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -58,7 +58,7 @@ rules:
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsregistervolumes", "cnsunregistervolumes"]
+    resources: ["cnsregistervolumes", "cnsunregistervolumes", "cnsunregistervolumes/status"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -58,7 +58,7 @@ rules:
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsregistervolumes", "cnsunregistervolumes"]
+    resources: ["cnsregistervolumes", "cnsunregistervolumes", "cnsunregistervolumes/status"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -58,7 +58,7 @@ rules:
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsregistervolumes", "cnsunregistervolumes"]
+    resources: ["cnsregistervolumes", "cnsunregistervolumes", "cnsunregistervolumes/status"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -58,7 +58,7 @@ rules:
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsregistervolumes", "cnsunregistervolumes"]
+    resources: ["cnsregistervolumes", "cnsunregistervolumes", "cnsunregistervolumes/status"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]


### PR DESCRIPTION
## What this PR does / why we need it
This PR grants status update privileges to the cluster role without which the reconciler will fail with the following error - 

```
{"level":"error","time":"2025-09-17T17:08:46.824617244Z","caller":"kubernetes/kubernetes.go:786","msg":"Failed to update status for CnsUnregisterVolume e2e-test/un-reg-new: cnsunregistervolumes.cns.vmware.com \"un-reg-new\" is forbidden: User \"system:serviceaccount:vmware-system-csi:vsphere-csi-controller\" cannot update resource \"cnsunregistervolumes/status\" in API group \"cns.vmware.com\" in the namespace \"e2e-test\"","TraceId":"8af95022-1cdd-41c4-9cd8-6194636a641b","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes.UpdateStatus\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/kubernetes/kubernetes.go:786\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.setInstanceSuccess\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/controller.go:310\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*Reconciler).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/controller.go:280\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

## Testing done

### Without the fix the reconciler is unable to update the status of the CR

<details><summary>Details</summary>
<p>

```
{"level":"error","time":"2025-09-18T07:21:02.109223438Z","caller":"kubernetes/kubernetes.go:786","msg":"Failed to update status for CnsUnregisterVolume cns-
unregister-volume/unregister-unused-vol: cnsunregistervolumes.cns.vmware.com \"unregister-unused-vol\" is forbidden: User \"system:serviceaccount:vmware-sys
tem-csi:vsphere-csi-controller\" cannot update resource \"cnsunregistervolumes/status\" in API group \"cns.vmware.com\" in the namespace \"cns-unregister-vo
lume\"","TraceId":"9a64b6b4-1cc1-4abb-8399-285d7bd2679b","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes.UpdateStatus\n\t/Users/vsatyanaraya/
src/github.com/vsphere-csi-driver/pkg/kubernetes/kubernetes.go:786\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.
setInstanceError\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/controller.go:300\nsigs.k8s.
io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsunregistervolume.(*Reconciler).Reconcile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-dri
ver/pkg/syncer/cnsoperator/controller/cnsunregistervolume/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Recon
cile\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/c
ontroller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/co
ntroller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\
t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controll
er-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/vsatyanaraya/src/github.com/vsphere-csi-driver/vendor/sigs.k8s.io/controller-r
untime/pkg/internal/controller/controller.go:224"}
```
```yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsUnregisterVolume
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsUnregisterVolume","metadata":{"annotations":{},"name":"unregister-unused-vol","namespace":"cns-unregister-volume"},"spec":{"volumeID":"f7766c13-e8a0-4f06-8a0f-04d571c82455"}}
  creationTimestamp: "2025-09-18T07:19:56Z"
  generation: 1
  name: unregister-unused-vol
  namespace: cns-unregister-volume
  resourceVersion: "12506713"
  uid: eca777e0-51d4-46ce-951e-d21ba113de5c
spec:
  volumeID: f7766c13-e8a0-4f06-8a0f-04d571c82455
```

</p>
</details> 

### With this fix the status got updated successfully
<details><summary>Details</summary>
<p>

```
{"level":"info","time":"2025-09-18T07:26:12.251913848Z","caller":"kubernetes/kubernetes.go:791","msg":"Successfully updated status for CnsUnregisterVolume c
ns-unregister-volume/unregister-unused-vol","TraceId":"eacec1fc-65ec-4d92-853e-9e46e3e83639"}
```

```yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsUnregisterVolume
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsUnregisterVolume","metadata":{"annotations":{},"name":"unregister-unused-vol","namespace":"cns-unregister-volume"},"spec":{"volumeID":"f7766c13-e8a0-4f06-8a0f-04d571c82455"}}
  creationTimestamp: "2025-09-18T07:19:56Z"
  generation: 1
  name: unregister-unused-vol
  namespace: cns-unregister-volume
  resourceVersion: "12510189"
  uid: eca777e0-51d4-46ce-951e-d21ba113de5c
spec:
  volumeID: f7766c13-e8a0-4f06-8a0f-04d571c82455
status:
  error: Failed to unregister volume "f7766c13-e8a0-4f06-8a0f-04d571c82455"
  unregistered: false
```

</p>
</details> 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix missing cnsunregistervolume/status update privileges for the clusterrole
```
