### PR TITLE
Changes to get volume ID from PV in case of detach if CnsNodeVmAttachment CR status doesn't have volume ID

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -71,6 +71,29 @@ var (
 	backOffDurationMapMutex = sync.Mutex{}
 )
 
+// Mockable function variables for testing
+var (
+	getVirtualCenterInstance = cnsvsphere.GetVirtualCenterInstance
+	connectToVCenter         = func(ctx context.Context, vc *cnsvsphere.VirtualCenter) error {
+		return vc.Connect(ctx)
+	}
+	createDatacenterFromVC = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+		dcMoref, host string) (*cnsvsphere.Datacenter, error) {
+		return &cnsvsphere.Datacenter{
+			Datacenter: object.NewDatacenter(vc.Client.Client,
+				vimtypes.ManagedObjectReference{
+					Type:  "Datacenter",
+					Value: dcMoref,
+				}),
+			VirtualCenterHost: host,
+		}, nil
+	}
+	getVMByUUIDFromVCenter = func(ctx context.Context, dc *cnsvsphere.Datacenter,
+		nodeUUID string) (*cnsvsphere.VirtualMachine, error) {
+		return dc.GetVirtualMachineByUUID(ctx, nodeUUID, false)
+	}
+)
+
 // Add creates a new CnsNodeVmAttachment Controller and adds it to the Manager,
 // vSphereSecretConfigInfo and VirtualCenterTypes. The Manager will set fields
 // on the Controller and Start it when the Manager is Started.
@@ -289,7 +312,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 		}
 		// Get node VM by nodeUUID.
 		var dc *cnsvsphere.Datacenter
-		vcenter, err := cnsvsphere.GetVirtualCenterInstance(internalCtx, r.configInfo, false)
+		vcenter, err := getVirtualCenterInstance(internalCtx, r.configInfo, false)
 		if err != nil {
 			msg := fmt.Sprintf("failed to get virtual center instance with error: %v", err)
 			instance.Status.Error = err.Error()
@@ -300,7 +323,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 			recordEvent(internalCtx, r, instance, v1.EventTypeWarning, msg)
 			return reconcile.Result{RequeueAfter: timeout}, csifault.CSIVCenterNotFoundFault, nil
 		}
-		err = vcenter.Connect(internalCtx)
+		err = connectToVCenter(internalCtx, vcenter)
 		if err != nil {
 			msg := fmt.Sprintf("failed to connect to VC with error: %v", err)
 			instance.Status.Error = err.Error()
@@ -311,17 +334,20 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 			recordEvent(internalCtx, r, instance, v1.EventTypeWarning, msg)
 			return reconcile.Result{RequeueAfter: timeout}, csifault.CSIInternalFault, nil
 		}
