### PR TITLE
Added wait time befoew querrying vm images

### DIFF
--- a/tests/e2e/vmservice_utils.go
+++ b/tests/e2e/vmservice_utils.go
@@ -361,6 +361,7 @@ func invokeVCRestAPIDeleteRequest(vcRestSessionId string, url string) ([]byte, i
 // waitNGetVmiForImageName waits and fetches VM image CR for given image name in the specified namespace
 func waitNGetVmiForImageName(ctx context.Context, c ctlrclient.Client, imageName string) string {
 	vmi := ""
+	time.Sleep(pollTimeoutShort)
 	err := wait.PollUntilContextTimeout(ctx, poll*5, pollTimeout, true,
 		func(ctx context.Context) (bool, error) {
 			vmImagesList := &vmopv1.VirtualMachineImageList{}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: To avoid failure due to infra slowness.
Added Wait time before quarrying images

**Testing done**:
Not need only added wait in the  waitNGetVmiForImageName

