### PR TITLE
Removing duplicate testcases from EF and CF UTS column

### DIFF
--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -1331,7 +1331,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 	   17. Delete SC and VolumeSnapshotClass
 	*/
 	ginkgo.It("[cf-vks][cf-vanilla-block][block-vanilla-snapshot][tkg-snapshot]"+
-		"[ef-vks-snapshot] Volume snapshot creation and restoration workflow with xfs "+
+		"Volume snapshot creation and restoration workflow with xfs "+
 		"filesystem", ginkgo.Label(p0, block, vanilla, tkg, snapshot, stable, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -177,7 +177,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// 13. delete the pod created in step 10.
 	// 14. delete PVC created in step 2.
 	// 15. delete SC created in step 1.
-	ginkgo.It("[cf-vks][ef-vks] Verify offline expansion triggers FS resize", ginkgo.Label(p0, block, tkg, vc70), func() {
+	ginkgo.It("[cf-vks] Verify offline expansion triggers FS resize", ginkgo.Label(p0, block, tkg, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		// Create a Pod to use this PVC, and verify volume has been attached.

--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 	// Verify volume is detached from VM.
 	// Delete PVC in GC.
 
-	ginkgo.It("[cf-vks][ef-vks] Verify CnsNodeVmAttachements existence in "+
+	ginkgo.It("[cf-vks] Verify CnsNodeVmAttachements existence in "+
 		"a pod lifecycle", ginkgo.Label(p0, block, tkg, vc70), func() {
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 	// Verify volumes are detached from VMs.
 	// Delete PVCs in GC.
 
-	ginkgo.It("[cf-vks][ef-vks] Verify CnsNodeVmAttachements crd existence when pods are created "+
+	ginkgo.It("[cf-vks] Verify CnsNodeVmAttachements crd existence when pods are created "+
 		"concurrently", ginkgo.Label(p0, block, tkg, vc70), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -390,7 +390,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 	// 11- Delete statefulset.
 	// 13- Delete PVCs.
 
-	ginkgo.It("[cf-vks][ef-vks] Detach Statefulset testing with default "+
+	ginkgo.It("[cf-vks] Detach Statefulset testing with default "+
 		"podManagementPolicy", ginkgo.Label(p0, block, tkg, vc70), func() {
 
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -565,7 +565,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 	// Verify Pod is deleted from GC.
 	// Verify volume is detached from VM.
 	// Delete PVC in GC.
-	ginkgo.It("[cf-vks][ef-vks] Create a Pod mounted with multiple PVC", ginkgo.Label(p0, block, tkg, vc70), func() {
+	ginkgo.It("[cf-vks] Create a Pod mounted with multiple PVC", ginkgo.Label(p0, block, tkg, vc70), func() {
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
 		var err error

--- a/tests/e2e/gc_metadata_syncer.go
+++ b/tests/e2e/gc_metadata_syncer.go
@@ -389,7 +389,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 	// 10. Delete PVCs.
 	// 11. Delete SC.
 
-	ginkgo.It("[ef-vks] Statefulset tests with label updates", ginkgo.Label(p1, block, tkg, vc70), func() {
+	ginkgo.It("[cf-vks] Statefulset tests with label updates", ginkgo.Label(p1, block, tkg, vc70), func() {
 		var sc *storagev1.StorageClass
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/gc_metadata_syncer.go
+++ b/tests/e2e/gc_metadata_syncer.go
@@ -389,7 +389,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 	// 10. Delete PVCs.
 	// 11. Delete SC.
 
-	ginkgo.It("[ef-vks][cf-vks] Statefulset tests with label updates", ginkgo.Label(p1, block, tkg, vc70), func() {
+	ginkgo.It("[ef-vks] Statefulset tests with label updates", ginkgo.Label(p1, block, tkg, vc70), func() {
 		var sc *storagev1.StorageClass
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -848,7 +848,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 	// 9. Wait for Pod name to be deleted in CNS.
 	// 10. Delete PVCs.
 
-	ginkgo.It("[cf-vks][ef-vks] Multiple PVCs - Verify Pod Name is updated/deleted "+
+	ginkgo.It("[cf-vks] Multiple PVCs - Verify Pod Name is updated/deleted "+
 		"on CNS", ginkgo.Label(p1, block, tkg, vc70), func() {
 		var sc *storagev1.StorageClass
 		var err error
@@ -1364,7 +1364,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 	//    and PVC in SV.
 	// 19.Delete the corresponding PVC on SV.
 
-	ginkgo.It("[cf-vks][ef-vks] Static provisioning across Guest Clusters.", ginkgo.Label(p1, block, tkg, vc70), func() {
+	ginkgo.It("[cf-vks] Static provisioning across Guest Clusters.", ginkgo.Label(p1, block, tkg, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 

--- a/tests/e2e/raw_block_volume.go
+++ b/tests/e2e/raw_block_volume.go
@@ -198,7 +198,7 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		8. Delete all PVCs from the tests namespace.
 		9. Delete the storage class.
 	*/
-	ginkgo.It("[ef-vanilla-block][cf-vks][csi-block-vanilla][csi-block-vanilla-parallelized][csi-guest][ef-vks] "+
+	ginkgo.It("[ef-vanilla-block][cf-vks][csi-block-vanilla][csi-block-vanilla-parallelized][csi-guest]"+
 		"Statefulset testing with raw block volume and default podManagementPolicy", ginkgo.Label(p0, block, vanilla,
 		tkg, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -416,7 +416,7 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		10. Delete pod.
 		11. Wait for volume to be detached.
 	*/
-	ginkgo.It("[ef-vanilla-block][cf-vks][csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized][ef-vks] "+
+	ginkgo.It("[ef-vanilla-block][cf-vks][csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized]"+
 		"Should create and delete pod with the same raw block volume", ginkgo.Label(p0, block, vanilla, tkg,
 		vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/storagepolicy.go
+++ b/tests/e2e/storagepolicy.go
@@ -90,7 +90,7 @@ var _ = ginkgo.Describe("Storage Policy Based Volume Provisioning", func() {
 	})
 
 	ginkgo.It("[ef-vanilla-block][ef-wcp][cf-vks][csi-block-vanilla] [csi-block-vanilla-parallelized] [csi-supervisor]"+
-		"[csi-guest][ef-vks] Verify dynamic volume provisioning works when storage policy specified "+
+		"[csi-guest] Verify dynamic volume provisioning works when storage policy specified "+
 		"in the storageclass is compliant for shared datastores", func() {
 		storagePolicyNameForSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 		ginkgo.By(fmt.Sprintf("Invoking test for storage policy: %s", storagePolicyNameForSharedDatastores))

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -135,7 +135,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	//    7.	Verify PV entry is deleted from CNS.
 	//    8.	Delete the SC.
 
-	ginkgo.It("[ef-wcp][cf-vks][csi-supervisor] [csi-guest][ef-vks] Verify health annotation added on the pvc is "+
+	ginkgo.It("[ef-wcp][cf-vks][csi-supervisor] [csi-guest] Verify health annotation added on the pvc is "+
 		"accessible", ginkgo.Label(p0, block, wcp, tkg, vc70), func() {
 
 		var storageclass *storagev1.StorageClass
@@ -1122,7 +1122,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 7. Delete PVC from the tests namespace.
 	// 8. Delete the storage class.
 
-	ginkgo.It("[cf-vks][csi-guest] [ef-vks] In Guest Cluster Verify Volume health on "+
+	ginkgo.It("[cf-vks][csi-guest] In Guest Cluster Verify Volume health on "+
 		"Statefulset", ginkgo.Label(p0, block, tkg, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -154,7 +154,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 	// 9. Delete Pod
 	// 10. Delete PVC and SC
 
-	ginkgo.It("[ef-vanilla-block][ef-wcp][cf-vks][csi-block-vanilla][csi-guest][csi-supervisor][ef-vks] Verify impact on "+
+	ginkgo.It("[ef-vanilla-block][ef-wcp][cf-vks][csi-block-vanilla][csi-guest][csi-supervisor] Verify impact on "+
 		"existing pv pvc when sc recreated with different binding mode", ginkgo.Label(p0,
 		block, wcp, tkg, vanilla, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -204,7 +204,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 12. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 13. Delete PVC, PV and Storage Class.
 
-	ginkgo.It("[ef-vanilla-block][cf-vks][csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] [ef-vks] "+
+	ginkgo.It("[ef-vanilla-block][cf-vks][csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized]"+
 		"Verify offline volume expansion workflow with xfs filesystem", ginkgo.Label(p0, block, vanilla, tkg, core,
 		vc70), func() {
 		invokeTestForVolumeExpansionWithFilesystem(f, client, namespace, xfsFSType, xfsFSType, storagePolicyName, profileID)
@@ -222,7 +222,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 6. Verify if the PVC expansion fails.
 
 	ginkgo.It("[cf-vks][csi-block-vanilla] [csi-guest]  [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"[ef-vks] Verify volume expansion not allowed", ginkgo.Label(p2, block, vanilla, tkg, core, vc70), func() {
+		"Verify volume expansion not allowed", ginkgo.Label(p2, block, vanilla, tkg, core, vc70), func() {
 		invokeTestForInvalidVolumeExpansion(f, client, namespace, storagePolicyName, profileID)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR takes care of removing duplicate testcases from EF and CF column.

**Testing done**:
Not required

