### PR TITLE
Add Status SubResource in CnsRegisterVolume CRD

### DIFF
--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -26,7 +26,7 @@ ARG BASE_IMAGE=photon:5.0
 ################################################################################
 # Build the manager as a statically compiled binary so it has no dependencies
 # libc, muscl, etc.
-FROM ${GOLANG_IMAGE} as builder
+FROM ${GOLANG_IMAGE} AS builder
 
 # This build arg is the version to embed in the CSI binary
 ARG VERSION=unknown
@@ -41,7 +41,7 @@ COPY cmd/    cmd/
 ENV CGO_ENABLED=0
 ENV GOFIPS=1
 ENV GOEXPERIMENT="boringcrypto"
-ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
+ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service.Version=${VERSION}" -o vsphere-csi ./cmd/vsphere-csi
 
 ################################################################################

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -22,7 +22,7 @@ ARG BASE_IMAGE=photon:5.0
 ################################################################################
 ##                              BUILD STAGE                                   ##
 ################################################################################
-FROM ${GOLANG_IMAGE} as builder
+FROM ${GOLANG_IMAGE} AS builder
 
 # This build arg is the version to embed in the CSI binary
 ARG VERSION=unknown
@@ -39,7 +39,7 @@ COPY cmd/    cmd/
 
 ENV CGO_ENABLED=0
 
-ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
+ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 
 ENV GOFIPS=1
 

--- a/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
@@ -93,6 +93,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3704 made a change to update Status instead of updating the CnsRegisterVolume CR, however, the status was not added as a subresource in the manifest. As a result, update status failed as shown in my manual testing below.

This PR added the missing Status Subresource.
Also changed to update status in setInstanceSuccess.
There is also a fix in the docker file in order for docker build to work.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/577 (passed)
VKS pre-checkin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/522/ (failed; pipeline issues; This PR has no VKS side changes)

Manual testing:
Without this fix, when CnsRegisterVolume fails with an error, the Status is not set.
```
root@42311cf475fc802678a958259317518f [ ~ ]# cat pop-pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pop-pvc
  namespace: test-ns
spec:
  storageClassName: wcpglobal-storage-profile
  dataSourceRef:
    apiGroup: vmoperator.vmware.com
    kind: VirtualMachine
    name: my-vm-1
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi

kubectl create -f pop-pvc.yaml

root@42311cf475fc802678a958259317518f [ ~ ]# kubectl get pvc -n test-ns
NAME      STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pop-pvc   Pending                                      wcpglobal-storage-profile   <unset>                 6s

root@42311cf475fc802678a958259317518f [ ~ ]# kubectl get pvc -n test-ns -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
apiVersion: cns.vmware.com/v1alpha1
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    creationTimestamp: "2025-11-04T02:45:50Z"
    finalizers:
    - kubernetes.io/pvc-protection
    name: pop-pvc
    namespace: test-ns
    resourceVersion: "2739890"
    uid: c6f4ddca-54a0-46c2-9057-f4ea31ea7ddd
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: my-vm-1
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: my-vm-1
    resources:
      requests:
        storage: 1Gi
    storageClassName: wcpglobal-storage-profile
    volumeMode: Filesystem
  status:
    phase: Pending <== PVC is pending
kind: List
metadata:
  resourceVersion: ""

root@42311cf475fc802678a958259317518f [ ~ ]# cat register.yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: static-volume
  namespace: test-ns
spec:
  volumeID: 1a27144d-8e66-4816-aea4-51bb6388d0f0
  accessMode: ReadWriteOnce
  pvcName: pop-pvc

root@42311cf475fc802678a958259317518f [ ~ ]# kubectl describe cnsregistervolume -n test-ns
Name:         static-volume
Namespace:    test-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsRegisterVolume
Metadata:
  Creation Timestamp:  2025-11-04T02:46:32Z
  Generation:          1
  Resource Version:    2740245
  UID:                 2ae46cdc-8c0e-4ced-b63e-faf3863194a1
Spec:
  Access Mode:  ReadWriteOnce
  Pvc Name:     pop-pvc
  Volume ID:    1a27144d-8e66-4816-aea4-51bb6388d0f0
Events:
  Type     Reason                   Age                   From            Message
  ----     ------                   ----                  ----            -------
  Warning  CnsRegisterVolumeFailed  3m41s (x11 over 17m)  cns.vmware.com  failed to create CNS volume. Error: ServerFaultCode: The object or item referred to could not be found.
  Warning  CnsRegisterVolumeFailed  14s (x7 over 77s)     cns.vmware.com  failed to create CNS volume. Error: ServerFaultCode: The object or item referred to could not be found.
<== "kubectl describe" shows CnsRegisterVolumeFailed events, however, these errors are not shown in CnsRegisterVolume Status below.

root@42311cf475fc802678a958259317518f [ ~ ]# kubectl get cnsregistervolume -n test-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-11-04T02:46:32Z"
    generation: 1
    name: static-volume
    namespace: test-ns
    resourceVersion: "2740245"
    uid: 2ae46cdc-8c0e-4ced-b63e-faf3863194a1
  spec:
    accessMode: ReadWriteOnce
    pvcName: pop-pvc
    volumeID: 1a27144d-8e66-4816-aea4-51bb6388d0f0
kind: List
metadata:
  resourceVersion: ""

<== "Registered" and "Error" are not shown in CnsRegisterVolume Status.
```
These errors are in the syncer logs.
```
It’s in the syncer logs:

{"level":"error","time":"2025-11-04T03:28:38.232246874Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:294","msg":"failed to create CNS volume. Error: ServerFaultCode: The object or item referred to could not be found.","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume.(*ReconcileCnsRegisterVolume).Reconcile\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:224"}
{"level":"error","time":"2025-11-04T03:28:38.23681318Z","caller":"kubernetes/kubernetes.go:787","msg":"Failed to update status. err: cnsregistervolumes.cns.vmware.com \"static-volume\" not found","kind":"CnsRegisterVolume","name":"test-ns/static-volume","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes.UpdateStatus\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/kubernetes/kubernetes.go:787\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume.setInstanceError\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go:1038\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume.(*ReconcileCnsRegisterVolume).Reconcile\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go:295\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:224"}
{"level":"error","time":"2025-11-04T03:28:38.23717805Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:1040","msg":"updateCnsRegisterVolume failed. err: cnsregistervolumes.cns.vmware.com \"static-volume\" not found","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume.setInstanceError\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go:1040\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume.(*ReconcileCnsRegisterVolume).Reconcile\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go:295\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/build/mts/release/sb-91548037/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:224"}

```
Manually updated the CnsRegisterVolume CRD to add Status Subresource.

