### PR TITLE
Fix fetch VM with version v1alpha4

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -424,8 +424,8 @@ func GetVirtualMachineAllApiVersions(ctx context.Context, vmKey types.Namespaced
 			log.Debugf("GetVirtualMachineAllApiVersions: converting v1alpha4 VirtualMachine "+
 				"to v1alpha5 VirtualMachine, name %s", vmV1alpha4.Name)
 			apiVersion = vmOperatorApiVersionPrefix + "/v1alpha4"
-			err = vmoperatorv1alpha4.Convert_v1alpha5_VirtualMachine_To_v1alpha4_VirtualMachine(
-				vm, vmV1alpha4, nil)
+			err = vmoperatorv1alpha4.Convert_v1alpha4_VirtualMachine_To_v1alpha5_VirtualMachine(
+				vmV1alpha4, vm, nil)
 			if err != nil {
 				return nil, apiVersion, err
 			}
@@ -451,7 +451,7 @@ func PatchVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
 	vmV1alpha2, old_vmV1alpha2 := &vmoperatorv1alpha2.VirtualMachine{}, &vmoperatorv1alpha2.VirtualMachine{}
 	vmV1alpha3, old_vmV1alpha3 := &vmoperatorv1alpha3.VirtualMachine{}, &vmoperatorv1alpha3.VirtualMachine{}
 	vmV1alpha4, old_vmV1alpha4 := &vmoperatorv1alpha4.VirtualMachine{}, &vmoperatorv1alpha4.VirtualMachine{}
-	log.Infof("PatchVirtualMachine: patch virtualmachine name: %s", vmV1alpha4.Name)
+	log.Infof("PatchVirtualMachine: patch virtualmachine name: %s", vm.Name)
 	// try patch virtualmachine with latest api version
 	vmPatch := client.MergeFromWithOptions(
 		old_vm.DeepCopy(),

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -811,7 +811,8 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 		}
 		virtualMachine = &vmoperatorv1alpha5.VirtualMachine{}
 	}
