### PR TITLE
Allow detach and attach to happen independently during CnsNodeVMBatchAttachment reconciliation

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -391,23 +391,24 @@ func (r *Reconciler) reconcileInstanceWithoutDeletionTimestamp(ctx context.Conte
 	vm *cnsvsphere.VirtualMachine) error {
 	log := logger.GetLogger(ctx)
 
-	// Call batch attach for volumes.
-	err := r.processBatchAttach(ctx, vm, instance)
-	if err != nil {
-		log.Errorf("failed to attach all volumes. Err: %+v", err)
-		return err
-	}
-
+	var detachErr error
 	// Call detach if there are some volumes which need to be detached.
 	if len(volumesToDetach) != 0 {
-		err := r.processDetach(ctx, vm, instance, volumesToDetach)
-		if err != nil {
-			log.Errorf("failed to detach all volumes. Err: +v", err)
-			return err
+		detachErr = r.processDetach(ctx, vm, instance, volumesToDetach)
+		if detachErr != nil {
+			log.Errorf("failed to detach all volumes. Err: %s", detachErr)
+		} else {
+			log.Infof("Successfully detached all volumes %+v", volumesToDetach)
 		}
-		log.Infof("Successfully detached all volumes %+v", volumesToDetach)
 	}
-	return nil
+
+	// Call batch attach for volumes.
+	attachErr := r.processBatchAttach(ctx, vm, instance)
+	if attachErr != nil {
+		log.Errorf("failed to attach all volumes. Err: %+v", attachErr)
+	}
+
+	return errors.Join(attachErr, detachErr)
 }
 
 // processDetach detaches each of the volumes in volumesToDetach by calling CNS DetachVolume API.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CnsBattachAttachment should do both attach and detach before sending back an error.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Simulated ResourceInUse fault for PVC-1  while also detaching PVC-2.
Noticed that attach for the PVC-1 failed but detach for PVC-2 succeeded.

```
Name:         test-new-2
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsNodeVmBatchAttachment
Metadata:
  Creation Timestamp:  2025-09-30T17:23:12Z
  Finalizers:
    cns.vmware.com
  Generation:        3
  Resource Version:  6102384
  UID:               17ebc4eb-be68-428a-afac-37e851bf5214
Spec:
  Nodeuuid:  424ea6db-49bd-4ba8-bd6b-676353617e3c
  Volumes:
    Name:  disk-1
    Persistent Volume Claim:
      Claim Name:  pvc-rwo-3
    Name:          disk-3
    Persistent Volume Claim:
      Claim Name:  pvc-rwo-fail
Status:
  Error:  failed to attach volumes: 4bdde6f2-d9e9-4a10-a4cb-35e2d78850fc
  Volumes:
    Name:  disk-1
    Persistent Volume Claim:
      Attached:       false
      Claim Name:     pvc-rwo-3
      Cns Volume Id:  4bdde6f2-d9e9-4a10-a4cb-35e2d78850fc
      Error:          failed to batch attach cns volume: "4bdde6f2-d9e9-4a10-a4cb-35e2d78850fc" to node vm: "VirtualMachine:vm-180 [VirtualCenterHost: lvn-dvm-10-161-45-209.dvm.lvn.broadcom.net, UUID: 424ea6db-49bd-4ba8-bd6b-676353617e3c, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: lvn-dvm-10-161-45-209.dvm.lvn.broadcom.net]]". fault: "vim.fault.ResourceInUse". opId: "cbefeed2"
    Name:             disk-3
    Persistent Volume Claim:
      Attached:       true
      Claim Name:     pvc-rwo-fail
      Cns Volume Id:  0ce82092-e479-4bad-b8f9-f25e1f226bbd
      Diskuuid:       6000C291-c8b7-dd94-7740-84d4449feea5
Events:
  Type     Reason                   Age                   From            Message
  ----     ------                   ----                  ----            -------
  Warning  NodeVmBatchAttachFailed  2s (x10 over 4m55s)   cns.vmware.com  failed to attach volumes: 4bdde6f2-d9e9-4a10-a4cb-35e2d78850fc
```

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/446/