### PR TITLE
Allow devops users to attach GC RWX file volume with VM service VMs

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -732,6 +732,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfileaccessconfigs"]
     verbs: ["get", "list", "update"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -737,6 +737,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfileaccessconfigs"]
     verbs: ["get", "list", "update"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -737,6 +737,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfileaccessconfigs"]
     verbs: ["get", "list", "update"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -737,6 +737,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfileaccessconfigs"]
     verbs: ["get", "list", "update"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
@@ -108,8 +108,23 @@ func cnsFileAccessConfigAlreadyExists(ctx context.Context, clientConfig *rest.Co
 		return "", err
 	}
 
+	// Obtain VM's UID.
+	vmUID, err := getVmUID(ctx, vm, namespace)
+	if err != nil {
+		log.Errorf("failed to get VM UID for VM %s. Err: %s", vm, err)
+		return "", err
+	}
+
+	// Obtain PVC's UID
+	pvcUID, err := getPVCUID(ctx, pvc, namespace)
+	if err != nil {
+		log.Errorf("failed to get PVC UID for PVC %s. Err: %s", pvc, err)
+		return "", err
+	}
+
 	// List only that CnsFileAccessConfig CRs which has the same VM name and PVC name labels.
-	labelSelector := labels.SelectorFromSet(labels.Set{vmNameLabelKey: vm, pvcNameLabelKey: pvc})
+	labelSelector := labels.SelectorFromSet(labels.Set{vmUIDLabelKey: vmUID, pvcUIDLabelKey: pvcUID})
+
 	// Get the list of all CnsFileAccessConfig CRs in the given namespace.
 	cnsFileAccessConfigList := &cnsfileaccessconfigv1alpha1.CnsFileAccessConfigList{}
 	err = cnsOperatorClient.List(ctx, cnsFileAccessConfigList, &client.ListOptions{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently we block attaching a a guest RWX volume's SV PVC to a VM service VM. There is a use case where it may be required.

So this change removes that restriction.

Also, this change changes the logic where both PVC and VM labels were being added to the CnsFileAccessConfig CR.
Instead of the name of the PVC or VM, we are now adding the UID so that it is more scalable.

**Testing done**:
Tested the following combinations of VM and PVC:
1. SV pvc with SV VM

```
Name:         sv-pvc-sv-vm
Namespace:    test-gc-e2e-demo-ns
Labels:       cns.vmware.com/pvc-uid=837df32b-3afc-45c3-aa4e-1e99ab157b79
              cns.vmware.com/user-created=true
              cns.vmware.com/vm-uid=17616e70-9698-4e64-80a0-932b5fef56c0
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2025-09-25T18:37:50Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Owner References:
    API Version:           vmoperator.vmware.com/v1alpha5
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  VirtualMachine
    Name:                  vm-gc-1
    UID:                   17616e70-9698-4e64-80a0-932b5fef56c0
  Resource Version:        893893
  UID:                     991d11a5-d9f5-41d5-b03b-f1ed86320758
Spec:
  Pvc Name:  rwm-pvc-gc
  Vm Name:   vm-gc-1
Status:
  Access Points:
    NFSv3:    host12.cibgst.com:/5232dc7b-0c0e-d8b6-7e84-cc621bf6f45c
    NFSv4.1:  host10.cibgst.com:/vsanfs/5232dc7b-0c0e-d8b6-7e84-cc621bf6f45c
  Done:       true
Events:
  Type     Reason                        Age   From            Message
  ----     ------                        ----  ----            -------
  Normal   CnsFileAccessConfigSucceeded  58s   cns.vmware.com  Successfully configured access points of VM: "vm-gc-1" on the volume: "rwm-pvc-gc"
```

2. GC PVC with GC VM (no labels added)

```
Name:         test-cluster-e2e-script-node-pool-1-qtjqg-r2p7r-jvbd2-ce016c89-f854-479a-b782-256cd9627b87-29c313df-bb92-42e2-aabd-c0fe9f1d6935
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2025-09-25T18:47:57Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Owner References:
    API Version:           vmoperator.vmware.com/v1alpha5
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  VirtualMachine
    Name:                  test-cluster-e2e-script-node-pool-1-qtjqg-r2p7r-jvbd2
    UID:                   39416de2-6d2c-4553-bfc2-c85ca6579531
  Resource Version:        900285
  UID:                     c5527b34-a239-4add-ba82-7427ae1378a2
Spec:
  Pvc Name:  ce016c89-f854-479a-b782-256cd9627b87-29c313df-bb92-42e2-aabd-c0fe9f1d6935
  Vm Name:   test-cluster-e2e-script-node-pool-1-qtjqg-r2p7r-jvbd2
Status:
  Access Points:
    NFSv3:    host10.cibgst.com:/520c8704-47bc-8b94-1b29-479329cce5e4
    NFSv4.1:  host10.cibgst.com:/vsanfs/520c8704-47bc-8b94-1b29-479329cce5e4
  Done:       true
Events:
  Type    Reason                        Age   From            Message
  ----    ------                        ----  ----            -------
  Normal  CnsFileAccessConfigSucceeded  29s   cns.vmware.com  Successfully configured access points of VM: "test-cluster-e2e-script-node-pool-1-qtjqg-r2p7r-jvbd2" on the volume: "ce016c89-f854-479a-b782-256cd9627b87-29c313df-bb92-42e2-aabd-c0fe9f1d6935"
```


3. GC PVC with SV VM

```
Name:         gc-pvc-sv-vm
Namespace:    test-gc-e2e-demo-ns
Labels:       cns.vmware.com/pvc-uid=c3d58fba-5236-44ce-9df6-931106d509c9
              cns.vmware.com/user-created=true
              cns.vmware.com/vm-uid=17616e70-9698-4e64-80a0-932b5fef56c0
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2025-09-25T18:40:57Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Owner References:
    API Version:           vmoperator.vmware.com/v1alpha5
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  VirtualMachine
    Name:                  vm-gc-1
    UID:                   17616e70-9698-4e64-80a0-932b5fef56c0
  Resource Version:        895858
  UID:                     816a201d-4d91-48c3-8ed3-412a206c880e
Spec:
  Pvc Name:  ce016c89-f854-479a-b782-256cd9627b87-2c0bfa50-7077-41b8-8c2c-b9bcdbb87fc9
  Vm Name:   vm-gc-1
Status:
  Access Points:
    NFSv3:    host13.cibgst.com:/52970ebf-05f6-8221-2b28-97805df78675
    NFSv4.1:  host10.cibgst.com:/vsanfs/52970ebf-05f6-8221-2b28-97805df78675
  Done:       true
Events:
  Type    Reason                        Age   From            Message
  ----    ------                        ----  ----            -------
  Normal  CnsFileAccessConfigSucceeded  11s   cns.vmware.com  Successfully configured access points of VM: "vm-gc-1" on the volume: "ce016c89-f854-479a-b782-256cd9627b87-2c0bfa50-7077-41b8-8c2c-b9bcdbb87fc9"
```

4. SV PVC with GC VM (failed as expected)

```
Name:         sv-pvc-gc-vm
Namespace:    test-gc-e2e-demo-ns
Labels:       cns.vmware.com/pvc-uid=33cec02a-add4-4def-b4cf-b7c2c6824989
              cns.vmware.com/user-created=true
              cns.vmware.com/vm-uid=4b1579dd-7b98-4006-9cc4-235dee5d9f12
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2025-09-25T18:45:00Z
  Generation:          2
  Resource Version:    898301
  UID:                 bd8442bf-4912-42cd-8b7f-405710a53457
Spec:
  Pvc Name:  rwm-pvc-gc-2
  Vm Name:   test-cluster-e2e-script-b9kcb-4hpfv
Status:
  Error:  CnsFileAccessConfig is created by devops user and has TKG VM test-cluster-e2e-script-b9kcb-4hpfv. Invalid combination.
Events:
  Type     Reason                     Age               From            Message
  ----     ------                     ----              ----            -------
  Warning  CnsFileAccessConfigFailed  7s (x5 over 20s)  cns.vmware.com  CnsFileAccessConfig is created by devops user and has TKG VM test-cluster-e2e-script-b9kcb-4hpfv. Invalid combination.
```
5. Tried created a CnsFileAccessConfig CR with the same VM and PVC and it failed:

```
root@420fe5a752cfe1034e7f80d586f417a8 [ ~ ]# k apply -f cfc.yaml 
Error from server: error when creating "cfc.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: CnsFileAccessConfig sv-pvc-sv-vm already exists for VM vm-gc-1 and PVC rwm-pvc-gc
```

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/388/
GC precheckin:  https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/428/