### PR TITLE
vmserviceVM - Check volume name before validating DataIntegrity

### DIFF
--- a/tests/e2e/vmservice_utils.go
+++ b/tests/e2e/vmservice_utils.go
@@ -1322,8 +1322,10 @@ func createVMServiceandWaitForVMtoGetIP(ctx context.Context, vmopC ctlrclient.Cl
 			vm, err = getVmsvcVM(ctx, vmopC, vm.Namespace, vm.Name) // refresh vm info
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			for i, vol := range vm.Status.Volumes {
-				volFolder := formatNVerifyPvcIsAccessible(vol.DiskUuid, i+1, vmIp)
-				verifyDataIntegrityOnVmDisk(vmIp, volFolder)
+				if vol.Name == pvclaimsList[j].Name {
+					volFolder := formatNVerifyPvcIsAccessible(vol.DiskUuid, i+1, vmIp)
+					verifyDataIntegrityOnVmDisk(vmIp, volFolder)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: vmserviceVM - Check volume name before validating DataIntegrity

**Testing done**:
Yes

**Special notes for your reviewer**: vmserviceVM - Check volume name before validating DataIntegrity in case of vsan-stratch-vmservice tests 

**Release note**:
vmserviceVM - Check volume name before validating DataIntegrity
