### PR TITLE
wcp-vsan-stretch : Changes to skip hosts from EdgeMgmtCluster and mgmt cluster

### DIFF
--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -186,7 +186,7 @@ func createFaultDomainMap(ctx context.Context, vs *vSphere) map[string]string {
 			hostInfo := host.Common.InventoryPath
 			hostIpInfo := strings.Split(hostInfo, "/")
 			hostCluster := hostIpInfo[len(hostIpInfo)-2]
-			if !strings.Contains(hostCluster, "EdgeMgmtCluster") {
+			if !strings.Contains(hostCluster, "EdgeMgmtCluster") || !strings.Contains(hostCluster, "mgmt") {
 				hostsInVsanStretchCluster = append(hostsInVsanStretchCluster, host)
 			}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:  Adding test code to skip reading hosts from EdgeMgmtCluster and mgmt cluster 

**Testing done**:
Not required 



