### PR TITLE
Fix nil pointer exception when PVC is already deleted while removing finalizer.

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -162,6 +162,10 @@ func (c *FakeK8SOrchestrator) GetPvcObjectByName(ctx context.Context,
 		return pvc, nil
 	}
 
+	if pvcName == "not-found-error" {
+		return nil, apierrors.NewNotFound(v1.Resource("persistentvolumeclaim"), pvcName)
+	}
+
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvcName,   // Name of the PVC

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -672,7 +672,6 @@ func addPvcFinalizer(ctx context.Context, client client.Client,
 	}
 
 	// Add annotation indicating that the PVC is being used by this VM.
-	log.Infof("PVC %s is shared", pvc.Name)
 	err = addPvcAnnotation(ctx, k8sClient, vmInstanceUUID, pvc)
 	if err != nil {
 		log.Errorf("failed to add annotation %s to PVC %s in namespace %s for VM %s", cnsoperatortypes.CNSPvcFinalizer,
@@ -732,7 +731,7 @@ func removePvcFinalizer(ctx context.Context, client client.Client,
 		}
 
 		// Verify if the PVC object itself has been deleted by querying the API server in case the cache is old.
-		pvc, err = k8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
+		pvc, err = k8sClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Infof("PVC %s has already been deleted. No action to be taken", pvcName)
@@ -744,7 +743,6 @@ func removePvcFinalizer(ctx context.Context, client client.Client,
 	}
 
 	// Remove usedby annotation
-	log.Infof("PVC %s is shared", pvc.Name)
 	err = removePvcAnnotation(ctx, k8sClient, vmInstanceUUID, pvc)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
There's a bug in the removePvcFinalizer function where if PVC is already deleted, then pvc.Namespace will cause nil pointer exception as PVC in nil.

This PR fixes the same.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Deleted the PVC first by removing finalizer by hand.
Then deleted the batchattach CR and observed that it for deleted successfully.

```
{"level":"info","time":"2025-11-21T07:51:54.420586454Z","caller":"volume/manager.go:1260","msg":"DetachVolume: volumeID: \"a81f7c32-f768-47b9-87e9-a02a8b14e5e2\", vm: \"VirtualMachine:vm-1022 [VirtualCenterHost: lvn-dvm-10-162-75-216.dvm.lvn.broadcom.net, UUID: 115fb267-e20b-4b6e-ada7-ba0855c1b6f2, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: lvn-dvm-10-162-75-216.dvm.lvn.broadcom.net]]\", opId: \"3a1a2487\"","TraceId":"4de927c8-8f5a-4790-ad6a-035e49dfcd0d"}
{"level":"info","time":"2025-11-21T07:51:54.420625964Z","caller":"volume/manager.go:1310","msg":"DetachVolume: Volume detached successfully. volumeID: \"a81f7c32-f768-47b9-87e9-a02a8b14e5e2\", vm: \"VirtualMachine:vm-1022 [VirtualCenterHost: lvn-dvm-10-162-75-216.dvm.lvn.broadcom.net, UUID: 115fb267-e20b-4b6e-ada7-ba0855c1b6f2, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: lvn-dvm-10-162-75-216.dvm.lvn.broadcom.net]]\", opId: \"3a1a2487\"","TraceId":"4de927c8-8f5a-4790-ad6a-035e49dfcd0d"}
{"level":"info","time":"2025-11-21T07:51:54.42066245Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:719","msg":"Acquired lock for PVC test/rwm-pvc","TraceId":"4de927c8-8f5a-4790-ad6a-035e49dfcd0d"}
{"level":"error","time":"2025-11-21T07:51:54.420880887Z","caller":"k8sorchestrator/k8sorchestrator.go:1574","msg":"failed to get pvc: rwm-pvc in namespace: test. err=persistentvolumeclaim \"rwm-pvc\" not found","TraceId":"4de927c8-8f5a-4790-ad6a-035e49dfcd0d","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).GetPvcObjectByName\n\t/build/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:1574\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment.removePvcFinalizer\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:726\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment.removeFinalizerAndStatusEntry\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:483\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment.(*Reconciler).detachVolumes\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:464\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment.(*Reconciler).processDetach\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:419\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment.(*Reconciler).reconcileInstanceWithDeletionTimestamp\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:372\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment.(*Reconciler).Reconcile\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:351\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:224"}
{"level":"info","time":"2025-11-21T07:51:54.433922502Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:737","msg":"PVC rwm-pvc has already been deleted. No action to be taken","TraceId":"4de927c8-8f5a-4790-ad6a-035e49dfcd0d"}
```

WCP precheckin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/644/
VKS precheckin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/606/
