### PR TITLE
Fix virtualmachinesnapshot controller to watch vmsnapshot crs

### DIFF
--- a/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -40,7 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -163,7 +162,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller.
 	err := ctrl.NewControllerManagedBy(mgr).Named("virtualmachinesnapshot-controller").
 		For(&vmoperatortypes.VirtualMachineSnapshot{}).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxWorkerThreads}).
 		Complete(r)
 	if err != nil {
@@ -277,7 +275,7 @@ func (r *ReconcileVirtualMachineSnapshot) reconcileNormal(ctx context.Context, l
 			deleteVMSnapshot = true
 		} else {
 			log.Infof("reconcileNormal: virtualmachinesnapshot %s/%s is set to delete, "+
-				"expecting to remove %s first", vmsnapshot.Namespace, vmsnapshot.Name,
+				"expecting to remove finalizer %s first", vmsnapshot.Namespace, vmsnapshot.Name,
 				VMSnapshotFinalizer)
 			return nil
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PR fixes the reconciliation of vmsnapshot cr when annotation added/updated on cr.
Removed predicates which only allow reconciliation on CR spec update, where in case of vmsnapshot we need to reconcile on annotation value added/updated.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
root@4212d6b381192d8688f21fcc9a11e609 [ ~ ]# k get pod -n vmware-system-csi -w
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-58f46f58bb-n9h8w   7/7     Running   0          17s
vsphere-csi-controller-58f46f58bb-pjxbv   7/7     Running   0          7s
vsphere-csi-webhook-6fbbb9cd6f-f98xl      1/1     Running   0          26h
vsphere-csi-webhook-6fbbb9cd6f-qvf2v      1/1     Running   0          26h
root@4212d6b381192d8688f21fcc9a11e609 [ ~ ]# k get vmsnapshot -A
NAMESPACE     NAME                   AGE
lubron-test   sn-1                   25h
test-ns       sample-vm-1-snapshot   3h5m
root@4212d6b381192d8688f21fcc9a11e609 [ ~ ]# k get vmsnapshot sample-vm-1-snapshot -n test-ns  -o yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachineSnapshot
metadata:
  annotations:
    csi.vsphere.volume.sync: requested
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"vmoperator.vmware.com/v1alpha5","kind":"VirtualMachineSnapshot","metadata":{"annotations":{},"name":"sample-vm-1-snapshot","namespace":"test-ns"},"spec":{"memory":false,"vmName":"sample-vm"}}
  creationTimestamp: "2025-10-10T12:03:47Z"
  finalizers:
  - vmoperator.vmware.com/virtualmachinesnapshot
  generation: 1
  labels:
    snapshot.vmoperator.vmware.com/vm-name: sample-vm
  name: sample-vm-1-snapshot
  namespace: test-ns
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha5
    kind: VirtualMachine
    name: sample-vm
    uid: d27408ea-4a2e-4aee-991e-f77f3185aa9e
  resourceVersion: "1896534"
  uid: 1e331927-3a91-480d-9ef7-8d5a4a434e6e
spec:
  vmName: sample-vm
status:
  conditions:
  - lastTransitionTime: "2025-10-10T12:04:04Z"
    message: Sync CSI volume requested
    reason: VirtualMachineSnapshotCSISyncInProgress
    status: "False"
    type: VirtualMachineSnapshotCSISynced
  - lastTransitionTime: "2025-10-10T12:04:04Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotCreated
  - lastTransitionTime: "2025-10-10T12:04:04Z"
    message: Snapshot is not ready because CSI volume sync hasn't been completed
    reason: VirtualMachineSnapshotWaitingForCSISync
    status: "False"
    type: VirtualMachineSnapshotReady
  powerState: PoweredOff
  storage:
    requested:
    - storageClass: wcpglobal-storage-profile
      total: 25Gi
    used: "7757391212"
  uniqueID: snapshot-288
```

With fix: annotation value set to completed
>>  csi.vsphere.volume.sync: completed
```
root@4212d6b381192d8688f21fcc9a11e609 [ ~ ]# k get vmsnapshot  -A
NAMESPACE     NAME                   AGE
lubron-test   sn-1                   25h
test-ns       sample-vm-1-snapshot   3h10m
root@4212d6b381192d8688f21fcc9a11e609 [ ~ ]# k get vmsnapshot  -n lubron-test   sn-1  -o yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachineSnapshot
metadata:
  annotations:
    csi.vsphere.volume.sync: completed
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"vmoperator.vmware.com/v1alpha5","kind":"VirtualMachineSnapshot","metadata":{"annotations":{},"name":"sn-1","namespace":"lubron-test"},"spec":{"vmName":"lubron-vm"}}
  creationTimestamp: "2025-10-09T13:15:06Z"
  finalizers:
  - cns.vmware.com/syncvolume
  - vmoperator.vmware.com/virtualmachinesnapshot
  generation: 1
  labels:
    snapshot.vmoperator.vmware.com/vm-name: lubron-vm
  name: sn-1
  namespace: lubron-test
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha5
    kind: VirtualMachine
    name: lubron-vm
    uid: 6af59123-9eeb-46f2-aee9-1a39eb6f1841
  resourceVersion: "2037190"
  uid: cb496848-6058-43d1-af32-22ff275f2871
