### PR TITLE
Some minor fixes for batchattach API

### DIFF
--- a/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
+++ b/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
@@ -138,7 +138,7 @@ type PersistentVolumeClaimStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=batchattach
-// +kubebuilder:printcolumn:name="NodeUUID",type="string",JSONPath=".spec.nodeUUID"
+// +kubebuilder:printcolumn:name="InstanceUUID",type="string",JSONPath=".spec.instanceUUID"
 
 // CnsNodeVMBatchAttachment is the Schema for the cnsnodevmbatchattachments API
 type CnsNodeVMBatchAttachment struct {

--- a/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
@@ -17,8 +17,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.nodeUUID
-      name: NodeUUID
+    - jsonPath: .spec.instanceUUID
+      name: InstanceUUID
       type: string
     name: v1alpha1
     schema:

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -252,6 +252,12 @@ func updatePvcStatusEntryName(ctx context.Context,
 		if _, ok := pvcsToDetach[volume.PersistentVolumeClaim.ClaimName]; !ok {
 			continue
 		}
+		if strings.HasSuffix(instance.Status.VolumeStatus[i].Name, detachSuffix) {
+			log.Infof("VolumeName %s for PVC %s already contains suffix %s. Skipping.",
+				instance.Status.VolumeStatus[i].Name, volume.PersistentVolumeClaim.ClaimName,
+				detachSuffix)
+			continue
+		}
 		newVolumeName := instance.Status.VolumeStatus[i].Name + detachSuffix
 		instance.Status.VolumeStatus[i].Name = newVolumeName
 		log.Infof("Updating status name entry to %s for detaching PVC %s",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR fixes some issues with batch attach API:
1. Change printer column from nodeUUID to instanceUUID.
2. Add ":detaching" prefix only when it doesn't already exist.

**Testing done**:

Printer column is correct:

```
root@4215b6b6ca2e9c2d02dcfe8f4eece2c1 [ ~ ]# k get batchattach -n test
NAME         INSTANCEUUID
test-new-2   66ea26ce-a2f7-4249-b654-948fd2bfab26
```


Attach was successful:

```
Name:         test-new-2
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsNodeVMBatchAttachment
Metadata:
  Creation Timestamp:  2025-11-14T09:39:01Z
  Finalizers:
    cns.vmware.com
  Generation:        1
  Resource Version:  11351546
  UID:               89244292-9bd3-45cf-a656-390593088bbe
Spec:
  Instance UUID:  66ea26ce-a2f7-4249-b654-948fd2bfab26
  Volumes:
    Name:  disk-1
    Persistent Volume Claim:
      Claim Name:      rwo-pvc-2
      Controller Key:  1000
      Disk Mode:       independent_persistent
      Sharing Mode:    sharingMultiWriter
      Unit Number:     5
Status:
  Volumes:
    Name:  disk-1
    Persistent Volume Claim:
      Attached:       true
      Claim Name:     rwo-pvc-2
      Cns Volume Id:  0a36d674-98d1-49fa-89b3-9edad600b0b9
      Disk UUID:      6000C296-e1be-9990-9a2c-1ee33e05c302
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  NodeVmBatchAttachSucceeded  11s   cns.vmware.com  ReconcileCnsNodeVMBatchAttachment: Successfully processed instance test/test-new-2 in namespace "test/test-new-2".
```

Detach was also successful:

```
Name:         test-new-2
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsNodeVMBatchAttachment
Metadata:
  Creation Timestamp:  2025-11-14T09:39:01Z
  Finalizers:
    cns.vmware.com
  Generation:        2
  Resource Version:  11353345
  UID:               89244292-9bd3-45cf-a656-390593088bbe
Spec:
  Instance UUID:  66ea26ce-a2f7-4249-b654-948fd2bfab26
Status:
Events:
  Type    Reason                      Age                 From            Message
  ----    ------                      ----                ----            -------
  Normal  NodeVmBatchAttachSucceeded  1s (x2 over 2m26s)  cns.vmware.com  ReconcileCnsNodeVMBatchAttachment: Successfully processed instance test/test-new-2 in namespace "test/test-new-2".
```


Failed detach purposely and observed that only ":detaching" suffix is added only once.

```
Name:         test-new-2
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsNodeVMBatchAttachment
Metadata:
  Creation Timestamp:  2025-11-14T09:39:01Z
  Finalizers:
    cns.vmware.com
  Generation:        4
  Resource Version:  11478572
  UID:               89244292-9bd3-45cf-a656-390593088bbe
Spec:
  Instance UUID:  66ea26ce-a2f7-4249-b654-948fd2bfab26
Status:
  Error:  failed to detach volumes: rwo-pvc-2
  Volumes:
    Name:  disk-1:detaching
    Persistent Volume Claim:
      Attached:       true
      Claim Name:     rwo-pvc-2
      Cns Volume Id:  0a36d674-98d1-49fa-89b3-9edad600b0b9
      Disk UUID:      6000C296-e1be-9990-9a2c-1ee33e05c302
      Error:          MOCK FAULT
Events:
  Type     Reason                      Age                From            Message
  ----     ------                      ----               ----            -------
  Normal   NodeVmBatchAttachSucceeded  29s (x2 over 85s)  cns.vmware.com  ReconcileCnsNodeVMBatchAttachment: Successfully processed instance test/test-new-2 in namespace "test/test-new-2".
  Warning  NodeVmBatchAttachFailed     3s (x4 over 10s)   cns.vmware.com  failed to detach volumes: rwo-pvc-2
```

WCP precheckin pipeline (In progress): https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/594/
VKS  precheckin pipeline (In progress):  https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/531/