### PR TITLE
Add ":detaching" suffix to batch attach CR only if it isn't already present

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -19,6 +19,8 @@ package cnsnodevmbatchattachment
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -26,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -230,55 +231,6 @@ func TestCnsNodeVMBatchAttachmentWhenVmOnVcenterReturnsError(t *testing.T) {
 
 		expectedReconcileError := fmt.Errorf("some error occurred while getting VM")
 		assert.EqualError(t, expectedReconcileError, updatedCnsNodeVMBatchAttachment.Status.Error)
-	})
-}
-
-func TestCnsNodeVMBatchAttachmentWhenVmOnVcenterReturnsNotFoundError(t *testing.T) {
-
-	t.Run("TestCnsNodeVMBatchAttachmentWhenVmOnVcenterReturnsNotFoundError", func(t *testing.T) {
-		testCnsNodeVMBatchAttachment := setupTestCnsNodeVMBatchAttachment()
-		testCnsNodeVMBatchAttachment.Spec.InstanceUUID = "test-3"
-
-		r := setTestEnvironment(&testCnsNodeVMBatchAttachment, true)
-
-		req := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      testCnsNodeVMBatchAttachmentName,
-				Namespace: testNamespace,
-			},
-		}
-
-		GetVMFromVcenter = MockGetVMFromVcenter
-		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
-
-		// Override with fake client
-		newClientFunc = func(ctx context.Context) (kubernetes.Interface, error) {
-			fakeK8sClient := getClientSetWithPvc()
-			return fakeK8sClient, nil
-		}
-
-		res, err := r.Reconcile(context.TODO(), req)
-		if err != nil {
-			t.Fatal("Unexpected reconcile error")
-		}
-		expectedReconcileResult := reconcile.Result{}
-		var expectedReconcileError error
-
-		assert.Equal(t, expectedReconcileResult, res)
-		assert.Equal(t, expectedReconcileError, err)
-
-		updatedCnsNodeVMBatchAttachment := &v1alpha1.CnsNodeVMBatchAttachment{}
-		err = r.client.Get(context.TODO(), req.NamespacedName, updatedCnsNodeVMBatchAttachment)
-		if err == nil {
-			t.Fatalf("failed to get cnsnodevmbatchattachemnt instance")
-		}
-
-		// Error should be not found
-		if statusErr, ok := err.(*errors.StatusError); ok {
-			assert.Equal(t, metav1.StatusReasonNotFound, statusErr.Status().Reason)
-		} else {
-			t.Fatalf("Unable to verify CnsNodeVMBatchAttachment error")
-		}
 	})
 }
 
