### PR TITLE
Correct the skip reading mgmt hosts logic

### DIFF
--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -186,10 +186,9 @@ func createFaultDomainMap(ctx context.Context, vs *vSphere) map[string]string {
 			hostInfo := host.Common.InventoryPath
 			hostIpInfo := strings.Split(hostInfo, "/")
 			hostCluster := hostIpInfo[len(hostIpInfo)-2]
-			if !strings.Contains(hostCluster, "EdgeMgmtCluster") || !strings.Contains(hostCluster, "mgmt") {
+			if !(strings.Contains(hostCluster, "EdgeMgmtCluster") || strings.Contains(hostCluster, "mgmt")) {
 				hostsInVsanStretchCluster = append(hostsInVsanStretchCluster, host)
 			}
-
 		}
 		hosts = hostsInVsanStretchCluster
 	}


### PR DESCRIPTION
Correct the skip reading mgmt hosts logic

Before this change
This condition is a bit tricky: it uses || (logical OR), so it includes hosts if either:

The cluster name does not contain "EdgeMgmtCluster", or

The cluster name does not contain "mgmt"

⚠️ Note: This logic might unintentionally include some management hosts. 

A more accurate condition might be the fix provided here

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Yes

**Special notes for your reviewer**:
NA

**Release note**:
NA
