### PR TITLE
Enhancement - Optimise CNSFileAccessConfig reconciliation workflow

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -46,7 +46,7 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs"]
+    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -46,7 +46,7 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs"]
+    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -46,7 +46,7 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs"]
+    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -46,7 +46,7 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs"]
+    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]

--- a/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
@@ -74,6 +74,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
## What this PR does / why we need it
Updates CNSFileAccessConfig reconciler to use status subresource endpoint to update status to avoid unintentional and unnecessary generation increments. 
Updates the reconciler to ignore events that do not have a change in the generation number.

## Testing done
<details><summary>In case of multiple reconciliations of an instance</summary>
<p>

Created some dummy CRs and verified that the generation is unchanged in multiple reconciles
<details><summary>List CR output</summary>
<p>

```yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsFileAccessConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsFileAccessConfig","metadata":{"annotations":{},"name":"cns-file-access-config-1","namespace":"cns-file-access-config"},"spec":{"pvcName":"pvc-1","vmName":"vm-1"}}
    creationTimestamp: "2025-10-06T09:02:30Z"
    generation: 1
    name: cns-file-access-config-1
    namespace: cns-file-access-config
    resourceVersion: "744166"
    uid: 681b5340-ada8-4053-a34e-df6e8b08bbf3
  spec:
    pvcName: pvc-1
    vmName: vm-1
  status:
    error: 'Failed to get virtualmachine instance for the VM with name: "vm-1". Error:
      virtualmachines.vmoperator.vmware.com "vm-1" not found'
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsFileAccessConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsFileAccessConfig","metadata":{"annotations":{},"name":"cns-file-access-config-10","namespace":"cns-file-access-config"},"spec":{"pvcName":"pvc-10","vmName":"vm-10"}}
    creationTimestamp: "2025-10-06T09:02:49Z"
    generation: 1
    name: cns-file-access-config-10
    namespace: cns-file-access-config
    resourceVersion: "744399"
    uid: 5993477b-7366-4e6c-b6ca-ac1b4796a2d0
  spec:
    pvcName: pvc-10
    vmName: vm-10
  status:
    error: 'Failed to get virtualmachine instance for the VM with name: "vm-10". Error:
      virtualmachines.vmoperator.vmware.com "vm-10" not found'
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsFileAccessConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsFileAccessConfig","metadata":{"annotations":{},"name":"cns-file-access-config-2","namespace":"cns-file-access-config"},"spec":{"pvcName":"pvc-2","vmName":"vm-2"}}
    creationTimestamp: "2025-10-06T09:02:32Z"
    generation: 1
    name: cns-file-access-config-2
    namespace: cns-file-access-config
    resourceVersion: "744189"
    uid: a951b47b-cda0-4604-ac69-744e48b537ef
  spec:
    pvcName: pvc-2
    vmName: vm-2
  status:
    error: 'Failed to get virtualmachine instance for the VM with name: "vm-2". Error:
      virtualmachines.vmoperator.vmware.com "vm-2" not found'
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsFileAccessConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsFileAccessConfig","metadata":{"annotations":{},"name":"cns-file-access-config-3","namespace":"cns-file-access-config"},"spec":{"pvcName":"pvc-3","vmName":"vm-3"}}
    creationTimestamp: "2025-10-06T09:02:34Z"
    generation: 1
    name: cns-file-access-config-3
    namespace: cns-file-access-config
    resourceVersion: "744213"
    uid: 627aa3dc-9b81-4830-907c-6374eba309ac
  spec:
    pvcName: pvc-3
    vmName: vm-3
  status:
    error: 'Failed to get virtualmachine instance for the VM with name: "vm-3". Error:
      virtualmachines.vmoperator.vmware.com "vm-3" not found'
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsFileAccessConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsFileAccessConfig","metadata":{"annotations":{},"name":"cns-file-access-config-4","namespace":"cns-file-access-config"},"spec":{"pvcName":"pvc-4","vmName":"vm-4"}}
    creationTimestamp: "2025-10-06T09:02:36Z"
    generation: 1
    name: cns-file-access-config-4
    namespace: cns-file-access-config
    resourceVersion: "744240"
    uid: 412781a7-8c5d-47d0-839b-5d07bee14d91
  spec:
    pvcName: pvc-4
    vmName: vm-4
  status:
    error: 'Failed to get virtualmachine instance for the VM with name: "vm-4". Error:
      virtualmachines.vmoperator.vmware.com "vm-4" not found'
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsFileAccessConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsFileAccessConfig","metadata":{"annotations":{},"name":"cns-file-access-config-5","namespace":"cns-file-access-config"},"spec":{"pvcName":"pvc-5","vmName":"vm-5"}}
    creationTimestamp: "2025-10-06T09:02:38Z"
    generation: 1
    name: cns-file-access-config-5
    namespace: cns-file-access-config
    resourceVersion: "744265"
    uid: 49935c1c-b350-4a7d-8cce-3501468e4be2
  spec:
    pvcName: pvc-5
    vmName: vm-5
  status:
    error: 'Failed to get virtualmachine instance for the VM with name: "vm-5". Error:
      virtualmachines.vmoperator.vmware.com "vm-5" not found'
kind: List
metadata:
  resourceVersion: ""
```

