### PR TITLE
Use Patch operation for CnsVolumeMetadata & CnsFileAccessConfig updates

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -19,6 +19,7 @@ package kubernetes
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net"
@@ -40,6 +41,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	clientset "k8s.io/client-go/kubernetes"
@@ -892,4 +895,47 @@ func RemoveFinalizer(ctx context.Context, c client.Client, obj client.Object, fi
 
 	log.Info("Removing finalizer from object.")
 	return c.Update(ctx, obj)
+}
+
+// PatchObject patches a Kubernetes object using strategic merge patch.
+// This function creates a patch between the original and modified objects and applies it using the client.
+// It returns an error if the patch operation fails.
+func PatchObject(ctx context.Context, k8sClient client.Client, original, modified client.Object) error {
+	log := logger.GetLogger(ctx)
+
+	// Marshal the original object
+	oldData, err := json.Marshal(original)
+	if err != nil {
+		log.Errorf("PatchObject: Failed to marshal original object %s/%s: %v",
+			original.GetNamespace(), original.GetName(), err)
+		return err
+	}
+
+	// Marshal the modified object
+	newData, err := json.Marshal(modified)
+	if err != nil {
+		log.Errorf("PatchObject: Failed to marshal modified object %s/%s: %v",
+			modified.GetNamespace(), modified.GetName(), err)
+		return err
+	}
+
+	// Create strategic merge patch
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, original)
+	if err != nil {
+		log.Errorf("PatchObject: Error creating strategic merge patch for object %s/%s: %v",
+			original.GetNamespace(), original.GetName(), err)
+		return err
+	}
+
+	// Apply the patch
+	patch := client.RawPatch(apitypes.StrategicMergePatchType, patchBytes)
+	if err := k8sClient.Patch(ctx, original, patch); err != nil {
+		log.Errorf("PatchObject: Failed to patch object %s/%s: %v",
+			original.GetNamespace(), original.GetName(), err)
+		return err
+	}
+
+	log.Debugf("PatchObject: Successfully patched object %s/%s",
+		original.GetNamespace(), original.GetName())
+	return nil
 }

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -532,7 +532,7 @@ func addPvcFinalizer(ctx context.Context,
 			pvc.Namespace)
 	}
 
