### PR TITLE
Fix for regression introduced by session manager changes

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -369,25 +369,25 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 	// SessionMgr.UserSession(ctx) retrieves and returns the SessionManager's
 	// CurrentSession field. Nil is returned if the session is not
 	// authenticated or timed out.
-	shouldLogin := false
 
 	userSession, err := sessionMgr.UserSession(ctx)
 	if err != nil {
 		log.Errorf("failed to obtain user session with err: %v", err)
-		// Login again if session is invalid
-		shouldLogin = true
-		//return err <- Check if we really want to return error here or follow with re-login
+		// An error here can mean the vcenter itself is down so
+		// we should return early with error
+		return err
 	}
 
 	restSession, err := vc.RestClient.Session(ctx)
 	if err != nil {
 		log.Errorf("failed to obtain rest user session with err: %v", err)
-		// Login again if session is invalid
-		shouldLogin = true
+		// An error here can mean the vcenter itself is down so
+		// we should return early with error
+		return err
 	}
 
 	// No need to re-login
-	if userSession != nil && restSession != nil && !shouldLogin {
+	if userSession != nil && restSession != nil {
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix for a regression introduced by session manager implementation https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/7591005c75649df9d377099f53fc89a20c21f0b0
Restarting the Vpxd api in vcenter would cause the csi driver to start making unauthenticated calls to some API. This broke
common operations like volume provisioning. The offending change has already been removed from main branch
https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/16c72e1383ff85399b3c553c2c56dcae669be61b

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
