### PR TITLE
Block RWX volume creation for VMFS datastores if policy is not EZT

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -527,6 +527,16 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			"failed to get vCenter from Manager. Error: %v", err)
 	}
 
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.SharedDiskFss) && isSharedRawBlockRequest(ctx, req.VolumeCapabilities) {
+		log.Infof("Volume request is for shared RWX volume. Validatig if policy is compatible for VMFS datastores.")
+		err := common.ValidateStoragePolicyForRWXVolume(ctx, vc, storagePolicyID)
+		if err != nil {
+			log.Errorf("failed validation for policy %s", storagePolicyID)
+			return nil, csifault.CSIInternalFault, err
+		}
+	}
+
 	// Fetch the accessibility requirements from the request.
 	topologyRequirement = req.GetAccessibilityRequirements()
 	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a validation in CSI to fail RWX volume creation if policy is for VMFS datastores and is NOT EZT.
This is a requirement for multiwriter.


**Testing done**:

DYNAMIC:

Created RWX volume with vSAN policy - reached Bound state.
Created RWX volume with VMFS EZT policy - reached Bound state.

Created RWX volume with VMFS non-EZT policy - stayed in Pending state. See below:


```
Name:          rwx-pvc-vmfs-non-ezt
Namespace:     test
StorageClass:  vmfs-1
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Block
Used By:       <none>
Events:
  Type     Reason                Age               From                                                                                          Message
  ----     ------                ----              ----                                                                                          -------
  Normal   ExternalProvisioning  11s               persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal   Provisioning          4s (x4 over 11s)  csi.vsphere.vmware.com_42153cccacdf638453d78f7d0390adf1_3583e745-e910-4532-aaad-545d77e3d05e  External provisioner is provisioning volume for claim "test/rwx-pvc-vmfs-non-ezt"
  Warning  ProvisioningFailed    4s (x4 over 11s)  csi.vsphere.vmware.com_42153cccacdf638453d78f7d0390adf1_3583e745-e910-4532-aaad-545d77e3d05e  failed to provision volume with StorageClass "vmfs-1": rpc error: code = Unknown desc = Policy 64059831-c138-49f1-a341-86b10564fbb2 is for VMFS datastores. It must be Thick Provision Eager Zero for RWX block volumes
```


Created RWXOvolume with vSAN policy - reached Bound state.
Created RWO volume with VMFS EZT policy - reached Bound state.
Created RWO volume with VMFS non-EZT policy -  reached Bound state.


STATIC:

Create RWX volume with vSAN policy - PVC and PV got created.
Create RWX volume with VMFS EZT policy - PVC and PV got created.
Create RWX volume with VMFS non-EZT policy - PVC and PV failed o get created. Error:

```
Name:         test4
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsRegisterVolume
Metadata:
  Creation Timestamp:  2025-11-06T13:56:11Z
  Generation:          1
  Resource Version:    3383517
  UID:                 fb1e2c6f-d80c-428d-9dd0-083eeb66c679
Spec:
  Access Mode:  ReadWriteMany
  Pvc Name:     rwx-block-vmfs-non-ezt
  Volume ID:    6658723e-5a2a-45dd-842e-2218739bf2dd
  Volume Mode:  Block
Status:
  Error:       Policy 64059831-c138-49f1-a341-86b10564fbb2 is for VMFS datastores. It must be Thick Provision Eager Zero for RWX block volumes
  Registered:  false
Events:
  Type     Reason                   Age   From            Message
  ----     ------                   ----  ----            -------
  Warning  CnsRegisterVolumeFailed  1s    cns.vmware.com  Policy 64059831-c138-49f1-a341-86b10564fbb2 is for VMFS datastores. It must be Thick Provision Eager Zero for RWX block volumes
```

Pre-checkin pipelines are in progress.