spec:
  vmName: lubron-vm
status:
  conditions:
  - lastTransitionTime: "2025-10-10T15:10:52Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotCSISynced
  - lastTransitionTime: "2025-10-09T13:15:07Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotCreated
  - lastTransitionTime: "2025-10-10T15:10:52Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotReady
  powerState: PoweredOff
  storage:
    requested:
    - storageClass: wcpglobal-storage-profile
      total: 25Gi
    used: "7540598357"
  uniqueID: snapshot-283
root@4212d6b381192d8688f21fcc9a11e609 [ ~ ]# k get vmsnapshot sample-vm-1-snapshot -n test-ns -o yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachineSnapshot
metadata:
  annotations:
    csi.vsphere.volume.sync: completed
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"vmoperator.vmware.com/v1alpha5","kind":"VirtualMachineSnapshot","metadata":{"annotations":{},"name":"sample-vm-1-snapshot","namespace":"test-ns"},"spec":{"memory":false,"vmName":"sample-vm"}}
  creationTimestamp: "2025-10-10T12:03:47Z"
  finalizers:
  - vmoperator.vmware.com/virtualmachinesnapshot
  - cns.vmware.com/syncvolume
  generation: 1
  labels:
    snapshot.vmoperator.vmware.com/vm-name: sample-vm
  name: sample-vm-1-snapshot
  namespace: test-ns
  ownerReferences:
  - apiVersion: vmoperator.vmware.com/v1alpha5
    kind: VirtualMachine
    name: sample-vm
    uid: d27408ea-4a2e-4aee-991e-f77f3185aa9e
  resourceVersion: "2037184"
  uid: 1e331927-3a91-480d-9ef7-8d5a4a434e6e
spec:
  vmName: sample-vm
status:
  conditions:
  - lastTransitionTime: "2025-10-10T15:10:52Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotCSISynced
  - lastTransitionTime: "2025-10-10T12:04:04Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotCreated
  - lastTransitionTime: "2025-10-10T15:10:52Z"
    message: ""
    reason: "True"
    status: "True"
    type: VirtualMachineSnapshotReady
  powerState: PoweredOff
  storage:
    requested:
    - storageClass: wcpglobal-storage-profile
      total: 25Gi
    used: "7757391212"
  uniqueID: snapshot-288
```
[vsphere-syncer.log](https://github.com/user-attachments/files/22852988/vsphere-syncer.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
 Fix virtualmachinesnapshot controller reconciliation of vmsnapshot crs  
```
