### PR TITLE
Support NonPersistent DiskMode and Update Spec - All Required Fields, nodeUUID rename to instanceUUID

### DIFF
--- a/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
+++ b/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
@@ -21,7 +21,7 @@ import (
 )
 
 // DiskMode describes the desired mode to use when attaching the volume.
-// +kubebuilder:validation:Enum=independent_persistent;persistent;independent_nonpersistent
+// +kubebuilder:validation:Enum=independent_persistent;persistent;independent_nonpersistent;nonpersistent
 type DiskMode string
 
 const (
@@ -34,6 +34,8 @@ const (
 	// and discarded at power off.
 	// It is not affected by snapshots.
 	IndependentNonPersistent = "independent_nonpersistent"
+	// Changes to virtual disk are made to a redo log and discarded at power off.
+	NonPersistent = "nonpersistent"
 )
 
 // SharingMode is the sharing mode of the virtual disk.
@@ -52,9 +54,9 @@ const (
 type CnsNodeVMBatchAttachmentSpec struct {
 	// +required
 
-	// NodeUUID indicates the UUID of the node where the volume needs to be attached to.
-	// Here NodeUUID is the instance UUID of the node.
-	NodeUUID string `json:"nodeUUID"`
+	// InstanceUUID indicates the instance UUID of the node where the volume needs to be attached to.
+	InstanceUUID string `json:"instanceUUID"`
+	// +required
 
 	// +listType=map
 	// +listMapKey=name
@@ -63,8 +65,12 @@ type CnsNodeVMBatchAttachmentSpec struct {
 }
 
 type VolumeSpec struct {
+	// +required
+
 	// Name of the volume as given by the user.
 	Name string `json:"name"`
+	// +required
+
 	// PersistentVolumeClaim contains details about the volume's desired state.
 	PersistentVolumeClaim PersistentVolumeClaimSpec `json:"persistentVolumeClaim"`
 }
@@ -74,22 +80,22 @@ type PersistentVolumeClaimSpec struct {
 
 	// ClaimName is the PVC name.
 	ClaimName string `json:"claimName"`
-	// +optional
+	// +required
 
 	// DiskMode is the desired mode to use when attaching the volume
-	DiskMode DiskMode `json:"diskMode,omitempty"`
-	// +optional
+	DiskMode DiskMode `json:"diskMode"`
+	// +required
 
 	// SharingMode indicates the sharing mode if the virtual disk while attaching.
-	SharingMode SharingMode `json:"sharingMode,omitempty"`
-	// +optional
+	SharingMode SharingMode `json:"sharingMode"`
+	// +required
 
 	// ControllerKey is the object key for the controller object for this device.
-	ControllerKey *int32 `json:"controllerKey,omitempty"`
-	// +optional
+	ControllerKey *int32 `json:"controllerKey"`
+	// +required
 
 	// UnitNumber of this device on its controller.
-	UnitNumber *int32 `json:"unitNumber,omitempty"`
+	UnitNumber *int32 `json:"unitNumber"`
 }
 
 // CnsNodeVMBatchAttachmentStatus defines the observed state of CnsNodeVMBatchAttachment
@@ -123,7 +129,7 @@ type PersistentVolumeClaimStatus struct {
 	// CnsVolumeID is the volume ID for the PVC.
 	CnsVolumeID string `json:"cnsVolumeId,omitempty"`
 	// DiskUUID is the ID obtained when volume is attached to a VM.
-	DiskUUID string `json:"DiskUUID,omitempty"`
+	DiskUUID string `json:"diskUUID,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
@@ -47,10 +47,9 @@ spec:
             description: CnsNodeVMBatchAttachmentSpec defines the desired state of
               CnsNodeVMBatchAttachment
             properties:
-              nodeUUID:
-                description: |-
-                  NodeUUID indicates the UUID of the node where the volume needs to be attached to.
-                  Here NodeUUID is the instance UUID of the node.
+              instanceUUID:
+                description: InstanceUUID indicates the instance UUID of the node
+                  where the volume needs to be attached to.
                 type: string
               volumes:
                 description: VolumeSpec reflects the desired state for each volume.
@@ -78,6 +77,7 @@ spec:
                           - independent_persistent
                           - persistent
                           - independent_nonpersistent
+                          - nonpersistent
                           type: string
                         sharingMode:
                           description: SharingMode indicates the sharing mode if the
@@ -92,6 +92,10 @@ spec:
                           type: integer
                       required:
                       - claimName
+                      - controllerKey
+                      - diskMode
+                      - sharingMode
+                      - unitNumber
                       type: object
                   required:
                   - name
@@ -102,7 +106,7 @@ spec:
                 - name
                 x-kubernetes-list-type: map
             required:
-            - nodeUUID
+            - instanceUUID
             - volumes
             type: object
           status:
@@ -123,10 +127,6 @@ spec:
                       description: PersistentVolumeClaim contains details about the
                         volume's current state.
                       properties:
-                        DiskUUID:
-                          description: DiskUUID is the ID obtained when volume is
-                            attached to a VM.
-                          type: string
                         attached:
                           description: |-
                             Attached indicates the attach status of a PVC.
@@ -139,6 +139,10 @@ spec:
                           type: string
                         cnsVolumeId:
                           description: CnsVolumeID is the volume ID for the PVC.
+                          type: string
+                        diskUUID:
+                          description: DiskUUID is the ID obtained when volume is
+                            attached to a VM.
                           type: string
                         error:
                           description: Error indicates the error which may have occurred

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -174,7 +174,7 @@ func removeStaleEntriesFromInstanceStatus(ctx context.Context,
 				// This kind of situation can happen when detach is successful but finalizer could not be removed
 				// because of which the instance is back in queue.
 				err := removePvcFinalizer(ctx, client, k8sClient, volumeStatus.PersistentVolumeClaim.ClaimName, instance.Namespace,
-					instance.Spec.NodeUUID)
+					instance.Spec.InstanceUUID)
 				if err != nil {
 					log.Errorf("failed to ensure that PVC finalizers are removed.")
 					return err
@@ -452,10 +452,10 @@ func getVmObject(ctx context.Context, client client.Client, configInfo config.Co
 	log := logger.GetLogger(ctx)
 
 	// Get vm from vCenter.
-	vm, err := GetVMFromVcenter(ctx, instance.Spec.NodeUUID, configInfo)
+	vm, err := GetVMFromVcenter(ctx, instance.Spec.InstanceUUID, configInfo)
 	if err != nil {
 		if err == cnsvsphere.ErrVMNotFound {
-			log.Infof("VM %s not found on VC", instance.Spec.NodeUUID)
+			log.Infof("VM %s not found on VC", instance.Spec.InstanceUUID)
 			return nil, nil
 		}
 		return nil, err
@@ -507,7 +507,7 @@ func getVolumesToDetachFromVM(ctx context.Context, client client.Client,
 		log.Errorf("failed to find the FCDs attached to VM %s. Err: %s", vm, err)
 		return map[string]string{}, err
 	}
-	log.Infof("List of attached FCDs %+v to VM %s", attachedFcdList, instance.Spec.NodeUUID)
+	log.Infof("List of attached FCDs %+v to VM %s", attachedFcdList, instance.Spec.InstanceUUID)
 
 	// Find volumes to be detached from the VM by takinga diff with FCDs attached to VM on vCenter.
 	volumesToDetach, err := getVolumesToDetachForVmFromVC(ctx, instance, client, k8sClient, attachedFcdList)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -67,7 +67,7 @@ func setupTestCnsNodeVMBatchAttachment() v1alpha1.CnsNodeVMBatchAttachment {
 				ResourceVersion: "1",
 			},
 			Spec: v1alpha1.CnsNodeVMBatchAttachmentSpec{
-				NodeUUID: testNodeUUID,
+				InstanceUUID: testNodeUUID,
 				Volumes: []v1alpha1.VolumeSpec{
 					{
 						Name: disk1,
@@ -203,7 +203,7 @@ func getClientSetWithPvc() *k8sFake.Clientset {
 func TestCnsNodeVMBatchAttachmentWhenVmOnVcenterReturnsError(t *testing.T) {
 	t.Run("TestCnsNodeVMBatchAttachmentWhenVmOnVcenterReturnsError", func(t *testing.T) {
 		testCnsNodeVMBatchAttachment := setupTestCnsNodeVMBatchAttachment()
-		testCnsNodeVMBatchAttachment.Spec.NodeUUID = "test-2"
+		testCnsNodeVMBatchAttachment.Spec.InstanceUUID = "test-2"
 
 		r := setTestEnvironment(&testCnsNodeVMBatchAttachment, false)
 
@@ -237,7 +237,7 @@ func TestCnsNodeVMBatchAttachmentWhenVmOnVcenterReturnsNotFoundError(t *testing.
 
 	t.Run("TestCnsNodeVMBatchAttachmentWhenVmOnVcenterReturnsNotFoundError", func(t *testing.T) {
 		testCnsNodeVMBatchAttachment := setupTestCnsNodeVMBatchAttachment()
-		testCnsNodeVMBatchAttachment.Spec.NodeUUID = "test-3"
+		testCnsNodeVMBatchAttachment.Spec.InstanceUUID = "test-3"
 
 		r := setTestEnvironment(&testCnsNodeVMBatchAttachment, true)
 
@@ -287,7 +287,7 @@ func TestCnsNodeVMBatchAttachmentWhenVmOnVcenterReturnsNotFoundErrorAndInstanceI
 		func(t *testing.T) {
 			testCnsNodeVMBatchAttachment := setupTestCnsNodeVMBatchAttachment()
 			nodeUUID := "test-3"
-			testCnsNodeVMBatchAttachment.Spec.NodeUUID = nodeUUID
+			testCnsNodeVMBatchAttachment.Spec.InstanceUUID = nodeUUID
 
 			r := setTestEnvironment(&testCnsNodeVMBatchAttachment, false)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR does 3 changes to the batch attach spec:
1. Adds DiskMode nonpersistent as VM operator is also going to allow it for traditional VMs being imported into K8s.
2. Makes all fields in the spec required.
3. Changes nodeUUID to instanceUUID (requested by VM op team).


**Testing done**:
Ran make images.

1. In a batch attach CR, kept on removing 1 after the other fields among (controllerKey, unitNumber, sharingMode, diskMode). Observed that K8s prevented creation of the CR until all fields were populated.
2. Attached a volume to the VM.
3. Detached a volume to the VM.
4. Verified that lowerCamelCase for diskUUID is also working:

```
status:
  volumes:
  - name: disk-1
    persistentVolumeClaim:
      attached: true
      claimName: rwx-pvc-1
      cnsVolumeId: e171a6c0-d143-42b9-afd2-4906c8c225f0
      diskUUID: 6000C298-6135-5c31-87cb-3bd775563711
```
Precheckin pipeline:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/Pre-Checkin-CSI-Stale/job/csi-wcp-precheckin-vds/41/
