### PR TITLE
Remove snapshot vmservice test from cf

### DIFF
--- a/tests/e2e/snapshot_vmservice_vm.go
+++ b/tests/e2e/snapshot_vmservice_vm.go
@@ -198,7 +198,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   11. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("[cf-wcp] Taking snapshot of a vm service vm attached to a dynamic "+
+	ginkgo.It("[cf-wcp-f] Taking snapshot of a vm service vm attached to a dynamic "+
 		"volume", ginkgo.Label(p0, block, wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Remove "Taking snapshot of a vm service vm attached to a dynamic Test" from CF

**Testing done**:
Not required only label update

