### PR TITLE
Fix CnsVolumeOperationRequest update logic when transaction support is enabled

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -2910,6 +2910,14 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 		faultType := ExtractFaultTypeFromErr(ctx, err)
 		return nil, faultType, logger.LogNewErrorf(log, "failed to create snapshot with error: %v", err)
 	}
+	// Persist the volume operation details.
+	volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, quotaInfo,
+		volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
+		createSnapshotsTask.Reference().Value, "", "", taskInvocationStatusInProgress, "")
+	if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
+		// Don't return if CreateSnapshot details can't be stored.
+		log.Warnf("failed to store CreateSnapshot details with error: %v", err)
+	}
 
 	var createSnapshotsTaskInfo *vim25types.TaskInfo
 	var faultType string

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest_test.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest_test.go
@@ -1,0 +1,667 @@
+package cnsvolumeoperationrequest
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	cnsvolumeoprequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
+)
+
+// setupTestEnvironment creates a test environment with fake clients
+func setupTestEnvironment(t *testing.T, csiTransactionEnabled bool) (*operationRequestStore, context.Context) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	err := cnsvolumeoprequestv1alpha1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("Failed to add scheme: %v", err)
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+
+	store := &operationRequestStore{
+		k8sclient: fakeClient,
+	}
+
+	// Set global variables
+	csiNamespace = "vmware-system-csi"
+	isCSITransactionSupportEnabled = csiTransactionEnabled
+
+	return store, ctx
+}
+
+// createTestVolumeOperationDetails creates a test VolumeOperationRequestDetails
+func createTestVolumeOperationDetails(name, volumeID, snapshotID, taskID, taskStatus, errorMsg string,
+	quotaDetails *QuotaDetails) *VolumeOperationRequestDetails {
+	return &VolumeOperationRequestDetails{
+		Name:         name,
+		VolumeID:     volumeID,
+		SnapshotID:   snapshotID,
+		QuotaDetails: quotaDetails,
+		OperationDetails: &OperationDetails{
+			TaskInvocationTimestamp: metav1.Now(),
+			TaskID:                  taskID,
+			TaskStatus:              taskStatus,
+			Error:                   errorMsg,
+		},
+	}
+}
+
+// createTestQuotaDetails creates test quota details
+func createTestQuotaDetails(reservedBytes int64) *QuotaDetails {
+	return &QuotaDetails{
+		Reserved:         resource.NewQuantity(reservedBytes, resource.BinarySI),
+		StoragePolicyId:  "test-policy-id",
+		StorageClassName: "test-storage-class",
+		Namespace:        "test-namespace",
+	}
+}
+
+// getCRDDirectly retrieves the full CnsVolumeOperationRequest CRD to access all operation details
+func getCRDDirectly(ctx context.Context, store *operationRequestStore,
+	instanceName string) (*cnsvolumeoprequestv1alpha1.CnsVolumeOperationRequest, error) {
+	instance := &cnsvolumeoprequestv1alpha1.CnsVolumeOperationRequest{}
+	err := store.k8sclient.Get(ctx, client.ObjectKey{Name: instanceName, Namespace: csiNamespace}, instance)
+	return instance, err
+}
+
+// TestStoreRequestDetails_CreateSnapshotWithImprovedIdempotencyCheck tests the pattern used in
+// createSnapshotWithImprovedIdempotencyCheck
+// Pattern: Single StoreRequestDetails call at the end with final status (Success/Error)
+func TestStoreRequestDetails_CreateSnapshotWithImprovedIdempotencyCheck(t *testing.T) {
+	store, ctx := setupTestEnvironment(t, false) // CSI Transaction Support disabled
+
+	testCases := []struct {
+		name         string
+		instanceName string
+		volumeID     string
+		snapshotID   string
+		taskID       string
+		taskStatus   string
+		errorMsg     string
+		quotaDetails *QuotaDetails
+		expectError  bool
+	}{
+		{
+			name:         "successful snapshot creation",
+			instanceName: "snapshot-test-volume-123",
+			volumeID:     "volume-123",
+			snapshotID:   "snapshot-456",
+			taskID:       "task-789",
+			taskStatus:   TaskInvocationStatusSuccess,
+			errorMsg:     "",
+			quotaDetails: createTestQuotaDetails(1024 * 1024 * 1024), // 1GB
+			expectError:  false,
+		},
+		{
+			name:         "failed snapshot creation",
+			instanceName: "snapshot-test-volume-456",
+			volumeID:     "volume-456",
+			snapshotID:   "",
+			taskID:       "task-101",
+			taskStatus:   TaskInvocationStatusError,
+			errorMsg:     "CNS CreateSnapshot failed",
+			quotaDetails: createTestQuotaDetails(2 * 1024 * 1024 * 1024), // 2GB
+			expectError:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create operation details
+			operationDetails := createTestVolumeOperationDetails(
+				tc.instanceName, tc.volumeID, tc.snapshotID, tc.taskID, tc.taskStatus, tc.errorMsg, tc.quotaDetails)
+
+			// Store the details (simulating the single call at the end of createSnapshotWithImprovedIdempotencyCheck)
+			err := store.StoreRequestDetails(ctx, operationDetails)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify the stored details
+			retrievedDetails, err := store.GetRequestDetails(ctx, tc.instanceName)
+			if err != nil {
+				t.Errorf("Failed to retrieve details: %v", err)
+				return
+			}
+			if retrievedDetails == nil {
+				t.Error("Retrieved details should not be nil")
+				return
+			}
+
+			// Verify the operation details
+			if retrievedDetails.OperationDetails.TaskStatus != tc.taskStatus {
+				t.Errorf("Expected TaskStatus %s, got %s", tc.taskStatus, retrievedDetails.OperationDetails.TaskStatus)
+			}
+			if retrievedDetails.OperationDetails.TaskID != tc.taskID {
+				t.Errorf("Expected TaskID %s, got %s", tc.taskID, retrievedDetails.OperationDetails.TaskID)
+			}
+			if retrievedDetails.OperationDetails.Error != tc.errorMsg {
+				t.Errorf("Expected Error %s, got %s", tc.errorMsg, retrievedDetails.OperationDetails.Error)
+			}
+
+			// Note: QuotaDetails are only returned by GetRequestDetails when isPodVMOnStretchSupervisorFSSEnabled is true
+			// Since we're not setting that flag in our test setup, we don't verify quota details here
+			// The important thing is that StoreRequestDetails succeeded without error
+		})
+	}
+}
+
+// TestStoreRequestDetails_CreateSnapshotWithTransaction tests the pattern used in createSnapshotWithTransaction
+// Pattern: 1) Initial call with empty TaskID, 2) Update with actual TaskID, 3) Defer call with final status
+func TestStoreRequestDetails_CreateSnapshotWithTransaction(t *testing.T) {
+	store, ctx := setupTestEnvironment(t, true) // CSI Transaction Support enabled
+
+	t.Run("successful transaction flow", func(t *testing.T) {
+		instanceName := "snapshot-test-volume-transaction"
+		volumeID := "volume-transaction-123"
+		quotaDetails := createTestQuotaDetails(1024 * 1024 * 1024) // 1GB
+
+		// Step 1: Initial call with empty TaskID (InProgress)
+		initialDetails := createTestVolumeOperationDetails(
+			instanceName, volumeID, "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+		err := store.StoreRequestDetails(ctx, initialDetails)
+		if err != nil {
+			t.Errorf("Failed to store initial details: %v", err)
+			return
+		}
+
+		// Verify initial state
+		retrievedDetails, err := store.GetRequestDetails(ctx, instanceName)
+		if err != nil {
+			t.Errorf("Failed to retrieve initial details: %v", err)
+			return
+		}
+		if retrievedDetails.OperationDetails.TaskStatus != TaskInvocationStatusInProgress {
+			t.Errorf("Expected TaskStatus %s, got %s", TaskInvocationStatusInProgress,
+				retrievedDetails.OperationDetails.TaskStatus)
+		}
+		if retrievedDetails.OperationDetails.TaskID != "" {
+			t.Errorf("Expected empty TaskID, got %s", retrievedDetails.OperationDetails.TaskID)
+		}
+
+		// Step 2: Update with actual TaskID (still InProgress)
+		taskID := "task-transaction-456"
+		updatedDetails := createTestVolumeOperationDetails(
+			instanceName, volumeID, "", taskID, TaskInvocationStatusInProgress, "", quotaDetails)
+		updatedDetails.OperationDetails.TaskInvocationTimestamp = initialDetails.OperationDetails.TaskInvocationTimestamp
+
+		err = store.StoreRequestDetails(ctx, updatedDetails)
+		if err != nil {
+			t.Errorf("Failed to store updated details: %v", err)
+			return
+		}
+
+		// Verify TaskID was updated
+		retrievedDetails, err = store.GetRequestDetails(ctx, instanceName)
+		if err != nil {
+			t.Errorf("Failed to retrieve updated details: %v", err)
+			return
+		}
+		if retrievedDetails.OperationDetails.TaskStatus != TaskInvocationStatusInProgress {
+			t.Errorf("Expected TaskStatus %s, got %s", TaskInvocationStatusInProgress,
+				retrievedDetails.OperationDetails.TaskStatus)
+		}
+		if retrievedDetails.OperationDetails.TaskID != taskID {
+			t.Errorf("Expected TaskID %s, got %s", taskID, retrievedDetails.OperationDetails.TaskID)
+		}
+
+		// Step 3: Final call with success status (defer function)
+		snapshotID := "snapshot-transaction-789"
+		finalDetails := createTestVolumeOperationDetails(
+			instanceName, volumeID, snapshotID, taskID, TaskInvocationStatusSuccess, "", quotaDetails)
+		finalDetails.OperationDetails.TaskInvocationTimestamp = initialDetails.OperationDetails.TaskInvocationTimestamp
+
+		err = store.StoreRequestDetails(ctx, finalDetails)
+		if err != nil {
+			t.Errorf("Failed to store final details: %v", err)
+			return
+		}
+
+		// Verify final state
+		retrievedDetails, err = store.GetRequestDetails(ctx, instanceName)
+		if err != nil {
+			t.Errorf("Failed to retrieve final details: %v", err)
+			return
+		}
+		if retrievedDetails.OperationDetails.TaskStatus != TaskInvocationStatusSuccess {
+			t.Errorf("Expected TaskStatus %s, got %s", TaskInvocationStatusSuccess, retrievedDetails.OperationDetails.TaskStatus)
+		}
+		if retrievedDetails.OperationDetails.TaskID != taskID {
+			t.Errorf("Expected TaskID %s, got %s", taskID, retrievedDetails.OperationDetails.TaskID)
+		}
+		if retrievedDetails.SnapshotID != snapshotID {
+			t.Errorf("Expected SnapshotID %s, got %s", snapshotID, retrievedDetails.SnapshotID)
+		}
+	})
+}
+
+// TestStoreRequestDetails_RetryDetectionAndTrackingAborted tests the retry detection logic
+// when CSI Transaction Support is enabled
+func TestStoreRequestDetails_RetryDetectionAndTrackingAborted(t *testing.T) {
+	store, ctx := setupTestEnvironment(t, true) // CSI Transaction Support enabled
+
+	t.Run("basic retry detection test", func(t *testing.T) {
+		instanceName := "snapshot-retry-test"
+		volumeID := "volume-retry-123"
+		quotaDetails := createTestQuotaDetails(1024 * 1024 * 1024) // 1GB
+
+		// Step 1: First attempt - initial call with empty TaskID
+		firstAttempt := createTestVolumeOperationDetails(
+			instanceName, volumeID, "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+		err := store.StoreRequestDetails(ctx, firstAttempt)
+		if err != nil {
+			t.Errorf("Failed to store first attempt: %v", err)
+			return
+		}
+
+		// Step 2: First attempt - update with TaskID
+		firstTaskID := "task-first-attempt-456"
+		firstTaskUpdate := createTestVolumeOperationDetails(
+			instanceName, volumeID, "", firstTaskID, TaskInvocationStatusInProgress, "", quotaDetails)
+		firstTaskUpdate.OperationDetails.TaskInvocationTimestamp = firstAttempt.OperationDetails.TaskInvocationTimestamp
+
+		err = store.StoreRequestDetails(ctx, firstTaskUpdate)
+		if err != nil {
+			t.Errorf("Failed to store first task update: %v", err)
+			return
+		}
+
+		// Simulate crash/restart - driver restarts and retries
+		// Step 3: Retry attempt - new initial call with empty TaskID (this should trigger retry detection)
+		retryAttempt := createTestVolumeOperationDetails(
+			instanceName, volumeID, "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+		err = store.StoreRequestDetails(ctx, retryAttempt)
+		if err != nil {
+			t.Errorf("Failed to store retry attempt: %v", err)
+			return
+		}
+
+		// The retry detection logic should have marked previous InProgress entries as TrackingAborted
+		// We can verify this worked by checking that the operation was stored successfully
+		retrievedDetails, err := store.GetRequestDetails(ctx, instanceName)
+		if err != nil {
+			t.Errorf("Failed to retrieve details after retry: %v", err)
+			return
+		}
+
+		// The latest operation should be the retry attempt
+		if retrievedDetails.OperationDetails.TaskStatus != TaskInvocationStatusInProgress {
+			t.Errorf("Expected TaskStatus %s, got %s", TaskInvocationStatusInProgress,
+				retrievedDetails.OperationDetails.TaskStatus)
+		}
+		if retrievedDetails.OperationDetails.TaskID != "" {
+			t.Errorf("Expected empty TaskID for retry attempt, got %s", retrievedDetails.OperationDetails.TaskID)
+		}
+	})
+
+	t.Run("no retry detection when CSI Transaction Support is disabled", func(t *testing.T) {
+		// Create a new store with CSI Transaction Support disabled
+		storeDisabled, ctx := setupTestEnvironment(t, false)
+
+		instanceName := "snapshot-no-retry-detection"
+		volumeID := "volume-no-retry-456"
+		quotaDetails := createTestQuotaDetails(512 * 1024 * 1024) // 512MB
+
+		// Step 1: First attempt
+		firstAttempt := createTestVolumeOperationDetails(
+			instanceName, volumeID, "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+		err := storeDisabled.StoreRequestDetails(ctx, firstAttempt)
+		if err != nil {
+			t.Errorf("Failed to store first attempt: %v", err)
+			return
+		}
+
+		// Step 2: Update with TaskID
+		taskID := "task-no-retry-789"
+		taskUpdate := createTestVolumeOperationDetails(
+			instanceName, volumeID, "", taskID, TaskInvocationStatusInProgress, "", quotaDetails)
+		taskUpdate.OperationDetails.TaskInvocationTimestamp = firstAttempt.OperationDetails.TaskInvocationTimestamp
+
+		err = storeDisabled.StoreRequestDetails(ctx, taskUpdate)
+		if err != nil {
+			t.Errorf("Failed to store task update: %v", err)
+			return
+		}
+
+		// Step 3: "Retry" attempt (should not trigger retry detection)
+		retryAttempt := createTestVolumeOperationDetails(
+			instanceName, volumeID, "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+		err = storeDisabled.StoreRequestDetails(ctx, retryAttempt)
+		if err != nil {
+			t.Errorf("Failed to store retry attempt: %v", err)
+			return
+		}
+
+		// Verify that the operation was stored (no retry detection should have occurred)
+		retrievedDetails, err := storeDisabled.GetRequestDetails(ctx, instanceName)
+		if err != nil {
+			t.Errorf("Failed to retrieve details: %v", err)
+			return
+		}
+
+		// Should have the latest operation details
+		if retrievedDetails.OperationDetails.TaskStatus != TaskInvocationStatusInProgress {
+			t.Errorf("Expected TaskStatus %s, got %s", TaskInvocationStatusInProgress,
+				retrievedDetails.OperationDetails.TaskStatus)
+		}
+	})
+}
+
+// TestStoreRequestDetails_RealWorkflowTransitions tests real workflow scenarios with multiple InProgress entries
+// leading to final Success or Error states, simulating actual driver behavior patterns
+func TestStoreRequestDetails_RealWorkflowTransitions(t *testing.T) {
+	store, ctx := setupTestEnvironment(t, true) // CSI Transaction Support enabled
+
+	t.Run("complete snapshot workflow with multiple retries and final success (CSI transactions enabled)",
+		func(t *testing.T) {
+			instanceName := "snapshot-workflow-success"
+			volumeID := "volume-workflow-123"
+			quotaDetails := createTestQuotaDetails(1024 * 1024 * 1024) // 1GB - testing quota integration
+
+			// === First Attempt (fails during task execution) ===
+			// Step 1: Initial InProgress with empty TaskID
+			attempt1Initial := createTestVolumeOperationDetails(
+				instanceName, volumeID, "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+			err := store.StoreRequestDetails(ctx, attempt1Initial)
+			if err != nil {
+				t.Errorf("Failed to store attempt 1 initial: %v", err)
+				return
+			}
+
+			// Step 2: Update with TaskID (still InProgress)
+			attempt1TaskID := "task-attempt1-456"
+			attempt1WithTask := createTestVolumeOperationDetails(
+				instanceName, volumeID, "", attempt1TaskID, TaskInvocationStatusInProgress, "", quotaDetails)
+			attempt1WithTask.OperationDetails.TaskInvocationTimestamp = attempt1Initial.OperationDetails.TaskInvocationTimestamp
+
+			err = store.StoreRequestDetails(ctx, attempt1WithTask)
+			if err != nil {
+				t.Errorf("Failed to store attempt 1 with task: %v", err)
+				return
+			}
+
+			// === Simulate crash during waitOnTask - first attempt never completes ===
+			// The first attempt remains InProgress with TaskID, then driver crashes/restarts
+
+			// === Second Attempt (driver restart/retry) ===
+			// Step 3: New retry attempt (should trigger TrackingAborted for any remaining InProgress)
+			attempt2Initial := createTestVolumeOperationDetails(
+				instanceName, volumeID, "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+			err = store.StoreRequestDetails(ctx, attempt2Initial)
+			if err != nil {
+				t.Errorf("Failed to store attempt 2 initial: %v", err)
+				return
+			}
+
+			// Step 4: Second attempt gets TaskID
+			attempt2TaskID := "task-attempt2-789"
+			attempt2WithTask := createTestVolumeOperationDetails(
+				instanceName, volumeID, "", attempt2TaskID, TaskInvocationStatusInProgress, "", quotaDetails)
+			attempt2WithTask.OperationDetails.TaskInvocationTimestamp = attempt2Initial.OperationDetails.TaskInvocationTimestamp
+
+			err = store.StoreRequestDetails(ctx, attempt2WithTask)
+			if err != nil {
+				t.Errorf("Failed to store attempt 2 with task: %v", err)
+				return
+			}
+
+			// Verify that previous InProgress operations were marked as TrackingAborted
+			crdInstance, err := getCRDDirectly(ctx, store, instanceName)
+			if err != nil {
+				t.Errorf("Failed to get CRD directly: %v", err)
+				return
+			}
+
+			// Check FirstOperationDetails for TrackingAborted
+			if crdInstance.Status.FirstOperationDetails.TaskStatus != TaskInvocationStatusTrackingAborted {
+				t.Errorf("Expected FirstOperationDetails TaskStatus to be %s, got %s",
+					TaskInvocationStatusTrackingAborted, crdInstance.Status.FirstOperationDetails.TaskStatus)
+			}
+
+			// Check LatestOperationDetails for TrackingAborted entries
+			trackingAbortedCount := 0
+			inProgressCount := 0
+			for _, detail := range crdInstance.Status.LatestOperationDetails {
+				if detail.TaskStatus == TaskInvocationStatusTrackingAborted {
+					trackingAbortedCount++
+					if detail.Error != "Operation tracking aborted due to retry attempt" {
+						t.Errorf("Expected TrackingAborted error message, got: %s", detail.Error)
+					}
+				} else if detail.TaskStatus == TaskInvocationStatusInProgress {
+					inProgressCount++
+				}
+			}
+
+			if trackingAbortedCount == 0 {
+				t.Error("Expected at least one TrackingAborted entry in LatestOperationDetails")
+			}
+			if inProgressCount == 0 {
+				t.Error("Expected at least one InProgress entry in LatestOperationDetails")
+			}
+
+			t.Logf("Found %d TrackingAborted and %d InProgress entries in LatestOperationDetails",
+				trackingAbortedCount, inProgressCount)
+
+			// Step 5: Second attempt succeeds
+			snapshotID := "snapshot-success-101"
+			attempt2Success := createTestVolumeOperationDetails(
+				instanceName, volumeID, snapshotID, attempt2TaskID, TaskInvocationStatusSuccess, "", quotaDetails)
+			attempt2Success.OperationDetails.TaskInvocationTimestamp = attempt2Initial.OperationDetails.TaskInvocationTimestamp
+
+			err = store.StoreRequestDetails(ctx, attempt2Success)
+			if err != nil {
+				t.Errorf("Failed to store attempt 2 success: %v", err)
+				return
+			}
+
+			// Verify final state
+			retrievedDetails, err := store.GetRequestDetails(ctx, instanceName)
+			if err != nil {
+				t.Errorf("Failed to retrieve final details: %v", err)
+				return
+			}
+
+			// Should have the successful operation as the latest
+			if retrievedDetails.OperationDetails.TaskStatus != TaskInvocationStatusSuccess {
+				t.Errorf("Expected final TaskStatus %s, got %s", TaskInvocationStatusSuccess,
+					retrievedDetails.OperationDetails.TaskStatus)
+			}
+			if retrievedDetails.OperationDetails.TaskID != attempt2TaskID {
+				t.Errorf("Expected final TaskID %s, got %s", attempt2TaskID, retrievedDetails.OperationDetails.TaskID)
+			}
+			if retrievedDetails.SnapshotID != snapshotID {
+				t.Errorf("Expected SnapshotID %s, got %s", snapshotID, retrievedDetails.SnapshotID)
+			}
+		})
+
+	t.Run("volume creation workflow with crash during waitOnTask and final error (CSI transactions enabled)",
+		func(t *testing.T) {
+			instanceName := "volume-workflow-error"
+			quotaDetails := createTestQuotaDetails(2 * 1024 * 1024 * 1024) // 2GB
+
+			// === First Attempt ===
+			// Step 1: Initial InProgress (before CNS call)
+			attempt1Initial := createTestVolumeOperationDetails(
+				instanceName, "", "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+			err := store.StoreRequestDetails(ctx, attempt1Initial)
+			if err != nil {
+				t.Errorf("Failed to store attempt 1 initial: %v", err)
+				return
+			}
+
+			// Step 2: CNS task created, update with TaskID
+			attempt1TaskID := "task-volume-create-123"
+			attempt1WithTask := createTestVolumeOperationDetails(
+				instanceName, "", "", attempt1TaskID, TaskInvocationStatusInProgress, "", quotaDetails)
+			attempt1WithTask.OperationDetails.TaskInvocationTimestamp = attempt1Initial.OperationDetails.TaskInvocationTimestamp
+
+			err = store.StoreRequestDetails(ctx, attempt1WithTask)
+			if err != nil {
+				t.Errorf("Failed to store attempt 1 with task: %v", err)
+				return
+			}
+
+			// === Simulate crash during waitOnTask - driver restarts ===
+			// Step 3: Retry attempt (should mark previous InProgress as TrackingAborted)
+			attempt2Initial := createTestVolumeOperationDetails(
+				instanceName, "", "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+			err = store.StoreRequestDetails(ctx, attempt2Initial)
+			if err != nil {
+				t.Errorf("Failed to store attempt 2 initial: %v", err)
+				return
+			}
+
+			// Step 4: Second attempt gets new TaskID
+			attempt2TaskID := "task-volume-create-456"
+			attempt2WithTask := createTestVolumeOperationDetails(
+				instanceName, "", "", attempt2TaskID, TaskInvocationStatusInProgress, "", quotaDetails)
+			attempt2WithTask.OperationDetails.TaskInvocationTimestamp = attempt2Initial.OperationDetails.TaskInvocationTimestamp
+
+			err = store.StoreRequestDetails(ctx, attempt2WithTask)
+			if err != nil {
+				t.Errorf("Failed to store attempt 2 with task: %v", err)
+				return
+			}
+
+			// Verify TrackingAborted status after retry detection
+			crdInstance, err := getCRDDirectly(ctx, store, instanceName)
+			if err != nil {
+				t.Errorf("Failed to get CRD directly: %v", err)
+				return
+			}
+
+			// Should have TrackingAborted entries from the first attempt
+			trackingAbortedCount := 0
+			for _, detail := range crdInstance.Status.LatestOperationDetails {
+				if detail.TaskStatus == TaskInvocationStatusTrackingAborted {
+					trackingAbortedCount++
+				}
+			}
+
+			if trackingAbortedCount == 0 {
+				t.Error("Expected TrackingAborted entries after retry detection")
+			}
+
+			t.Logf("Volume workflow: Found %d TrackingAborted entries after retry", trackingAbortedCount)
+
+			// Step 5: Second attempt also fails with error
+			errorMsg := "CNS CreateVolume failed: datastore out of space"
+			attempt2Error := createTestVolumeOperationDetails(
+				instanceName, "", "", attempt2TaskID, TaskInvocationStatusError, errorMsg, quotaDetails)
+			attempt2Error.OperationDetails.TaskInvocationTimestamp = attempt2Initial.OperationDetails.TaskInvocationTimestamp
+
+			err = store.StoreRequestDetails(ctx, attempt2Error)
+			if err != nil {
+				t.Errorf("Failed to store attempt 2 error: %v", err)
+				return
+			}
+
+			// Verify final error state
+			retrievedDetails, err := store.GetRequestDetails(ctx, instanceName)
+			if err != nil {
+				t.Errorf("Failed to retrieve final details: %v", err)
+				return
+			}
+
+			if retrievedDetails.OperationDetails.TaskStatus != TaskInvocationStatusError {
+				t.Errorf("Expected final TaskStatus %s, got %s", TaskInvocationStatusError,
+					retrievedDetails.OperationDetails.TaskStatus)
+			}
+			if retrievedDetails.OperationDetails.TaskID != attempt2TaskID {
+				t.Errorf("Expected final TaskID %s, got %s", attempt2TaskID, retrievedDetails.OperationDetails.TaskID)
+			}
+			if retrievedDetails.OperationDetails.Error != errorMsg {
+				t.Errorf("Expected error message %s, got %s", errorMsg, retrievedDetails.OperationDetails.Error)
+			}
+		})
+
+	t.Run("multiple rapid retries with variable quota (CSI transactions enabled)", func(t *testing.T) {
+		instanceName := "rapid-retries-workflow"
+		volumeID := "volume-rapid-789"
+
+		// Test multiple rapid retries with different quota sizes
+		for i := 1; i <= 3; i++ {
+			// Each attempt has different quota size
+			quotaDetails := createTestQuotaDetails(int64(i * 512 * 1024 * 1024)) // Variable quota sizes
+
+			// Initial InProgress
+			initialDetails := createTestVolumeOperationDetails(
+				instanceName, volumeID, "", "", TaskInvocationStatusInProgress, "", quotaDetails)
+
+			err := store.StoreRequestDetails(ctx, initialDetails)
+			if err != nil {
+				t.Errorf("Failed to store attempt %d initial: %v", i, err)
+				return
+			}
+
+			// Update with TaskID
+			taskID := "task-rapid-" + string(rune('0'+i))
+			taskDetails := createTestVolumeOperationDetails(
+				instanceName, volumeID, "", taskID, TaskInvocationStatusInProgress, "", quotaDetails)
+			taskDetails.OperationDetails.TaskInvocationTimestamp = initialDetails.OperationDetails.TaskInvocationTimestamp
+
+			err = store.StoreRequestDetails(ctx, taskDetails)
+			if err != nil {
+				t.Errorf("Failed to store attempt %d with task: %v", i, err)
+				return
+			}
+
+			// Only the last attempt succeeds
+			if i == 3 {
+				snapshotID := "snapshot-rapid-final"
+				successDetails := createTestVolumeOperationDetails(
+					instanceName, volumeID, snapshotID, taskID, TaskInvocationStatusSuccess, "", quotaDetails)
+				successDetails.OperationDetails.TaskInvocationTimestamp = initialDetails.OperationDetails.TaskInvocationTimestamp
+
+				err = store.StoreRequestDetails(ctx, successDetails)
+				if err != nil {
+					t.Errorf("Failed to store attempt %d success: %v", i, err)
+					return
+				}
+			}
+		}
+
+		// Verify final successful state
+		retrievedDetails, err := store.GetRequestDetails(ctx, instanceName)
+		if err != nil {
+			t.Errorf("Failed to retrieve final details: %v", err)
+			return
+		}
+
+		if retrievedDetails.OperationDetails.TaskStatus != TaskInvocationStatusSuccess {
+			t.Errorf("Expected final TaskStatus %s, got %s", TaskInvocationStatusSuccess,
+				retrievedDetails.OperationDetails.TaskStatus)
+		}
+		if retrievedDetails.OperationDetails.TaskID != "task-rapid-3" {
+			t.Errorf("Expected final TaskID %s, got %s", "task-rapid-3", retrievedDetails.OperationDetails.TaskID)
+		}
+		if retrievedDetails.SnapshotID != "snapshot-rapid-final" {
+			t.Errorf("Expected SnapshotID %s, got %s", "snapshot-rapid-final", retrievedDetails.SnapshotID)
+		}
+	})
+}

--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -35,6 +35,10 @@ const (
 	TaskInvocationStatusSuccess = "Success"
 	// TaskInvocationStatusPartiallyFailed represents a task thats status is PartiallyFailed.
 	TaskInvocationStatusPartiallyFailed = "PartiallyFailed"
+	// TaskInvocationStatusTrackingAborted represents a task thats status is TrackingAborted.
+	// This status appears when CSI Transaction Support is enabled and the task was never seen to
+	// completion or error, and a retry was initiated.
+	TaskInvocationStatusTrackingAborted = "TrackingAborted"
 )
 
 // VolumeOperationRequestDetails stores details about a single operation

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -51,6 +51,9 @@ import (
 	ccV1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	apiutils "sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	cr_log "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/go-logr/zapr"
 
 	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	storagev1 "k8s.io/api/storage/v1"
@@ -217,6 +220,9 @@ func NewSupervisorSnapshotClient(ctx context.Context, config *restclient.Config)
 func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName string) (client.Client, error) {
 	var err error
 	log := logger.GetLogger(ctx)
+
+	// Initialize controller-runtime logger to prevent log.SetLogger warning
+	cr_log.SetLogger(zapr.NewLogger(log.Desugar()))
 
 	scheme := runtime.NewScheme()
 	switch groupName {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements retry detection and TrackingAborted status handling for CnsVolumeOperationRequest when CSI Transaction Support is enabled. It addresses quota leakage issues that occur when the driver crashes during operations and retries are initiated, leading to multiple quota reservations increment

- Skip SPU reservation increments when syncing: prevent incrementing SPU reservation when the objects are initially syncing on startup
- Retry Detection Logic: When CSI Transaction Support is enabled and a new InProgress operation with empty TaskID is stored, the system now marks any existing InProgress entries as TrackingAborted to indicate they were abandoned due to retry attempts.
- TrackingAborted Status: Introduced a new task status TaskInvocationStatusTrackingAborted to track operations that were never seen to completion due to driver crashes/restarts.
- Quota Leak Prevention: Modified cnsvolumeoperationrequestCRAdded in metadatasyncer to prevent multiple quota increments when CSI Transaction Support is enabled and multiple operation details exist (indicating retries).
- Set up controller runtime logging earlier
- Delete snapshot specified the vmware-system-csi namespace in the quota, fixed this.

CSI Transaction Support Plumbing: Added proper plumbing to pass the isCSITransactionSupportEnabled flag through InitVolumeOperationRequestInterface to all relevant components.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Precheckins:
WCP:(Passed) https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/423/
TKG: (Passed) https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/449/
Vanilla: (Passed) https://jenkins-vcf-csifvt.devops.broadcom.net/view/lvn-csi-e2e-pre-check-in/job/block-vanilla-e2e-pre-checkin/118/

```
Create Volume 
{"level":"info","time":"2025-09-30T05:19:08.105956503Z","caller":"volume/manager.go:726","msg":"QuotaInfo during CreateVolume call: {Reserved:1Gi StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad StorageClassName:vsan-default-storage-policy Namespace:testns Ag
gregatedSnapshotSize:<nil> SnapshotLatestOperationCompleteTime:0001-01-01 00:00:00 +0000 UTC}","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:08.69161379Z","caller":"volume/listview.go:200","msg":"AddTask called for Task:task-1047","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:08.705048736Z","caller":"volume/listview.go:218","msg":"client is valid. trying to add task to listview object","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:08.717954636Z","caller":"volume/listview.go:241","msg":"task Task:task-1047 added to listView","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:08.719355284Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-1047 Task:Task:task-1047 Description:<nil> Name: Descri
ptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc000ad5350 QueueTime:2025-09-30 05:19:09.062354 +0000
UTC StartTime:2025-09-30 05:19:09.086326 +0000 UTC CompleteTime:<nil> EventChainId:13523 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:9674c475}}","TraceId":"e4baaca9-3cd7-4946-ad5d-30f86f498e01"}
{"level":"info","time":"2025-09-30T05:19:56.807783917Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-1047 Task:Task:task-1047 Description:<nil> Name: Descri
ptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc000d333f0 QueueTime:2025-09-30 05:19:09.062354 +0000
UTC StartTime:2025-09-30 05:19:09.086326 +0000 UTC CompleteTime:<nil> EventChainId:13523 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:9674c475}}","TraceId":"e4baaca9-3cd7-4946-ad5d-30f86f498e01"}
{"level":"info","time":"2025-09-30T05:19:56.962347882Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-1047 Task:Task:task-1047 Description:<nil> Name: Descri
ptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:success Cancelled:false Cancelable:false Error:<nil> Result:{DynamicData:{} VolumeResults:[0xc0009efe40]} Progress:0 ProgressDetails:[] Reason:0xc0006e2c20 Que
ueTime:2025-09-30 05:19:09.062354 +0000 UTC StartTime:2025-09-30 05:19:09.086326 +0000 UTC CompleteTime:2025-09-30 05:19:57.790368 +0000 UTC EventChainId:13523 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:9674c475}}","TraceId":"e4baaca9-3cd7-4946-ad5d-30f8
6f498e01"}
{"level":"info","time":"2025-09-30T05:19:56.96978273Z","caller":"volume/listview.go:267","msg":"client is valid. trying to remove task from listview object","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:56.977662957Z","caller":"volume/listview.go:273","msg":"task Task:task-1047 removed from listView","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:56.977901966Z","caller":"volume/manager.go:468","msg":"CreateVolume: VolumeName: \"pvc-21068b2d-4dd7-4306-bea2-8b8a083f6e42\", opId: \"9674c475\"","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:56.988992416Z","caller":"volume/util.go:362","msg":"Volume created successfully. VolumeName: \"pvc-21068b2d-4dd7-4306-bea2-8b8a083f6e42\", volumeID: \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\"","TraceId":"8fbd32da-b2a3-4dde-8
f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:56.98916542Z","caller":"volume/manager.go:757","msg":"Setting the reserved field for VolumeOperationDetails instance pvc-21068b2d-4dd7-4306-bea2-8b8a083f6e42 to 0","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:57.063825728Z","caller":"k8sorchestrator/topology.go:1586","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:az1]]","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:57.064294556Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:205","msg":"creating cnsvolumeinfo for volumeID: \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\", StoragePolicyID: \"aa6d5a82-1c88-45da-85d3-3d74b91a5bad\", StorageCl
assName: \"vsan-default-storage-policy\", vCenter: \"lvn-dvm-10-161-22-255.dvm.lvn.broadcom.net\", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} in the namespace: \"vmware-system-csi\"","TraceId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:57.104837051Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:235","msg":"Successfully created CNSVolumeInfo CR for volumeID: \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\" ,StoragePolicyID: \"aa6d5a82-1c88-45da-85d3-3d74b91a5b
ad\",StorageClassName: \"vsan-default-storage-policy\", vCenter: \"lvn-dvm-10-161-22-255.dvm.lvn.broadcom.net\", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} mapping in the namespace: \"vmware-system-csi\". IsLinkedClone: false","Trac
eId":"8fbd32da-b2a3-4dde-8f68-0e8eb5cee0c4"}
{"level":"info","time":"2025-09-30T05:19:57.104975963Z","caller":"wcp/controller.go:1675","msg":"Volume created successfully. Volume Handle: \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\", PV Name: \"pvc-21068b2d-4dd7-4306-bea2-8b8a083f6e42\"","TraceId":"8fbd32da-b2a3-
4dde-8f68-0e8eb5cee0c4"}


Create Snapshot:
{"level":"info","time":"2025-09-30T05:30:16.120155517Z","caller":"wcp/controller.go:2402","msg":"WCP CreateSnapshot: called with args source_volume_id:\"21068b2d-4dd7-4306-bea2-8b8a083f6e42\"  name:\"snapshot-fa9ba6ed-7204-4340-86c4-b7aa34351277\"  parameters:{key:\"csi.storage.k8s.io/volumesnapshot/name\"  value:\"vs-1\"}  parameters:{key:\"csi.storage.k8s.io/volumesnapshot/namespace\"  value:\"testns\"}  parameters:{key:\"csi.storage.k8s.io/volumesnapshotcontent/name\"  value:\"snapcontent-fa9ba6ed-7204-4340-86c4-b7aa34351277\"}","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:16.122571492Z","caller":"utils/utils.go:305","msg":"Invoking QueryAllVolumeUtil with Filter: {DynamicData:{} VolumeIds:[{DynamicData:{} Id:21068b2d-4dd7-4306-bea2-8b8a083f6e42}] Names:[] ContainerClusterIds:[] StoragePolicyId: Datastores:[] Labels:[] ComplianceStatus: DatastoreAccessibilityStatus: Cursor:<nil> HealthStatus:}, Selection: {DynamicData:{} Names:[BACKING_OBJECT_DETAILS VOLUME_TYPE DATASTORE_URL]}","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:16.148845902Z","caller":"utils/utils.go:312","msg":"Number of results from QueryAllVolumeUtil: 1","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:16.160952626Z","caller":"volume/manager.go:2868","msg":"QuotaInfo during CreateSnapshot call: {Reserved:1Gi StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad StorageClassName:vsan-default-storage-policy Namespace:testns AggregatedSnapshotSize:<nil> SnapshotLatestOperationCompleteTime:0001-01-01 00:00:00 +0000 UTC}","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:16.226206574Z","caller":"volume/util.go:439","msg":"Calling CnsClient.CreateSnapshots: VolumeID [\"21068b2d-4dd7-4306-bea2-8b8a083f6e42\"] Description [\"snapshot-fa9ba6ed-7204-4340-86c4-b7aa34351277-21068b2d-4dd7-4306-bea2-8b8a083f6e42\"] cnsSnapshotCreateSpecList [[]types.CnsSnapshotCreateSpec{types.CnsSnapshotCreateSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"21068b2d-4dd7-4306-bea2-8b8a083f6e42\"}, Description:\"snapshot-fa9ba6ed-7204-4340-86c4-b7aa34351277-21068b2d-4dd7-4306-bea2-8b8a083f6e42\", SnapshotId:(*types.CnsSnapshotId)(0xc000297160)}}]","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:16.694637793Z","caller":"volume/listview.go:200","msg":"AddTask called for Task:task-1057","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:16.703565536Z","caller":"volume/listview.go:218","msg":"client is valid. trying to add task to listview object","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:16.70974462Z","caller":"volume/listview.go:241","msg":"task Task:task-1057 added to listView","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:16.711696584Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-1057 Task:Task:task-1057 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createsnapshot Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc0008025b0 QueueTime:2025-09-30 05:30:17.0971 +0000 UTC StartTime:2025-09-30 05:30:17.128272 +0000 UTC CompleteTime:<nil> EventChainId:13553 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:9674c836}}","TraceId":"e4baaca9-3cd7-4946-ad5d-30f86f498e01"}
{"level":"info","time":"2025-09-30T05:30:25.754689901Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-1057 Task:Task:task-1057 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createsnapshot Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc000d32010 QueueTime:2025-09-30 05:30:17.0971 +0000 UTC StartTime:2025-09-30 05:30:17.128272 +0000 UTC CompleteTime:<nil> EventChainId:13553 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:9674c836}}","TraceId":"e4baaca9-3cd7-4946-ad5d-30f86f498e01"}
{"level":"info","time":"2025-09-30T05:30:25.771236336Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-1057 Task:Task:task-1057 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createsnapshot Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc000802010 QueueTime:2025-09-30 05:30:17.0971 +0000 UTC StartTime:2025-09-30 05:30:17.128272 +0000 UTC CompleteTime:<nil> EventChainId:13553 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:9674c836}}","TraceId":"e4baaca9-3cd7-4946-ad5d-30f86f498e01"}
{"level":"info","time":"2025-09-30T05:30:30.191329662Z","caller":"volume/listview.go:410","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-1057 Task:Task:task-1057 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createsnapshot Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:success Cancelled:false Cancelable:false Error:<nil> Result:{DynamicData:{} VolumeResults:[0xc0004211f0]} Progress:0 ProgressDetails:[] Reason:0xc00082f070 QueueTime:2025-09-30 05:30:17.0971 +0000 UTC StartTime:2025-09-30 05:30:17.128272 +0000 UTC CompleteTime:2025-09-30 05:30:31.025276 +0000 UTC EventChainId:13553 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:9674c836}}","TraceId":"e4baaca9-3cd7-4946-ad5d-30f86f498e01"}
{"level":"info","time":"2025-09-30T05:30:30.199299678Z","caller":"volume/listview.go:267","msg":"client is valid. trying to remove task from listview object","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.205804749Z","caller":"volume/listview.go:273","msg":"task Task:task-1057 removed from listView","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.206376267Z","caller":"volume/manager.go:2938","msg":"CreateSnapshots: VolumeID: \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\", opId: \"9674c836\"","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.206532114Z","caller":"volume/manager.go:2960","msg":"For volumeID \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\" new AggregatedSnapshotSize is 1 and SnapshotLatestOperationCompleteTime is \"2025-09-30 05:30:31.025276 +0000 UTC\"","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.206832053Z","caller":"volume/manager.go:2967","msg":"Update quotainfo on successful snapshot \"fa9ba6ed-7204-4340-86c4-b7aa34351277\" creation for volume \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\": {Reserved:1Gi StoragePolicyId:aa6d5a82-1c88-45da-85d3-3d74b91a5bad StorageClassName:vsan-default-storage-policy Namespace:testns AggregatedSnapshotSize:1Mi SnapshotLatestOperationCompleteTime:2025-09-30 05:30:31.025276 +0000 UTC}","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.206938614Z","caller":"volume/manager.go:2976","msg":"CreateSnapshot: Snapshot created successfully. VolumeID: \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\", SnapshotID: \"fa9ba6ed-7204-4340-86c4-b7aa34351277\", SnapshotCreateTime: \"2025-09-30 05:30:31.025276 +0000 UTC\", opId: \"9674c836\"","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.207032357Z","caller":"volume/manager.go:2889","msg":"Setting the reserved field for VolumeOperationDetails instance snapshot-fa9ba6ed-7204-4340-86c4-b7aa34351277-21068b2d-4dd7-4306-bea2-8b8a083f6e42 to 0","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.250759879Z","caller":"common/util.go:472","msg":"retrieved aggregated snapshot capacity 1 for volume \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\"","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.296168879Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:305","msg":"attempt: 1, Successfully patched the cnsvolumeinfo \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\" namespace \"vmware-system-csi\"","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.297859349Z","caller":"wcp/controller.go:2486","msg":"successfully updated aggregated snapshot capacity: 1 for volume \"21068b2d-4dd7-4306-bea2-8b8a083f6e42\" and snapshot \"21068b2d-4dd7-4306-bea2-8b8a083f6e42+fa9ba6ed-7204-4340-86c4-b7aa34351277\"","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}
{"level":"info","time":"2025-09-30T05:30:30.300083122Z","caller":"wcp/controller.go:2507","msg":"CreateSnapshot succeeded for snapshot 21068b2d-4dd7-4306-bea2-8b8a083f6e42+fa9ba6ed-7204-4340-86c4-b7aa34351277 on volume 21068b2d-4dd7-4306-bea2-8b8a083f6e42 size 1073741824 Time proto seconds:1759210231  nanos:25276000 Timestamp 2025-09-30 05:30:31.025276 +0000 UTC Response: snapshot:{size_bytes:1073741824  snapshot_id:\"21068b2d-4dd7-4306-bea2-8b8a083f6e42+fa9ba6ed-7204-4340-86c4-b7aa34351277\"  source_volume_id:\"21068b2d-4dd7-4306-bea2-8b8a083f6e42\"  creation_time:{seconds:1759210231  nanos:25276000}  ready_to_use:true}","TraceId":"649c58bc-73d4-42e2-8ec2-62ffc4678b7b"}


root@42068e6d563fc16a07d910f7d367a1be [ ~ ]# kubectl -n vmware-system-csi get cnsvolumeoperationrequests.cns.vmware.com -oyaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsVolumeOperationRequest
  metadata:
    creationTimestamp: "2025-09-30T05:19:08Z"
    generation: 3
    name: pvc-21068b2d-4dd7-4306-bea2-8b8a083f6e42
    namespace: vmware-system-csi
    resourceVersion: "602915"
    uid: 88b51487-f036-410d-ab30-d14db44a0dcb
  spec:
    name: pvc-21068b2d-4dd7-4306-bea2-8b8a083f6e42
  status:
    firstOperationDetails:
      opId: 9674c475
      taskId: task-1047
      taskInvocationTimestamp: "2025-09-30T05:19:08Z"
      taskStatus: Success
    latestOperationDetails:
    - opId: 9674c475
      taskId: task-1047
      taskInvocationTimestamp: "2025-09-30T05:19:08Z"
      taskStatus: Success
    quotaDetails:
      namespace: testns
      reserved: "0"
      storageClassName: vsan-default-storage-policy
      storagePolicyId: aa6d5a82-1c88-45da-85d3-3d74b91a5bad
    volumeID: 21068b2d-4dd7-4306-bea2-8b8a083f6e42
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsVolumeOperationRequest
  metadata:
    creationTimestamp: "2025-09-30T05:30:16Z"
    generation: 3
    name: snapshot-fa9ba6ed-7204-4340-86c4-b7aa34351277-21068b2d-4dd7-4306-bea2-8b8a083f6e42
    namespace: vmware-system-csi
    resourceVersion: "609374"
    uid: ff9bc89c-06f7-4466-b821-9231e9589f86
  spec:
    name: snapshot-fa9ba6ed-7204-4340-86c4-b7aa34351277-21068b2d-4dd7-4306-bea2-8b8a083f6e42
  status:
    firstOperationDetails:
      opId: 9674c836
      taskId: task-1057
      taskInvocationTimestamp: "2025-09-30T05:30:16Z"
      taskStatus: Success
    latestOperationDetails:
    - opId: 9674c836
      taskId: task-1057
      taskInvocationTimestamp: "2025-09-30T05:30:16Z"
      taskStatus: Success
    quotaDetails:
      aggregatedsnapshotsize: 1Mi
      namespace: testns
      reserved: "0"
      snapshotlatestoperationcompletetime: "2025-09-30T05:30:31Z"
      storageClassName: vsan-default-storage-policy
      storagePolicyId: aa6d5a82-1c88-45da-85d3-3d74b91a5bad
    snapshotID: fa9ba6ed-7204-4340-86c4-b7aa34351277
    volumeID: 21068b2d-4dd7-4306-bea2-8b8a083f6e42
kind: List
metadata:
  resourceVersion: ""
```

**Special notes for your reviewer**:

**Release note**:
```release-note
```
