### PR TITLE
Bump up Golang to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/vsphere-csi-driver/v3
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.2
+toolchain go1.25.0
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -49,7 +49,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=<docker-registry>/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.24
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.25
 
 ARCH=amd64
 OSVERSION=1809

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.24
+ARG GOLANG_IMAGE=golang:1.25
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.24
+ARG GOLANG_IMAGE=golang:1.25
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.24
+ARG GOLANG_IMAGE=golang:1.25
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.24
+ARG GOLANG_IMAGE=golang:1.25
 ARG OSVERSION
 ARG ARCH=amd64
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bump up Golang to 1.25

**Testing done**:
TBA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up Golang to 1.25
```
