### PR TITLE
Chore - Enable profiling by default

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -401,7 +401,7 @@ spec:
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
           args:
-            - "--enable-profile-server=false"
+            - "--enable-profile-server=true"
           ports:
             - containerPort: 2112
               name: prometheus
@@ -473,7 +473,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
             - "--webhook-client-cert-verification"
-            - "--enable-profile-server=false"
+            - "--enable-profile-server=true"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -404,7 +404,7 @@ spec:
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
           args:
-            - "--enable-profile-server=false"
+            - "--enable-profile-server=true"
           ports:
             - containerPort: 2112
               name: prometheus
@@ -476,7 +476,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
             - "--webhook-client-cert-verification"
-            - "--enable-profile-server=false"
+            - "--enable-profile-server=true"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -404,7 +404,7 @@ spec:
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
           args:
-            - "--enable-profile-server=false"
+            - "--enable-profile-server=true"
           ports:
             - containerPort: 2112
               name: prometheus
@@ -476,7 +476,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
             - "--webhook-client-cert-verification"
-            - "--enable-profile-server=false"
+            - "--enable-profile-server=true"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -404,7 +404,7 @@ spec:
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
           args:
-            - "--enable-profile-server=false"
+            - "--enable-profile-server=true"
           ports:
             - containerPort: 2112
               name: prometheus
@@ -476,7 +476,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--storagequota-sync-interval=10m"
             - "--webhook-client-cert-verification"
-            - "--enable-profile-server=false"
+            - "--enable-profile-server=true"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"


### PR DESCRIPTION
## What this PR does / why we need it:
Since we enabled profiling for the first time, we wanted to be conservative and provide a way only for this to be enabled in scaled envs. But it makes much more sense to enable profiling by default so that the samples can be collected whenever an issue is observed in cx envs. This PR enables the profiling by default.

## Testing
Since no code changes are being introduced, successful pre-checkin runs are sufficient.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enable profiling endpoints by default
```