-	err = util.PatchObject(ctx, client, original, pvc)
+	err = k8s.PatchObject(ctx, client, original, pvc)
 	if err != nil {
 		return fmt.Errorf("failed to add finalizer %s on PVC %s in namespace %s", cnsoperatortypes.CNSPvcFinalizer,
 			instance.Spec.PvcName, instance.Namespace)
@@ -606,7 +606,7 @@ func removeFinalizerFromPVC(ctx context.Context, client client.Client,
 		return err
 	}
 
-	err = util.PatchObject(ctx, client, original, pvc)
+	err = k8s.PatchObject(ctx, client, original, pvc)
 	if err != nil {
 		return fmt.Errorf("failed to remove finalizer %s from PVC %s in namespace %s",
 			cnsoperatortypes.CNSPvcFinalizer, pvcName, pvc.Namespace)
@@ -875,7 +875,7 @@ func updateCnsFileAccessConfig(ctx context.Context, client client.Client,
 	instance *v1a1.CnsFileAccessConfig) error {
 	log := logger.GetLogger(ctx)
 	original := instance.DeepCopy()
-	err := util.PatchObject(ctx, client, original, instance)
+	err := k8s.PatchObject(ctx, client, original, instance)
 	if err != nil {
 		log.Errorf("failed to patch CnsFileAccessConfig instance: %q on namespace: %q. Error: %+v",
 			instance.Name, instance.Namespace, err)

--- a/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller_test.go
@@ -29,8 +29,8 @@ import (
 
 	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
-	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 func TestCnsVolumeMetadata_PatchOperations(t *testing.T) {
@@ -211,7 +211,7 @@ func TestCnsVolumeMetadata_PatchOperations(t *testing.T) {
 			fakeClient, original, modified := tt.setupFunc()
 
 			// Execute the patch operation using our common utility
-			err := cnsoperatorutil.PatchObject(ctx, fakeClient, original, modified)
+			err := k8s.PatchObject(ctx, fakeClient, original, modified)
 
 			// Validate results
 			if tt.expectError {
@@ -253,7 +253,7 @@ func TestCnsVolumeMetadata_PatchErrorHandling(t *testing.T) {
 		modified.Finalizers = append(modified.Finalizers, cnsoperatortypes.CNSFinalizer)
 
 		// Execute the patch operation - should fail
-		err := cnsoperatorutil.PatchObject(ctx, fakeClient, original, modified)
+		err := k8s.PatchObject(ctx, fakeClient, original, modified)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
@@ -282,7 +282,7 @@ func TestCnsVolumeMetadata_PatchErrorHandling(t *testing.T) {
 		}
 
 		// This should succeed as the objects are valid
-		err := cnsoperatorutil.PatchObject(ctx, fakeClient, original, modified)
+		err := k8s.PatchObject(ctx, fakeClient, original, modified)
 		assert.NoError(t, err)
 
 		// Verify the patch was applied

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -31,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
@@ -398,47 +396,4 @@ func GetMaxWorkerThreads(ctx context.Context, key string, defaultVal int) int {
 			workerThreads)
 	}
 	return workerThreads
-}
-
-// PatchObject patches a Kubernetes object using strategic merge patch.
-// This function creates a patch between the original and modified objects and applies it using the client.
-// It returns an error if the patch operation fails.
-func PatchObject(ctx context.Context, k8sClient client.Client, original, modified client.Object) error {
-	log := logger.GetLogger(ctx)
-
-	// Marshal the original object
-	oldData, err := json.Marshal(original)
-	if err != nil {
-		log.Errorf("PatchObject: Failed to marshal original object %s/%s: %v",
-			original.GetNamespace(), original.GetName(), err)
-		return err
-	}
-
-	// Marshal the modified object
-	newData, err := json.Marshal(modified)
-	if err != nil {
-		log.Errorf("PatchObject: Failed to marshal modified object %s/%s: %v",
-			modified.GetNamespace(), modified.GetName(), err)
-		return err
-	}
-
-	// Create strategic merge patch
-	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, original)
-	if err != nil {
-		log.Errorf("PatchObject: Error creating strategic merge patch for object %s/%s: %v",
-			original.GetNamespace(), original.GetName(), err)
-		return err
-	}
-
-	// Apply the patch
-	patch := client.RawPatch(apitypes.StrategicMergePatchType, patchBytes)
-	if err := k8sClient.Patch(ctx, original, patch); err != nil {
-		log.Errorf("PatchObject: Failed to patch object %s/%s: %v",
-			original.GetNamespace(), original.GetName(), err)
-		return err
-	}
-
-	log.Debugf("PatchObject: Successfully patched object %s/%s",
-		original.GetNamespace(), original.GetName())
-	return nil
 }

--- a/pkg/syncer/cnsoperator/util/util_test.go
+++ b/pkg/syncer/cnsoperator/util/util_test.go
@@ -32,6 +32,7 @@ import (
 	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
 func TestGetSnatIpFromNamespaceNetworkInfo(t *testing.T) {
@@ -345,7 +346,7 @@ func TestPatchObject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient, original, modified := tt.setupFunc()
 
-			err := PatchObject(ctx, fakeClient, original, modified)
+			err := k8s.PatchObject(ctx, fakeClient, original, modified)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -41,7 +41,6 @@ import (
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
-	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 var (
@@ -146,7 +145,7 @@ func PvcsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) er
 				log.Infof("FullSync: Patching CnsVolumeMetadata %v on the supervisor cluster", guestObject.Name)
 				original := supervisorObject.DeepCopy()
 				supervisorObject.Spec = guestObject.Spec
-				if err := cnsoperatorutil.PatchObject(ctx, metadataSyncer.cnsOperatorClient, original,
+				if err := k8s.PatchObject(ctx, metadataSyncer.cnsOperatorClient, original,
 					supervisorObject); err != nil {
 					log.Warnf("FullSync: Failed to patch CnsVolumeMetadata %v. Err: %v", supervisorObject.Name, err)
 				}

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -28,7 +28,7 @@ import (
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
-	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
 // pvcsiVolumeUpdated updates persistent volume claim and persistent volume
@@ -80,7 +80,7 @@ func pvcsiVolumeUpdated(ctx context.Context, resourceType interface{},
 	newMetadata.ResourceVersion = currentMetadata.ResourceVersion
 	newMetadata.Namespace = supervisorNamespace
 	log.Debugf("pvCSI VolumeUpdated: Invoking patch on CnsVolumeMetadata with spec: %+v", spew.Sdump(newMetadata))
-	if err := cnsoperatorutil.PatchObject(ctx, metadataSyncer.cnsOperatorClient, currentMetadata,
+	if err := k8s.PatchObject(ctx, metadataSyncer.cnsOperatorClient, currentMetadata,
 		newMetadata); err != nil {
 		log.Errorf("pvCSI VolumeUpdated: Failed to patch CnsVolumeMetadata: %v. Error: %v", newMetadata.Name, err)
 		return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR ensures usage of Patch() operation instead of Update() for CnsVolumeMetadata & CnsFileAccessConfig CR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

```
VKS pipeline:
<br> PR 3756<br>
Ran 6 of 1844 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 1838 Skipped | 0 Flaked

WCP Pipeline:
Ran 16 of 1844 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 1828 Skipped | 0 Flaked
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use Patch operation for CnsVolumeMetadata updates
```
