### PR TITLE
fix isDatastoreAccessibleToAZClusters for multiple clusters per zone

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -83,30 +83,18 @@ func isDatastoreAccessibleToAZClusters(ctx context.Context, vc *vsphere.VirtualC
 	azClustersMap map[string][]string, datastoreURL string) bool {
 	log := logger.GetLogger(ctx)
 	for _, clusterIDs := range azClustersMap {
-		var found bool
 		for _, clusterID := range clusterIDs {
 			sharedDatastores, _, err := vsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterID, false)
 			if err != nil {
 				log.Warnf("Failed to get candidate datastores for cluster: %s with err: %+v", clusterID, err)
 				continue
 			}
-			found = false
 			for _, ds := range sharedDatastores {
 				if ds.Info.Url == datastoreURL {
 					log.Infof("Found datastoreUrl: %s is accessible to cluster: %s", datastoreURL, clusterID)
-					found = true
+					return true
 				}
 			}
-			// If datastoreURL was found in the list of datastores accessible to the
-			// cluster with clusterID, continue checking for the rest of the clusters
-			// in AZ. Otherwise, break and check the next AZ in azClustersMap.
-			if !found {
-				break
-			}
-		}
-		// datastoreURL was found in all the clusters with clusterIDs.
-		if found {
-			return true
 		}
 	}
 	return false

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnsregistervolume
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/vim25/types"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+)
+
+// TestIsDatastoreAccessibleToAZClusters tests the isDatastoreAccessibleToAZClusters function
+// using standard Go testing framework to avoid conflicts with existing Ginkgo suites
+func TestIsDatastoreAccessibleToAZClusters(t *testing.T) {
+	// Initialize backOffDuration map to prevent nil map assignment panic
+	backOffDuration = make(map[apitypes.NamespacedName]time.Duration)
+
+	ctx := context.Background()
+	mockVC := &cnsvsphere.VirtualCenter{}
+	datastoreURL := "ds:///vmfs/volumes/test-datastore"
+
+	t.Run("1 cluster per zone - datastore accessible to 1 cluster", func(t *testing.T) {
+		azClustersMap := map[string][]string{
+			"zone-a": {"cluster-a1"},
+			"zone-b": {"cluster-b1"},
+		}
+
+		patches := gomonkey.ApplyFunc(cnsvsphere.GetCandidateDatastoresInCluster,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter, clusterID string,
+				includevSANDirectDatastores bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+				if clusterID == "cluster-a1" {
+					return []*cnsvsphere.DatastoreInfo{
+						{
+							Info: &types.DatastoreInfo{
+								Url: datastoreURL,
+							},
+						},
+					}, []*cnsvsphere.DatastoreInfo{}, nil
+				}
+				return []*cnsvsphere.DatastoreInfo{}, []*cnsvsphere.DatastoreInfo{}, nil
+			})
+		defer patches.Reset()
+
+		result := isDatastoreAccessibleToAZClusters(ctx, mockVC, azClustersMap, datastoreURL)
+		assert.True(t, result)
+	})
+
+	t.Run("2 clusters per zone - datastore accessible to all clusters", func(t *testing.T) {
+		azClustersMap := map[string][]string{
+			"zone-a": {"cluster-a1", "cluster-a2"},
+			"zone-b": {"cluster-b1", "cluster-b2"},
+		}
+
+		patches := gomonkey.ApplyFunc(cnsvsphere.GetCandidateDatastoresInCluster,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter, clusterID string,
+				includevSANDirectDatastores bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+				return []*cnsvsphere.DatastoreInfo{
+					{
+						Info: &types.DatastoreInfo{
+							Url: datastoreURL,
+						},
+					},
+				}, []*cnsvsphere.DatastoreInfo{}, nil
+			})
+		defer patches.Reset()
+
+		result := isDatastoreAccessibleToAZClusters(ctx, mockVC, azClustersMap, datastoreURL)
+		assert.True(t, result)
+	})
+
+	t.Run("2 clusters per zone - datastore accessible to only 1 cluster", func(t *testing.T) {
+		azClustersMap := map[string][]string{
+			"zone-a": {"cluster-a1", "cluster-a2"},
+			"zone-b": {"cluster-b1", "cluster-b2"},
+		}
+
+		patches := gomonkey.ApplyFunc(cnsvsphere.GetCandidateDatastoresInCluster,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter, clusterID string,
+				includevSANDirectDatastores bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+				if clusterID == "cluster-a1" {
+					return []*cnsvsphere.DatastoreInfo{
+						{
+							Info: &types.DatastoreInfo{
+								Url: datastoreURL,
+							},
+						},
+					}, []*cnsvsphere.DatastoreInfo{}, nil
+				}
+				return []*cnsvsphere.DatastoreInfo{}, []*cnsvsphere.DatastoreInfo{}, nil
+			})
+		defer patches.Reset()
+
+		result := isDatastoreAccessibleToAZClusters(ctx, mockVC, azClustersMap, datastoreURL)
+		assert.True(t, result)
+	})
+
+	t.Run("2 clusters per zone - datastore accessible to only 1 cluster in different zone",
+		func(t *testing.T) {
+			azClustersMap := map[string][]string{
+				"zone-a": {"cluster-a1", "cluster-a2"},
+				"zone-b": {"cluster-b1", "cluster-b2"},
+			}
+
+			patches := gomonkey.ApplyFunc(cnsvsphere.GetCandidateDatastoresInCluster,
+				func(ctx context.Context, vc *cnsvsphere.VirtualCenter, clusterID string,
+					includevSANDirectDatastores bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+					if clusterID == "cluster-b2" {
+						return []*cnsvsphere.DatastoreInfo{
+							{
+								Info: &types.DatastoreInfo{
+									Url: datastoreURL,
+								},
+							},
+						}, []*cnsvsphere.DatastoreInfo{}, nil
+					}
+					return []*cnsvsphere.DatastoreInfo{}, []*cnsvsphere.DatastoreInfo{}, nil
+				})
+			defer patches.Reset()
+
+			result := isDatastoreAccessibleToAZClusters(ctx, mockVC, azClustersMap, datastoreURL)
+			assert.True(t, result)
+		})
+
+	t.Run("datastore not accessible to any cluster", func(t *testing.T) {
+		azClustersMap := map[string][]string{
+			"zone-a": {"cluster-a1"},
+			"zone-b": {"cluster-b1"},
+		}
+
+		patches := gomonkey.ApplyFunc(cnsvsphere.GetCandidateDatastoresInCluster,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter, clusterID string,
+				includevSANDirectDatastores bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+				return []*cnsvsphere.DatastoreInfo{}, []*cnsvsphere.DatastoreInfo{}, nil
+			})
+		defer patches.Reset()
+
+		result := isDatastoreAccessibleToAZClusters(ctx, mockVC, azClustersMap, datastoreURL)
+		assert.False(t, result)
+	})
+
+	t.Run("error handling - should continue processing other clusters", func(t *testing.T) {
+		azClustersMap := map[string][]string{
+			"zone-a": {"cluster-a1"},
+			"zone-b": {"cluster-b1"},
+		}
+
+		patches := gomonkey.ApplyFunc(cnsvsphere.GetCandidateDatastoresInCluster,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter, clusterID string,
+				includevSANDirectDatastores bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+				if clusterID == "cluster-a1" {
+					return nil, nil, fmt.Errorf("failed to get datastores for cluster-a1")
+				}
+				if clusterID == "cluster-b1" {
+					return []*cnsvsphere.DatastoreInfo{
+						{
+							Info: &types.DatastoreInfo{
+								Url: datastoreURL,
+							},
+						},
+					}, []*cnsvsphere.DatastoreInfo{}, nil
+				}
+				return []*cnsvsphere.DatastoreInfo{}, []*cnsvsphere.DatastoreInfo{}, nil
+			})
+		defer patches.Reset()
+
+		result := isDatastoreAccessibleToAZClusters(ctx, mockVC, azClustersMap, datastoreURL)
+		assert.True(t, result)
+	})
+
+	t.Run("empty azClustersMap", func(t *testing.T) {
+		azClustersMap := map[string][]string{}
+		result := isDatastoreAccessibleToAZClusters(ctx, mockVC, azClustersMap, datastoreURL)
+		assert.False(t, result)
+	})
+
+	t.Run("empty cluster lists in zones", func(t *testing.T) {
+		azClustersMap := map[string][]string{
+			"zone-a": {},
+			"zone-b": {},
+		}
+		result := isDatastoreAccessibleToAZClusters(ctx, mockVC, azClustersMap, datastoreURL)
+		assert.False(t, result)
+	})
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is fixing isDatastoreAccessibleToAZClusters func to ensure it returns true if datastore is accessible to one of the cluster supplied in the azClustersMap.