@@ -715,6 +667,143 @@ func TestIsSharedPvc(t *testing.T) {
 			result := isSharedPvc(pvc)
 			if result != tt.expected {
 				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetUniqueVolumeName(t *testing.T) {
+	tests := []struct {
+		name                   string
+		currentName            string
+		allVolumeNamesInStatus map[string]bool
+		expected               string
+	}{
+		{
+			name:                   "No existing volumes — first name available",
+			currentName:            "vol1",
+			allVolumeNamesInStatus: map[string]bool{},
+			expected:               "vol1-1" + detachSuffix,
+		},
+		{
+			name:        "First detaching name already exists — use next index",
+			currentName: "vol1",
+			allVolumeNamesInStatus: map[string]bool{
+				"vol1-1:detaching": true,
+			},
+			expected: "vol1-2" + detachSuffix,
+		},
+		{
+			name:        "Several existing detaching names — find next available",
+			currentName: "vol1",
+			allVolumeNamesInStatus: map[string]bool{
+				"vol1-1:detaching": true,
+				"vol1-2:detaching": true,
+				"vol1-3:detaching": true,
+			},
+			expected: "vol1-4" + detachSuffix,
+		},
+		{
+			name:        "Different volume names in status — should not affect result",
+			currentName: "volX",
+			allVolumeNamesInStatus: map[string]bool{
+				"volA-1:detaching": true,
+				"volB-2:detaching": true,
+			},
+			expected: "volX-1" + detachSuffix,
+		},
+		{
+			name:        "Handles long existing name list gracefully",
+			currentName: "vol99",
+			allVolumeNamesInStatus: func() map[string]bool {
+				m := make(map[string]bool)
+				for i := 1; i <= 50; i++ {
+					m["vol99-"+strconv.Itoa(i)+":detaching"] = true
+				}
+				return m
+			}(),
+			expected: "vol99-51" + detachSuffix,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getUniqueVolumeName(tc.currentName, tc.allVolumeNamesInStatus)
+			if got != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestGetVolumeNamesInStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance v1alpha1.CnsNodeVMBatchAttachment
+		expected map[string]bool
+	}{
+		{
+			name: "No volumes in status",
+			instance: v1alpha1.CnsNodeVMBatchAttachment{
+				Status: v1alpha1.CnsNodeVMBatchAttachmentStatus{
+					VolumeStatus: []v1alpha1.VolumeStatus{},
+				},
+			},
+			expected: map[string]bool{},
+		},
+		{
+			name: "Single volume in status",
+			instance: v1alpha1.CnsNodeVMBatchAttachment{
+				Status: v1alpha1.CnsNodeVMBatchAttachmentStatus{
+					VolumeStatus: []v1alpha1.VolumeStatus{
+						{Name: "vol1"},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"vol1": true,
+			},
+		},
+		{
+			name: "Multiple unique volumes",
+			instance: v1alpha1.CnsNodeVMBatchAttachment{
+				Status: v1alpha1.CnsNodeVMBatchAttachmentStatus{
+					VolumeStatus: []v1alpha1.VolumeStatus{
+						{Name: "vol1"},
+						{Name: "vol2"},
+						{Name: "vol3"},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"vol1": true,
+				"vol2": true,
+				"vol3": true,
+			},
+		},
+		{
+			name: "Duplicate volume names should not create duplicates in map",
+			instance: v1alpha1.CnsNodeVMBatchAttachment{
+				Status: v1alpha1.CnsNodeVMBatchAttachmentStatus{
+					VolumeStatus: []v1alpha1.VolumeStatus{
+						{Name: "vol1"},
+						{Name: "vol1"},
+						{Name: "vol2"},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"vol1": true,
+				"vol2": true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getVolumeNamesInStatus(&tc.instance)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("expected %+v, got %+v", tc.expected, got)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
":detaching" suffix is added to the status of a volume if it is being detached. But this suffix should only be added once.

Also, this PR takes care of the corner case where the CRD might maintain multiple entries for the same volumeName in the status (explained in testing done). For this purpose it is important to ensure that the volumeName being added is always unique. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Created a batch attach CR with PVC-1 and volumeName as disk-1. It got attached successfully.

```
Spec has disk-1 <-> PVC-1

Status has disk-1 <-> PVC-1
```

After this, I changed PVC-1 to PVC-2.

```
Spec has disk-1 <-> PVC-2

Status has disk-1 <-> PVC-1
```

Observed that the status got changed to:

```
Spec has disk-1 <-> PVC-2

Status has 
disk-1 <-> PVC-2
disk-1-1:detaching <-> PVC-1
```
As I am purposefully failing detach, the entry for detach is never removed from status.

After this, I changed PVC-2 in spec to PVC-3
```
Spec has disk-1 <-> PVC-3

Status has 
disk-1 <-> PVC-2
disk-1-1:detaching <-> PVC-1
```

Observed that the status also got updated to the following:

```
Spec has disk-1 <-> PVC-3

Status has 
disk-1 <-> PVC-3
disk-1-1:detaching <-> PVC-1
disk-1-2:detaching <-> PVC-2
```


This way we can ensure that the volumeName in batchAttach CR is always unique.


```
Status:
  Error:  failed to attach volumes: e5e0bfe3-4377-4e53-b6a3-f0f59a8644db
failed to detach volumes: rwo-pvc-2,rwo-pvc-3
  Volumes:
    Name:  disk-1-1:detaching <======= -1:detaching
    Persistent Volume Claim:
      Attached:       true
      Claim Name:     rwo-pvc-3
      Cns Volume Id:  88b7cd2b-8753-4372-95eb-df242994692f
      Disk UUID:      6000C291-b55d-939d-d03b-773762d13237
      Error:          FAILURE
    Name:             disk-1-2:detaching <======= -2:detaching
    Persistent Volume Claim:
      Attached:       true
      Claim Name:     rwo-pvc-2
      Cns Volume Id:  e5f20944-f8c9-47ca-ad77-dc88489fe4e0
      Disk UUID:      6000C292-a5c3-42dd-9311-fbe2225ac1b6
      Error:          FAILURE
    Name:             disk-1 <======== original volumeName
    Persistent Volume Claim:
      Attached:       false
      Claim Name:     rwo-pvc-1
      Cns Volume Id:  e5e0bfe3-4377-4e53-b6a3-f0f59a8644db
      Error:          failed to batch attach cns volume: "e5e0bfe3-4377-4e53-b6a3-f0f59a8644db" to node vm: "VirtualMachine:vm-156 [VirtualCenterHost: lvn-dvm-10-162-192-71.dvm.lvn.broadcom.net, UUID: 48d35dcc-e167-445d-97c2-10a0ec4f76ad, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: lvn-dvm-10-162-192-71.dvm.lvn.broadcom.net]]". fault: "vim.fault.InvalidDeviceSpec". opId: "57de5b10"
```

Pipeline suceeded: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/561/