### PR TITLE
bump worker threads for node-vm attachment and batch attachment

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -485,6 +485,10 @@ spec:
               value: "30"
             - name: VOLUME_HEALTH_INTERVAL_MINUTES
               value: "5"
+            - name: WORKER_THREADS_NODEVM_ATTACH
+              value: "20"
+            - name: WORKER_THREADS_NODEVM_BATCH_ATTACH
+              value: "20"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"
             - name: POD_LISTENER_SERVICE_PORT

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -488,6 +488,10 @@ spec:
               value: "30"
             - name: VOLUME_HEALTH_INTERVAL_MINUTES
               value: "5"
+            - name: WORKER_THREADS_NODEVM_ATTACH
+              value: "20"
+            - name: WORKER_THREADS_NODEVM_BATCH_ATTACH
+              value: "20"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"
             - name: POD_LISTENER_SERVICE_PORT

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -488,6 +488,10 @@ spec:
               value: "30"
             - name: VOLUME_HEALTH_INTERVAL_MINUTES
               value: "5"
+            - name: WORKER_THREADS_NODEVM_ATTACH
+              value: "20"
+            - name: WORKER_THREADS_NODEVM_BATCH_ATTACH
+              value: "20"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"
             - name: POD_LISTENER_SERVICE_PORT

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -488,6 +488,10 @@ spec:
               value: "30"
             - name: VOLUME_HEALTH_INTERVAL_MINUTES
               value: "5"
+            - name: WORKER_THREADS_NODEVM_ATTACH
+              value: "20"
+            - name: WORKER_THREADS_NODEVM_BATCH_ATTACH
+              value: "20"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"
             - name: POD_LISTENER_SERVICE_PORT

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -58,7 +58,7 @@ import (
 
 const (
 	workerThreadsEnvVar     = "WORKER_THREADS_NODEVM_ATTACH"
-	defaultMaxWorkerThreads = 10
+	defaultMaxWorkerThreads = 20
 )
 
 // backOffDuration is a map of cnsnodevmattachment name's to the time after

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -75,7 +75,7 @@ var (
 
 const (
 	workerThreadsEnvVar     = "WORKER_THREADS_NODEVM_BATCH_ATTACH"
-	defaultMaxWorkerThreads = 10
+	defaultMaxWorkerThreads = 20
 )
 
 var newClientFunc = func(ctx context.Context) (kubernetes.Interface, error) {

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -368,8 +368,7 @@ func GetDatacenterObjectList(ctx context.Context,
 // spawned by a controller to reconciler instances of a CRD. It reads the
 // value from an environment variable identified by 'key'. If the environment
 // variable is not set or has an invalid value, it returns the 'defaultVal'.
-// The value of the environment variable should be a positive integer less
-// than or equal to 'defaultVal'.
+// The value of the environment variable should be a positive integer
 func GetMaxWorkerThreads(ctx context.Context, key string, defaultVal int) int {
 	log := logger.GetLogger(ctx).With("field", key)
 	workerThreads := defaultVal
@@ -388,7 +387,7 @@ func GetMaxWorkerThreads(ctx context.Context, key string, defaultVal int) int {
 	}
 
 	switch {
-	case val <= 0 || val > defaultVal:
+	case val <= 0:
 		log.Warnf("Value %d for environment variable is invalid. Using default value %d",
 			val, defaultVal)
 	default:

--- a/pkg/syncer/cnsoperator/util/util_test.go
+++ b/pkg/syncer/cnsoperator/util/util_test.go
@@ -185,20 +185,4 @@ func TestGetMaxWorkerThreads(t *testing.T) {
 		// Assert
 		assert.Equal(t, expVal, val)
 	})
-
-	t.Run("WhenEnvValid", func(t *testing.T) {
-		// Setup
-		err := os.Setenv(envVar, "10")
-		if err != nil {
-			t.Fatalf("Failed to set env var: %v", err)
-		}
-
-		defVal, expVal := 50, 10
-
-		// Execute
-		val := GetMaxWorkerThreads(context.Background(), envVar, defVal)
-
-		// Assert
-		assert.Equal(t, expVal, val)
-	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- bump worker threads for node-vm attachment and batch attachment reconciler.
- remove max worker threads check.

MaxConcurrentReconciles for VM Operator is set to 20, meaning VM Operator will be able to create/delete cnsnodevmattachment with max worker thread 20. In CSI we were setting MaxConcurrentReconciles to 10 for cnsnodevmattachment and cnsnodevmbatchattachment CRs. Since CSI has lower concurrent reconciles , requests getting queued in the supervisor and impacting performance.

**Testing done**:

pre-checkin pipelines
- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/439/
- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/461/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
bump worker threads for node-vm attachment and batch attachment
```