Current implementation does not work when AZ has multiple clusters, and only returns true when all clusters has datastore mounted on it.

With this PR we are also adding unit tests to cover following cases

- 1 cluster per zone scenarios
- 2 clusters per zone scenarios
- 2 clusters per zone - datastore accessible to 1 cluster
- Error handling and
- Edge cases (empty maps, empty URLs, etc.)


**Testing done**:

Unit tests

```
% go test -v ./pkg/syncer/cnsoperator/controller/cnsregistervolume -run TestIsDatastoreAccessibleToAZClusters
=== RUN   TestIsDatastoreAccessibleToAZClusters
=== RUN   TestIsDatastoreAccessibleToAZClusters/1_cluster_per_zone_-_datastore_accessible_to_1_cluster
{"level":"info","time":"2025-10-28T13:37:42.485035-07:00","caller":"cnsregistervolume/util.go:94","msg":"Found datastoreUrl: ds:///vmfs/volumes/test-datastore is accessible to cluster: cluster-a1"}
=== RUN   TestIsDatastoreAccessibleToAZClusters/2_clusters_per_zone_-_datastore_accessible_to_all_clusters
{"level":"info","time":"2025-10-28T13:37:42.485395-07:00","caller":"cnsregistervolume/util.go:94","msg":"Found datastoreUrl: ds:///vmfs/volumes/test-datastore is accessible to cluster: cluster-a1"}
=== RUN   TestIsDatastoreAccessibleToAZClusters/2_clusters_per_zone_-_datastore_accessible_to_only_1_cluster
{"level":"info","time":"2025-10-28T13:37:42.485455-07:00","caller":"cnsregistervolume/util.go:94","msg":"Found datastoreUrl: ds:///vmfs/volumes/test-datastore is accessible to cluster: cluster-a1"}
=== RUN   TestIsDatastoreAccessibleToAZClusters/2_clusters_per_zone_-_datastore_accessible_to_only_1_cluster_in_different_zone
{"level":"info","time":"2025-10-28T13:37:42.485503-07:00","caller":"cnsregistervolume/util.go:94","msg":"Found datastoreUrl: ds:///vmfs/volumes/test-datastore is accessible to cluster: cluster-b2"}
=== RUN   TestIsDatastoreAccessibleToAZClusters/datastore_not_accessible_to_any_cluster
=== RUN   TestIsDatastoreAccessibleToAZClusters/error_handling_-_should_continue_processing_other_clusters
{"level":"warn","time":"2025-10-28T13:37:42.485594-07:00","caller":"cnsregistervolume/util.go:89","msg":"Failed to get candidate datastores for cluster: cluster-a1 with err: failed to get datastores for cluster-a1"}
{"level":"info","time":"2025-10-28T13:37:42.485606-07:00","caller":"cnsregistervolume/util.go:94","msg":"Found datastoreUrl: ds:///vmfs/volumes/test-datastore is accessible to cluster: cluster-b1"}
=== RUN   TestIsDatastoreAccessibleToAZClusters/empty_azClustersMap
=== RUN   TestIsDatastoreAccessibleToAZClusters/empty_cluster_lists_in_zones
--- PASS: TestIsDatastoreAccessibleToAZClusters (0.00s)
    --- PASS: TestIsDatastoreAccessibleToAZClusters/1_cluster_per_zone_-_datastore_accessible_to_1_cluster (0.00s)
    --- PASS: TestIsDatastoreAccessibleToAZClusters/2_clusters_per_zone_-_datastore_accessible_to_all_clusters (0.00s)
    --- PASS: TestIsDatastoreAccessibleToAZClusters/2_clusters_per_zone_-_datastore_accessible_to_only_1_cluster (0.00s)
    --- PASS: TestIsDatastoreAccessibleToAZClusters/2_clusters_per_zone_-_datastore_accessible_to_only_1_cluster_in_different_zone (0.00s)
    --- PASS: TestIsDatastoreAccessibleToAZClusters/datastore_not_accessible_to_any_cluster (0.00s)
    --- PASS: TestIsDatastoreAccessibleToAZClusters/error_handling_-_should_continue_processing_other_clusters (0.00s)
    --- PASS: TestIsDatastoreAccessibleToAZClusters/empty_azClustersMap (0.00s)
    --- PASS: TestIsDatastoreAccessibleToAZClusters/empty_cluster_lists_in_zones (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume   (cached)
```

