### PR TITLE
fix getNodeTopologyInfo for multi vCenter deployment

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -48,8 +48,8 @@ type Manager interface {
 	DiscoverNode(ctx context.Context, nodeUUID string) error
 	// GetK8sNode returns Kubernetes Node object for the given node name
 	GetK8sNode(ctx context.Context, nodename string) (*v1.Node, error)
-	// GetNode refreshes and returns the VirtualMachine for a registered node
-	// given its UUID. If datacenter is present, GetNode will search within this
+	// GetNodeVMAndUpdateCache refreshes and returns the VirtualMachine for a registered node
+	// given its UUID. If datacenter is present, GetNodeVMAndUpdateCache will search within this
 	// datacenter given its UUID. If not, it will search in all registered
 	// datacenters.
 	GetNodeVMAndUpdateCache(ctx context.Context, nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error)

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -18,6 +18,7 @@ package csinodetopology
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -40,10 +41,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node"
-	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
@@ -206,7 +207,6 @@ type ReconcileCSINodeTopology struct {
 	configInfo          *cnsconfig.ConfigurationInfo
 	recorder            record.EventRecorder
 	enableTKGsHAinGuest bool
-	isMultiVCFSSEnabled bool
 	vmOperatorClient    client.Client
 	supervisorNamespace string
 }
@@ -281,7 +281,7 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 		nodeVM, err = nodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeID)
 	}
 	if err != nil {
-		if err == node.ErrNodeNotFound {
+		if errors.Is(err, node.ErrNodeNotFound) {
 			log.Warnf("Node %q is not yet registered in the node manager. Error: %+v", nodeID, err)
 			return reconcile.Result{}, err
 		}
@@ -316,7 +316,7 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 		}
 
 		// Fetch topology labels for nodeVM.
-		topologyLabels, err := getNodeTopologyInfo(ctx, nodeVM, r.configInfo.Cfg, r.isMultiVCFSSEnabled)
+		topologyLabels, err := getNodeTopologyInfo(ctx, nodeVM, r.configInfo.Cfg)
 		if err != nil {
 			msg := fmt.Sprintf("failed to fetch topology information for the nodeVM %q. Error: %v",
 				instance.Name, err)
@@ -485,28 +485,19 @@ func updateCRStatus(ctx context.Context, r *ReconcileCSINodeTopology, instance *
 	return nil
 }
 
-func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine, cfg *cnsconfig.Config,
-	isMultiVCFSSEnabled bool) ([]csinodetopologyv1alpha1.TopologyLabel, error) {
+func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine,
+	cfg *cnsconfig.Config) ([]csinodetopologyv1alpha1.TopologyLabel, error) {
 	log := logger.GetLogger(ctx)
 	var (
 		vcenter *cnsvsphere.VirtualCenter
 		err     error
 	)
 	// Get VC instance.
-	if isMultiVCFSSEnabled {
-		vcenter, err = cnsvsphere.GetVirtualCenterInstanceForVCenterHost(ctx, nodeVM.VirtualCenterHost, true)
-		if err != nil {
-			return nil, logger.LogNewErrorf(log, "failed to get vCenterInstance for vCenter Host: %q, err: %v",
-				nodeVM.VirtualCenterHost, err)
-		}
-	} else {
-		vcenter, err = cnsvsphere.GetVirtualCenterInstance(ctx, &cnsconfig.ConfigurationInfo{Cfg: cfg}, false)
-		if err != nil {
-			log.Errorf("failed to get virtual center instance with error: %v", err)
-			return nil, err
-		}
+	vcenter, err = cnsvsphere.GetVirtualCenterInstanceForVCenterHost(ctx, nodeVM.VirtualCenterHost, true)
+	if err != nil {
+		return nil, logger.LogNewErrorf(log, "failed to get vCenterInstance for vCenter Host: %q, err: %v",
+			nodeVM.VirtualCenterHost, err)
 	}
-
 	// Get tag manager instance.
 	tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

While removing FSS for multi vCenter in this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3399
We missed to update code in getNodeTopologyInfo() func. This function was relying on `r.isMultiVCFSSEnabled` which is not set to true any where in the code.

Without this fix, csinodetopology CR instance fails to discover node on the multi vCenter deployment. 


**Testing done**:

pre-checkin pipeline - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vanilla-instapp-e2e-pre-checkin/170/ - Pass

Replaced syncer image on the multi VC deployment and confirmed nodes deployed on multile vCenters are discovered correctly.

```
# kubectl describe  csinodetopology
Name:         k8s-control-752-1761915288
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:45Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-control-752-1761915288
    UID:             94544976-2d78-4a2c-a703-b94f0d91acc2
  Resource Version:  80958
  UID:               7f80ace5-92c5-452b-a108-a5d612e1d1d2
Spec:
  Node ID:   k8s-control-752-1761915288
  Nodeuuid:  4236a9a2-dd52-ed9e-bd0f-213028a91769
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-3
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  14s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-control-752-1761915288"


Name:         k8s-control-795-1761914990
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:44Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-control-795-1761914990
    UID:             c969cd5b-1bc1-442c-bfc9-c5bbdd015800
  Resource Version:  80925
  UID:               74e8d8c8-da3f-4b07-991d-7ec36526c129
Spec:
  Node ID:   k8s-control-795-1761914990
  Nodeuuid:  423a6acb-63a2-a02a-586e-ef7dfa746deb
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-2
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  17s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-control-795-1761914990"


Name:         k8s-control-930-1761848892
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:44Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-control-930-1761848892
    UID:             fbfbf52c-1026-499e-b381-79e5e9a091ab
  Resource Version:  80937
  UID:               1fa50c1b-92ea-4b3b-868f-dcda4d2a6b4c
Spec:
  Node ID:   k8s-control-930-1761848892
  Nodeuuid:  4217c2e3-1427-7df0-8fd0-f6d768079a9d
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-1
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  16s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-control-930-1761848892"


Name:         k8s-node-209-1761915302
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:41Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-209-1761915302
    UID:             01bd7155-e582-446f-8059-34d3189688f0
  Resource Version:  80906
  UID:               f5bc11ca-f2e8-45b3-b2c5-133a1d369c55
Spec:
  Node ID:   k8s-node-209-1761915302
  Nodeuuid:  42362099-d379-6e60-37bf-1a0321cd1fde
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-3
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  17s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-node-209-1761915302"


Name:         k8s-node-33-1761915295
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:45Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-33-1761915295
    UID:             52fa7e77-878e-4adb-bcb7-7678d53d0d14
  Resource Version:  80965
  UID:               9dd8563d-0d75-42d4-9825-5d0505ba6ee9
Spec:
  Node ID:   k8s-node-33-1761915295
  Nodeuuid:  42368e2a-edb4-71c9-0de8-41a0580afca0
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-3
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  13s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-node-33-1761915295"


Name:         k8s-node-473-1761849499
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:45Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-473-1761849499
    UID:             df14f521-4a7a-4823-a8c7-7226696260eb
  Resource Version:  80953
  UID:               dec1914f-ab81-40da-9f8b-056c97619be4
Spec:
  Node ID:   k8s-node-473-1761849499
  Nodeuuid:  42172633-9542-1dfd-5b89-ac61f17dd016
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-1
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  14s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-node-473-1761849499"


Name:         k8s-node-669-1761849505
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:45Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-669-1761849505
    UID:             0ad77dde-1f7f-40b9-b5e4-96ef3f996a2a
  Resource Version:  80948
  UID:               c370d601-57f9-484a-91a9-ab52266c6b3d
Spec:
  Node ID:   k8s-node-669-1761849505
  Nodeuuid:  4217793c-f226-931a-e43f-d745fe9629d3
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-1
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  15s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-node-669-1761849505"


Name:         k8s-node-706-1761849494
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:42Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-706-1761849494
    UID:             15549c22-38bf-4143-a3ac-06175f75d9e3
  Resource Version:  80944
  UID:               d781e921-eef0-4462-b196-71c04a9a4ea2
Spec:
  Node ID:   k8s-node-706-1761849494
  Nodeuuid:  42173e89-c581-0e25-4a16-870f9120cc63
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-1
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  15s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-node-706-1761849494"


Name:         k8s-node-77-1761915002
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:44Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-77-1761915002
    UID:             0624ac2d-94cc-4993-af5d-87f1587ae693
  Resource Version:  80917
  UID:               e5af2f85-4e37-4a84-b995-8f262b613ec8
Spec:
  Node ID:   k8s-node-77-1761915002
  Nodeuuid:  423a4dd5-f3c0-a4f6-afeb-0368beff8904
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-2
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  17s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-node-77-1761915002"


Name:         k8s-node-906-1761914997
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2025-11-04T19:44:42Z
  Generation:          2
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-906-1761914997
    UID:             09a6c5c0-8bd9-4e78-90e9-4236b127d4cb
  Resource Version:  80931
  UID:               51186505-1988-489f-9272-429e0c221367
Spec:
  Node ID:   k8s-node-906-1761914997
  Nodeuuid:  423ad649-28a2-f9b8-fe11-599ac634d956
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.csi.vmware.com/k8s-zone
    Value:  zone-2
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  16s   cns.vmware.com  Topology labels successfully updated for nodeVM "k8s-node-906-1761914997"
```

CSI Node Daemonsets pods are not going in CLBO due to fail to discover node's topology

```
# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-5fb986ddd8-wj587   7/7     Running   0          59m
vsphere-csi-node-8mndj                    3/3     Running   0          65s
vsphere-csi-node-cswf8                    3/3     Running   0          65s
vsphere-csi-node-n7q2q                    3/3     Running   0          65s
vsphere-csi-node-nlwjc                    3/3     Running   0          65s
vsphere-csi-node-nwfxj                    3/3     Running   0          65s
vsphere-csi-node-nwjgr                    3/3     Running   0          65s
vsphere-csi-node-sflgs                    3/3     Running   0          65s
vsphere-csi-node-ttlpp                    3/3     Running   0          65s
vsphere-csi-node-xxkxp                    3/3     Running   0          65s
vsphere-csi-node-xxmtv                    3/3     Running   0          65s
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix getNodeTopologyInfo for multi vCenter deployment
```
