### PR TITLE
Increased sleep time in vmservice-vsan-stretch secondary site down 

### DIFF
--- a/tests/e2e/csi_snapshot_negative.go
+++ b/tests/e2e/csi_snapshot_negative.go
@@ -281,7 +281,7 @@ var _ = ginkgo.Describe("[block-snapshot-negative] Volume Snapshot Fault-Injecti
 	})
 
 	ginkgo.It("[pq-wcp-neg-snpt][block-vanilla-snapshot] [tkg-snapshot][supervisor-snapshot]"+
-		"[pq-vks-snapshot] create volume snapshot when CNS goes down", ginkgo.Label(p1, block, vanilla,
+		"[pq-f-vks-snapshot] create volume snapshot when CNS goes down", ginkgo.Label(p1, block, vanilla,
 		tkg, snapshot, disruptive, negative, vc90), func() {
 
 		serviceName = vsanhealthServiceName

--- a/tests/e2e/vm_service_vsan_stretch_cluster.go
+++ b/tests/e2e/vm_service_vsan_stretch_cluster.go
@@ -258,7 +258,7 @@ var _ bool = ginkgo.Describe("[vsan-stretch-vmsvc] vm service with csi vol tests
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
-			time.Sleep(5 * time.Minute)
+			time.Sleep(8 * time.Minute)
 			// Check if csi pods are running fine after site failure
 			ginkgo.By("Check if csi pods are running fine after site failure")
 			err = fpod.WaitForPodsRunningReady(ctx, client, csiNs, len(csipods.Items),
@@ -306,7 +306,7 @@ var _ bool = ginkgo.Describe("[vsan-stretch-vmsvc] vm service with csi vol tests
 		11.Bring secondary site up and wait for testbed to be back to normal.
 		12.Delete all objects created in this test.
 	*/
-	ginkgo.It("[pq-vmsvc-vsanstretch] VMService - secondary site down",
+	ginkgo.It("[pq-f-vmsvc-vsanstretch] VMService - secondary site down",
 		ginkgo.Label(p0, vmsvc, vsanStretch, block, wcp), func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -397,7 +397,7 @@ var _ bool = ginkgo.Describe("[vsan-stretch-vmsvc] vm service with csi vol tests
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
-			time.Sleep(5 * time.Minute)
+			time.Sleep(10 * time.Minute)
 			// Check if csi pods are running fine after site failure
 			ginkgo.By("Check if csi pods are running fine after site failure")
 			err = fpod.WaitForPodsRunningReady(ctx, client, csiNs, len(csipods.Items),

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -831,7 +831,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	   6.  Bring primary site up and wait for testbed to be back to normal
 	   7.  Delete PVCs created in step 2
 	*/
-	ginkgo.It("[pq-vanilla-vsanstretch][pq-f-wcp-vsanstretch][pq-vks-vsanstretch] PVC creation while primary site "+
+	ginkgo.It("[pq-vanilla-vsanstretch][pq-f-wcp-vsanstretch][pq-f-vks-vsanstretch] PVC creation while primary site "+
 		"goes down", ginkgo.Label(p0, vsanStretch, file, block, vanilla, wcp, tkg, primaryCentric, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -983,7 +983,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		6.	Re-establish primary site network and wait for testbed to be back to normal
 		7.	Delete all objects created in step 2
 	*/
-	ginkgo.It("[pq-vanilla-vsanstretch-distributed][pq-f-wcp-vsanstretch][pq-vks-vsanstretch]"+
+	ginkgo.It("[pq-vanilla-vsanstretch-distributed][pq-f-wcp-vsanstretch][pq-f-vks-vsanstretch]"+
 		"[pq-vanilla-vsanstretch-controlplaneonprimary][pq-vanilla-vsanstretch-primarycentric] Primary site network "+
 		"isolation", ginkgo.Label(p0, vsanStretch, file, block, vanilla, wcp, tkg, primaryCentric,
 		controlPlaneOnPrimary, distributed, vc70), func() {
@@ -1153,7 +1153,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		6.	Verify PVs and CNS volumes associated with PVCs created in step 2 are also deleted successfully
 		7.	Bring primary site up and wait for testbed to be back to normal
 	*/
-	ginkgo.It("[pq-vanilla-vsanstretch-primarycentric][pq-f-wcp-vsanstretch][pq-vks-vsanstretch] PVC deletion while "+
+	ginkgo.It("[pq-vanilla-vsanstretch-primarycentric][pq-f-wcp-vsanstretch][pq-f-vks-vsanstretch] PVC deletion while "+
 		"primary site goes down", ginkgo.Label(p0, vsanStretch, file, block, vanilla, wcp, tkg, primaryCentric,
 		vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1423,7 +1423,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	   8.  Delete the PVCs created in step 2
 	   9.  Bring primary site up and wait for testbed to be back to normal
 	*/
-	ginkgo.It("[pq-vanilla-vsanstretch-primarycentric][pq-f-wcp-vsanstretch][pq-vks-vsanstretch] Label updates to PV"+
+	ginkgo.It("[pq-vanilla-vsanstretch-primarycentric][pq-f-wcp-vsanstretch][pq-f-vks-vsanstretch] Label updates to PV"+
 		", PVC, pod while primary site goes down", ginkgo.Label(p0, vsanStretch, file, block, vanilla, wcp, tkg,
 		primaryCentric, vc70), func() {
 
@@ -2108,7 +2108,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		6.	Bring secondary site up and wait for testbed to be back to normal
 		7.	Delete all objects created in step 2 and 5
 	*/
-	ginkgo.It("[pq-vanilla-vsanstretch-controlplaneonprimary][pq-f-wcp-vsanstretch][pq-vks-vsanstretch] Secondary "+
+	ginkgo.It("[pq-vanilla-vsanstretch-controlplaneonprimary][pq-f-wcp-vsanstretch][pq-f-vks-vsanstretch] Secondary "+
 		"site down", ginkgo.Label(p0, vsanStretch, file, block, vanilla, wcp, tkg, controlPlaneOnPrimary,
 		vc70), func() {
 
@@ -2291,7 +2291,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			volume and application lifecycle actions work fine
 		11.	Cleanup all objects created so far in the test
 	*/
-	ginkgo.It("[pq-vanilla-vsanstretch-distributed][pq-f-wcp-vsanstretch][pq-vks-vsanstretch]"+
+	ginkgo.It("[pq-vanilla-vsanstretch-distributed][pq-f-wcp-vsanstretch][pq-f-vks-vsanstretch]"+
 		"[pq-vanilla-vsanstretch-controlplaneonprimary] Network failure between sites", ginkgo.Label(p0, vsanStretch,
 		file, block, vanilla, wcp, tkg, controlPlaneOnPrimary, distributed, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -2529,7 +2529,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		5.	Run volume and application lifecycle actions
 		6.	Cleanup all objects created in step 3 and 5
 	*/
-	ginkgo.It("[pq-vanilla-vsanstretch-distributed][pq-f-wcp-vsanstretch][pq-vks-vsanstretch] Witness "+
+	ginkgo.It("[pq-vanilla-vsanstretch-distributed][pq-f-wcp-vsanstretch][pq-f-vks-vsanstretch] Witness "+
 		"failure", ginkgo.Label(p0, vsanStretch, file, block, vanilla, wcp, tkg, distributed, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -4122,7 +4122,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		19. Bring primary site up and wait for testbed to be back to normal
 
 	*/
-	ginkgo.It("[pq-vanilla-vsanstretch-distributed][pq-f-wcp-vsanstretch][pq-vks-vsanstretch]"+
+	ginkgo.It("[pq-vanilla-vsanstretch-distributed][pq-f-wcp-vsanstretch][pq-f-vks-vsanstretch]"+
 		"[pq-vanilla-vsanstretch-primarycentric] Primary site failover during full sync", ginkgo.Label(p0, vsanStretch,
 		file, block, vanilla, wcp, tkg, primaryCentric, distributed, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -4834,7 +4834,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	   8.  Delete statefulsets and its pvcs created in step 2
 	   9.  Bring primary site up and wait for testbed to be back to normal
 	*/
-	ginkgo.It("[pq-f-wcp-vsanstretch][pq-vks-vsanstretch] PSOD hosts on secondary "+
+	ginkgo.It("[pq-f-wcp-vsanstretch][pq-f-vks-vsanstretch] PSOD hosts on secondary "+
 		"site", ginkgo.Label(p0, vsanStretch, block, wcp, tkg, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Increased sleep time in vmservice-vsan-stretch secondary site down 

**Testing done**:
Yes

**Special notes for your reviewer**: 
Increased sleep time in vmservice-vsan-stretch secondary site down 
updated pq-f-vks-snapshot and pq-f-vks-vsanstretch for VKS strteched vsan