```
kubectl edit crd cnsregistervolumes.cns.vmware.com

    served: true
    storage: true
    subresources:      # <== Added
      status: {}       # <== Added
```

Tested this fix after updating the CRD. When CnsRegisterVolume fails with an error, the Status is now set with the proper error.
```
root@42311cf475fc802678a958259317518f [ ~ ]# kubectl get cnsregistervolume -n test-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-11-04T05:24:25Z"
    generation: 1
    name: static-volume
    namespace: test-ns
    resourceVersion: "2842558"
    uid: 95457cc2-58fb-46fd-97ce-8cc936764c2e
  spec:
    accessMode: ReadWriteOnce
    pvcName: pop-pvc
    volumeID: 1a27144d-8e66-4816-aea4-51bb6388d0f0
  status:
    error: 'failed to create CNS volume. Error: ServerFaultCode: The object or item
      referred to could not be found.'  <== proper error message is shown in Status
    registered: false
kind: List
metadata:
  resourceVersion: ""
```

Also tested with a CnsRegisterVolume with an invalid diskURLPath.
```
root@42311cf475fc802678a958259317518f [ ~ ]# cat register2.yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: static-volume-path
  namespace: test-ns
spec:
  pvcName: pop-pvc
  diskURLPath: "https://10.162.28.47/folder/testdisk/testdisk.vmdk?dcPath=test-vpx-1761951135-4189814-wcp.wcp-sanity-min-hosts&dsName=sharedVmfs-0"

root@42311cf475fc802678a958259317518f [ ~ ]# kubectl create -f register2.yaml
cnsregistervolume.cns.vmware.com/static-volume-path created

root@42311cf475fc802678a958259317518f [ ~ ]# kubectl get cnsregistervolume -n test-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-11-04T18:15:46Z"
    generation: 1
    name: static-volume-path
    namespace: test-ns
    resourceVersion: "3311091"
    uid: b5a41202-3391-40f2-b174-30ecb25a8127
  spec:
    diskURLPath: https://10.162.28.47/folder/testdisk/testdisk.vmdk?dcPath=test-vpx-1761951135-4189814-wcp.wcp-sanity-min-hosts&dsName=sharedVmfs-0
    pvcName: pop-pvc
  status:
    error: 'failed to create CNS volume. Error: failed to create volume with fault:
      "(*types.LocalizedMethodFault)(0xc000068c20)({\n DynamicData: (types.DynamicData)
      {\n },\n Fault: (*types.CnsFault)(0xc0011c2c90)({\n  MethodFault: (types.MethodFault)
      {\n   FaultCause: (*types.LocalizedMethodFault)(<nil>),\n   FaultMessage: ([]types.LocalizableMessage)
      <nil>\n  },\n  Reason: (string) (len=41) \"Fault cause: vmodl.fault.InvalidArgument\\n\"\n
      }),\n LocalizedMessage: (string) (len=57) \"CnsFault error: Fault cause: vmodl.fault.InvalidArgument\\n\"\n})\n"'
    registered: false
kind: List
metadata:
  resourceVersion: ""
```
Positive test case.
```
root@42311cf475fc802678a958259317518f [ ~ ]# kubectl get cnsregistervolume -n test-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-11-04T21:33:22Z"
    generation: 1
    name: static-volume
    namespace: test-ns
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: PersistentVolumeClaim
      name: pop-pvc
      uid: 2cf5d8d0-a996-4344-8856-f7b6ea7b6940
    resourceVersion: "3492926"
    uid: eb849c6b-cb17-4cb8-8938-dc947db876d5
  spec:
    accessMode: ReadWriteOnce
    pvcName: pop-pvc
    volumeID: 1e55252b-1ef9-45ac-a362-ed71094ae73d
  status:
    registered: true
kind: List
metadata:
  resourceVersion: ""

root@42311cf475fc802678a958259317518f [ ~ ]# kubectl get pvc -n test-ns
NAME      STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pop-pvc   Bound    static-pv-1e55252b-1ef9-45ac-a362-ed71094ae73d   1Gi        RWO            wcpglobal-storage-profile   <unset>                 112s
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add Status Subresource in CnsRegisterVolume CRD.
```
