### PR TITLE
Update only status sub-resource when CnsRegisterVolume fails

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -58,7 +58,7 @@ rules:
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsregistervolumes", "cnsunregistervolumes", "cnsunregistervolumes/status"]
+    resources: ["cnsregistervolumes", "cnsregistervolumes/status", "cnsunregistervolumes", "cnsunregistervolumes/status"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -58,7 +58,7 @@ rules:
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsregistervolumes", "cnsunregistervolumes", "cnsunregistervolumes/status"]
+    resources: ["cnsregistervolumes", "cnsregistervolumes/status", "cnsunregistervolumes", "cnsunregistervolumes/status"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -58,7 +58,7 @@ rules:
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsregistervolumes", "cnsunregistervolumes", "cnsunregistervolumes/status"]
+    resources: ["cnsregistervolumes", "cnsregistervolumes/status", "cnsunregistervolumes", "cnsunregistervolumes/status"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -58,7 +58,7 @@ rules:
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsregistervolumes", "cnsunregistervolumes", "cnsunregistervolumes/status"]
+    resources: ["cnsregistervolumes", "cnsregistervolumes/status", "cnsunregistervolumes", "cnsunregistervolumes/status"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -1035,7 +1035,7 @@ func setInstanceError(ctx context.Context, r *ReconcileCnsRegisterVolume,
 	instance *cnsregistervolumev1alpha1.CnsRegisterVolume, errMsg string) {
 	log := logger.GetLogger(ctx)
 	instance.Status.Error = errMsg
-	err := updateCnsRegisterVolume(ctx, r.client, instance)
+	err := k8s.UpdateStatus(ctx, r.client, instance)
 	if err != nil {
 		log.Errorf("updateCnsRegisterVolume failed. err: %v", err)
 	}


### PR DESCRIPTION
### <!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When a CnsRegisterVolume operation fails, the operator currently updates the entire CR instance instead of just the status sub-resource. This triggers an increase in the resource’s generation ID, causing the controller to immediately requeue and reconcile the object again without any backoff interval. As a result, repeated registration failures lead to a continuous stream of API calls attempting to re-register the volume, putting unnecessary load on vCenter.

This PR updates only status sub-resource when CnsRegisterVolume fails.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update only status sub-resource when CnsRegisterVolume fails
```
