### PR TITLE
[cherry-pick release-3.6] fix getNodeTopologyInfo for multi vCenter deployment

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -48,8 +48,8 @@ type Manager interface {
 	DiscoverNode(ctx context.Context, nodeUUID string) error
 	// GetK8sNode returns Kubernetes Node object for the given node name
 	GetK8sNode(ctx context.Context, nodename string) (*v1.Node, error)
-	// GetNode refreshes and returns the VirtualMachine for a registered node
-	// given its UUID. If datacenter is present, GetNode will search within this
+	// GetNodeVMAndUpdateCache refreshes and returns the VirtualMachine for a registered node
+	// given its UUID. If datacenter is present, GetNodeVMAndUpdateCache will search within this
 	// datacenter given its UUID. If not, it will search in all registered
 	// datacenters.
 	GetNodeVMAndUpdateCache(ctx context.Context, nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherry picking https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3723 to release-3.6 branch.


**Testing done**:
Vanilla pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vanilla-instapp-e2e-pre-checkin/171/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix getNodeTopologyInfo for multi vCenter deployment
```
