### PR TITLE
Remove validations for batch attach

### DIFF
--- a/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
+++ b/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
@@ -29,6 +29,9 @@ const (
 	IndependentPersistent DiskMode = "independent_persistent"
 	// Changes are immediately and permanently written to the virtual disk.
 	Persistent DiskMode = "persistent"
+	// Changes to virtual disk are made to a redo log and discarded at power off.
+	// It is not affected by snapshots.
+	IndependentNonPersistent = "independent_nonpersistent"
 )
 
 // The sharing mode of the virtual disk.

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -516,16 +516,6 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			"failed to get vCenter from Manager. Error: %v", err)
 	}
 
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
-		common.SharedDiskFss) && isSharedRawBlockRequest(ctx, req.VolumeCapabilities) {
-		log.Infof("Volume request is for shared RWX volume. Validatig if policy is compatible for VMFS datastores.")
-		err := validateStoragePolicyForVmfs(ctx, vc, storagePolicyID)
-		if err != nil {
-			log.Errorf("failed validation for policy %s", storagePolicyID)
-			return nil, csifault.CSIInternalFault, err
-		}
-	}
-
 	// Fetch the accessibility requirements from the request.
 	topologyRequirement = req.GetAccessibilityRequirements()
 	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -50,12 +50,6 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
 )
 
-var (
-	vmfsNamespace         = "com.vmware.storage.volumeallocation"
-	vmfsNamespaceEztValue = "Fully initialized"
-	vmfsClusteredVmdk     = "Clustered"
-)
-
 // validateCreateBlockReqParam is a helper function used to validate the parameter
 // name received in the CreateVolume request for block volumes on WCP CSI driver.
 // Returns true if the parameter name is valid, false otherwise.
@@ -90,64 +84,6 @@ func validateCreateFileReqParam(paramName, value string) bool {
 		paramName == common.AttributePvcNamespace ||
 		paramName == common.AttributeStorageClassName ||
 		paramName == common.AttributeIsLinkedCloneKey
-}
-
-// verifyStoragePolicyForVmfsUtil goes through each rule in the policy to
-// find out if it is fully intialized and has clustered VMDK enabled for VMFS datastores.
-// This check is required for RWX shared block volumes as for VMFS, the policy must be EZT
-// and clustered.
-func verifyStoragePolicyForVmfsUtil(ctx context.Context,
-	spbmPolicyContentList []vsphere.SpbmPolicyContent,
-	storagePolicyId string) error {
-	log := logger.GetLogger(ctx)
-
-	isEzt := false
-	isClustered := false
-	isVmfsNamespace := false
-
-	for _, polictContent := range spbmPolicyContentList {
-		for _, profile := range polictContent.Profiles {
-			for _, rule := range profile.Rules {
-				if rule.Ns == vmfsNamespace {
-					isVmfsNamespace = true
-					switch rule.Value {
-					case vmfsNamespaceEztValue:
-						isEzt = true
-					case vmfsClusteredVmdk:
-						isClustered = true
-					}
-				}
-			}
-		}
-	}
-
-	// If any policy is for VMFS and it is not EZT or clustered, then send back error.
-	if isVmfsNamespace && (!isEzt || !isClustered) {
-		msg := fmt.Sprintf("Policy %s is for VMFS datastores. "+
-			"It must be fully initialized and must have clustered VMDK enabled for "+
-			"RWX block volumes", storagePolicyId)
-		err := errors.New(msg)
-		log.Errorf(msg)
-		return err
-	}
-
-	log.Debugf("Policy %s validated correctly", storagePolicyId)
-	return nil
-}
-
-// validateStoragePolicyForVmfs checks whether the policy is compatible for VMFS datastores.
-// This function is only called for RWX shared block volumes.
-func validateStoragePolicyForVmfs(ctx context.Context,
-	vc *vsphere.VirtualCenter, storagePolicyId string) error {
-	log := logger.GetLogger(ctx)
-
-	spbmPolicyContentList, err := vc.PbmRetrieveContent(ctx, []string{storagePolicyId})
-	if err != nil {
-		log.Errorf("failed to retrieve policy %s", storagePolicyId)
-		return err
-	}
-
-	return verifyStoragePolicyForVmfsUtil(ctx, spbmPolicyContentList, storagePolicyId)
 }
 
 // validateWCPCreateVolumeRequest is the helper function to validate

--- a/pkg/csi/service/wcp/controller_helper_test.go
+++ b/pkg/csi/service/wcp/controller_helper_test.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -131,95 +130,6 @@ func TestGetPodVMUUID(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "mock-vm-uuid", vmUUID)
 	})
-}
-
-func TestVerifyStoragePolicyForVmfsUtil(t *testing.T) {
-	ctx := context.TODO()
-	policyId := "policy-123"
-
-	tests := []struct {
-		name        string
-		input       []cnsvsphere.SpbmPolicyContent
-		expectError bool
-	}{
-		{
-			name: "Valid VMFS policy with EZT and Clustered VMDK",
-			input: []cnsvsphere.SpbmPolicyContent{
-				{
-					Profiles: []cnsvsphere.SpbmPolicySubProfile{
-						{
-							Rules: []cnsvsphere.SpbmPolicyRule{
-								{Ns: vmfsNamespace, Value: vmfsNamespaceEztValue},
-								{Ns: vmfsNamespace, Value: vmfsClusteredVmdk},
-							},
-						},
-					},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "VMFS policy missing EZT",
-			input: []cnsvsphere.SpbmPolicyContent{
-				{
-					Profiles: []cnsvsphere.SpbmPolicySubProfile{
-						{
-							Rules: []cnsvsphere.SpbmPolicyRule{
-								{Ns: vmfsNamespace, Value: vmfsClusteredVmdk},
-							},
-						},
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "VMFS policy missing Clustered VMDK",
-			input: []cnsvsphere.SpbmPolicyContent{
-				{
-					Profiles: []cnsvsphere.SpbmPolicySubProfile{
-						{
-							Rules: []cnsvsphere.SpbmPolicyRule{
-								{Ns: vmfsNamespace, Value: vmfsNamespaceEztValue},
-							},
-						},
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "Non-VMFS policy should pass",
-			input: []cnsvsphere.SpbmPolicyContent{
-				{
-					Profiles: []cnsvsphere.SpbmPolicySubProfile{
-						{
-							Rules: []cnsvsphere.SpbmPolicyRule{
-								{Ns: "non-vmfs", Value: "some-value"},
-							},
-						},
-					},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name:        "Empty policy list should pass",
-			input:       []cnsvsphere.SpbmPolicyContent{},
-			expectError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := verifyStoragePolicyForVmfsUtil(ctx, tt.input, policyId)
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
 }
 
 func newMockPod(name, namespace, nodeName string, volumes []string,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove all validations for batch attach volumes as it will be taken care of by VMop and we want to allow all combinations for attach.

**Testing done**:

1. Was able to create an RWX shared block PVC with VMFS policy which does not have have EZT capability.
2. Verified that CSI is not throwing an error when using RWX volume persistent diskMode and RWO with independent_persistent mode. But since CNS is still blocking it, I am not able to get a successful attach.