### PR TITLE
Improve logging for vitualmachine snapshot controller

### DIFF
--- a/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -502,7 +502,7 @@ func (r *ReconcileVirtualMachineSnapshot) syncVolumesAndUpdateCNSVolumeInfo(ctx 
 			val, ok := cnsvolume.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 			if ok {
 				log.Infof("syncVolumesAndUpdateCNSVolumeInfo: fetched aggregated capacity for volume %s "+
-					"AggregatedSnapshotCapacityInMb %s", cnsvolume.VolumeId.Id, val.AggregatedSnapshotCapacityInMb)
+					"AggregatedSnapshotCapacityInMb %d", cnsvolume.VolumeId.Id, val.AggregatedSnapshotCapacityInMb)
 
 				//  Update CNSVolumeInfo with latest aggregated Size and Update SPU used value.
 				patch, err := common.GetCNSVolumeInfoPatch(ctx, val.AggregatedSnapshotCapacityInMb,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Improve logging for virtualmachine snapshot controller

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing
```
root@423b6f9a6bb8ec63db6d5ae584de591e [ ~ ]# k get pod -n vmware-system-csi 
NAME                                     READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-744ccf954-lklvl   7/7     Running   0             3m9s
vsphere-csi-webhook-59d867c6d5-q6fq7     1/1     Running   8 (43h ago)   3d21h
root@423b6f9a6bb8ec63db6d5ae584de591e [ ~ ]# k apply -f vmsnapshot.yaml 
virtualmachinesnapshot.vmoperator.vmware.com/sample-vm-1-snapshot created
root@423b6f9a6bb8ec63db6d5ae584de591e [ ~ ]# k get vmsnapshot -n test-ns  sample-vm-1-snapshot  
NAME                   AGE
sample-vm-1-snapshot   2m57s
root@423b6f9a6bb8ec63db6d5ae584de591e [ ~ ]# k get vmsnapshot -n test-ns  sample-vm-1-snapshot  -o yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachineSnapshot
metadata:
  annotations:
    csi.vsphere.volume.sync: completed
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"vmoperator.vmware.com/v1alpha5","kind":"VirtualMachineSnapshot","metadata":{"annotations":{},"name":"sample-vm-1-snapshot","namespace":"test-ns"},"spec":{"memory":false,"vmName":"sample-vm-1"}}
  creationTimestamp: "2025-10-03T15:08:31Z"
  finalizers:
  - vmoperator.vmware.com/virtualmachinesnapshot
  - cns.vmware.com/syncvolume
  generation: 1
  labels:
    snapshot.vmoperator.vmware.com/vm-name: sample-vm-1
  name: sample-vm-1-snapshot
  namespace: test-ns
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha5
    kind: VirtualMachine
    name: sample-vm-1
    uid: 3e97ba62-56c5-45ac-baee-0873445c4de1
  resourceVersion: "3616144"
  uid: 7da4c177-c22d-4c62-8584-b346fdf9a626
spec:
  vmName: sample-vm-1
status:
  conditions:
  - lastTransitionTime: "2025-10-03T15:08:38Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotCSISynced
  - lastTransitionTime: "2025-10-03T15:08:36Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotCreated
  - lastTransitionTime: "2025-10-03T15:08:38Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotReady
  powerState: PoweredOff
  storage:
    requested:
    - storageClass: wcpglobal-storage-profile
      total: 25Gi
    used: "13274997718"
  uniqueID: snapshot-286
```
Syncer Logs:
```
root@423b6f9a6bb8ec63db6d5ae584de591e [ ~ ]# k logs -n vmware-system-csi vsphere-csi-controller-744ccf954-lklvl  -c vsphere-syncer -f
{"level":"info","time":"2025-10-03T15:05:51.043990295Z","caller":"logger/logger.go:41","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2025-10-03T15:05:51.045062618Z","caller":"syncer/main.go:102","msg":"Version : v2.1.0-rc.1-2418-g658a6a09","TraceId":"5cc19ab2-343e-4b09-a553-a3655d5f8d87"}
...
...
{"level":"info","time":"2025-10-03T15:08:37.746892418Z","caller":"virtualmachinesnapshot/virtualmachinesnapshot_controller.go:489","msg":"syncVolumesAndUpdateCNSVolumeInfo: volumes are synced successfully. will update related CNSVolumeInfos","TraceId":"805c07d9-3aa5-4b74-9079-489afe9760e7"}
{"level":"info","time":"2025-10-03T15:08:38.370323934Z","caller":"virtualmachinesnapshot/virtualmachinesnapshot_controller.go:504","msg":"syncVolumesAndUpdateCNSVolumeInfo: fetched aggregated capacity for volume f1722abc-0907-4686-9046-cfc7c8440e43 AggregatedSnapshotCapacityInMb 396","TraceId":"805c07d9-3aa5-4b74-9079-489afe9760e7"}
{"level":"info","time":"2025-10-03T15:08:38.372518111Z","caller":"common/util.go:518","msg":"retrieved aggregated snapshot capacity 396 for volume \"f1722abc-0907-4686-9046-cfc7c8440e43\""}
...
```

full logs:
[Uploading vmsnap_controler_vsphere-syncer.log…]()


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Improve logging for virtualmachine snapshot controller
```
