### PR TITLE
Initiate storage-quota Periodic syncs only after metasyncer is Initialized

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -479,13 +479,6 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 						cnsvolumeinfov1alpha1.CnsVolumeInfoSingular, cnsVolumeInfoCRInformerErr)
 					os.Exit(1)
 				}
-				// start periodic sync for storage quota
-				err := initStorageQuotaPeriodicSync(ctx, metadataSyncer)
-				if err != nil {
-					log.Errorf("initStorageQuotaPeriodicSync: Failed to initialize the storagequota "+
-						"periodic sync, with error Error: %v", err)
-					os.Exit(1)
-				}
 			}
 		}
 
@@ -871,6 +864,16 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 					break
 				}
 			}()
+			isStorageQuotaM2Enabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.StorageQuotaM2)
+			if isStorageQuotaM2Enabled {
+				// start periodic sync for storage quota
+				err := initStorageQuotaPeriodicSync(ctx, metadataSyncer)
+				if err != nil {
+					log.Errorf("initStorageQuotaPeriodicSync: Failed to initialize the storagequota "+
+						"periodic sync, with error Error: %v", err)
+					os.Exit(1)
+				}
+			}
 		}
 	}
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix panics in storage-quota periodic sync due to pvLister not set on metasyncer
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manutal testing logs
storage-quota periodic sync executed without panic:
```
root@423b6f9a6bb8ec63db6d5ae584de591e [ ~ ]# k get StorageQuotaPeriodicSync -n vmware-system-csi   storage-quota-periodic-sync 
NAME                          AGE
storage-quota-periodic-sync   3d19h
root@423b6f9a6bb8ec63db6d5ae584de591e [ ~ ]# k get StorageQuotaPeriodicSync -n vmware-system-csi   storage-quota-periodic-sync  -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StorageQuotaPeriodicSync
metadata:
  creationTimestamp: "2025-09-29T17:50:41Z"
  generation: 1
  name: storage-quota-periodic-sync
  namespace: vmware-system-csi
  resourceVersion: "3552601"
  uid: 19515d47-c9b6-4d9b-9da7-523eec961df5
spec:
  syncIntervalInMinutes: 10
status:
  expectedReservedValues:
  - namespace: storage-policy-test
    reserved:
      27755a44-0017-4284-b175-a921b3dd9992: "0"
  - namespace: svc-example-bz7q6
    reserved:
      3b25d94b-8029-4968-8a62-4e4564d99e0e: "0"
      4c9bc515-8ad7-4e7a-b570-963818a198a5: "0"
      4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
      57d708a5-8b94-42e5-9760-1ef752ef6470: "0"
      27755a44-0017-4284-b175-a921b3dd9992: "0"
      a6e02469-e1b9-42a3-adac-66cf18a1e0cd: "0"
      a9423670-7455-11e8-adc0-fa7ae01bbebc: "0"
      aa6d5a82-1c88-45da-85d3-3d74b91a5bad: "0"
      b1263970-8662-69e2-adc6-fa8ae01abecc: "0"
      b6423670-8552-66e8-adc1-fa6ae01abeac: "0"
      bb7e6b13-2d99-46eb-96e4-3d85c91a5bde: "0"
      d109de24-c966-428f-8da2-d281e6671e35: "0"
  - namespace: svc-tkg-u9efs
    reserved:
      4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
      57d708a5-8b94-42e5-9760-1ef752ef6470: "0"
      a9423670-7455-11e8-adc0-fa7ae01bbebc: "0"
      aa6d5a82-1c88-45da-85d3-3d74b91a5bad: "0"
      b1263970-8662-69e2-adc6-fa8ae01abecc: "0"
      b6423670-8552-66e8-adc1-fa6ae01abeac: "0"
      bb7e6b13-2d99-46eb-96e4-3d85c91a5bde: "0"
      d109de24-c966-428f-8da2-d281e6671e35: "0"
  - namespace: svc-velero-qf8h7
    reserved:
      4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
      57d708a5-8b94-42e5-9760-1ef752ef6470: "0"
      a9423670-7455-11e8-adc0-fa7ae01bbebc: "0"
      aa6d5a82-1c88-45da-85d3-3d74b91a5bad: "0"
      b1263970-8662-69e2-adc6-fa8ae01abecc: "0"
      b6423670-8552-66e8-adc1-fa6ae01abeac: "0"
      bb7e6b13-2d99-46eb-96e4-3d85c91a5bde: "0"
      d109de24-c966-428f-8da2-d281e6671e35: "0"
  - namespace: test-mobility-relocate-ns
    reserved:
      a6e02469-e1b9-42a3-adac-66cf18a1e0cd: "0"
  - namespace: test-ns
    reserved:
      4c9bc515-8ad7-4e7a-b570-963818a198a5: "0"
      57d708a5-8b94-42e5-9760-1ef752ef6470: "0"
      aa6d5a82-1c88-45da-85d3-3d74b91a5bad: "0"
  lastSyncTimestamp: "2025-10-03T13:32:39Z"
```

