### PR TITLE
Tag CSI Images as v3.6.0-rc.2

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -149,7 +149,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.6.0-rc.1
+          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.6.0-rc.2
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -279,7 +279,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.6.0-rc.1
+          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.6.0-rc.2
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -340,7 +340,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.6.0-rc.1
+          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.6.0-rc.2
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -475,7 +475,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.6.0-rc.1
+          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.6.0-rc.2
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -624,7 +624,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: vsphere-csi-node
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.6.0-rc.1
+          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.6.0-rc.2
           command:
             - "csi.exe"
           args:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Tag CSI Images as v3.6.0-rc.2

**Testing Done**:

Not needed as the rc2 is created from latest commits in 3.6 and individual commits have the testing results.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Tag CSI Images as v3.6.0-rc.2
```
