### PR TITLE
Allow CnsNodeVMBatchAttachment CRD to have empty list of volumes in its spec.

### DIFF
--- a/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
+++ b/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
@@ -74,12 +74,11 @@ type CnsNodeVMBatchAttachmentSpec struct {
 
 	// InstanceUUID indicates the instance UUID of the node where the volume needs to be attached to.
 	InstanceUUID string `json:"instanceUUID"`
-	// +required
 
 	// +listType=map
 	// +listMapKey=name
 	// VolumeSpec reflects the desired state for each volume.
-	Volumes []VolumeSpec `json:"volumes"`
+	Volumes []VolumeSpec `json:"volumes,omitempty"`
 }
 
 type VolumeSpec struct {

--- a/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
@@ -107,7 +107,6 @@ spec:
                 x-kubernetes-list-type: map
             required:
             - instanceUUID
-            - volumes
             type: object
           status:
             description: CnsNodeVMBatchAttachmentStatus defines the observed state

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -326,8 +326,6 @@ func (r *Reconciler) Reconcile(ctx context.Context,
 
 	// The CR is not being deleted, so call attach and detach for volumes.
 	if instance.DeletionTimestamp == nil {
-		log.Infof("Starting reconciliation for instance %s", request.NamespacedName.String())
-
 		// Add finalizer to CR if it does not already exist.
 		if !controllerutil.ContainsFinalizer(instance, cnsoperatortypes.CNSFinalizer) {
 			log.Debugf("Finalizer %s not found on instance %s. Adding it now.",
@@ -520,6 +518,11 @@ func (r *Reconciler) processBatchAttach(ctx context.Context, k8sClient kubernete
 	vm *cnsvsphere.VirtualMachine,
 	instance *v1alpha1.CnsNodeVMBatchAttachment) error {
 	log := logger.GetLogger(ctx)
+
+	if len(instance.Spec.Volumes) == 0 {
+		log.Infof("No volumes to attach to VM %q", instance.Spec.InstanceUUID)
+		return nil
+	}
 
 	// Construct batch attach request
 	pvcsInSpec, volumeIdsInSpec, batchAttachRequest, err := constructBatchAttachRequest(ctx, instance)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -356,6 +356,26 @@ func TestReconcileWithoutDeletionTimestamp(t *testing.T) {
 	})
 }
 
+func TestReconcileWithoutDeletionTimestampWithNoVolumestoAttach(t *testing.T) {
+
+	t.Run("TestReconcileWithoutDeletionTimestampWithNoVolumestoAttach", func(t *testing.T) {
+		testCnsNodeVMBatchAttachment := setupTestCnsNodeVMBatchAttachment()
+		testCnsNodeVMBatchAttachment.Spec.Volumes = []v1alpha1.VolumeSpec{}
+		r := setTestEnvironment(&testCnsNodeVMBatchAttachment, false)
+		mockVolumeManager := &unittestcommon.MockVolumeManager{}
+		r.volumeManager = mockVolumeManager
+		commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+		volumesToDetach := map[string]string{}
+		vm := &cnsvsphere.VirtualMachine{}
+		clientset := getClientSetWithPvc()
+
+		err := r.reconcileInstanceWithoutDeletionTimestamp(context.TODO(),
+			clientset,
+			&testCnsNodeVMBatchAttachment, volumesToDetach, vm)
+		assert.NoError(t, err)
+	})
+}
+
 func TestReconcileWithoutDeletionTimestampWhenAttachFails(t *testing.T) {
 
 	t.Run("TestReconcileWithoutDeletionTimestamp", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow CnsNodeVMBatchAttachment CRD to have empty list of volumes in its spec.


**Testing done**:
Created an instance with empty volume spec:

```
Name:         test-new-2
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsNodeVMBatchAttachment
Metadata:
  Creation Timestamp:  2025-11-06T06:37:02Z
  Finalizers:
    cns.vmware.com
  Generation:        1
  Resource Version:  3070962
  UID:               087c47bf-17f7-4c59-8129-6e949f7d2a87
Spec:
  Instance UUID:  66ea26ce-a2f7-4249-b654-948fd2bfab26
Status:
  Conditions:
    Last Transition Time:  2025-11-06T06:37:02Z
    Message:               
    Reason:                True
    Status:                True
    Type:                  Ready
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  NodeVmBatchAttachSucceeded  19s   cns.vmware.com  ReconcileCnsNodeVMBatchAttachment: Successfully processed instance test/test-new-2 in namespace "test/test-new-2".
```

Unit test:

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestReconcileWithoutDeletionTimestampWithNoVolumestoAttach$ sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment

ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment	3.524s
```
