### PR TITLE
Add finalizer on RWX PVCs

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -25,10 +25,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	k8sFake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -131,6 +135,7 @@ func setTestEnvironment(testCnsNodeVmBatchAttachment *v1alpha1.CnsNodeVmBatchAtt
 	s := scheme.Scheme
 	s.AddKnownTypes(SchemeGroupVersion, cnsNodeVmBatchAttachment)
 	metav1.AddToGroupVersion(s, SchemeGroupVersion)
+	VolumeLock = &sync.Map{}
 
 	fakeClient := fake.NewClientBuilder().
 		WithStatusSubresource(cnsNodeVmBatchAttachment).
@@ -150,6 +155,49 @@ func setTestEnvironment(testCnsNodeVmBatchAttachment *v1alpha1.CnsNodeVmBatchAtt
 
 	return r
 
+}
+
+func getClientSetWithPvc() *k8sFake.Clientset {
+	// Define a RWO PVC
+	pvc1 := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-1",
+			Namespace: "test-ns",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	// Define pvc-2
+	pvc2 := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-2",
+			Namespace: "test-ns",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+
+	// Initialize fake clientset with the PVC
+	clientset := k8sFake.NewSimpleClientset(pvc1, pvc2)
+
+	return clientset
 }
 
 func TestCnsNodeVmBatchAttachmentWhenVmOnVcenterReturnsError(t *testing.T) {
@@ -203,6 +251,12 @@ func TestCnsNodeVmBatchAttachmentWhenVmOnVcenterReturnsNotFoundError(t *testing.
 		GetVMFromVcenter = MockGetVMFromVcenter
 		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
 
+		// Override with fake client
+		newClientFunc = func(ctx context.Context) (kubernetes.Interface, error) {
+			fakeK8sClient := getClientSetWithPvc()
+			return fakeK8sClient, nil
+		}
+
 		res, err := r.Reconcile(context.TODO(), req)
 		if err != nil {
 			t.Fatal("Unexpected reconcile error")
@@ -247,6 +301,12 @@ func TestCnsNodeVmBatchAttachmentWhenVmOnVcenterReturnsNotFoundErrorAndInstanceI
 			GetVMFromVcenter = MockGetVMFromVcenter
 			commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
 
+			// Override with fake client
+			newClientFunc = func(ctx context.Context) (kubernetes.Interface, error) {
+				fakeK8sClient := getClientSetWithPvc()
+				return fakeK8sClient, nil
+			}
+
 			res, err := r.Reconcile(context.TODO(), req)
 			assert.NoError(t, err)
 
@@ -272,14 +332,19 @@ func TestReconcileWithDeletionTimestamp(t *testing.T) {
 		testCnsNodeVmBatchAttachment := setupTestCnsNodeVmBatchAttachment()
 		r := setTestEnvironment(&testCnsNodeVmBatchAttachment, false)
 		mockVolumeManager := &unittestcommon.MockVolumeManager{}
+		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+
 		r.volumeManager = mockVolumeManager
 
 		volumesToDetach := map[string]string{
 			"pvc-1": "123-456",
 			"pvc-2": "789-012",
 		}
+		clientset := getClientSetWithPvc()
+
 		vm := &cnsvsphere.VirtualMachine{}
 		err := r.reconcileInstanceWithDeletionTimestamp(context.TODO(),
+			clientset,
 			&testCnsNodeVmBatchAttachment, volumesToDetach, vm)
 		assert.NoError(t, err)
 	})
@@ -302,7 +367,11 @@ func TestReconcileWithDeletionTimestampWhenDetachFails(t *testing.T) {
 			VirtualMachine: vmObj,
 		}
 
+		clientset := getClientSetWithPvc()
+
+		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
 		err := r.reconcileInstanceWithDeletionTimestamp(context.TODO(),
+			clientset,
 			&testCnsNodeVmBatchAttachment, volumesToDetach, vm)
 		if err == nil {
 			t.Fatal("Expected reconcile error")
@@ -327,7 +396,10 @@ func TestReconcileWithoutDeletionTimestamp(t *testing.T) {
 		}
 
 		vm := &cnsvsphere.VirtualMachine{}
+		clientset := getClientSetWithPvc()
+
 		err := r.reconcileInstanceWithoutDeletionTimestamp(context.TODO(),
+			clientset,
 			&testCnsNodeVmBatchAttachment, volumesToDetach, vm)
 		assert.NoError(t, err)
 	})
@@ -356,7 +428,10 @@ func TestReconcileWithoutDeletionTimestampWhenAttachFails(t *testing.T) {
 		}
 
 		vm := &cnsvsphere.VirtualMachine{}
+		clientset := getClientSetWithPvc()
+
 		err := r.reconcileInstanceWithoutDeletionTimestamp(context.TODO(),
+			clientset,
 			&testCnsNodeVmBatchAttachment, volumesToDetach, vm)
 		if err == nil {
 			t.Fatal("Expected reconcile error")
@@ -364,6 +439,231 @@ func TestReconcileWithoutDeletionTimestampWhenAttachFails(t *testing.T) {
 		expectedErrorMsg := fmt.Errorf("failed to attach volume")
 		assert.EqualError(t, expectedErrorMsg, err.Error())
 	})
+}
+
+func TestAddPvcAnnotation(t *testing.T) {
+	ctx := context.TODO()
+	vmUUID := "test-vm-uuid"
+	expectedKey := attachedVmPrefix + vmUUID
+
+	tests := []struct {
+		name               string
+		initialAnnotations map[string]string
+		expectError        bool
+	}{
+		{
+			name:               "PVC with no annotations",
+			initialAnnotations: nil,
+			expectError:        false,
+		},
+		{
+			name:               "PVC with existing annotations",
+			initialAnnotations: map[string]string{"existing": "value"},
+			expectError:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := k8sFake.NewSimpleClientset()
+
+			// Create PVC in fake cluster
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pvc",
+					Namespace:   "default",
+					Annotations: tt.initialAnnotations,
+				},
+			}
+
+			_, err := client.CoreV1().PersistentVolumeClaims("default").Create(ctx, pvc, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("failed to create pvc in fake client: %v", err)
+			}
+
+			// Get PVC from fake client
+			pvcFromClient, err := client.CoreV1().PersistentVolumeClaims("default").Get(ctx, "test-pvc", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get pvc: %v", err)
+			}
+
+			err = addPvcAnnotation(ctx, client, vmUUID, pvcFromClient)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Verify annotation is added
+			updatedPVC, err := client.CoreV1().PersistentVolumeClaims("default").Get(ctx, "test-pvc", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get updated pvc: %v", err)
+			}
+
+			val, ok := updatedPVC.Annotations[expectedKey]
+			if !ok {
+				t.Errorf("expected annotation %s not found", expectedKey)
+			}
+			if val != "" {
+				t.Errorf("expected annotation value '', got '%s'", val)
+			}
+		})
+	}
+}
+
+func TestRemovePvcAnnotation(t *testing.T) {
+	ctx := context.TODO()
+	vmUUID := "test-vm-uuid"
+	annotationKey := attachedVmPrefix + vmUUID
+
+	tests := []struct {
+		name               string
+		initialAnnotations map[string]string
+		expectError        bool
+	}{
+		{
+			name:               "PVC with no annotations",
+			initialAnnotations: nil,
+			expectError:        false,
+		},
+		{
+			name:               "PVC without target annotation",
+			initialAnnotations: map[string]string{"some-other": "value"},
+			expectError:        false,
+		},
+		{
+			name:               "PVC with target annotation",
+			initialAnnotations: map[string]string{annotationKey: ""},
+			expectError:        false,
+		},
+		{
+			name: "PVC with multiple annotations including target",
+			initialAnnotations: map[string]string{
+				annotationKey: "",
+				"keep-me":     "yes",
+				"another-key": "value",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := k8sFake.NewSimpleClientset()
+
+			// Create PVC in fake cluster
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pvc",
+					Namespace:   "default",
+					Annotations: tt.initialAnnotations,
+				},
+			}
+
+			_, err := client.CoreV1().PersistentVolumeClaims("default").Create(ctx, pvc, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("failed to create pvc in fake client: %v", err)
+			}
+
+			// Get PVC from fake client to pass to removePvcAnnotation
+			pvcFromClient, err := client.CoreV1().PersistentVolumeClaims("default").Get(ctx, "test-pvc", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get pvc: %v", err)
+			}
+
+			err = removePvcAnnotation(ctx, client, vmUUID, pvcFromClient)
+			if (err != nil) != tt.expectError {
+				t.Fatalf("unexpected error status: got %v, want error? %v", err, tt.expectError)
+			}
+
+			// Get PVC again to verify annotations
+			updatedPVC, err := client.CoreV1().PersistentVolumeClaims("default").Get(ctx, "test-pvc", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get updated pvc: %v", err)
+			}
+
+			_, found := updatedPVC.Annotations[annotationKey]
+
+			if found {
+				t.Errorf("annotation not expected after removal. Found annotations: %+v", updatedPVC.Annotations)
+			}
+
+			// Verify that other annotations remain intact
+			for k, v := range tt.initialAnnotations {
+				if k == annotationKey {
+					continue
+				}
+				if updatedPVC.Annotations[k] != v {
+					t.Errorf("annotation %q changed: got %q, want %q", k, updatedPVC.Annotations[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestPvcHasUsedByAnnotation(t *testing.T) {
+	ctx := context.TODO()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "No annotations",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name: "Annotations without matching prefix",
+			annotations: map[string]string{
+				"some.other/annotation": "value",
+			},
+			expected: false,
+		},
+		{
+			name: "Annotations with matching prefix",
+			annotations: map[string]string{
+				attachedVmPrefix + "vm-uuid": "attached",
+			},
+			expected: true,
+		},
+		{
+			name: "Multiple annotations, one with matching prefix",
+			annotations: map[string]string{
+				"foo":                           "bar",
+				attachedVmPrefix + "another-vm": "attached",
+				"something.else":                "value",
+			},
+			expected: true,
+		},
+		{
+			name: "Multiple annotations, none with matching prefix",
+			annotations: map[string]string{
+				"foo":               "bar",
+				"cns.vmware.com/no": "value",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pvc",
+					Annotations: tt.annotations,
+				},
+			}
+
+			result := pvcHasUsedByAnnotaion(ctx, pvc)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func MockGetVMFromVcenter(ctx context.Context, nodeUUID string,


### PR DESCRIPTION
**What this PR does / why we need it**:
RWX block volumes are now supported.
It is important to ensure that PVC protection finalizer from a RWX volume is removed only no other VM is using it.

For this, used-by annotation will be added to RWX block PVC for each VM that it is attached to.
This annotation is removed when the PVC is detached from a VM. When the last VM is also detached from the PVC, PVC protection finalizer can be safely removed from the PVC.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

**TEST 1**

Created a shared RWX volume and attached it to 2 VMs. Observed that PVC protection finalizer got added to the PVC and annotation for both the VMs was also added:
```
Name:          new-pvc-rwx
Namespace:     test
StorageClass:  vsan-default-storage-policy
Status:        Bound
Volume:        pvc-8d5b9395-e47f-4038-863c-eb2678bfe7b8
Labels:        <none>
Annotations:   cns.vmware.com/usedby-vm-424ea6db-49bd-4ba8-bd6b-676353617e3c:  <==== used by annotation
               cns.vmware.com/usedby-vm-562c8b56-5c99-4064-a47c-9e6de5ce3a0a:  <==== used by annotation
               csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Tue Oct  7 07:11:25 UTC 2025
Finalizers:    [kubernetes.io/pvc-protection cns.vmware.com/pvc-protection] <=== PVC protection finalizer
Capacity:      100Mi
Access Modes:  RWX
VolumeMode:    Block
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                          Message
  ----    ------                 ----               ----                                                                                          -------
  Normal  Provisioning           40m                csi.vsphere.vmware.com_420f2936b5a48026112dd8df50191b5f_43b83375-757b-4a66-9ef4-d5cae10a5d1b  External provisioner is provisioning volume for claim "test/new-pvc-rwx"
  Normal  ProvisioningSucceeded  40m                csi.vsphere.vmware.com_420f2936b5a48026112dd8df50191b5f_43b83375-757b-4a66-9ef4-d5cae10a5d1b  Successfully provisioned volume pvc-8d5b9395-e47f-4038-863c-eb2678bfe7b8
  Normal  ExternalProvisioning   40m (x3 over 40m)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
```

Deleted the volume and observed that it got stuck in Terminating state.

Detached the PVC from 1 VM and observed that annotation for that PVC got removed but was still stuck in pending state.

Detached the PVC from the second VM and observed the PVC got deleted successfully.

**TEST 2**

Deleted the batch attachment CR for instance using shared block PVC and observed that the finalizer and annotation from the PVC also got removed.
Logs for the same:

Logs
```

{"level":"info","time":"2025-10-07T07:50:05.828649336Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:669","msg":"Acquired lock for PVC test/new-pvc-rwo","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:05.828803738Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:683","msg":"PVC new-pvc-rwo is shared","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:05.828925461Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:535","msg":"Removing annotation cns.vmware.com/usedby-vm-424ea6db-49bd-4ba8-bd6b-676353617e3c from PVC new-pvc-rwo","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:05.829666429Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:557","msg":"Patching PVC new-pvc-rwo with updated annotation","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:05.905913258Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:688","msg":"Successfully updated annotations on PVC new-pvc-rwo for VM 424ea6db-49bd-4ba8-bd6b-676353617e3c","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:05.959976277Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:591","msg":"PVC new-pvc-rwo does not contain any annotations with prefix cns.vmware.com/usedby-vm-","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:05.961684404Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:704","msg":"VM 424ea6db-49bd-4ba8-bd6b-676353617e3c was the last attached VM for the PVC new-pvc-rwo. Finalizer cns.vmware.com/pvc-protection can be safely removed fromt the PVC","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:05.96248781Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:717","msg":"Removing cns.vmware.com/pvc-protection finalizer from PVC: new-pvc-rwo on namespace: test","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:06.076247207Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:730","msg":"Successfully removed finalizer cns.vmware.com/pvc-protection from PVC new-pvc-rwo","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:06.076422276Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:672","msg":"Released lock for PVC test/new-pvc-rwo","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:06.076563539Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:497","msg":"Successfully detached volume new-pvc-rwo from VM 424ea6db-49bd-4ba8-bd6b-676353617e3c","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
{"level":"info","time":"2025-10-07T07:50:06.07659472Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:473","msg":"Detach call ended for PVC new-pvc-rwo in namespace test for instance test-new-1","TraceId":"5c1bc92f-1f61-4fc6-a374-19017e8de085"}
```

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/440/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/463/