### PR TITLE
fix createSnapshotWithTransaction workflow

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -2795,13 +2795,13 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 // This function ensures that no orphaned snapshots are left behind on the vSphere backend
 // in case of failures during the snapshot creation process
 func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volumeID string,
-	snapshotID string, extraParams interface{}) (*CnsSnapshotInfo, string, error) {
+	snapshotName string, extraParams interface{}) (*CnsSnapshotInfo, string, error) {
 	log := logger.GetLogger(ctx)
 	var (
 		// Reference to the CreateSnapshot task on CNS.
 		createSnapshotsTask *object.Task
 		// Name of the CnsVolumeOperationRequest instance.
-		instanceName = snapshotID + "-" + volumeID
+		instanceName = snapshotName + "-" + volumeID
 		// Local instance of CreateSnapshot details that needs to be persisted.
 		volumeOperationDetails *cnsvolumeoperationrequest.VolumeOperationRequestDetails
 		// error
@@ -2809,6 +2809,15 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 		quotaInfo                  *cnsvolumeoperationrequest.QuotaDetails
 		isStorageQuotaM2FSSEnabled bool
 	)
+	// By default, external-snapshotter sets the snapshot name prefix to "snapshot-".
+	// This logic will break if the prefix configuration is changed.
+	// In Supervisor deployments, we assume this configuration remains unchanged by admin/DevOps.
+	// In Vanilla deployments, we publish the deployment manifest with the default configuration to ensure consistency.
+	if !strings.HasPrefix(snapshotName, "snapshot-") {
+		return nil, csifault.CSIInternalFault,
+			logger.LogNewErrorf(log, "invalid snapshotName %q: must start with 'snapshot-'", snapshotName)
+	}
+	snapshotID := strings.TrimPrefix(snapshotName, "snapshot-")
 	if extraParams != nil {
 		createSnapParams, ok := extraParams.(*CreateSnapshotExtraParams)
 		if !ok {
@@ -2888,8 +2897,20 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 			"from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 	}
 	log.Infof("CreateSnapshots: VolumeID: %q, opId: %q", volumeID, createSnapshotsTaskInfo.ActivationId)
-
-	snapshotCreateResult := interface{}(createSnapshotsTaskInfo).(*cnstypes.CnsSnapshotCreateResult)
+	createSnapshotsTaskResult, err := cns.GetTaskResult(ctx, createSnapshotsTaskInfo)
+	if err != nil || createSnapshotsTaskResult == nil {
+		return nil, "", logger.LogNewErrorf(log, "unable to find the task result for CreateSnapshots task: %q "+
+			"from vCenter %q with err: %v", createSnapshotsTaskInfo.Task.Value, m.virtualCenter.Config.Host, err)
+	}
+	snapshotCreateResult, ok := createSnapshotsTaskResult.(*cnstypes.CnsSnapshotCreateResult)
+	if !ok || snapshotCreateResult == nil {
+		return nil, "", logger.LogNewErrorf(log,
+			"invalid task result: got %T with value %+v", createSnapshotsTaskResult, createSnapshotsTaskResult)
+	}
+	if snapshotCreateResult.Fault != nil {
+		return nil, "", logger.LogNewErrorf(log, "failed to create snapshot %q on volume %q with fault: %+v",
+			instanceName, volumeID, snapshotCreateResult.Fault)
+	}
 	cnsSnapshotInfo := &CnsSnapshotInfo{
 		SnapshotID:                          snapshotCreateResult.Snapshot.SnapshotId.Id,
 		SourceVolumeID:                      snapshotCreateResult.Snapshot.VolumeId.Id,
@@ -2947,14 +2968,15 @@ func (m *defaultManager) CreateSnapshot(
 			}
 		}
 		if createSnapParams != nil && createSnapParams.IsCSITransactionSupportEnabled {
-			var snapcontentPrefix = "snapcontent-"
 			cnssnapshotInfo, fault, err := m.createSnapshotWithTransaction(ctx, volumeID,
-				strings.TrimPrefix(snapshotName, snapcontentPrefix), extraParams)
+				snapshotName, extraParams)
 			if err != nil {
 				if IsNotSupportedFaultType(ctx, fault) {
 					log.Infof("Creating Snapshot with Transaction is not supported. " +
 						"Re-creating Snapshot without setting Snapshot ID in the spec")
 					return m.createSnapshotWithImprovedIdempotencyCheck(ctx, volumeID, snapshotName, extraParams)
+				} else {
+					return nil, logger.LogNewErrorf(log, "failed to create snapshot. error :%+v", err)
 				}
 			}
 			return cnssnapshotInfo, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes issues in the createSnapshotWithTransaction function of the Volume Manager to properly handle CnsFault.
Previously, when a fault was returned, the function could trigger a panic.

Additionally, this PR ensures that the correct SnapshotID is supplied. The backend requires snapshot IDs in a strict UUID format. Earlier, the driver was sending IDs with the snapshot- prefix, which led to CnsFault errors.


**Testing done**:
Verified replacing image on the setup causing CNSFault while creating VolumeSnapshot.
Driver does not go into CLBO.

Log for handing CNSFault
----
> {"level":"info","time":"2025-09-23T01:02:32.57972566Z","caller":"volume/manager.go:2890","msg":"CreateSnapshots: VolumeID: \"6887ff91-bc23-4604-b2fa-8f99db861280\", opId: \"cd0965be\"","TraceId":"b2718a51-5031-44af-89e7-ffde8d2e2f8b"}
{"level":"error","time":"2025-09-23T01:02:32.579857253Z","caller":"volume/manager.go:2902","msg":"failed to create snapshot \"snapshot-65a47191-a2d4-4b45-beb1-31d265d84236-6887ff91-bc23-4604-b2fa-8f99db861280\" on volume \"6887ff91-bc23-4604-b2fa-8f99db861280\" with fault: &{DynamicData:{} Fault:0xc000bc3680 LocalizedMessage:CnsFault error: VSLM task failed}","TraceId":"b2718a51-5031-44af-89e7-ffde8d2e2f8b","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume.(*defaultManager).createSnapshotWithTransaction\n\t/build/pkg/common/cns-lib/volume/manager.go:2902\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume.(*defaultManager).CreateSnapshot.func1\n\t/build/pkg/common/cns-lib/volume/manager.go:2963\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume.(*defaultManager).CreateSnapshot\n\t/build/pkg/common/cns-lib/volume/manager.go:2982\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common.CreateSnapshotUtil\n\t/build/pkg/csi/service/common/vsphereutil.go:1193\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateSnapshot.func1\n\t/build/pkg/csi/service/wcp/controller.go:2448\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateSnapshot\n\t/build/pkg/csi/service/wcp/controller.go:2521\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_CreateSnapshot_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.11.0/lib/go/csi/csi_grpc.pb.go:588\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.68.1/server.go:1394\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.68.1/server.go:1805\ngoogle.golang.org/grpc.(*Server).serveStreams.func2.1\n\t/go/pkg/mod/google.golang.org/grpc@v1.68.1/server.go:1029"}


Verified Creating VolumeSnapshot using transaction by supplying UID of VolumeSnapshot object as SnapShotID


```
# kubectl get vs -n transaction-support-ns -o json
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "snapshot.storage.k8s.io/v1",
            "kind": "VolumeSnapshot",
            "metadata": {
                "annotations": {
                    "csi.vsphere.volume/snapshot": "d4b7435f-6375-438d-8e6c-8bbd2159d196+f53860fd-248b-4808-b1bc-b4795aa824a5"
                },
                "creationTimestamp": "2025-09-23T11:11:28Z",
                "finalizers": [
                    "snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection",
                    "snapshot.storage.kubernetes.io/volumesnapshot-bound-protection"
                ],
                "generation": 1,
                "name": "test-snapshot",
                "namespace": "transaction-support-ns",
                "resourceVersion": "940268",
                "uid": "f53860fd-248b-4808-b1bc-b4795aa824a5"
            },
            "spec": {
                "source": {
                    "persistentVolumeClaimName": "pvc-xlsb7"
                },
                "volumeSnapshotClassName": "volumesnapshotclass-delete"
            },
            "status": {
                "boundVolumeSnapshotContentName": "snapcontent-f53860fd-248b-4808-b1bc-b4795aa824a5",
                "creationTime": "2025-09-23T11:11:29Z",
                "readyToUse": true,
                "restoreSize": "10Gi"
            }
        }
    ],
    "kind": "List",
    "metadata": {
        "resourceVersion": ""
    }
}


# kubectl get volumesnapshotcontent -n transaction-support-ns -o json
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "snapshot.storage.k8s.io/v1",
            "kind": "VolumeSnapshotContent",
            "metadata": {
                "creationTimestamp": "2025-09-23T11:11:29Z",
                "finalizers": [
                    "snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection"
                ],
                "generation": 1,
                "name": "snapcontent-f53860fd-248b-4808-b1bc-b4795aa824a5",
                "resourceVersion": "940266",
                "uid": "cc520d21-ef11-431a-a9be-052684a0520c"
            },
            "spec": {
                "deletionPolicy": "Delete",
                "driver": "csi.vsphere.vmware.com",
                "source": {
                    "volumeHandle": "d4b7435f-6375-438d-8e6c-8bbd2159d196"
                },
                "sourceVolumeMode": "Filesystem",
                "volumeSnapshotClassName": "volumesnapshotclass-delete",
                "volumeSnapshotRef": {
                    "apiVersion": "snapshot.storage.k8s.io/v1",
                    "kind": "VolumeSnapshot",
                    "name": "test-snapshot",
                    "namespace": "transaction-support-ns",
                    "resourceVersion": "940238",
                    "uid": "f53860fd-248b-4808-b1bc-b4795aa824a5"
                }
            },
            "status": {
                "creationTime": 1758625889685324000,
                "readyToUse": true,
                "restoreSize": 10737418240,
                "snapshotHandle": "d4b7435f-6375-438d-8e6c-8bbd2159d196+f53860fd-248b-4808-b1bc-b4795aa824a5"
            }
        }
    ],
    "kind": "List",
    "metadata": {
        "resourceVersion": ""
    }
}

```




**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix createSnapshotWithTransaction workflow
```