Verified registering volume on the namespace with multiple zones, each zone having multiple clusters.

```
# kubectl describe cnsregistervolume.cns.vmware.com/import-fcd-1 -n test2clusterzonal2
Name:         import-fcd-1
Namespace:    test2clusterzonal2
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsRegisterVolume
Metadata:
  Creation Timestamp:  2025-10-29T06:07:40Z
  Generation:          2
  Owner References:
    API Version:           v1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  PersistentVolumeClaim
    Name:                  fcd-pvc
    UID:                   7729834b-eb67-4f8a-9857-3ed30f9755de
  Resource Version:        7481760
  UID:                     13d46d29-c80c-4cbe-9d2c-1b5fa0c39309
Spec:
  Access Mode:  ReadWriteOnce
  Pvc Name:     fcd-pvc
  Volume ID:    2ac383c3-8257-47c6-a405-e23257c260ef
Status:
  Registered:  true
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  CnsRegisterVolumeSucceeded  5s    cns.vmware.com  Successfully registered the volume on namespace: test2clusterzonal2




# kubectl describe pvc fcd-pvc -n test2clusterzonal2
Name:          fcd-pvc
Namespace:     test2clusterzonal2
StorageClass:  zonal-policy
Status:        Bound
Volume:        static-pv-2ac383c3-8257-47c6-a405-e23257c260ef
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"zone2"}]
               pv.kubernetes.io/bind-completed: yes
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:        <none>





# kubectl describe pv static-pv-2ac383c3-8257-47c6-a405-e23257c260ef
Name:              static-pv-2ac383c3-8257-47c6-a405-e23257c260ef
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection external-provisioner.volume.kubernetes.io/finalizer]
StorageClass:      zonal-policy
Status:            Bound
Claim:             test2clusterzonal2/fcd-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          5Gi
Node Affinity:
  Required Terms:
    Term 0:        topology.kubernetes.io/zone in [zone2]
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      2ac383c3-8257-47c6-a405-e23257c260ef
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>

```




**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix isDatastoreAccessibleToAZClusters for multiple clusters per zone
```
