### PR TITLE
Moving static Vol tests to EF and removing vmservice test from CF 

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -846,7 +846,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 9. Verify PV is deleted automatically.
 	// 10. Verify Volume id deleted automatically.
 	// 11. Verify CRD deleted automatically.
-	ginkgo.It("[cf-wcp-f][ef-f-stretched-svc][csi-supervisor] [stretched-svc] Verify static provisioning workflow on "+
+	ginkgo.It("[ef-wcp][ef-f-stretched-svc][csi-supervisor] [stretched-svc] Verify static provisioning workflow on "+
 		"SVC import FCD", ginkgo.Label(p0, block, wcp, vc70), func() {
 		var err error
 		var totalQuotaUsedBefore, storagePolicyQuotaBefore, storagePolicyUsageBefore *resource.Quantity

--- a/tests/e2e/snapshot_vmservice_vm.go
+++ b/tests/e2e/snapshot_vmservice_vm.go
@@ -198,7 +198,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   11. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("[cf-wcp] Taking snapshot of a vm service vm attached to a dynamic "+
+	ginkgo.It("[cf-f-wcp] Taking snapshot of a vm service vm attached to a dynamic "+
 		"volume", ginkgo.Label(p0, block, wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -1307,7 +1307,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			13. Verify File system has increased
 			14. Delete POD, PVC, PV, CNSregisterVolume and SC
 	*/
-	ginkgo.It("[cf-wcp-f] [csi-supervisor] Offline and Online volume resize on statically "+
+	ginkgo.It("[ef-wcp] [csi-supervisor] Offline and Online volume resize on statically "+
 		"created volume", ginkgo.Label(p0, block, wcp, vc70), func() {
 		var err error
 		var fsSize int64


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Moving static Vol tests to EF and removing vmservice test due to bug 3598795


**Testing done**:
Not required

**Special notes for your reviewer**:
Moving static Vol tests to EF and removing vmservice test due to bug 3598795