### PR TITLE
Handle Late enablement of shared disk capability

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -173,6 +173,11 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			return logger.LogNewErrorf(log, "failed to start zone informer. Error: %v", err)
 		}
 	}
+	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.SharedDiskFss) {
+		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
+			common.SharedDiskFss, "", "")
+	}
 	if idempotencyHandlingEnabled {
 		log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
 		operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx,

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -157,6 +157,10 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 			go containerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
 				common.LinkedCloneSupport, "", "")
 		}
+		if !featureIsSharedDiskEnabled {
+			go containerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
+				common.SharedDiskFss, "", "")
+		}
 		if err := startCNSCSIWebhookManager(ctx, enableWebhookClientCertVerification,
 			containerOrchestratorUtility); err != nil {
 			return fmt.Errorf("unable to run the webhook manager: %w", err)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -359,6 +359,10 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,
 				common.WCPMobilityNonDisruptiveImport, "", "")
 		}
+		if !isSharedDiskEabled {
+			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
+				clusterFlavor, common.SharedDiskFss, "", "")
+		}
 	}
 
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We need to handle late enablement of shared disk capability as supervisor upgrade may happen before VC upgrade. 


**Testing done**:
Start with a cluster where the capability is disabled.

Note that batchattach CRD is not yet created.

Now, enable the capability.

Observed that CSI pod got restarted and batchattach CRD was also created automatically.

```
{"level":"info","time":"2025-11-17T07:00:59.665546958Z","caller":"k8sorchestrator/k8sorchestrator.go:1244","msg":"Capability supports_shared_disks_with_VM_service_VMs changed state to true in capabilities CR supervisor-capabilities. Restarting the container as capability has changed.","TraceId":"469c37fe-8b8f-4ced-8f8f-641fc2736f7e"}
```

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/598/
VKS precheckin (in prgress): https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/532/
