### PR TITLE
Fixing PVC creations size for raw block volume

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -63,6 +63,7 @@ const (
 	disklibUnlinkErr                           = "DiskLib_Unlink"
 	diskSize1GB                                = "1Gi"
 	diskSize                                   = "2Gi"
+	diskSize4GB                                = "4Gi"
 	diskSizeSmall                              = "100Mi"
 	diskSizeLarge                              = "100Gi"
 	diskSizeInMb                               = int64(2048)

--- a/tests/e2e/raw_block_volume.go
+++ b/tests/e2e/raw_block_volume.go
@@ -739,6 +739,9 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		ginkgo.By("Creating raw block PVC")
 		pvcspec := getPersistentVolumeClaimSpecWithStorageClass(namespace, "", sc, nil, "")
 		pvcspec.Spec.VolumeMode = &rawBlockVolumeMode
+		diskSize := resource.MustParse(diskSize4GB)
+		pvcspec.Spec.Resources.Requests[corev1.ResourceStorage] = diskSize
+
 		pvc, err = fpv.CreatePVC(ctx, client, namespace, pvcspec)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to create pvc with err: %v", err))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now PVC size is only "2Gb" and we are trying to write raw block volume data which requires enough disk space.

I have increased PVC size to "4Gb" from "2Gb"


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Yes


