### PR TITLE
Test fix for VCreboot : PR-3591504

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -6930,7 +6930,7 @@ func checkVcServicesHealthPostReboot(ctx context.Context, host string, timeout .
 
 	//list of default stopped services in VC
 	var defaultStoppedServicesList = []string{"vmcam", "vmware-imagebuilder", "vmware-netdumper",
-		"vmware-perfcharts", "vmware-rbd-watchdog", "vmware-vcha"}
+		"vmware-rbd-watchdog", "vmware-vcha"}
 	waitErr := wait.PollUntilContextTimeout(ctx, pollTimeoutShort, pollTime, true,
 		func(ctx context.Context) (bool, error) {
 			var pendingServiceslist []string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:  vmware-perfcharts service is removed from services 

**Testing done**: Yes 

**Special notes for your reviewer**:
"vmware-perfcharts"  is removed from services
