### PR TITLE
Update csi-provisioner sidecar version

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -307,7 +307,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.9
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.10
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -307,7 +307,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.9
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.10
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -307,7 +307,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.9
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.10
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update csi-provisioner sidecar version to include changes done for adding file share export paths as PVC annotations.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
wcp pre-checkin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/453/

Changes are verified manually as part of testing https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3629.

**Special notes for your reviewer**:

**Release note**:
```release-note
Update csi-provisioner sidecar version
```