-		dc = &cnsvsphere.Datacenter{
-			Datacenter: object.NewDatacenter(vcenter.Client.Client,
-				vimtypes.ManagedObjectReference{
-					Type:  "Datacenter",
-					Value: dcMoref,
-				}),
-			VirtualCenterHost: host,
+		dc, err = createDatacenterFromVC(internalCtx, vcenter, dcMoref, host)
+		if err != nil {
+			msg := fmt.Sprintf("failed to create datacenter with error: %v", err)
+			instance.Status.Error = err.Error()
+			err = k8s.UpdateStatus(internalCtx, r.client, instance)
+			if err != nil {
+				log.Errorf("updateCnsNodeVMAttachment failed. err: %v", err)
+			}
+			recordEvent(internalCtx, r, instance, v1.EventTypeWarning, msg)
+			return reconcile.Result{RequeueAfter: timeout}, csifault.CSIInternalFault, nil
 		}
 		nodeUUID := instance.Spec.NodeUUID
 		if !instance.Status.Attached && instance.DeletionTimestamp == nil {
-			nodeVM, err := dc.GetVirtualMachineByUUID(internalCtx, nodeUUID, false)
+			nodeVM, err := getVMByUUIDFromVCenter(internalCtx, dc, nodeUUID)
 			if err != nil {
 				msg := fmt.Sprintf("failed to find the VM with UUID: %q for CnsNodeVmAttachment "+
 					"request with name: %q on namespace: %q. Err: %+v",
@@ -458,7 +484,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 				}
 			}
 			volumeOpType = prometheus.PrometheusDetachVolumeOpType
-			nodeVM, err := dc.GetVirtualMachineByUUID(internalCtx, nodeUUID, false)
+			nodeVM, err := getVMByUUIDFromVCenter(internalCtx, dc, nodeUUID)
 			if err != nil {
 				msg := fmt.Sprintf("failed to find the VM on VC with UUID: %s for "+
 					"CnsNodeVmAttachment request with name: %q on namespace: %s. Err: %+v",
@@ -527,13 +553,26 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 				return reconcile.Result{}, faulttype, nil
 			}
 			var cnsVolumeID string
+			var faulttype string
 			var ok bool
 			if cnsVolumeID, ok = instance.Status.AttachmentMetadata[v1a1.AttributeCnsVolumeID]; !ok {
-				log.Debugf("CnsNodeVmAttachment does not have CNS volume ID. AttachmentMetadata: %+v",
+				log.Infof("CnsNodeVmAttachment does not have CNS volume ID. "+
+					"AttachmentMetadata: %+v. Attempting to get volumeID from PVC.",
 					instance.Status.AttachmentMetadata)
-				msg := "CnsNodeVmAttachment does not have CNS volume ID."
-				recordEvent(internalCtx, r, instance, v1.EventTypeWarning, msg)
-				return reconcile.Result{RequeueAfter: timeout}, csifault.CSIInternalFault, nil
+				// Try to get volumeID using getVolumeID function
+				var err error
+				cnsVolumeID, faulttype, err = getVolumeID(internalCtx, r.client,
+					instance.Spec.VolumeName, instance.Namespace)
+				if err != nil {
+					msg := fmt.Sprintf("Failed to get CNS volume ID for PVC: %q in "+
+						"namespace: %q. Err: %+v", instance.Spec.VolumeName,
+						instance.Namespace, err)
+					log.Error(msg)
+					recordEvent(internalCtx, r, instance, v1.EventTypeWarning, msg)
+					return reconcile.Result{RequeueAfter: timeout}, faulttype, nil
+				}
+				log.Infof("Successfully retrieved CNS volume ID: %q from PVC: %q",
+					cnsVolumeID, instance.Spec.VolumeName)
 			}
 			log.Infof("vSphere CSI driver is detaching volume: %q to nodevm: %+v for "+
 				"CnsNodeVmAttachment request with name: %q on namespace: %q",

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
@@ -1,0 +1,331 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnsnodevmattachment
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1a1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
+)
+
+// TestReconcileDetachWithVolumeIDFallback tests the end-to-end reconcile workflow
+// for the DETACH path where volumeID is missing from AttachmentMetadata and must be
+// retrieved using the getVolumeID() fallback mechanism in controller.
+// This test mocks the vCenter calls and volume manager to verify the detach operation
+// proceeds successfully when getVolumeID retrieves the volumeID from PV.
+func TestReconcileDetachWithVolumeIDFallback(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up the scheme
+	SchemeGroupVersion := schema.GroupVersion{
+		Group:   "cns.vmware.com",
+		Version: "v1alpha1",
+	}
+	s := scheme.Scheme
+	s.AddKnownTypes(SchemeGroupVersion, &v1a1.CnsNodeVmAttachment{})
+	metav1.AddToGroupVersion(s, SchemeGroupVersion)
+
+	// Create PVC that is bound to a PV
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-pvc",
+			Namespace:  "test-ns",
+			Finalizers: []string{"cns.vmware.com/pvc-protection"},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "test-pv",
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+		},
+	}
+
+	// Create PV with volumeID in CSI VolumeHandle
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       "csi.vsphere.vmware.com",
+					VolumeHandle: "test-volume-handle-12345",
+				},
+			},
+		},
+	}
+
+	// Create CnsNodeVmAttachment with DeletionTimestamp set (detach flow)
+	// and AttachmentMetadata missing CNS volume ID (do that it triggers getVolumeID fallback)
+	now := metav1.NewTime(time.Now())
+	instance := &v1a1.CnsNodeVmAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-attachment",
+			Namespace:         "test-ns",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"cns.vmware.com/cnsnodevmattachment"},
+		},
+		Spec: v1a1.CnsNodeVmAttachmentSpec{
+			NodeUUID:   "test-node-uuid",
+			VolumeName: "test-pvc",
+		},
+		Status: v1a1.CnsNodeVmAttachmentStatus{
+			// AttachmentMetadata is missing CNS volume ID - this triggers the fallback
+			AttachmentMetadata: map[string]string{},
+			Attached:           true,
+		},
+	}
+
+	// Create fake client with all objects
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(instance).
+		WithRuntimeObjects(instance, pvc, pv).
+		Build()
+
+	// Initialize backOffDuration map (required by controller)
+	backOffDuration = make(map[k8stypes.NamespacedName]time.Duration)
+
+	// Create reconciler with properly configured vCenter config
+	r := &ReconcileCnsNodeVMAttachment{
+		client: fakeClient,
+		scheme: s,
+		configInfo: &config.ConfigurationInfo{
+			Cfg: &config.Config{
+				VirtualCenter: map[string]*config.VirtualCenterConfig{
+					"test-vc": {
+						Datacenters: "dc-1",
+					},
+				},
+			},
+		},
+		recorder: record.NewFakeRecorder(1024),
+	}
+
+	// Mock the volume manager using the same pattern as cnsnodevmbatchattachment tests
+	mockVolumeManager := &unittestcommon.MockVolumeManager{}
+	r.volumeManager = mockVolumeManager
+
+	// Mock all vCenter-related functions to bypass actual vCenter calls
+	originalGetVirtualCenterInstance := getVirtualCenterInstance
+	originalConnectToVCenter := connectToVCenter
+	originalCreateDatacenterFromVC := createDatacenterFromVC
+	originalGetVMByUUID := getVMByUUIDFromVCenter
+	defer func() {
+		getVirtualCenterInstance = originalGetVirtualCenterInstance
+		connectToVCenter = originalConnectToVCenter
+		createDatacenterFromVC = originalCreateDatacenterFromVC
+		getVMByUUIDFromVCenter = originalGetVMByUUID
+	}()
+
+	// Mock getVirtualCenterInstance to return a minimal fake VirtualCenter
+	getVirtualCenterInstance = func(ctx context.Context, cfg *config.ConfigurationInfo,
+		filterSuspendedDatastores bool) (*cnsvsphere.VirtualCenter, error) {
+		return &cnsvsphere.VirtualCenter{}, nil
+	}
+
+	// Mock connectToVCenter to skip the actual connection
+	connectToVCenter = func(ctx context.Context, vc *cnsvsphere.VirtualCenter) error {
+		return nil
+	}
+
+	// Mock createDatacenterFromVC to return a minimal datacenter without needing real client
+	createDatacenterFromVC = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+		dcMoref, host string) (*cnsvsphere.Datacenter, error) {
+		return &cnsvsphere.Datacenter{}, nil
+	}
+
+	// Mock getVMByUUIDFromVCenter to return a mock VM
+	getVMByUUIDFromVCenter = func(ctx context.Context, dc *cnsvsphere.Datacenter,
+		nodeUUID string) (*cnsvsphere.VirtualMachine, error) {
+		return &cnsvsphere.VirtualMachine{}, nil
+	}
+
+	// Create reconcile request
+	req := reconcile.Request{
+		NamespacedName: k8stypes.NamespacedName{
+			Name:      "test-attachment",
+			Namespace: "test-ns",
+		},
+	}
+
+	// Run reconcile
+	result, err := r.Reconcile(ctx, req)
+
+	// Assertions:
+	// 1. No error should be returned
+	assert.NoError(t, err, "Reconcile should succeed")
+	// 2. Result should indicate successful completion (no requeue)
+	assert.Equal(t, reconcile.Result{}, result, "Should not requeue on success")
+
+	// Verify that the detach operation completed successfully
+	// The key validation is that:
+	// - getVolumeID was called (evidenced by log: "Successfully retrieved CNS volume ID")
+	// - DetachVolume was called with the retrieved volumeID
+	// - No error was returned from reconcile
+
+	t.Logf("✓ Reconcile successfully completed detach using volumeID fallback from PV")
+}
+
+// TestReconcileDetachWithVolumeIDFallbackFailure tests the end-to-end reconcile workflow
+// for the DETACH path where volumeID is missing from AttachmentMetadata and the
+// getVolumeID() fallback also fails (e.g., PVC not found, PVC not bound, PV not found).
+// This verifies that the controller returns an error and requeues for retry.
+func TestReconcileDetachWithVolumeIDFallbackFailure(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up the scheme
+	SchemeGroupVersion := schema.GroupVersion{
+		Group:   "cns.vmware.com",
+		Version: "v1alpha1",
+	}
+	s := scheme.Scheme
+	s.AddKnownTypes(SchemeGroupVersion, &v1a1.CnsNodeVmAttachment{})
+	metav1.AddToGroupVersion(s, SchemeGroupVersion)
+
+	// Create CnsNodeVmAttachment with DeletionTimestamp set (detach flow)
+	// and AttachmentMetadata missing CNS volume ID (triggers getVolumeID fallback)
+	// Note: We're NOT creating the PVC, so getVolumeID will fail
+	now := metav1.NewTime(time.Now())
+	instance := &v1a1.CnsNodeVmAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-attachment-fail",
+			Namespace:         "test-ns",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"cns.vmware.com/cnsnodevmattachment"},
+		},
+		Spec: v1a1.CnsNodeVmAttachmentSpec{
+			NodeUUID:   "test-node-uuid",
+			VolumeName: "nonexistent-pvc", // This PVC doesn't exist
+		},
+		Status: v1a1.CnsNodeVmAttachmentStatus{
+			// AttachmentMetadata is missing CNS volume ID - this triggers the fallback
+			AttachmentMetadata: map[string]string{},
+			Attached:           true,
+		},
+	}
+
+	// Create fake client with only the instance (no PVC/PV)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(instance).
+		WithRuntimeObjects(instance).
+		Build()
+
+	// Initialize backOffDuration map (required by controller)
+	backOffDuration = make(map[k8stypes.NamespacedName]time.Duration)
+
+	// Create reconciler with properly configured vCenter config
+	r := &ReconcileCnsNodeVMAttachment{
+		client: fakeClient,
+		scheme: s,
+		configInfo: &config.ConfigurationInfo{
+			Cfg: &config.Config{
+				VirtualCenter: map[string]*config.VirtualCenterConfig{
+					"test-vc": {
+						Datacenters: "dc-1",
+					},
+				},
+			},
+		},
+		recorder: record.NewFakeRecorder(1024),
+	}
+
+	// Mock the volume manager
+	mockVolumeManager := &unittestcommon.MockVolumeManager{}
+	r.volumeManager = mockVolumeManager
+
+	// Mock all vCenter-related functions
+	originalGetVirtualCenterInstance := getVirtualCenterInstance
+	originalConnectToVCenter := connectToVCenter
+	originalCreateDatacenterFromVC := createDatacenterFromVC
+	originalGetVMByUUID := getVMByUUIDFromVCenter
+	defer func() {
+		getVirtualCenterInstance = originalGetVirtualCenterInstance
+		connectToVCenter = originalConnectToVCenter
+		createDatacenterFromVC = originalCreateDatacenterFromVC
+		getVMByUUIDFromVCenter = originalGetVMByUUID
+	}()
+
+	getVirtualCenterInstance = func(ctx context.Context, cfg *config.ConfigurationInfo,
+		filterSuspendedDatastores bool) (*cnsvsphere.VirtualCenter, error) {
+		return &cnsvsphere.VirtualCenter{}, nil
+	}
+
+	connectToVCenter = func(ctx context.Context, vc *cnsvsphere.VirtualCenter) error {
+		return nil
+	}
+
+	createDatacenterFromVC = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+		dcMoref, host string) (*cnsvsphere.Datacenter, error) {
+		return &cnsvsphere.Datacenter{}, nil
+	}
+
+	getVMByUUIDFromVCenter = func(ctx context.Context, dc *cnsvsphere.Datacenter,
+		nodeUUID string) (*cnsvsphere.VirtualMachine, error) {
+		return &cnsvsphere.VirtualMachine{}, nil
+	}
+
+	// Create reconcile request
+	req := reconcile.Request{
+		NamespacedName: k8stypes.NamespacedName{
+			Name:      "test-attachment-fail",
+			Namespace: "test-ns",
+		},
+	}
+
+	// Run reconcile
+	result, err := r.Reconcile(ctx, req)
+
+	// Assertions:
+	// 1. No error should be returned (controller handles gracefully)
+	assert.NoError(t, err, "Reconcile should not return error (handles internally)")
+	// 2. Result should indicate requeue for retry
+	assert.NotEqual(t, reconcile.Result{}, result, "Should requeue for retry")
+	assert.True(t, result.RequeueAfter > 0, "Should requeue after timeout")
+
+	// The key validation is that:
+	// - getVolumeID was called and failed (evidenced by log: "Failed to get CNS volume ID")
+	// - Controller handled the error gracefully and returned RequeueAfter
+	// - No panic or unhandled error occurred
+
+	t.Logf("✓ Reconcile correctly handled getVolumeID failure and requeued for retry")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverting earlier changes made through https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3720. We need to rework this fix to consider following things.

