### PR TITLE
Update webhook certs mountpath from /tmp directory to /etc/vmware/wcp to eliminate security risk

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -519,7 +519,7 @@ spec:
               readOnly: true
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
-            - mountPath: /tmp/k8s-webhook-server/serving-certs/client-ca
+            - mountPath: /etc/vmware/wcp/webhook-certs/client-ca
               name: client-ca
               readOnly: true
         - name: csi-snapshotter
@@ -819,6 +819,8 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10
+      securityContext:
+        fsGroup: 65533
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
@@ -861,11 +863,11 @@ spec:
             runAsUser: 65534
             runAsGroup: 65533
           volumeMounts:
-            - mountPath: /tmp/k8s-webhook-server/serving-certs
+            - mountPath: /etc/vmware/wcp/webhook-certs
               name: webhook-certs
               readOnly: true
       volumes:
         - name: webhook-certs
           secret:
-            defaultMode: 420
+            defaultMode: 0440
             secretName: vmware-system-csi-webhook-service-cert

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -519,7 +519,7 @@ spec:
               readOnly: true
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
-            - mountPath: /tmp/k8s-webhook-server/serving-certs/client-ca
+            - mountPath: /etc/vmware/wcp/webhook-certs/client-ca
               name: client-ca
               readOnly: true
         - name: csi-snapshotter
@@ -819,6 +819,8 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10
+      securityContext:
+        fsGroup: 65533
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
@@ -861,11 +863,11 @@ spec:
             runAsUser: 65534
             runAsGroup: 65533
           volumeMounts:
-            - mountPath: /tmp/k8s-webhook-server/serving-certs
+            - mountPath: /etc/vmware/wcp/webhook-certs
               name: webhook-certs
               readOnly: true
       volumes:
         - name: webhook-certs
           secret:
-            defaultMode: 420
+            defaultMode: 0440
             secretName: vmware-system-csi-webhook-service-cert

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -519,7 +519,7 @@ spec:
               readOnly: true
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
-            - mountPath: /tmp/k8s-webhook-server/serving-certs/client-ca
+            - mountPath: /etc/vmware/wcp/webhook-certs/client-ca
               name: client-ca
               readOnly: true
         - name: csi-snapshotter
@@ -819,6 +819,8 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10
+      securityContext:
+        fsGroup: 65533
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
@@ -861,11 +863,11 @@ spec:
             runAsUser: 65534
             runAsGroup: 65533
           volumeMounts:
-            - mountPath: /tmp/k8s-webhook-server/serving-certs
+            - mountPath: /etc/vmware/wcp/webhook-certs
               name: webhook-certs
               readOnly: true
       volumes:
         - name: webhook-certs
           secret:
-            defaultMode: 420
+            defaultMode: 0440
             secretName: vmware-system-csi-webhook-service-cert

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -43,6 +43,7 @@ const (
 	MutationWebhookPath              = "/mutate"
 	DefaultWebhookPort               = 9883
 	DefaultWebhookMetricsBindAddress = "0"
+	DefaultWebhookCertDir            = "/etc/vmware/wcp/webhook-certs"
 	devopsUserLabelKey               = "cns.vmware.com/user-created"
 	vmUIDLabelKey                    = "cns.vmware.com/vm-uid"
 	pvcUIDLabelKey                   = "cns.vmware.com/pvc-uid"
@@ -113,6 +114,7 @@ func startCNSCSIWebhookManager(ctx context.Context, enableWebhookClientCertVerif
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:         webhookPort,
+			CertDir:      DefaultWebhookCertDir,
 			TLSOpts:      tlsConfigOpts,
 			ClientCAName: clientCAName,
 		})}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update webhook certs mountpath from /tmp directory to /etc/vmware/wcp to eliminate security risk.
Considered following things while making these changes:
- Mount certificates to a secure, non-world-writable directory.
- Use Kubernetes secrets or a dedicated secrets management system for storing and accessing sensitive data securely.
- The private key have world readable permissions, restrict it accordingly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
wcp pre-checkin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/Pre-Checkin-CSI-Stale/job/csi-wcp-precheckin-vds/40/   (passed)
(Started this new pipeline with the help of Kavya)

```
12:28:06  Ran 8 of 1100 Specs in 1162.863 seconds
12:28:06  SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 1092 Skipped
12:28:06  PASS
```

Manually created a PVC with these changes and verified that there is no regression.
```
# cat pvc.yaml 
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: example-rwo-pvc
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: wcp-profile-xl96sypo6u 

# k apply -f pvc.yaml -n storage-policy-test
persistentvolumeclaim/example-rwo-pvc created

# k get pvc -A
NAMESPACE             NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             VOLUMEATTRIBUTESCLASS   AGE
storage-policy-test   example-rwo-pvc      Bound    pvc-db55f99c-09a4-4e12-ae5e-02c394711d74   1Gi        RWO            wcp-profile-xl96sypo6u   <unset>                 6s
...
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Update webhook certs mountpath from /tmp directory to /etc/vmware/wcp to eliminate security risk
```