syncer logs:
```
{"level":"info","time":"2025-10-03T13:32:39.777264708Z","caller":"syncer/metadatasyncer.go:1070","msg":"syncStorageQuotaReserved: Sync started for storage quota","TraceId":"16ca772d-82a2-4dfe-aa70-bbcff4bb8d75"}
{"level":"info","time":"2025-10-03T13:32:39.827350715Z","caller":"syncer/volume_health.go:39","msg":"csiGetVolumeHealthStatus: start","TraceId":"6420c484-20d7-41b0-8c16-98aeb4a129d1"}
{"level":"info","time":"2025-10-03T13:32:39.880590118Z","caller":"syncer/metadatasyncer.go:1539","msg":"fetchPVs: Fetching PersistentVolumes","TraceId":"16ca772d-82a2-4dfe-aa70-bbcff4bb8d75"}
{"level":"info","time":"2025-10-03T13:32:40.358769048Z","caller":"syncer/volume_health.go:127","msg":"GetVolumeHealthStatus: end","TraceId":"6420c484-20d7-41b0-8c16-98aeb4a129d1"}
{"level":"info","time":"2025-10-03T13:32:45.394732019Z","caller":"syncer/metadatasyncer.go:4000","msg":"storagePolicyUsageCRSync: Starting storage policy usage CR sync","TraceId":"095cf465-446f-4021-a158-88e35ae73878"}
{"level":"info","time":"2025-10-03T13:32:45.520050194Z","caller":"syncer/metadatasyncer.go:4119","msg":"storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: wcp-profile-changing-name-kmnyxlbro0-latebinding-pvc-usage in namespace: storage-policy-test field is matching with the total capacity. Used: 0 Skipping the Patch operation","TraceId":"095cf465-446f-4021-a158-88e35ae73878"}
{"level":"info","time":"2025-10-03T13:32:45.520572881Z","caller":"syncer/metadatasyncer.go:4119","msg":"storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: wcp-profile-changing-name-kmnyxlbro0-pvc-usage in namespace: storage-policy-test field is matching with the total capacity. Used: 0 Skipping the Patch operation","TraceId":"095cf465-446f-4021-a158-88e35ae73878"}
{"level":"info","time":"2025-10-03T13:32:45.52070522Z","caller":"syncer/metadatasyncer.go:4119","msg":"storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: wcp-profile-kmnyxlbro0-latebinding-pvc-usage in namespace: storage-policy-test field is matching with the total capacity. Used: 0 Skipping the Patch operation","TraceId":"095cf465-446f-4021-a158-88e35ae73878"}
```

vsphere-syncer full logs:
[periodic_sync_vsphere-syncer.log](https://github.com/user-attachments/files/22681811/periodic_sync_vsphere-syncer.log)



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Initiate storage-quota periodic syncer afeter pvLister is set.
```