We need to consider long running attach task, if attach task is in progress on vCenter, and reconciler flip to detach workflow due to deletion timestamp on the CR instance and prior attach is timed out just at CSI layer, reconciler should issue detach workflow and confirm disk is detached before deleting CNSNodeVMAttachment. CNSNodeVMAttachment Reconciler should not assume attach has not happned because state in the CNSNodeVMAttachment says it is not attached. otherwise we may just remove CNSNodeVMAttachment while long running attach task later attach disk to VM and we will have inconsistent volume attachment state in k8s and vc.

During detach workflow, trying to fetch volume ID from the PVC/PV, just like how we are obtaining during attach call when instance.Status.AttachmentMetadata[v1a1.AttributeCnsVolumeID] does not have volume ID. If we get volume ID, then detach the volume and delete CnsNodeVmAttachment CR. Otherwise, retry the operation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
wcp pre-checkin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/600/
```
Ran 13 of 1841 Specs
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 1828 Skipped | 0 Flaked
```

Added unit tests for success and failure case. These unit tests are passing.
```
=== RUN   TestReconcileDetachWithVolumeIDFallback
{"level":"info","time":"2025-11-17T18:37:09.766453+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:208","msg":"Received Reconcile for request: \"test-ns/test-attachment\"","TraceId":"48d782e0-16aa-4711-9364-94f065ddfa18"}
{"level":"info","time":"2025-11-17T18:37:09.767429+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:221","msg":"Started Reconcile for CnsNodeVMAttachment request: \"test-ns/test-attachment\"","TraceId":"6bb87f2b-3afe-49fc-bb51-86a127097df4"}
{"level":"info","time":"2025-11-17T18:37:09.767657+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:245","msg":"Reconciling CnsNodeVmAttachment with Request.Name: \"test-attachment\" Namespace \"test-ns\" timeout \"1s\" seconds","TraceId":"6bb87f2b-3afe-49fc-bb51-86a127097df4"}
{"level":"info","time":"2025-11-17T18:37:09.76784+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:559","msg":"CnsNodeVmAttachment does not have CNS volume ID. AttachmentMetadata: map[]. Attempting to get volumeID from PVC.","TraceId":"6bb87f2b-3afe-49fc-bb51-86a127097df4"}
{"level":"info","time":"2025-11-17T18:37:09.768747+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:574","msg":"Successfully retrieved CNS volume ID: \"test-volume-handle-12345\" from PVC: \"test-pvc\"","TraceId":"6bb87f2b-3afe-49fc-bb51-86a127097df4"}
{"level":"info","time":"2025-11-17T18:37:09.7694+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:577","msg":"vSphere CSI driver is detaching volume: \"test-volume-handle-12345\" to nodevm: <nil> [VirtualCenterHost: , UUID: , Datacenter: <nil>] for CnsNodeVmAttachment request with name: \"test-attachment\" on namespace: \"test-ns\"","TraceId":"6bb87f2b-3afe-49fc-bb51-86a127097df4"}
{"level":"info","time":"2025-11-17T18:37:09.76961+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:938","msg":"ReconcileCnsNodeVMAttachment: Successfully updated entry in CNS for instance with name \"test-attachment\" and namespace \"test-ns\".","TraceId":"6bb87f2b-3afe-49fc-bb51-86a127097df4"}
{"level":"info","time":"2025-11-17T18:37:09.769626+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:642","msg":"Finished Reconcile for CnsNodeVMAttachment request: \"test-ns/test-attachment\"","TraceId":"6bb87f2b-3afe-49fc-bb51-86a127097df4"}
{"level":"info","time":"2025-11-17T18:37:09.769715+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:674","msg":"Reconcile for request: \"test-ns/test-attachment\" End.","TraceId":"48d782e0-16aa-4711-9364-94f065ddfa18"}
    cnsnodevmattachment_controller_test.go:205: ✓ Reconcile successfully completed detach using volumeID fallback from PV
--- PASS: TestReconcileDetachWithVolumeIDFallback (0.00s)


=== RUN   TestReconcileDetachWithVolumeIDFallbackFailure
{"level":"info","time":"2025-11-17T18:37:09.770147+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:208","msg":"Received Reconcile for request: \"test-ns/test-attachment-fail\"","TraceId":"6049ed3b-e8e8-42ed-bb06-fe3c27d21cdd"}
{"level":"info","time":"2025-11-17T18:37:09.770425+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:221","msg":"Started Reconcile for CnsNodeVMAttachment request: \"test-ns/test-attachment-fail\"","TraceId":"6bb186a0-63e1-49c6-b3f4-6f2aad83901a"}
{"level":"info","time":"2025-11-17T18:37:09.771329+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:245","msg":"Reconciling CnsNodeVmAttachment with Request.Name: \"test-attachment-fail\" Namespace \"test-ns\" timeout \"1s\" seconds","TraceId":"6bb186a0-63e1-49c6-b3f4-6f2aad83901a"}
{"level":"info","time":"2025-11-17T18:37:09.771531+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:559","msg":"CnsNodeVmAttachment does not have CNS volume ID. AttachmentMetadata: map[]. Attempting to get volumeID from PVC.","TraceId":"6bb186a0-63e1-49c6-b3f4-6f2aad83901a"}
{"level":"error","time":"2025-11-17T18:37:09.771545+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:847","msg":"failed to get PVC with volumename: \"nonexistent-pvc\" on namespace: \"test-ns\". Err: persistentvolumeclaims \"nonexistent-pvc\" not found","TraceId":"6bb186a0-63e1-49c6-b3f4-6f2aad83901a","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.getVolumeID\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:847\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile.func2\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:564\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:651\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.TestReconcileDetachWithVolumeIDFallbackFailure\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go:316\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
{"level":"error","time":"2025-11-17T18:37:09.771572+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:570","msg":"Failed to get CNS volume ID for PVC: \"nonexistent-pvc\" in namespace: \"test-ns\". Err: persistentvolumeclaims \"nonexistent-pvc\" not found","TraceId":"6bb186a0-63e1-49c6-b3f4-6f2aad83901a","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile.func2\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:570\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:651\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.TestReconcileDetachWithVolumeIDFallbackFailure\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go:316\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
{"level":"error","time":"2025-11-17T18:37:09.771615+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:931","msg":"Failed to get CNS volume ID for PVC: \"nonexistent-pvc\" in namespace: \"test-ns\". Err: persistentvolumeclaims \"nonexistent-pvc\" not found","TraceId":"6bb186a0-63e1-49c6-b3f4-6f2aad83901a","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.recordEvent\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:931\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile.func2\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:571\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:651\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.TestReconcileDetachWithVolumeIDFallbackFailure\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go:316\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
{"level":"error","time":"2025-11-17T18:37:09.77172+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:665","msg":"Operation failed, reporting failure status to Prometheus. Operation Type: \"detach-volume\", Volume Type: \"block\", Fault Type: \"csi.fault.ApiServerOperation\"","TraceId":"6049ed3b-e8e8-42ed-bb06-fe3c27d21cdd","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:665\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.TestReconcileDetachWithVolumeIDFallbackFailure\n\t/Users/vkotkar/csi/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go:316\ntesting.tRunner\n\t/Users/vkotkar/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-amd64/src/testing/testing.go:1792"}
{"level":"info","time":"2025-11-17T18:37:09.771746+05:30","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:674","msg":"Reconcile for request: \"test-ns/test-attachment-fail\" End.","TraceId":"6049ed3b-e8e8-42ed-bb06-fe3c27d21cdd"}
    cnsnodevmattachment_controller_test.go:330: ✓ Reconcile correctly handled getVolumeID failure and requeued for retry
--- PASS: TestReconcileDetachWithVolumeIDFallbackFailure (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment 4.289s
```


