### PR TITLE
Add snapshot limit enforcement for WCP with per-volume serialization

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -353,6 +353,18 @@ const (
 	// Guest cluster.
 	SupervisorVolumeSnapshotAnnotationKey = "csi.vsphere.guest-initiated-csi-snapshot"
 
+	// ConfigMapCSILimits is the ConfigMap name for CSI limits configuration
+	ConfigMapCSILimits = "cns-csi-limits"
+
+	// ConfigMapKeyMaxSnapshotsPerVolume is the ConfigMap key for snapshot limit per volume
+	ConfigMapKeyMaxSnapshotsPerVolume = "max-snapshots-per-volume"
+
+	// DefaultMaxSnapshotsPerVolume is the default maximum number of snapshots per block volume in WCP
+	DefaultMaxSnapshotsPerVolume = 4
+
+	// AbsoluteMaxSnapshotsPerVolume is the hard cap for maximum snapshots per block volume
+	AbsoluteMaxSnapshotsPerVolume = 32
+
 	// AttributeSupervisorVolumeSnapshotClass represents name of VolumeSnapshotClass
 	AttributeSupervisorVolumeSnapshotClass = "svvolumesnapshotclass"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The default number of max snapshot is 4, this can be overridden via a ConfigMap in the namespace. The snapshot limit enforcement reads configuration from a ConfigMap named `cns-csi-limits` in each namespace with key `max-snapshots-per-volume`.

**Design decisions**:
- ConfigMap location: Per-namespace (allows tenant-level customization)
- Default behavior: If ConfigMap not found, uses default limit of 4
- Validation: If ConfigMap exists but key is missing, request fails to prevent misconfiguration
- Clamping: Values exceeding absolute max (32) are clamped with a warning
- Invalid values (negative or non-numeric) fail the request immediately
- Per-volume locking ensures serialized snapshot operations

**Which issue this PR fixes**: fixes #

**Testing done**:

Precheckins:
WCP(PASS): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/748/
VKS(PASS): https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/

- All existing unit tests pass
- Build successful with no compilation errors
- Test results: `ok sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp 3.216s`
- Integration Test: https://gist.github.com/deepakkinni/faa1c69b3f21ffeb3843011b60fad7ee
```
=== RUN   TestGetSnapshotLimitForNamespace
=== RUN   TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValidValue
=== RUN   TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValueEqualsMax
=== RUN   TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValueExceedsMax
=== RUN   TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValueIsZero
=== RUN   TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValueIsNegative
=== RUN   TestGetSnapshotLimitForNamespace/WhenConfigMapExists_InvalidFormat
=== RUN   TestGetSnapshotLimitForNamespace/WhenConfigMapExists_MissingKey
=== RUN   TestGetSnapshotLimitForNamespace/WhenConfigMapNotFound
=== RUN   TestGetSnapshotLimitForNamespace/WhenK8sClientCreationFails
--- PASS: TestGetSnapshotLimitForNamespace (0.00s)
    --- PASS: TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValidValue (0.00s)
    --- PASS: TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValueEqualsMax (0.00s)
    --- PASS: TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValueExceedsMax (0.00s)
    --- PASS: TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValueIsZero (0.00s)
    --- PASS: TestGetSnapshotLimitForNamespace/WhenConfigMapExists_ValueIsNegative (0.00s)
    --- PASS: TestGetSnapshotLimitForNamespace/WhenConfigMapExists_InvalidFormat (0.00s)
    --- PASS: TestGetSnapshotLimitForNamespace/WhenConfigMapExists_MissingKey (0.00s)
    --- PASS: TestGetSnapshotLimitForNamespace/WhenConfigMapNotFound (0.00s)
    --- PASS: TestGetSnapshotLimitForNamespace/WhenK8sClientCreationFails (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp	0.976s


Ran Tests on real setup:
Test #1: Under Limit - ConfigMap=5, create 3 snapshots → ✅ PASSED
Test #2: At Limit Minus One - ConfigMap=5, existing=3, create 4th → ✅ PASSED
Test #3: At Limit - ConfigMap=5, existing=5 READY, try create 6th → ✅ PASSED (correctly denied)
Test #4: Over Limit - ConfigMap=3, existing=4 READY, try create 5th → ✅ PASSED (correctly denied)
Test #5: No ConfigMap - Use Default - No ConfigMap, create 3 snapshots → ✅ PASSED
Test #6: Valid ConfigMap Value - ConfigMap=3, create 2 snapshots → ✅ PASSED
Test #7: Absolute Max Enforcement - ConfigMap=100, webhook caps at 32, create 32, 33rd denied → ✅ PASSED
Test #8: Count Multiple Snapshots - ConfigMap=10, create 9 snapshots, verify all counted → ✅ PASSED
Test #9: Different PVCs Same Namespace - ConfigMap=3, PVC1 has 2, PVC2 has 2 → ✅ PASSED
Test #10: Different PVCs Independent Limits - ConfigMap=3, PVC1 has 3, PVC2 create 2 → ✅ PASSED
Test #11: Empty Snapshot List - ConfigMap=3, no existing snapshots, create first → ✅ PASSED
Test #12: Delete and Recreate - ConfigMap=2, create 2, delete 1, create another → ✅ PASSED
Test #13: Rapid Creation - ConfigMap=5, rapidly create 5 snapshots sequentially → ✅ PASSED
Test #14: Error Message Content - ConfigMap=2, existing=2, verify error message format → ✅ PASSED
```



**Special notes for your reviewer**:
- No RBAC changes required (controller already has ConfigMap read permissions)
- If ConfigMap not found, defaults to limit of 4
- If ConfigMap exists but key is missing, request fails (intentional)

**Release note**:
```release-note
Snapshot limits are now configured via ConfigMap cns-csi-limits for WCP
```