### PR TITLE
CnsNodeVMAttachment : Modify log level for return paths & finalizer updates

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -664,7 +664,7 @@ func removeFinalizerFromCRDInstance(ctx context.Context,
 	log := logger.GetLogger(ctx)
 	for i, finalizer := range instance.Finalizers {
 		if finalizer == cnsoptypes.CNSFinalizer {
-			log.Debugf("Removing %q finalizer from CnsNodeVmAttachment instance with name: %q on namespace: %q",
+			log.Infof("Removing %q finalizer from CnsNodeVmAttachment instance with name: %q on namespace: %q",
 				cnsoptypes.CNSFinalizer, request.Name, request.Namespace)
 			instance.Finalizers = append(instance.Finalizers[:i], instance.Finalizers[i+1:]...)
 		}
@@ -695,7 +695,7 @@ func removeFinalizerFromPVC(ctx context.Context, client client.Client,
 	finalizerFound := false
 	for i, finalizer := range pvc.Finalizers {
 		if finalizer == cnsoptypes.CNSPvcFinalizer {
-			log.Debugf("Removing %q finalizer from PersistentVolumeClaim: %q on namespace: %q",
+			log.Infof("Removing %q finalizer from PersistentVolumeClaim: %q on namespace: %q",
 				cnsoptypes.CNSPvcFinalizer, pvc.Name, pvc.Namespace)
 			pvc.Finalizers = append(pvc.Finalizers[:i], pvc.Finalizers[i+1:]...)
 			finalizerFound = true
@@ -703,7 +703,7 @@ func removeFinalizerFromPVC(ctx context.Context, client client.Client,
 		}
 	}
 	if !finalizerFound {
-		log.Debugf("Finalizer: %q not found on PersistentVolumeClaim: %q on namespace: %q not found. Returning nil",
+		log.Infof("Finalizer: %q not found on PersistentVolumeClaim: %q on namespace: %q not found. Returning nil",
 			cnsoptypes.CNSPvcFinalizer, pvc.Name, pvc.Namespace)
 		return "", nil
 	}
@@ -743,7 +743,7 @@ func updateSVPVC(ctx context.Context, client client.Client,
 			if removeCnsPvcFinalizer {
 				for i, finalizer := range latestPVCObject.Finalizers {
 					if finalizer == cnsoptypes.CNSPvcFinalizer {
-						log.Debugf("Removing %q finalizer from PersistentVolumeClaim: %q on namespace: %q",
+						log.Infof("Removing %q finalizer from PersistentVolumeClaim: %q on namespace: %q",
 							cnsoptypes.CNSPvcFinalizer, pvc.Name, pvc.Namespace)
 						latestPVCObject.Finalizers = append(latestPVCObject.Finalizers[:i], latestPVCObject.Finalizers[i+1:]...)
 						break


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Modifies log level for return paths & finalizer updates from debug to info. This is needed to capture critical paths which can help in debugging issues.


**Testing done**:
[pre-check-in results](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3751#issuecomment-3554013401)
Not adding/modifying unit tests as it is just a log level update.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
CnsNodeVMAttachment : Modify log level for return paths & finalizer updates
```
