### PR TITLE
Ensure that during detach PVC has a unique entry in volumeStatus

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -40,6 +40,10 @@ var (
 	GetVMFromVcenter = cnsoperatorutil.GetVMFromVcenter
 )
 
+const (
+	detachSuffix = ":detaching"
+)
+
 // removeFinalizerFromCRDInstance will remove the CNS Finalizer, cns.vmware.com,
 // from a given nodevmbatchattachment instance.
 func removeFinalizerFromCRDInstance(ctx context.Context,
@@ -165,9 +169,34 @@ func getVolumesToDetachForVmFromVC(ctx context.Context,
 	}
 	log.Debugf("Obtained volumes to detach %+v for instance %s", pvcsToDetach, instance.Name)
 
+	updatePvcStatusEntryName(ctx, instance, pvcsToDetach)
+
 	// Ensure that there are no extra entries in instance status from a previous detach call.
 	removeStaleEntriesFromInstanceStatus(ctx, instance, pvcsToDetach, volumeNamesInSpec)
 	return pvcsToDetach, nil
+}
+
+// updatePvcStatusEntryName goes through each of the PVCs to detach and updates their
+// status to have the suffix ":detaching".
+// This is required to avoid the case where disk-1 was associated with pvc-1 and got attached.
+// disk-1 is then associated with pvc-2.
+// This means, PVC-1 should get detached and PVC-2 should get attached to the VM.
+// But they both have the same entry in the status which is wrong. By adding the suffix,
+// the volume name entry for the PVC getting detached becomes unique.
+func updatePvcStatusEntryName(ctx context.Context,
+	instance *v1alpha1.CnsNodeVmBatchAttachment, pvcsToDetach map[string]string) {
+	log := logger.GetLogger(ctx)
+
+	for i, volume := range instance.Status.VolumeStatus {
+		if _, ok := pvcsToDetach[volume.PersistentVolumeClaim.ClaimName]; !ok {
+			continue
+		}
+		newVolumeName := instance.Status.VolumeStatus[i].Name + detachSuffix
+		instance.Status.VolumeStatus[i].Name = newVolumeName
+		log.Infof("Updating status name entry to %s for detaching PVC %s",
+			newVolumeName,
+			volume.PersistentVolumeClaim.ClaimName)
+	}
 }
 
 // updateInstanceStatus updates the given nodevmbatchattachment instance's status.


### PR DESCRIPTION
**What this PR does / why we need it**:

There can be a case where disk-1 was associated with pvc-1 and got attached.
disk-1 is then associated with pvc-2.
This means, PVC-1 should get detached and PVC-2 should get attached to the VM.
But they both have the same entry in the status which is wrong. By adding the suffix, the volume name entry for the PVC getting detached becomes unique.

**Testing done**:

Created batch attach CRD with disk1 pointing to pvc-1 and disk2 poinitng pvc-2.
Then I changed the spec so that disk1 starts pointing to PVC-3.

I observed that PVC-3 got attached to the VM and PVC-1 got detached.

Verified from the logs that the PVC-1's entry in status was also updated:

```
root@420fe5a752cfe1034e7f80d586f417a8 [ ~ ]# k logs vsphere-csi-controller-8ccc45b87-vjjfs -n vmware-system-csi -c vsphere-syncer | grep "Updating status name entry to"
{"level":"info","time":"2025-09-30T17:24:50.949881111Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:185","msg":"Updating status name entry to disk-1:detaching for detaching PVC pvc-1,"TraceId":"de413522-e3ca-4058-9ba4-b99e179ceab6"}
```

As detach is successful the entry of the PVC was removed from the status.

WCP precheckin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/
VKS precheckin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/