### PR TITLE
Skip volumes with existing PVC UID in Volume DeletionMap during full sync

### DIFF
--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -49,12 +49,6 @@ type FakeK8SOrchestrator struct {
 	csiNodeTopologyInstances []interface{}
 }
 
-func (c *FakeK8SOrchestrator) HandleLateEnablementOfCapability(
-	ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, capability, gcPort, gcEndpoint string) {
-	//TODO implement me
-	panic("implement me")
-}
-
 // volumeMigration holds mocked migrated volume information
 type mockVolumeMigration struct {
 	// volumePath to volumeId map

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -26,8 +26,10 @@ import (
 	"strings"
 	"sync"
 
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/simulator/vpx"
@@ -193,6 +195,16 @@ func (c *FakeK8SOrchestrator) ClearFakeAttached(ctx context.Context, volumeID st
 	log := logger.GetLogger(ctx)
 	return logger.LogNewErrorCode(log, codes.Unimplemented,
 		"ClearFakeAttached for FakeK8SOrchestrator is not yet implemented.")
+}
+
+func (c *FakeK8SOrchestrator) GetPVCNamespacedNameByUID(uid string) (k8stypes.NamespacedName, bool) {
+	return k8stypes.NamespacedName{}, false
+}
+
+func (c *FakeK8SOrchestrator) HandleLateEnablementOfCapability(
+	ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, capability, gcPort, gcEndpoint string) {
+	//TODO implement me
+	panic("implement me")
 }
 
 // GetNodeTopologyLabels fetches the topology information of a node from the CSINodeTopology CR.

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	storagev1 "k8s.io/api/storage/v1"
@@ -125,6 +126,9 @@ type COCommonInterface interface {
 	GetPvcObjectByName(ctx context.Context, pvcName string, namespace string) (*v1.PersistentVolumeClaim, error)
 	HandleLateEnablementOfCapability(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, capability,
 		gcPort, gcEndpoint string)
+	// GetPVCNamespacedNameByUID returns the PVC's namespaced name (namespace/name) for the given UID.
+	// If the PVC is not found in the cache, it returns an empty string and false.
+	GetPVCNamespacedNameByUID(uid string) (k8stypes.NamespacedName, bool)
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -44,6 +45,11 @@ import (
 // MockCOCommonInterface is a mock implementation of COCommonInterface
 type MockCOCommonInterface struct {
 	mock.Mock
+}
+
+func (m *MockCOCommonInterface) GetPVCNamespacedNameByUID(uid string) (apitypes.NamespacedName, bool) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m *MockCOCommonInterface) GetVolumeSnapshotPVCSource(ctx context.Context, volumeSnapshotNamespace,

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -222,6 +222,11 @@ func (m *mockVolumeManager) SyncVolume(ctx context.Context,
 
 type mockCOCommon struct{}
 
+func (m *mockCOCommon) GetPVCNamespacedNameByUID(uid string) (types.NamespacedName, bool) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockCOCommon) EnableFSS(ctx context.Context, featureName string) error {
 	//TODO implement me
 	panic("implement me")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Skip volumes with an existing PVC UID in the Volume DeletionMap during full sync.

With transaction support, when a volume is created with a PVC UID, a backend issue may cause the volume to exist in CNS but not return success immediately. In such cases, the volume may be picked up by the full sync process for de-registration, and its metadata is removed temporarily.

Once the backend recovers, the volume is created successfully, and the metadata is re-added.

This PR updates the full sync logic to skip volumes whose PVC UID already exists, preventing unnecessary de-registration of volume metadata.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Pre-checkin pipelines

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/465/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/474/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Skip volumes with existing PVC UID in Volume DeletionMap during full sync
```