Manual testing logs:
Simulated this situation by manually deleting cnsVolumeId from CnsNodeVmAttachment CR and later deleted this CR. As observed in logs, it doesn't get cnsVolumeId from status and later retrieves it from the PVC/PV and successfully detaches the volume.
```
{"level":"info","time":"2025-11-18T12:11:07.070789845Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:208","msg":"Received Reconcile for request: \"gc-ns/sample-vm-sample-vol\"","TraceId":"e3e85c8b-4cfa-4891-8277-48c444dd21aa"}
{"level":"info","time":"2025-11-18T12:11:07.071677451Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:221","msg":"Started Reconcile for CnsNodeVMAttachment request: \"gc-ns/sample-vm-sample-vol\"","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
{"level":"info","time":"2025-11-18T12:11:07.071887496Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:245","msg":"Reconciling CnsNodeVmAttachment with Request.Name: \"sample-vm-sample-vol\" Namespace \"gc-ns\" timeout \"1s\" seconds","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
{"level":"info","time":"2025-11-18T12:11:07.099048136Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:559","msg":"CnsNodeVmAttachment does not have CNS volume ID. AttachmentMetadata: map[]. Attempting to get volumeID from PVC.","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
{"level":"info","time":"2025-11-18T12:11:07.109704845Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:574","msg":"Successfully retrieved CNS volume ID: \"d623ebb6-aca8-40ec-b636-c59d92dde82a\" from PVC: \"sample-claim\"","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
{"level":"info","time":"2025-11-18T12:11:07.110104619Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:577","msg":"vSphere CSI driver is detaching volume: \"d623ebb6-aca8-40ec-b636-c59d92dde82a\" to nodevm: VirtualMachine:vm-255 [VirtualCenterHost: lvn-dvm-10-192-0-178.dvm.lvn.broadcom.net, UUID: cd070fce-1f5f-4823-9756-6251f661c7f3, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-40, VirtualCenterHost: lvn-dvm-10-192-0-178.dvm.lvn.broadcom.net]] for CnsNodeVmAttachment request with name: \"sample-vm-sample-vol\" on namespace: \"gc-ns\"","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
{"level":"info","time":"2025-11-18T12:11:07.132477058Z","caller":"volume/listview.go:200","msg":"AddTask called for Task:task-822","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
...
{"level":"info","time":"2025-11-18T12:11:07.549759866Z","caller":"volume/manager.go:1260","msg":"DetachVolume: volumeID: \"d623ebb6-aca8-40ec-b636-c59d92dde82a\", vm: \"VirtualMachine:vm-255 [VirtualCenterHost: lvn-dvm-10-192-0-178.dvm.lvn.broadcom.net, UUID: cd070fce-1f5f-4823-9756-6251f661c7f3, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-40, VirtualCenterHost: lvn-dvm-10-192-0-178.dvm.lvn.broadcom.net]]\", opId: \"e7383389\"","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
{"level":"info","time":"2025-11-18T12:11:07.549851078Z","caller":"volume/manager.go:1310","msg":"DetachVolume: Volume detached successfully. volumeID: \"d623ebb6-aca8-40ec-b636-c59d92dde82a\", vm: \"VirtualMachine:vm-255 [VirtualCenterHost: lvn-dvm-10-192-0-178.dvm.lvn.broadcom.net, UUID: cd070fce-1f5f-4823-9756-6251f661c7f3, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-40, VirtualCenterHost: lvn-dvm-10-192-0-178.dvm.lvn.broadcom.net]]\", opId: \"e7383389\"","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
{"level":"info","time":"2025-11-18T12:11:07.628743324Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:938","msg":"ReconcileCnsNodeVMAttachment: Successfully updated entry in CNS for instance with name \"sample-vm-sample-vol\" and namespace \"gc-ns\".","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
{"level":"info","time":"2025-11-18T12:11:07.628800262Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:642","msg":"Finished Reconcile for CnsNodeVMAttachment request: \"gc-ns/sample-vm-sample-vol\"","TraceId":"4e2ced6e-a298-4d92-ab5c-22f17c5b8f47"}
```


**Special notes for your reviewer**:

**Release note**:
```release-note
Changes to get volume ID from PV in case of detach if CnsNodeVmAttachment CR status doesn't have volume ID
```
