### PR TITLE
Wait until topology annotation gets added on supervisor PVCs while adding node affinity rules on PVs in guest cluster

### DIFF
--- a/pkg/syncer/pvcsi_fullsync_test.go
+++ b/pkg/syncer/pvcsi_fullsync_test.go
@@ -17,11 +17,18 @@ limitations under the License.
 package syncer
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 )
 
 func TestGenerateVolumeNodeAffinity(t *testing.T) {
@@ -105,5 +112,180 @@ func TestGenerateVolumeNodeAffinity(t *testing.T) {
 			result := GenerateVolumeNodeAffinity(tt.accessibleTopology)
 			assert.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func TestAddNodeAffinityRulesOnPVTopologyAnnotationPresent(t *testing.T) {
+	ctx := context.Background()
+
+	// Create supervisor PVC with topology annotation
+	supPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "volume-1",
+			Namespace: "sv-namespace",
+			Annotations: map[string]string{
+				common.AnnVolumeAccessibleTopology: `[{"zone":"zone-a"}]`,
+			},
+		},
+	}
+	// Create guest PV without node affinity
+	guestPV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-1",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: "volume-1",
+				},
+			},
+		},
+	}
+
+	// Setup supervisor client with PVC
+	supervisorClient := k8sfake.NewSimpleClientset(supPVC)
+	// Setup guest client with PV
+	guestClient := k8sfake.NewSimpleClientset(guestPV)
+
+	// Setup metadataSyncer
+	metadataSyncer := &metadataSyncInformer{
+		supervisorClient: supervisorClient,
+	}
+	metadataSyncer.configInfo = &cnsconfig.ConfigurationInfo{
+		Cfg: &cnsconfig.Config{
+			GC: cnsconfig.GCConfig{
+				Endpoint: "endpoint",
+				Port:     "443",
+			},
+		},
+	}
+
+	// Patch k8sNewClient to return our guestClient
+	origK8sClient := k8sNewClient
+	defer func() {
+		k8sNewClient = origK8sClient
+	}()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) {
+		return guestClient, nil
+	}
+
+	// Patch getPVsInBoundAvailableOrReleased to return our PV
+	origGetPVs := getPVsInBoundAvailableOrReleased
+	defer func() {
+		getPVsInBoundAvailableOrReleased = origGetPVs
+	}()
+	getPVsInBoundAvailableOrReleased = func(ctx context.Context,
+		syncer *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+		return []*v1.PersistentVolume{guestPV}, nil
+	}
+
+	// Patch cnsconfig.GetSupervisorNamespace to return our namespace
+	origGetSuperNS := cnsconfigGetSupervisorNamespace
+	defer func() {
+		cnsconfigGetSupervisorNamespace = origGetSuperNS
+	}()
+	cnsconfigGetSupervisorNamespace = func(ctx context.Context) (string, error) {
+		return "sv-namespace", nil
+	}
+
+	// Run function
+	AddNodeAffinityRulesOnPV(ctx, metadataSyncer)
+
+	// Verify node affinity added
+	gotPV, err := guestClient.CoreV1().PersistentVolumes().Get(ctx, "pv-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("PV not found: %v", err)
+	}
+	if gotPV.Spec.NodeAffinity == nil || len(gotPV.Spec.NodeAffinity.Required.NodeSelectorTerms) == 0 {
+		t.Errorf("Expected node affinity to be set on PV when supervisor PVC has topology annotation")
+	}
+}
+
+func TestAddNodeAffinityRulesOnPVTopologyAnnotationAbsent(t *testing.T) {
+	ctx := context.Background()
+
+	// Create supervisor PVC without annotation
+	supPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "volume-2",
+			Namespace:   "sv-namespace",
+			Annotations: map[string]string{},
+		},
+	}
+	// Create guest PV without node affinity
+	guestPV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-2",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: "volume-2",
+				},
+			},
+		},
+	}
+
+	supervisorClient := k8sfake.NewSimpleClientset(supPVC)
+	guestClient := k8sfake.NewSimpleClientset(guestPV)
+
+	// Setup metadataSyncer
+	metadataSyncer := &metadataSyncInformer{
+		supervisorClient: supervisorClient,
+	}
+	metadataSyncer.configInfo = &cnsconfig.ConfigurationInfo{
+		Cfg: &cnsconfig.Config{
+			GC: cnsconfig.GCConfig{
+				Endpoint: "endpoint",
+				Port:     "443",
+			},
+		},
+	}
+
+	// Patch k8sNewClient to return our guestClient
+	origK8sClient := k8sNewClient
+	defer func() {
+		k8sNewClient = origK8sClient
+	}()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) {
+		return guestClient, nil
+	}
+
+	// Patch getPVsInBoundAvailableOrReleased to return our PV
+	origGetPVs := getPVsInBoundAvailableOrReleased
+	defer func() {
+		getPVsInBoundAvailableOrReleased = origGetPVs
+	}()
+	getPVsInBoundAvailableOrReleased = func(ctx context.Context,
+		syncer *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+		return []*v1.PersistentVolume{guestPV}, nil
+	}
+
+	// Patch cnsconfig.GetSupervisorNamespace to return our namespace
+	origGetSuperNS := cnsconfigGetSupervisorNamespace
+	defer func() {
+		cnsconfigGetSupervisorNamespace = origGetSuperNS
+	}()
+	cnsconfigGetSupervisorNamespace = func(ctx context.Context) (string, error) {
+		return "sv-namespace", nil
+	}
+
+	// Reduce timeout value used in code for testing
+	origTimeout := timeoutAddNodeAffinityOnPVs
+	defer func() {
+		timeoutAddNodeAffinityOnPVs = origTimeout
+	}()
+	timeoutAddNodeAffinityOnPVs = 15 * time.Second
+
+	// Run function
+	AddNodeAffinityRulesOnPV(ctx, metadataSyncer)
+
+	// Verify node affinity NOT added as supervisor PVC doesn't have topology annotation
+	gotPV, err := guestClient.CoreV1().PersistentVolumes().Get(ctx, "pv-2", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("PV not found: %v", err)
+	}
+	if gotPV.Spec.NodeAffinity != nil {
+		t.Errorf("Expected node affinity NOT to be set on PV when supervisor PVC has no topology annotation")
 	}
 }

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -55,7 +55,7 @@ const (
 
 // getPVsInBoundAvailableOrReleased return PVs in Bound, Available or Released
 // state.
-func getPVsInBoundAvailableOrReleased(ctx context.Context,
+var getPVsInBoundAvailableOrReleased = func(ctx context.Context,
 	metadataSyncer *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
 	log := logger.GetLogger(ctx)
 	var pvsInDesiredState []*v1.PersistentVolume
@@ -940,10 +940,6 @@ func hasClusterDistributionSet(ctx context.Context, volume cnstypes.CnsVolume,
 func generateVolumeAccessibleTopologyFromPVCAnnotation(claim *v1.PersistentVolumeClaim) (
 	[]map[string]string, error) {
 	volumeAccessibleTopology := claim.Annotations[common.AnnVolumeAccessibleTopology]
-	if volumeAccessibleTopology == "" {
-		return nil, fmt.Errorf("annotation %q is not set for the claim: %q, namespace: %q",
-			common.AnnVolumeAccessibleTopology, claim.Name, claim.Namespace)
-	}
 	volumeAccessibleTopologyArray := make([]map[string]string, 0)
 	err := json.Unmarshal([]byte(volumeAccessibleTopology), &volumeAccessibleTopologyArray)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Node affinity is added on supervisor PVs along with topology annotation on associated PVCs through full sync code once WLDI feature is enabled.

Node affinity is added on Guest PVs once WLDI feature is enabled and it checks if associated supervisor PVC has topology annotation added.
If there are lot of PVCs, this process will happen in parallel on guest and supervisor. If supervisor PVC doesn’t have topology annotation added, then associated Guest PV will not get node affinity added. And in next full sync cycle after 30 min it gets added. 
Added a logic to wait until topology annotation gets added on supervisor PVCs while adding node affinity rules on PVs in guest cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
vks pre-checkin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/429/
```
vk016860 <br> PR 3588<br>
Ran 6 of 1775 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 1769 Skipped | 0 Flaked
```
wldi pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/E2E-Management-Workload-domain-Isolation-Pipeline/140/

Unit tests passed:
```
=== RUN   TestAddNodeAffinityRulesOnPVTopologyAnnotationPresent
{"level":"info","time":"2025-09-25T15:50:51.344888+05:30","caller":"syncer/pvcsi_fullsync.go:313","msg":"AddNodeAffinityRulesOnPV Start."}
{"level":"info","time":"2025-09-25T15:50:51.351955+05:30","caller":"syncer/pvcsi_fullsync.go:393","msg":"patched PV: pv-1 with node affinity &VolumeNodeAffinity{Required:&NodeSelector{NodeSelectorTerms:[]NodeSelectorTerm{NodeSelectorTerm{MatchExpressions:[]NodeSelectorRequirement{NodeSelectorRequirement{Key:zone,Operator:In,Values:[zone-a],},},MatchFields:[]NodeSelectorRequirement{},},},},}"}
{"level":"info","time":"2025-09-25T15:50:51.351995+05:30","caller":"syncer/pvcsi_fullsync.go:429","msg":"AddNodeAffinityRulesOnPV End."}
--- PASS: TestAddNodeAffinityRulesOnPVTopologyAnnotationPresent (0.01s)


=== RUN   TestAddNodeAffinityRulesOnPVTopologyAnnotationAbsent
{"level":"info","time":"2025-09-25T15:50:51.352593+05:30","caller":"syncer/pvcsi_fullsync.go:313","msg":"AddNodeAffinityRulesOnPV Start."}
{"level":"error","time":"2025-09-25T15:50:51.35261+05:30","caller":"syncer/pvcsi_fullsync.go:350","msg":"Annotation \"csi.vsphere.volume-accessible-topology\" is not set on the PVC: \"volume-2\", namespace: \"sv-namespace\"","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.AddNodeAffinityRulesOnPV.func1\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/pvcsi_fullsync.go:350\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.AddNodeAffinityRulesOnPV\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/pvcsi_fullsync.go:399\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.TestAddNodeAffinityRulesOnPVTopologyAnnotationAbsent\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/pvcsi_fullsync_test.go:281\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
{"level":"error","time":"2025-09-25T15:50:51.352655+05:30","caller":"syncer/pvcsi_fullsync.go:350","msg":"Annotation \"csi.vsphere.volume-accessible-topology\" is not set on the PVC: \"volume-2\", namespace: \"sv-namespace\"","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.AddNodeAffinityRulesOnPV.func1\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/pvcsi_fullsync.go:350\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.AddNodeAffinityRulesOnPV\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/pvcsi_fullsync.go:418\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.TestAddNodeAffinityRulesOnPVTopologyAnnotationAbsent\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/pvcsi_fullsync_test.go:281\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
{"level":"error","time":"2025-09-25T15:51:01.35411+05:30","caller":"syncer/pvcsi_fullsync.go:350","msg":"Annotation \"csi.vsphere.volume-accessible-topology\" is not set on the PVC: \"volume-2\", namespace: \"sv-namespace\"","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.AddNodeAffinityRulesOnPV.func1\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/pvcsi_fullsync.go:350\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.AddNodeAffinityRulesOnPV\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/pvcsi_fullsync.go:418\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.TestAddNodeAffinityRulesOnPVTopologyAnnotationAbsent\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/pvcsi_fullsync_test.go:281\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
{"level":"info","time":"2025-09-25T15:51:11.355843+05:30","caller":"syncer/pvcsi_fullsync.go:411","msg":"Timeout exceeded for adding node affinity rules on PVs. Waited 5 minutes to get volume accessibility topology annotation added on supervisor PVCs."}
{"level":"info","time":"2025-09-25T15:51:11.356131+05:30","caller":"syncer/pvcsi_fullsync.go:429","msg":"AddNodeAffinityRulesOnPV End."}
--- PASS: TestAddNodeAffinityRulesOnPVTopologyAnnotationAbsent (20.01s)
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Wait until topology annotation gets added on supervisor PVCs while adding node affinity rules on PVs in guest cluster
```