</p>
</details> 


</p>
</details> 


<details><summary>Delete workflow</summary>
<p>

```
> kc delete cnsfileaccessconfigs --all
cnsfileaccessconfig.cns.vmware.com "cns-file-access-config-1" deleted
cnsfileaccessconfig.cns.vmware.com "cns-file-access-config-2" deleted
cnsfileaccessconfig.cns.vmware.com "cns-file-access-config-3" deleted
cnsfileaccessconfig.cns.vmware.com "cns-file-access-config-4" deleted
cnsfileaccessconfig.cns.vmware.com "cns-file-access-config-5" deleted

> kc get cnsfileaccessconfigs
No resources found in cns-file-access-config namespace.
```

</p>
</details> 

<details><summary>Provision and attach RWX PVC in a guest cluster</summary>
<p>

1. Created a RWX PVC in a guest cluster and attached it to a pod
2. Verified that CNSFileAccessConfig CR got created successfully and the Pod came to running state

```yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsFileAccessConfig
metadata:
  creationTimestamp: "2025-10-08T07:42:44Z"
  finalizers:
  - cns.vmware.com
  generation: 1
  name: test-cluster-e2e-script-node-pool-1-4n6wq-4825v-22nhz-869b5308-523b-46bf-b966-c34e7dfa63fd-c86b89c1-10a8-4eb2-8d9e-8eb8a3a6650c
  namespace: test-gc-e2e-demo-ns
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha5
    blockOwnerDeletion: true
    controller: true
    kind: VirtualMachine
    name: test-cluster-e2e-script-node-pool-1-4n6wq-4825v-22nhz
    uid: 0fba6df1-1275-4056-a390-8c79d4f62ab0
  resourceVersion: "675990"
  uid: cabbece1-2d0d-4b7c-a887-14caf2ab955e
spec:
  pvcName: 869b5308-523b-46bf-b966-c34e7dfa63fd-c86b89c1-10a8-4eb2-8d9e-8eb8a3a6650c
  vmName: test-cluster-e2e-script-node-pool-1-4n6wq-4825v-22nhz
status:
  accessPoints:
    NFSv3: host13.cibgst.com:/527d5c31-26c0-36bb-5117-8e30377882a3
    NFSv4.1: host10.cibgst.com:/vsanfs/527d5c31-26c0-36bb-5117-8e30377882a3
  done: true
```
3. Delete the Pod and verified that the CR got deleted too
```
> kubectl -n cns-file-access-config get cnsfileaccessconfigs
No resources found in test-gc-e2e-demo-ns namespace.
```

</p>
</details> 

### Observations:
The behaviour of the reconciler is as expected in all the cases and the generation of the CRs remained at `1`.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Optimize CNSFileAccessConfig reconciliation workflow
```
