### PR TITLE
Surface NotSupported error message during AttachVolume call

### DIFF
--- a/pkg/common/cns-lib/volume/manager_test.go
+++ b/pkg/common/cns-lib/volume/manager_test.go
@@ -2,10 +2,12 @@ package volume
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	vim25types "github.com/vmware/govmomi/vim25/types"
 )
 
@@ -48,5 +50,121 @@ func performSlowTask(ch chan TaskResult, delay time.Duration) {
 	ch <- TaskResult{
 		TaskInfo: &vim25types.TaskInfo{State: vim25types.TaskInfoStateSuccess},
 		Err:      nil,
+	}
+}
+
+// Test CnsFault with NotSupported fault cause detection
+func TestCnsFaultNotSupportedDetection(t *testing.T) {
+	tests := []struct {
+		name               string
+		fault              vim25types.BaseMethodFault
+		expectCnsFault     bool
+		expectNotSupported bool
+		expectedMessage    string
+	}{
+		{
+			name: "CnsFault with NotSupported cause",
+			fault: &cnstypes.CnsFault{
+				MethodFault: vim25types.MethodFault{
+					FaultCause: &vim25types.LocalizedMethodFault{
+						LocalizedMessage: "The operation is not supported on the object.",
+						Fault: &vim25types.NotSupported{
+							RuntimeFault: vim25types.RuntimeFault{
+								MethodFault: vim25types.MethodFault{
+									FaultMessage: []vim25types.LocalizableMessage{
+										{
+											Message: "Attaching mutually shared fcd disks to same VM is not supported.",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Reason: "VSLM task failed",
+			},
+			expectCnsFault:     true,
+			expectNotSupported: true,
+			expectedMessage:    "Attaching mutually shared fcd disks to same VM is not supported.",
+		},
+		{
+			name: "CnsFault with NotSupported cause - multiple messages",
+			fault: &cnstypes.CnsFault{
+				MethodFault: vim25types.MethodFault{
+					FaultCause: &vim25types.LocalizedMethodFault{
+						LocalizedMessage: "The operation is not supported on the object.",
+						Fault: &vim25types.NotSupported{
+							RuntimeFault: vim25types.RuntimeFault{
+								MethodFault: vim25types.MethodFault{
+									FaultMessage: []vim25types.LocalizableMessage{
+										{
+											Message: "First error message.",
+										},
+										{
+											Message: "Second error message.",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Reason: "VSLM task failed",
+			},
+			expectCnsFault:     true,
+			expectNotSupported: true,
+			expectedMessage:    "First error message. - Second error message.",
+		},
+		{
+			name: "CnsFault without NotSupported cause",
+			fault: &cnstypes.CnsFault{
+				MethodFault: vim25types.MethodFault{
+					FaultMessage: []vim25types.LocalizableMessage{
+						{Message: "Some other error"},
+					},
+				},
+				Reason: "VSLM task failed",
+			},
+			expectCnsFault:     true,
+			expectNotSupported: false,
+		},
+		{
+			name: "Non-CnsFault",
+			fault: &vim25types.MethodFault{
+				FaultMessage: []vim25types.LocalizableMessage{
+					{Message: "Generic fault"},
+				},
+			},
+			expectCnsFault:     false,
+			expectNotSupported: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test type assertions that would be used in the AttachVolume function
+			cnsFault, isCnsFault := tt.fault.(*cnstypes.CnsFault)
+			assert.Equal(t, tt.expectCnsFault, isCnsFault)
+
+			if isCnsFault && cnsFault.FaultCause != nil {
+				notSupportedFault, isNotSupportedFault := cnsFault.FaultCause.Fault.(*vim25types.NotSupported)
+				assert.Equal(t, tt.expectNotSupported, isNotSupportedFault)
+
+				if isNotSupportedFault && tt.expectedMessage != "" {
+					// Test message extraction logic - only extract from FaultMessage array
+					var errorMessages []string
+					for _, faultMsg := range notSupportedFault.FaultMessage {
+						if faultMsg.Message != "" {
+							errorMessages = append(errorMessages, faultMsg.Message)
+						}
+					}
+
+					if len(errorMessages) > 0 {
+						extractedMessage := strings.Join(errorMessages, " - ")
+						assert.Equal(t, tt.expectedMessage, extractedMessage)
+					}
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The change surfaces the error message from cnsfault NotSupported error.

Existing limitations on FCD linked clones disallow linkedclones to be attached to a VM in following cases:
1. The source volume and the linkedclone are attached to the same VM.
2. Two linkedclone volumes from the same source attached to the same VM.

In either of the above cases a NotSupported fault is thrown.

In the current vmoperator implementation, the error message is truncated to just "failed to attach CNS volume", this is insufficient for end users to determine what happened.

The current change surfaces a detailed message to the CnsNodeVMAttachment status, which is copied over into the VM service VM status. This is eventually reflected in the guest cluster Pod describe outputs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Precheckins:
WCP: PASSED(1 unrelated failure)https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/377/
TKG: tot FAILING, changed don't affect TKG.

```
root@423d969511ba1a686df8bb373bdb950b [ ~ ]# cat pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: pod1
spec:
  containers:
    - name: test-container
      image: cns-docker-dev-local.packages.vcfd.broadcom.net/dkinni/busybox:1.24
      command: ["/bin/sh", "-c", "echo 'hello sdfasf fgdsfgdfg dfgdgdghdg trretete etretert rtyreytut dfgsdgyhrhsrtyhgfhsrtyegdsf' > /mnt/volume1/index.html  && chmod o+rX /mnt /mnt/volume1/index.html && while true ; do sleep 2 ; done"]
      volumeMounts:
        - name: test-volume
          mountPath: /mnt/volume1
        - name: test-volume-1
          mountPath: /mnt/volume2
  restartPolicy: Never
  volumes:
    - name: test-volume 
      persistentVolumeClaim:
        claimName: vs1-lc-1<==================================== LinkedClone volume
    - name: test-volume-1
      persistentVolumeClaim:
        claimName: src-pvc<==================================== Source volume

Error reflected in the Pod describe

root@423d969511ba1a686df8bb373bdb950b [ ~ ]# kubectl --kubeconfig gcconfig.yaml -n testns describe pod pod1
Name:             pod1
Namespace:        testns
Priority:         0
Service Account:  default
Node:             gc-1-worker-phrwr-2sjcp-4gqhd/192.168.128.66
Start Time:       Tue, 23 Sep 2025 19:33:56 +0000
Labels:           <none>
Annotations:      <none>
Status:           Pending
IP:
IPs:              <none>
Containers:
  test-container:
    Container ID:
    Image:         cns-docker-dev-local.packages.vcfd.broadcom.net/dkinni/busybox:1.24
    Image ID:
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
      -c
      echo 'hello sdfasf fgdsfgdfg dfgdgdghdg trretete etretert rtyreytut dfgsdgyhrhsrtyhgfhsrtyegdsf' > /mnt/volume1/index.html  && chmod o+rX /mnt /mnt/volume1/index.html && while true ; do sleep 2 ; done
    State:          Waiting
      Reason:       ContainerCreating
    Ready:          False
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /mnt/volume1 from test-volume (rw)
      /mnt/volume2 from test-volume-1 (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-62rbf (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   False
  Initialized                 True
  Ready                       False
  ContainersReady             False
  PodScheduled                True
Volumes:
  test-volume:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  vs1-lc-1
    ReadOnly:   false
  test-volume-1:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  src-pvc
    ReadOnly:   false
  kube-api-access-62rbf:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason                  Age               From                     Message
  ----     ------                  ----              ----                     -------
  Normal   Scheduled               37s               default-scheduler        Successfully assigned testns/pod1 to gc-1-worker-phrwr-2sjcp-4gqhd
  Normal   SuccessfulAttachVolume  34s               attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-b0e43909-da05-43bc-b34e-7ea46379200f"
  Warning  FailedAttachVolume      0s (x7 over 34s)  attachdetach-controller  AttachVolume.Attach failed for volume "pvc-caabe4b2-af5e-4134-aec5-ce88ba0116fe" : rpc error: code = Internal desc = observed Error: "\"Attaching mutually shared fcd disks to same VM is not supported.\" Failed to attach cns volume" is set on the volume "76498e28-5fb2-4fef-a1a9-352b39f4b919-caabe4b2-af5e-4134-aec5-ce88ba0116fe" on virtualmachine "gc-1-worker-phrwr-2sjcp-4gqhd"

The error surfaced into CnsNodeVmAttachement

root@423d969511ba1a686df8bb373bdb950b [ ~ ]# kubectl get cnsnodevmattachment -n testns gc-1-worker-phrwr-2sjcp-4gqhd-76498e28-5fb2-4fef-a1a9-352b39f4b919-caabe4b2-af5e-4134-aec5-ce88ba0116fe -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsNodeVmAttachment
metadata:
  creationTimestamp: "2025-09-23T19:33:56Z"
  finalizers:
  - cns.vmware.com
  generation: 1
  name: gc-1-worker-phrwr-2sjcp-4gqhd-76498e28-5fb2-4fef-a1a9-352b39f4b919-caabe4b2-af5e-4134-aec5-ce88ba0116fe
  namespace: testns
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha5
    blockOwnerDeletion: true
    controller: true
    kind: VirtualMachine
    name: gc-1-worker-phrwr-2sjcp-4gqhd
    uid: 10f0b748-9e64-49e9-bd46-424c00848355
  resourceVersion: "445956"
  uid: 579cf6ef-4587-454e-b0e4-67eb505a4c27
spec:
  nodeuuid: da5f274a-2b63-4223-a48d-d356aa9a2ac7
  volumename: 76498e28-5fb2-4fef-a1a9-352b39f4b919-caabe4b2-af5e-4134-aec5-ce88ba0116fe
status:
  attached: false
  error: '"Attaching mutually shared fcd disks to same VM is not supported." Failed
    to attach cns volume: "aa4c3b49-7f38-4674-a4d6-599f68062091" to node vm: "VirtualMachine:vm-229
    [VirtualCenterHost: lvn-dvm-10-161-47-60.dvm.lvn.broadcom.net, UUID: da5f274a-2b63-4223-a48d-d356aa9a2ac7,
    Datacenter: Datacenter [Datacenter: Datacenter:datacenter-26, VirtualCenterHost:
    lvn-dvm-10-161-47-60.dvm.lvn.broadcom.net]]". fault: "(*types.LocalizedMethodFault)(0xc0002b6a00)({\n
    DynamicData: (types.DynamicData) {\n },\n Fault: (*types.CnsFault)(0xc0019af2c0)({\n  MethodFault:
    (types.MethodFault) {\n   FaultCause: (*types.LocalizedMethodFault)(0xc0002b6a40)({\n    DynamicData:
    (types.DynamicData) {\n    },\n    Fault: (*types.NotSupported)(0xc0002b6a80)({\n     RuntimeFault:
    (types.RuntimeFault) {\n      MethodFault: (types.MethodFault) {\n       FaultCause:
    (*types.LocalizedMethodFault)(<nil>),\n       FaultMessage: ([]types.LocalizableMessage)
    (len=1 cap=1) {\n        (types.LocalizableMessage) {\n         DynamicData: (types.DynamicData)
    {\n         },\n         Key: (string) (len=59) \"com.vmware.vim.fcd.error.unsupportedMutuallySharedFcdAttach\",\n         Arg:
    ([]types.KeyAnyValue) (len=1 cap=1) {\n          (types.KeyAnyValue) {\n           DynamicData:
    (types.DynamicData) {\n           },\n           Key: (string) (len=3) \"fcd\",\n           Value:
    (string) (len=36) \"aa4c3b49-7f38-4674-a4d6-599f68062091\"\n          }\n         },\n         Message:
    (string) (len=64) \"Attaching mutually shared fcd disks to same VM is not supported.\"\n        }\n       }\n      }\n     }\n    }),\n    LocalizedMessage:
    (string) (len=45) \"The operation is not supported on the object.\"\n   }),\n   FaultMessage:
    ([]types.LocalizableMessage) <nil>\n  },\n  Reason: (string) (len=16) \"VSLM task
    failed\"\n }),\n LocalizedMessage: (string) (len=32) \"CnsFault error: VSLM task
    failed\"\n})\n". opId: "50d77c7e"'



Finally, in the VM status

root@423d969511ba1a686df8bb373bdb950b [ ~ ]# kubectl get vm -n testns gc-1-worker-phrwr-2sjcp-4gqhd -o yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachine
metadata:
  annotations:
    virtualmachine.vmoperator.vmware.com/first-boot-done: "true"
    vmoperator.vmware.com/bootstrap-hash-configspec: 2e1472b57af294d1
    vmoperator.vmware.com/created-at-build-version: 0.1.0+532f5cc+1.9.0+b391d084+24969740
    vmoperator.vmware.com/created-at-schema-version: v1alpha5
    vmoperator.vmware.com/last-resized-vm-class: '{"name":"best-effort-xsmall","uid":"6c02957a-6a97-42cb-84cf-525c26f46a66","generation":1}'
    vmoperator.vmware.com/manager-id: 4e004326-e4b9-446e-ab09-c15c00ef5920
    vmoperator.vmware.com/upgraded-to-build-version: 0.1.0+532f5cc+1.9.0+b391d084+24969740
    vmoperator.vmware.com/upgraded-to-schema-version: v1alpha5
    vsphere-cluster-module-group: gc-1-workers-0
    vsphere-cluster-module-group-uuid: 5205df03-0f1c-68cf-8e67-f0a0278151dc
    vsphere-tag: WorkerVmVmAATag
  creationTimestamp: "2025-09-23T18:13:11Z"
  finalizers:
  - vmoperator.vmware.com/virtualmachine
  generation: 16
  labels:
    capv.vmware.com/cluster.name: gc-1
    capv.vmware.com/cluster.role: node
    capw.vmware.com/cluster.name: gc-1
    capw.vmware.com/cluster.role: node
    cluster.x-k8s.io/cluster-name: gc-1
    topology.kubernetes.io/zone: domain-c36
  name: gc-1-worker-phrwr-2sjcp-4gqhd
  namespace: testns
  ownerReferences:
  - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: VSphereMachine
    name: gc-1-worker-phrwr-2sjcp-4gqhd
    uid: d43c56c5-b920-4612-98e2-7cf398cbee1e
  resourceVersion: "444794"
  uid: 10f0b748-9e64-49e9-bd46-424c00848355
spec:
  biosUUID: da5f274a-2b63-4223-a48d-d356aa9a2ac7
  bootstrap:
    cloudInit:
      instanceID: da5f274a-2b63-4223-a48d-d356aa9a2ac7
      rawCloudConfig:
        key: user-data
        name: gc-1-worker-phrwr-2sjcp-4gqhd
  className: best-effort-xsmall
  hardware:
    ideControllers:
    - busNumber: 0
    - busNumber: 1
    scsiControllers:
    - busNumber: 0
      pciSlotNumber: 160
      sharingMode: None
      type: ParaVirtual
  image:
    kind: VirtualMachineImage
    name: vmi-163a1a8d6538912f4
  imageName: vmi-163a1a8d6538912f4
  instanceUUID: 2309bc46-757b-4743-8727-e58b891e7207
  network:
    interfaces:
    - name: eth0
      network:
        apiVersion: netoperator.vmware.com/v1alpha1
        kind: Network
        name: primary
  powerOffMode: Hard
  powerState: PoweredOn
  promoteDisksMode: Online
  reserved:
    resourcePolicyName: gc-1
  restartMode: TrySoft
  storageClass: wcpglobal-storage-profile
  suspendMode: TrySoft
  volumes:
  - name: 76498e28-5fb2-4fef-a1a9-352b39f4b919-b0e43909-da05-43bc-b34e-7ea46379200f
    persistentVolumeClaim:
      claimName: 76498e28-5fb2-4fef-a1a9-352b39f4b919-b0e43909-da05-43bc-b34e-7ea46379200f
      controllerType: SCSI
      diskMode: Persistent
  - name: 76498e28-5fb2-4fef-a1a9-352b39f4b919-caabe4b2-af5e-4134-aec5-ce88ba0116fe
    persistentVolumeClaim:
      claimName: 76498e28-5fb2-4fef-a1a9-352b39f4b919-caabe4b2-af5e-4134-aec5-ce88ba0116fe
      controllerType: SCSI
      diskMode: Persistent
status:
  biosUUID: da5f274a-2b63-4223-a48d-d356aa9a2ac7
  changeBlockTracking: false
  class:
    apiVersion: vmoperator.vmware.com/v1alpha5
    kind: VirtualMachineClass
    name: best-effort-xsmall
  conditions:
  - lastTransitionTime: "2025-09-23T18:15:08Z"
    message: ""
    reason: "True"
    status: "True"
    type: GuestCustomization
  - lastTransitionTime: "2025-09-23T18:13:12Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineBootstrapReady
  - lastTransitionTime: "2025-09-23T18:15:02Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineClassConfigurationSynced
  - lastTransitionTime: "2025-09-23T18:13:12Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineClassReady
  - lastTransitionTime: "2025-09-23T18:13:12Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineConditionPlacementReady
  - lastTransitionTime: "2025-09-23T18:13:12Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineConditionVMSetResourcePolicyReady
  - lastTransitionTime: "2025-09-23T18:15:01Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineCreated
  - lastTransitionTime: "2025-09-23T18:05:45Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineImageReady
  - lastTransitionTime: "2025-09-23T18:13:12Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineNetworkReady
  - lastTransitionTime: "2025-09-23T18:15:02Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineReconcileReady
  - lastTransitionTime: "2025-09-23T18:13:12Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineStorageReady
  - lastTransitionTime: "2025-09-23T18:15:36Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineTools
  guest:
    guestFullName: VMware Photon OS (64-bit)
    guestID: vmwarePhoton64Guest
  hardware:
    controllers:
    - busNumber: 0
      type: IDE
    - busNumber: 1
      type: IDE
    cpu:
      total: 2
    memory:
      total: 2048M
  hardwareVersion: 22
  instanceUUID: 2309bc46-757b-4743-8727-e58b891e7207
  network:
    config:
      dns:
        hostName: gc-1-worker-phrwr-2sjcp-4gqhd
        nameservers:
        - 192.19.189.10
        - 192.19.189.20
      interfaces:
      - dns:
          nameservers:
          - 192.19.189.10
          - 192.19.189.20
        ip:
          addresses:
          - 192.168.128.66/16
          gateway4: 192.168.1.1
        name: eth0
    hostName: gc-1-worker-phrwr-2sjcp-4gqhd
    interfaces:
    - deviceKey: 4000
      ip:
        addresses:
        - address: 192.168.128.66
          state: preferred
        - address: fe80::250:56ff:febd:1037
          state: unknown
        macAddr: 00:50:56:bd:10:37
      name: eth0
    ipStacks:
    - dns:
        domainName: .
        hostName: gc-1-worker-phrwr-2sjcp-4gqhd
        nameservers:
        - 192.19.189.10
        - 192.19.189.20
        searchDomains:
        - .
      ipRoutes:
      - gateway:
          address: 192.168.1.1
          device: "0"
        networkAddress: 0.0.0.0/0
      - gateway:
          device: "0"
        networkAddress: 192.168.0.0/16
    primaryIP4: 192.168.128.66
  nodeName: 10.161.40.253
  powerState: PoweredOn
  storage:
    requested:
      disks: 20Gi
    total: "23708692430"
    usage:
      disks: "9280946748"
      other: "2233855950"
  uniqueID: vm-229
  volumes:
  - error: '"Attaching mutually shared fcd disks to same VM is not supported." Failed
      to attach cns volume'
    limit: 1Gi
    name: 76498e28-5fb2-4fef-a1a9-352b39f4b919-caabe4b2-af5e-4134-aec5-ce88ba0116fe
    requested: 1Gi
    type: Managed
  - attached: true
    diskUUID: 6000C291-36ae-b108-fe14-e2a64aac0fdc
    limit: 1Gi
    name: 76498e28-5fb2-4fef-a1a9-352b39f4b919-b0e43909-da05-43bc-b34e-7ea46379200f
    requested: 1Gi
    type: Managed
    used: "1049321"
  - attached: true
    diskUUID: 6000C295-2808-e55c-e249-c7ddcf32b747
    limit: 20Gi
    name: gc-1-worker-phrwr-2sjcp-4gqhd
    requested: 20Gi
    type: Classic
    used: "9280946748"
  zone: domain-c36

```

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