-
+	log.Infof("check if volume attached to virtualmachine name %s, namespace %s",
+		virtualMachine.Name, virtualMachine.Namespace)
 	for _, volume := range virtualMachine.Status.Volumes {
 		if volume.Name == req.VolumeId && volume.Attached && volume.DiskUUID != "" {
 			diskUUID = volume.DiskUUID


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix issue fetch virtual machine with version v1alpha4

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running pre-checkins
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/484/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/487/

Performed manual testing on setup, now pods which are stuck in pending state are in running state
Manual Testing logs:
```
root@420f7528e73e637b52ced8eeb3921e36 [ ~ ]# k get pod -n st-iis 
NAME                           READY   STATUS    RESTARTS   AGE
windows-iis-6f7796c545-k86c6   1/1     Running   0          7m10s
root@420f7528e73e637b52ced8eeb3921e36 [ ~ ]# k get pvc windows-iis-pvc  -n st-iis  
NAME              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
windows-iis-pvc   Bound    pvc-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae   1Gi        RWO            vsansp         <unset>                 5d3h
root@420f7528e73e637b52ced8eeb3921e36 [ ~ ]# k get  pv pvc-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae  
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                    STORAGECLASS   VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae   1Gi        RWO            Delete           Bound    st-iis/windows-iis-pvc   vsansp         <unset>                          5d3h
root@420f7528e73e637b52ced8eeb3921e36 [ ~ ]# k get  pv pvc-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae   -o yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
    volume.kubernetes.io/provisioner-deletion-secret-name: ""
    volume.kubernetes.io/provisioner-deletion-secret-namespace: ""
  creationTimestamp: "2025-10-15T09:37:24Z"
  finalizers:
  - kubernetes.io/pv-protection
  - external-attacher/csi-vsphere-vmware-com
  name: pvc-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae
  resourceVersion: "4692"
  uid: 0ee1425a-b804-4186-8f82-abd6c231fc3b
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: windows-iis-pvc
    namespace: st-iis
    resourceVersion: "4666"
    uid: d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae
  csi:
    driver: csi.vsphere.vmware.com
    fsType: ext4
    volumeAttributes:
      storage.kubernetes.io/csiProvisionerIdentity: 1760520534083-785-csi.vsphere.vmware.com
      type: vSphere CNS Block Volume
    volumeHandle: f04e37f1-aacf-45d3-80fe-8dd9c4951c78-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: topology.kubernetes.io/zone
          operator: In
          values:
          - domain-c10
  persistentVolumeReclaimPolicy: Delete
  storageClassName: vsansp
  volumeMode: Filesystem
status:
  lastPhaseTransitionTime: "2025-10-15T09:37:24Z"
  phase: Bound

root@420f7528e73e637b52ced8eeb3921e36 [ ~ ]# k get vm vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h -n vks35-cc35-etcd-323-ppwu-35ns1 -o yaml
apiVersion: vmoperator.vmware.com/v1alpha4
kind: VirtualMachine
metadata:
  annotations:
    ...
    vmoperator.vmware.com/created-at-schema-version: v1alpha4 
    ...
  creationTimestamp: "2025-10-18T09:02:20Z"
  finalizers:
  - vmoperator.vmware.com/virtualmachine
  generation: 4
  labels:
    ...
    topology.kubernetes.io/zone: domain-c10
  name: vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h
  namespace: vks35-cc35-etcd-323-ppwu-35ns1
...
spec:
  biosUUID: 158fabc4-54e7-46f6-8e22-a3f352440b65
  ...
  powerOffMode: Hard
  powerState: PoweredOn
  promoteDisksMode: Online
  ...
  volumes:
  ...
  - name: f04e37f1-aacf-45d3-80fe-8dd9c4951c78-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae
    persistentVolumeClaim:
      claimName: f04e37f1-aacf-45d3-80fe-8dd9c4951c78-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae
status:
  biosUUID: 158fabc4-54e7-46f6-8e22-a3f352440b65
  ...
  uniqueID: vm-5887
  volumes:
  ...
  - attached: true
    diskUUID: 6000C29b-31c8-033b-e761-04354f57d591
    limit: 1Gi
    name: f04e37f1-aacf-45d3-80fe-8dd9c4951c78-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae
    requested: 1Gi
    type: Managed
    used: "0"
  ...
  zone: domain-c10

```
logs:
```
{"level":"info","time":"2025-10-20T12:47:18.417989313Z","caller":"wcpguest/controller.go:697","msg":"ControllerPublishVolume: called with args volume_id:\"f04e37f1-aacf-45d3-80fe-8dd9c4951c78-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae\" node_id:\"vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h\" volume_capability:{mount:{fs_type:\"ext4\"} access_mode:{mode:SINGLE_NODE_WRITER}} volume_context:{key:\"storage.kubernetes.io/csiProvisionerIdentity\" value:\"1760520534083-785-csi.vsphere.vmware.com\"} volume_context:{key:\"type\" value:\"vSphere CNS Block Volume\"}","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
{"level":"info","time":"2025-10-20T12:47:18.418697187Z","caller":"wcpguest/controller_helper.go:442","msg":"attacherTimeout is set to 4 minutes","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
{"level":"info","time":"2025-10-20T12:47:18.418756839Z","caller":"utils/utils.go:376","msg":"get machine with vm-operator api version v1alpha5 name: vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h, namespace: vks35-cc35-etcd-323-ppwu-35ns1","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
..
{"level":"info","time":"2025-10-20T12:47:18.42993815Z","caller":"utils/utils.go:439","msg":"successfully fetched the virtual machines with name vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h and namespace vks35-cc35-etcd-323-ppwu-35ns1","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
{"level":"info","time":"2025-10-20T12:47:18.429998576Z","caller":"utils/utils.go:454","msg":"PatchVirtualMachine: patch virtualmachine name: vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
{"level":"info","time":"2025-10-20T12:47:18.432343554Z","caller":"utils/utils.go:461","msg":"PatchVirtualMachine: converting VirtualMachine to v1alpha4 VirtualMachine, name: vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
..
{"level":"info","time":"2025-10-20T12:47:18.497655375Z","caller":"utils/utils.go:538","msg":"PatchVirtualMachine: successfully patched the virtualmachine, name: vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
{"level":"info","time":"2025-10-20T12:47:18.497716824Z","caller":"wcpguest/controller.go:814","msg":"check if volume attached to virtualmachine name vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h, namespace vks35-cc35-etcd-323-ppwu-35ns1","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
{"level":"info","time":"2025-10-20T12:47:18.506586005Z","caller":"wcpguest/controller.go:858","msg":"converting v1alpha1 VirtualMachine to v1alpha5 VirtualMachine, name vks35-cc35-etcd-323-ppwu-35ns1-c1-np1-worker-668q5-crw8q-nw82h","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
..
{"level":"info","time":"2025-10-20T12:47:19.049027168Z","caller":"wcpguest/controller.go:903","msg":"observed disk UUID \"6000C29b-31c8-033b-e761-04354f57d591\" is set for the volume \"f04e37f1-aacf-45d3-80fe-8dd9c4951c78-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae\" on virtualmachine \"vks35-cc35-etcd-323-ppwu-35ns1-c1-np2-worker-pztrh-9b2xp-5wp5h\"","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
{"level":"info","time":"2025-10-20T12:47:19.049072098Z","caller":"wcpguest/controller.go:930","msg":"ControllerPublishVolume: Volume attached successfully \"f04e37f1-aacf-45d3-80fe-8dd9c4951c78-d4a21f0c-4515-41bd-9cb4-c3986e9bf8ae\"","TraceId":"282379a9-29e9-44e3-822b-0aa0042116c7"}
```

logs: 
[v1alpha4_manual_testing.log](https://github.com/user-attachments/files/23001900/v1alpha4_manual_testing.log)
[v1alpha4_csi_controller_syncer.log](https://github.com/user-attachments/files/23001901/v1alpha4_csi_controller_syncer.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix issue fetch virtual machine with version v1alpha4
```
