### PR TITLE
Added unit tests for function setFileShareAnnotationsOnPVC in fullsync

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -681,6 +681,7 @@ func setFileShareAnnotationsOnPVC(ctx context.Context, k8sClient clientset.Inter
 	if err != nil {
 		log.Errorf("setFileShareAnnotationsOnPVC: Error while performing QueryVolume on volume %s, Err: %+v",
 			pv.Spec.CSI.VolumeHandle, err)
+		return err
 	}
 	vSANFileBackingDetails := volume.BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails)
 	accessPoints := make(map[string]string)

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -1,0 +1,461 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+)
+
+func TestSetFileShareAnnotationsOnPVC_Success(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test PVC
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pvc",
+			Namespace:   "test-namespace",
+			Annotations: make(map[string]string),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "test-pv",
+		},
+	}
+
+	// Create test PV
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: "test-volume-handle",
+				},
+			},
+		},
+	}
+
+	// Create fake k8s client with PV and PVC
+	k8sClient := k8sfake.NewSimpleClientset(pv, pvc)
+
+	// Create expected volume response with file share backing details
+	expectedVolume := &cnstypes.CnsVolume{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: "test-volume-handle",
+		},
+		BackingObjectDetails: &cnstypes.CnsVsanFileShareBackingDetails{
+			AccessPoints: []types.KeyValue{
+				{
+					Key:   common.Nfsv3AccessPointKey,
+					Value: "192.168.1.100:/nfs/v3/path",
+				},
+				{
+					Key:   common.Nfsv4AccessPointKey,
+					Value: "192.168.1.100:/nfs/v4/path",
+				},
+			},
+		},
+	}
+
+	// Mock the QueryVolumeUtil function using gomonkey
+	patches := gomonkey.ApplyFunc(utils.QueryVolumeUtil,
+		func(ctx context.Context, volManager volumes.Manager, queryFilter cnstypes.CnsQueryFilter,
+			querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+			assert.Equal(t, "test-volume-handle", queryFilter.VolumeIds[0].Id)
+			assert.NotNil(t, querySelection)
+			assert.Contains(t, querySelection.Names, string(cnstypes.QuerySelectionNameTypeBackingObjectDetails))
+			return &cnstypes.CnsQueryResult{
+				Volumes: []cnstypes.CnsVolume{*expectedVolume},
+			}, nil
+		})
+	defer patches.Reset()
+
+	// Call the function under test
+	err := setFileShareAnnotationsOnPVC(ctx, k8sClient, nil, pvc)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Equal(t, "192.168.1.100:/nfs/v3/path", pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Equal(t, "192.168.1.100:/nfs/v4/path", pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+}
+
+func TestSetFileShareAnnotationsOnPVC_PVNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test PVC
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pvc",
+			Namespace:   "test-namespace",
+			Annotations: make(map[string]string),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "non-existent-pv",
+		},
+	}
+
+	// Create fake k8s client without the PV
+	k8sClient := k8sfake.NewSimpleClientset()
+
+	// Call the function under test
+	err := setFileShareAnnotationsOnPVC(ctx, k8sClient, nil, pvc)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// Verify no annotations were added
+	assert.Empty(t, pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Empty(t, pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+}
+
+func TestSetFileShareAnnotationsOnPVC_QueryVolumeError(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test PVC
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pvc",
+			Namespace:   "test-namespace",
+			Annotations: make(map[string]string),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "test-pv",
+		},
+	}
+
+	// Create test PV
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: "test-volume-handle",
+				},
+			},
+		},
+	}
+
+	// Create fake k8s client with PV and PVC
+	k8sClient := k8sfake.NewSimpleClientset(pv, pvc)
+
+	// Mock the QueryVolumeUtil function to return error using gomonkey
+	expectedError := errors.New("query volume failed")
+	patches := gomonkey.ApplyFunc(utils.QueryVolumeUtil,
+		func(ctx context.Context, volManager volumes.Manager, queryFilter cnstypes.CnsQueryFilter,
+			querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+			return nil, expectedError
+		})
+	defer patches.Reset()
+
+	// Call the function under test
+	err := setFileShareAnnotationsOnPVC(ctx, k8sClient, nil, pvc)
+
+	// Assertions - The function should return the QueryVolume error
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "query volume failed")
+}
+
+func TestSetFileShareAnnotationsOnPVC_PVCUpdateError(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test PVC
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pvc",
+			Namespace:   "test-namespace",
+			Annotations: make(map[string]string),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "test-pv",
+		},
+	}
+
+	// Create test PV
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: "test-volume-handle",
+				},
+			},
+		},
+	}
+
+	// Create fake k8s client with PV and configure it to fail on PVC update
+	k8sClient := k8sfake.NewSimpleClientset(pv)
+	k8sClient.PrependReactor("update", "persistentvolumeclaims",
+		func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("update failed")
+		})
+
+	// Create expected volume response with file share backing details
+	expectedVolume := &cnstypes.CnsVolume{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: "test-volume-handle",
+		},
+		BackingObjectDetails: &cnstypes.CnsVsanFileShareBackingDetails{
+			AccessPoints: []types.KeyValue{
+				{
+					Key:   common.Nfsv3AccessPointKey,
+					Value: "192.168.1.100:/nfs/v3/path",
+				},
+				{
+					Key:   common.Nfsv4AccessPointKey,
+					Value: "192.168.1.100:/nfs/v4/path",
+				},
+			},
+		},
+	}
+
+	// Mock the QueryVolumeUtil function using gomonkey
+	patches := gomonkey.ApplyFunc(utils.QueryVolumeUtil,
+		func(ctx context.Context, volManager volumes.Manager, queryFilter cnstypes.CnsQueryFilter,
+			querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+			return &cnstypes.CnsQueryResult{
+				Volumes: []cnstypes.CnsVolume{*expectedVolume},
+			}, nil
+		})
+	defer patches.Reset()
+
+	// Call the function under test
+	err := setFileShareAnnotationsOnPVC(ctx, k8sClient, nil, pvc)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update failed")
+
+	// Verify annotations were set on the PVC object (even though update failed)
+	assert.Equal(t, "192.168.1.100:/nfs/v3/path", pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Equal(t, "192.168.1.100:/nfs/v4/path", pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+}
+
+func TestSetFileShareAnnotationsOnPVC_OnlyNFSv4AccessPoint(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test PVC
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pvc",
+			Namespace:   "test-namespace",
+			Annotations: make(map[string]string),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "test-pv",
+		},
+	}
+
+	// Create test PV
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: "test-volume-handle",
+				},
+			},
+		},
+	}
+
+	// Create fake k8s client with PV and PVC
+	k8sClient := k8sfake.NewSimpleClientset(pv, pvc)
+
+	// Create expected volume response with only NFSv4 access point
+	expectedVolume := &cnstypes.CnsVolume{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: "test-volume-handle",
+		},
+		BackingObjectDetails: &cnstypes.CnsVsanFileShareBackingDetails{
+			AccessPoints: []types.KeyValue{
+				{
+					Key:   common.Nfsv4AccessPointKey,
+					Value: "192.168.1.100:/nfs/v4/path",
+				},
+			},
+		},
+	}
+
+	// Mock the QueryVolumeUtil function using gomonkey
+	patches := gomonkey.ApplyFunc(utils.QueryVolumeUtil,
+		func(ctx context.Context, volManager volumes.Manager, queryFilter cnstypes.CnsQueryFilter,
+			querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+			return &cnstypes.CnsQueryResult{
+				Volumes: []cnstypes.CnsVolume{*expectedVolume},
+			}, nil
+		})
+	defer patches.Reset()
+
+	// Call the function under test
+	err := setFileShareAnnotationsOnPVC(ctx, k8sClient, nil, pvc)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Empty(t, pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Equal(t, "192.168.1.100:/nfs/v4/path", pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+}
+
+func TestSetFileShareAnnotationsOnPVC_EmptyAccessPoints(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test PVC
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pvc",
+			Namespace:   "test-namespace",
+			Annotations: make(map[string]string),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "test-pv",
+		},
+	}
+
+	// Create test PV
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: "test-volume-handle",
+				},
+			},
+		},
+	}
+
+	// Create fake k8s client with PV and PVC
+	k8sClient := k8sfake.NewSimpleClientset(pv, pvc)
+
+	// Create expected volume response with empty access points
+	expectedVolume := &cnstypes.CnsVolume{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: "test-volume-handle",
+		},
+		BackingObjectDetails: &cnstypes.CnsVsanFileShareBackingDetails{
+			AccessPoints: []types.KeyValue{},
+		},
+	}
+
+	// Mock the QueryVolumeUtil function using gomonkey
+	patches := gomonkey.ApplyFunc(utils.QueryVolumeUtil,
+		func(ctx context.Context, volManager volumes.Manager, queryFilter cnstypes.CnsQueryFilter,
+			querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+			return &cnstypes.CnsQueryResult{
+				Volumes: []cnstypes.CnsVolume{*expectedVolume},
+			}, nil
+		})
+	defer patches.Reset()
+
+	// Call the function under test
+	err := setFileShareAnnotationsOnPVC(ctx, k8sClient, nil, pvc)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Empty(t, pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Empty(t, pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+}
+
+func TestSetFileShareAnnotationsOnPVC_ExistingAnnotations(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test PVC with existing annotations
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				"existing-annotation": "existing-value",
+			},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "test-pv",
+		},
+	}
+
+	// Create test PV
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: "test-volume-handle",
+				},
+			},
+		},
+	}
+
+	// Create fake k8s client with PV and PVC
+	k8sClient := k8sfake.NewSimpleClientset(pv, pvc)
+
+	// Create expected volume response with file share backing details
+	expectedVolume := &cnstypes.CnsVolume{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: "test-volume-handle",
+		},
+		BackingObjectDetails: &cnstypes.CnsVsanFileShareBackingDetails{
+			AccessPoints: []types.KeyValue{
+				{
+					Key:   common.Nfsv3AccessPointKey,
+					Value: "192.168.1.100:/nfs/v3/path",
+				},
+			},
+		},
+	}
+
+	// Mock the QueryVolumeUtil function using gomonkey
+	patches := gomonkey.ApplyFunc(utils.QueryVolumeUtil,
+		func(ctx context.Context, volManager volumes.Manager, queryFilter cnstypes.CnsQueryFilter,
+			querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+			return &cnstypes.CnsQueryResult{
+				Volumes: []cnstypes.CnsVolume{*expectedVolume},
+			}, nil
+		})
+	defer patches.Reset()
+
+	// Call the function under test
+	err := setFileShareAnnotationsOnPVC(ctx, k8sClient, nil, pvc)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Equal(t, "existing-value", pvc.Annotations["existing-annotation"])
+	assert.Equal(t, "192.168.1.100:/nfs/v3/path", pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Empty(t, pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added units test for function setFileShareAnnotationsOnPVC in fullsync.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Unit tests added are passing.

```
=== RUN   TestSetFileShareAnnotationsOnPVC_Success
{"level":"info","time":"2025-10-14T17:59:58.151366+05:30","caller":"syncer/fullsync.go:665","msg":"setFileShareAnnotationsOnPVC: Setting file share annotation for PVC: \"test-pvc\", namespace: \"test-namespace\""}
{"level":"info","time":"2025-10-14T17:59:58.166822+05:30","caller":"syncer/fullsync.go:708","msg":"setFileShareAnnotationsOnPVC: Added file share export paths annotation successfully on PVC \"test-pvc\", namespce \"test-namespace\""}
--- PASS: TestSetFileShareAnnotationsOnPVC_Success (0.03s)

=== RUN   TestSetFileShareAnnotationsOnPVC_PVNotFound
{"level":"info","time":"2025-10-14T17:59:58.189475+05:30","caller":"syncer/fullsync.go:665","msg":"setFileShareAnnotationsOnPVC: Setting file share annotation for PVC: \"test-pvc\", namespace: \"test-namespace\""}
{"level":"error","time":"2025-10-14T17:59:58.189858+05:30","caller":"syncer/fullsync.go:670","msg":"setFileShareAnnotationsOnPVC: failed to get PV for PVC: \"test-pvc\", namespace: \"test-namespace\"","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.setFileShareAnnotationsOnPVC\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/fullsync.go:670\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.TestSetFileShareAnnotationsOnPVC_PVNotFound\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/fullsync_test.go:130\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
--- PASS: TestSetFileShareAnnotationsOnPVC_PVNotFound (0.00s)

=== RUN   TestSetFileShareAnnotationsOnPVC_QueryVolumeError
{"level":"info","time":"2025-10-14T17:59:58.191511+05:30","caller":"syncer/fullsync.go:665","msg":"setFileShareAnnotationsOnPVC: Setting file share annotation for PVC: \"test-pvc\", namespace: \"test-namespace\""}
{"level":"error","time":"2025-10-14T17:59:58.192094+05:30","caller":"common/vsphereutil.go:1094","msg":"QueryVolumeUtil failed for volumeID: test-volume-handle with error query volume failed","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common.init.func3\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/csi/service/common/vsphereutil.go:1094\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common.QueryVolumeByID\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/csi/service/common/vsphereutil.go:1106\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.setFileShareAnnotationsOnPVC\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/fullsync.go:681\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.TestSetFileShareAnnotationsOnPVC_QueryVolumeError\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/fullsync_test.go:183\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
{"level":"error","time":"2025-10-14T17:59:58.192178+05:30","caller":"syncer/fullsync.go:683","msg":"setFileShareAnnotationsOnPVC: Error while performing QueryVolume on volume test-volume-handle, Err: query volume failed","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.setFileShareAnnotationsOnPVC\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/fullsync.go:683\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.TestSetFileShareAnnotationsOnPVC_QueryVolumeError\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/fullsync_test.go:183\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
--- PASS: TestSetFileShareAnnotationsOnPVC_QueryVolumeError (0.00s)

=== RUN   TestSetFileShareAnnotationsOnPVC_PVCUpdateError
{"level":"info","time":"2025-10-14T17:59:58.192386+05:30","caller":"syncer/fullsync.go:665","msg":"setFileShareAnnotationsOnPVC: Setting file share annotation for PVC: \"test-pvc\", namespace: \"test-namespace\""}
{"level":"error","time":"2025-10-14T17:59:58.192489+05:30","caller":"syncer/fullsync.go:704","msg":"setFileShareAnnotationsOnPVC: Error updating PVC \"\" in namespace \"\", Err: update failed","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.setFileShareAnnotationsOnPVC\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/fullsync.go:704\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.TestSetFileShareAnnotationsOnPVC_PVCUpdateError\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/fullsync_test.go:256\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
--- PASS: TestSetFileShareAnnotationsOnPVC_PVCUpdateError (0.00s)

=== RUN   TestSetFileShareAnnotationsOnPVC_OnlyNFSv4AccessPoint
{"level":"info","time":"2025-10-14T17:59:58.192655+05:30","caller":"syncer/fullsync.go:665","msg":"setFileShareAnnotationsOnPVC: Setting file share annotation for PVC: \"test-pvc\", namespace: \"test-namespace\""}
{"level":"info","time":"2025-10-14T17:59:58.192695+05:30","caller":"syncer/fullsync.go:708","msg":"setFileShareAnnotationsOnPVC: Added file share export paths annotation successfully on PVC \"test-pvc\", namespce \"test-namespace\""}
--- PASS: TestSetFileShareAnnotationsOnPVC_OnlyNFSv4AccessPoint (0.00s)

=== RUN   TestSetFileShareAnnotationsOnPVC_EmptyAccessPoints
{"level":"info","time":"2025-10-14T17:59:58.192812+05:30","caller":"syncer/fullsync.go:665","msg":"setFileShareAnnotationsOnPVC: Setting file share annotation for PVC: \"test-pvc\", namespace: \"test-namespace\""}
{"level":"info","time":"2025-10-14T17:59:58.192849+05:30","caller":"syncer/fullsync.go:708","msg":"setFileShareAnnotationsOnPVC: Added file share export paths annotation successfully on PVC \"test-pvc\", namespce \"test-namespace\""}
--- PASS: TestSetFileShareAnnotationsOnPVC_EmptyAccessPoints (0.00s)

=== RUN   TestSetFileShareAnnotationsOnPVC_ExistingAnnotations
{"level":"info","time":"2025-10-14T17:59:58.192994+05:30","caller":"syncer/fullsync.go:665","msg":"setFileShareAnnotationsOnPVC: Setting file share annotation for PVC: \"test-pvc\", namespace: \"test-namespace\""}
{"level":"info","time":"2025-10-14T17:59:58.193028+05:30","caller":"syncer/fullsync.go:708","msg":"setFileShareAnnotationsOnPVC: Added file share export paths annotation successfully on PVC \"test-pvc\", namespce \"test-namespace\""}
--- PASS: TestSetFileShareAnnotationsOnPVC_ExistingAnnotations (0.00s)
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Added unit test for function setFileShareAnnotationsOnPVC
```
