### PR TITLE
Add file share export paths to volume attributes so that CSI provisioner can add them as PVC annotations

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -144,8 +144,17 @@ const (
 	// UnknownVolumeType is assigned to CNS volumes whose type couldn't be determined.
 	UnknownVolumeType = "UNKNOWN"
 
+	// Nfsv3AccessPointKey is the key for NFSv3 access point.
+	Nfsv3AccessPointKey = "NFSv3"
+
 	// Nfsv4AccessPointKey is the key for NFSv4 access point.
 	Nfsv4AccessPointKey = "NFSv4.1"
+
+	// Nfsv3ExportPathAnnotationKey specifies the NFSv3 export path annotation key on PVC
+	Nfsv3ExportPathAnnotationKey = "csi.vsphere.exportpath.nfs3"
+
+	// Nfsv4ExportPathAnnotationKey specifies the NFSv4.1 export path annotation key on PVC
+	Nfsv4ExportPathAnnotationKey = "csi.vsphere.exportpath.nfs41"
 
 	// Nfsv4AccessPoint is the access point of file volume.
 	Nfsv4AccessPoint = "Nfsv4AccessPoint"

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -1013,6 +1013,15 @@ func runTestCsiFullSync_WorkloadCluster(t *testing.T) {
 		commonco.ContainerOrchestratorUtility = originalCO
 	}()
 
+	// Store the original K8sNewclient to restore later
+	origK8sClient := k8sNewClient
+	defer func() {
+		k8sNewClient = origK8sClient
+	}()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) {
+		return k8sclient, nil
+	}
+
 	// Create a WORKLOAD cluster metadataSyncer (note: volumeManagers map is NOT populated)
 	// This simulates the real WORKLOAD cluster setup where only volumeManager is set
 	workloadMetadataSyncer := &metadataSyncInformer{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR takes care of following things:
1. Adds file share export paths to volume context attributes in response once volume provisioning for file volume is successful. Later CSI provisioner reads these attributes and adds file share export paths as annotation on the PVC.
2. Adds full sync code to check if file share export paths are available on PVC annotations, if not add them in full sync code. This is useful for cases where file volumes are created before upgrade to the VC 9.1.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
wcp changes pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/451/

Manual testing:
Create a file PVC with these changes and verified that file share export paths are added as PVC annotations.
```
# k apply -f pvc.yaml -n svc-tkg-v59n1
persistentvolumeclaim/example-file-pvc created


# k get pvc -A
NAMESPACE       NAME               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  VOLUMEATTRIBUTESCLASS   AGE
svc-tkg-v59n1   example-file-pvc   Bound    pvc-fb559df1-f848-4e94-88d5-cb6d53d74efc   1Gi        RWX            vsan-default-storage-policy   <unset>                 17s


# k get pvc example-file-pvc  -n svc-tkg-v59n1 -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    csi.vsphere.exportpath.nfs3: host10.cibgst.com:/52f2c68a-6d2c-4f39-f2e8-93529a690863.                <<<<<
    csi.vsphere.exportpath.nfs41: host10.cibgst.com:/vsanfs/52f2c68a-6d2c-4f39-f2e8-93529a690863.   <<<<<
    csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
...
spec:
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 1Gi
  storageClassName: vsan-default-storage-policy
  volumeMode: Filesystem
  volumeName: pvc-fb559df1-f848-4e94-88d5-cb6d53d74efc
status:
  accessModes:
  - ReadWriteMany
  capacity:
    storage: 1Gi
  phase: Bound
```


CSI controller logs:
```
{"level":"info","time":"2025-10-03T11:46:26.301484137Z","caller":"wcp/controller.go:1536","msg":"Access point details for volume pvc-fb559df1-f848-4e94-88d5-cb6d53d74efc are map[NFSv3:host10.cibgst.com:/52f2c68a-6d2c-4f39-f2e8-93529a690863 NFSv4.1:host10.cibgst.com:/vsanfs/52f2c68a-6d2c-4f39-f2e8-93529a690863]","TraceId":"2ad86870-5013-4549-86b6-1294c85af57e"}
```

CSI provisioner logs:
```
I1003 11:46:26.303865       1 controller.go:974] create volume rep: {CapacityBytes:1073741824 VolumeId:file:90a5e387-d1d1-40f0-9237-f38e51c8ade6 VolumeContext:map[csi.vsphere.exportpath.nfs3:host10.cibgst.com:/52f2c68a-6d2c-4f39-f2e8-93529a690863 csi.vsphere.exportpath.nfs41:host10.cibgst.com:/vsanfs/52f2c68a-6d2c-4f39-f2e8-93529a690863 type:vSphere CNS File Volume] ContentSource:<nil> AccessibleTopology:[segments:<key:"topology.kubernetes.io/zone" value:"az1" > ] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1003 11:46:26.304288       1 controller.go:1083] successfully created PV pvc-fb559df1-f848-4e94-88d5-cb6d53d74efc for PVC example-file-pvc and csi volume name file:90a5e387-d1d1-40f0-9237-f38e51c8ade6
I1003 11:46:26.304404       1 controller.go:1171] Setting file share export paths as annotation on pvc: "example-file-pvc", namespace: "svc-tkg-v59n1"
```

To test fullsync changes, manually edited PVC to remove file share export path annotations from PVC and verified that fullsync added back those annotations.
Syncer logs:
```
{"level":"info","time":"2025-10-03T12:26:12.83378061Z","caller":"syncer/fullsync.go:661","msg":"setFileShareAnnotationsOnPVC: Setting file share annotation for pvc: \"example-file-pvc-2\", namespace: \"svc-tkg-v59n1\"","TraceId":"6cef2eff-ed1f-4671-87c4-9ba615b381ee"}
{"level":"info","time":"2025-10-03T12:26:13.180160851Z","caller":"syncer/fullsync.go:694","msg":"setFileShareAnnotationsOnPVC: Access point details for volume example-file-pvc-2 are map[NFSv3:host11.cibgst.com:/52ab0bf9-4c7d-7f89-1113-e3653295d095 NFSv4.1:host10.cibgst.com:/vsanfs/52ab0bf9-4c7d-7f89-1113-e3653295d095]","TraceId":"6cef2eff-ed1f-4671-87c4-9ba615b381ee"}
{"level":"info","time":"2025-10-03T12:26:13.258312896Z","caller":"syncer/fullsync.go:704","msg":"setFileShareAnnotationsOnPVC: Added file share export paths annotation successfully on PVC \"example-file-pvc-2\", namespce \"svc-tkg-v59n1\"","TraceId":"6cef2eff-ed1f-4671-87c4-9ba615b381ee"}
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Add file share export paths to volume attributes so that CSI provisioner can add them as PVC annotations
```
