### PR TITLE
Revert "Change service type to ClusterIP for vsphere-csi-controller service (#3519)

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -609,7 +609,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: ClusterIP
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -611,7 +611,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: ClusterIP
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -611,7 +611,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: ClusterIP
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -611,7 +611,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: ClusterIP
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This reverts commit 3a80b838043fe53e85ff005f79baac3db6b0869b.
We have observed supervisor upgrade is failing due to this change. 
Service is not getting deleted due to `"netoperator.vmware.com/service"` finalizer which is added for service of the type LoadBalancer is not getting removed when service is deleted.

Observed delete service is stuck

```
# kubectl get service -n vmware-system-csi -o json
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "v1",
            "kind": "Service",
            "metadata": {
                "annotations": {
                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"vsphere-csi-controller\"},\"name\":\"vsphere-csi-controller\",\"namespace\":\"vmware-system-csi\"},\"spec\":{\"ports\":[{\"name\":\"ctlr\",\"port\":2112,\"protocol\":\"TCP\",\"targetPort\":2112},{\"name\":\"syncer\",\"port\":2113,\"protocol\":\"TCP\",\"targetPort\":2113}],\"selector\":{\"app\":\"vsphere-csi-controller\"},\"type\":\"ClusterIP\"}}\n",
                    "kubernetes.io/change-cause": "kubectl create --filename=/usr/lib/vmware-wcp/objects/csi/1.29 --record=true"
                },
                "creationTimestamp": "2025-09-26T17:46:21Z",
                "deletionGracePeriodSeconds": 0,
                "deletionTimestamp": "2025-09-26T19:08:56Z",
                "finalizers": [
                    "netoperator.vmware.com/service"
                ],
                "labels": {
                    "app": "vsphere-csi-controller"
                },
                "name": "vsphere-csi-controller",
                "namespace": "vmware-system-csi",
                "resourceVersion": "612940",
                "uid": "9cf7af27-3d3c-49a2-b603-2900c8c8a379"
            },

```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Revert "Change service type to ClusterIP for vsphere-csi-controller service (#3519)
```
