### PR TITLE
Feat - Implement snapshot informer cache and event listeners

### DIFF
--- a/manifests/guestcluster/1.33/pvcsi.yaml
+++ b/manifests/guestcluster/1.33/pvcsi.yaml
@@ -64,7 +64,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list", "patch"]
+    verbs: [ "get", "list", "watch", "patch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]

--- a/manifests/guestcluster/1.34/pvcsi.yaml
+++ b/manifests/guestcluster/1.34/pvcsi.yaml
@@ -88,7 +88,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list", "patch"]
+    verbs: [ "get", "list", "watch", "patch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]

--- a/manifests/guestcluster/1.35/pvcsi.yaml
+++ b/manifests/guestcluster/1.35/pvcsi.yaml
@@ -89,7 +89,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list", "patch"]
+    verbs: [ "get", "list", "watch", "patch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]

--- a/manifests/guestcluster/1.36/pvcsi.yaml
+++ b/manifests/guestcluster/1.36/pvcsi.yaml
@@ -89,7 +89,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list", "patch"]
+    verbs: [ "get", "list", "watch", "patch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -304,106 +304,119 @@ func Newk8sOrchestrator(ctx context.Context, controllerClusterFlavor cnstypes.Cn
 		k8sClient         clientset.Interface
 		snapshotterClient snapshotterClientSet.Interface
 	)
-	if atomic.LoadUint32(&k8sOrchestratorInstanceInitialized) == 0 {
-		k8sOrchestratorInitMutex.Lock()
-		defer k8sOrchestratorInitMutex.Unlock()
-		if k8sOrchestratorInstanceInitialized == 0 {
-			log := logger.GetLogger(ctx)
-			log.Info("Initializing k8sOrchestratorInstance")
 
-			// Create a K8s client
-			k8sClient, coInstanceErr = k8s.NewClient(ctx)
-			if coInstanceErr != nil {
-				log.Errorf("Creating Kubernetes client failed. Err: %v", coInstanceErr)
-				return nil, coInstanceErr
-			}
+	if atomic.LoadUint32(&k8sOrchestratorInstanceInitialized) != 0 {
+		return k8sOrchestratorInstance, nil
+	}
 
-			// Create a snapshotter client
-			snapshotterClient, coInstanceErr = k8s.NewSnapshotterClient(ctx)
-			if coInstanceErr != nil {
-				log.Errorf("Creating Snapshotter client failed. Err: %v", coInstanceErr)
-				return nil, coInstanceErr
-			}
+	k8sOrchestratorInitMutex.Lock()
+	defer k8sOrchestratorInitMutex.Unlock()
+	if k8sOrchestratorInstanceInitialized != 0 {
+		return k8sOrchestratorInstance, nil
+	}
 
-			k8sOrchestratorInstance = &K8sOrchestrator{}
-			k8sOrchestratorInstance.clusterFlavor = controllerClusterFlavor
-			k8sOrchestratorInstance.k8sClient = k8sClient
-			k8sOrchestratorInstance.snapshotterClient = snapshotterClient
-			k8sOrchestratorInstance.informerManager = k8s.NewInformer(ctx, k8sClient)
-			coInstanceErr = initFSS(ctx, k8sClient, controllerClusterFlavor, params)
-			if coInstanceErr != nil {
-				log.Errorf("Failed to initialize the orchestrator. Error: %v", coInstanceErr)
-				return nil, coInstanceErr
-			}
+	log := logger.GetLogger(ctx)
+	log.Info("Initializing k8sOrchestratorInstance")
 
-			if controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-				svInitParams, ok := params.(K8sSupervisorInitParams)
-				if !ok {
-					return nil, fmt.Errorf("expected orchestrator params of type K8sSupervisorInitParams, got %T instead", params)
-				}
-				operationMode = svInitParams.OperationMode
-			} else if controllerClusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				vanillaInitParams, ok := params.(K8sVanillaInitParams)
-				if !ok {
-					return nil, fmt.Errorf("expected orchestrator params of type K8sVanillaInitParams, got %T instead", params)
-				}
-				operationMode = vanillaInitParams.OperationMode
-				k8sOrchestratorInstance.releasedVanillaFSS = getReleasedVanillaFSS()
-			} else if controllerClusterFlavor == cnstypes.CnsClusterFlavorGuest {
-				guestInitParams, ok := params.(K8sGuestInitParams)
-				if !ok {
-					return nil, fmt.Errorf("expected orchestrator params of type K8sGuestInitParams, got %T instead", params)
-				}
-				operationMode = guestInitParams.OperationMode
-			} else {
-				return nil, fmt.Errorf("wrong orchestrator params type")
-			}
+	// Create a K8s client
+	k8sClient, coInstanceErr = k8s.NewClient(ctx)
+	if coInstanceErr != nil {
+		log.Errorf("Creating Kubernetes client failed. Err: %v", coInstanceErr)
+		return nil, coInstanceErr
+	}
 
-			if (controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload ||
-				(controllerClusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
-					k8sOrchestratorInstance.IsFSSEnabled(ctx, common.ListVolumes))) &&
-				(operationMode != operationModeWebHookServer) {
-				err := initVolumeHandleToPvcMap(ctx, controllerClusterFlavor)
-				if err != nil {
-					return nil, fmt.Errorf("failed to create volume handle to PVC map. Error: %v", err)
-				}
-			}
+	// Create a snapshotter client - needed for snapshot API calls across all
+	// cluster flavors (e.g. GetVolumeSnapshotPVCSource, GetLinkedCloneSourceSnapshotUID).
+	snapshotterClient, coInstanceErr = k8s.NewSnapshotterClient(ctx)
+	if coInstanceErr != nil {
+		log.Errorf("Creating Snapshotter client failed. Err: %v", coInstanceErr)
+		return nil, coInstanceErr
+	}
 
-			// check capabilities CR reading for workload cluster
-			if controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-				err := checkCapabilitiesCR(ctx, controllerClusterFlavor)
-				if err != nil {
-					log.Errorf("Failed to fetch the capabilities CR. Error: %v", err)
-					os.Exit(1)
-				}
-			}
+	k8sOrchestratorInstance = &K8sOrchestrator{}
+	k8sOrchestratorInstance.clusterFlavor = controllerClusterFlavor
+	k8sOrchestratorInstance.k8sClient = k8sClient
+	k8sOrchestratorInstance.snapshotterClient = snapshotterClient
+	k8sOrchestratorInstance.informerManager = k8s.NewInformer(ctx, k8sClient)
+	coInstanceErr = initFSS(ctx, k8sClient, controllerClusterFlavor, params)
+	if coInstanceErr != nil {
+		log.Errorf("Failed to initialize the orchestrator. Error: %v", coInstanceErr)
+		return nil, coInstanceErr
+	}
 
-			if (controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload) &&
-				(operationMode != operationModeWebHookServer) {
-				// Initialize the map for volumeName to nodes, as it is needed for WCP detach volume handling
-				err := initVolumeNameToNodesMap(ctx, controllerClusterFlavor)
-				if err != nil {
-					return nil, fmt.Errorf("failed to create PV name to node names map. Error: %v", err)
-				}
-				err = initNodeIDToNameMap(ctx)
-				if err != nil {
-					return nil, fmt.Errorf("failed to create node ID to name map. Error: %v", err)
-				}
-			} else if operationMode != operationModeWebHookServer {
-				// Initialize the map for volumeName to nodes, for non-WCP flavors and when ListVolume FSS is on
-				if k8sOrchestratorInstance.IsFSSEnabled(ctx, common.ListVolumes) {
-					err := initVolumeNameToNodesMap(ctx, controllerClusterFlavor)
-					if err != nil {
-						return nil, fmt.Errorf("failed to create PV name to node names map. Error: %v", err)
-					}
-				}
-			}
+	if controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		svInitParams, ok := params.(K8sSupervisorInitParams)
+		if !ok {
+			return nil, fmt.Errorf("expected orchestrator params of type K8sSupervisorInitParams, got %T instead", params)
+		}
+		operationMode = svInitParams.OperationMode
+	} else if controllerClusterFlavor == cnstypes.CnsClusterFlavorVanilla {
+		vanillaInitParams, ok := params.(K8sVanillaInitParams)
+		if !ok {
+			return nil, fmt.Errorf("expected orchestrator params of type K8sVanillaInitParams, got %T instead", params)
+		}
+		operationMode = vanillaInitParams.OperationMode
+		k8sOrchestratorInstance.releasedVanillaFSS = getReleasedVanillaFSS()
+	} else if controllerClusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		guestInitParams, ok := params.(K8sGuestInitParams)
+		if !ok {
+			return nil, fmt.Errorf("expected orchestrator params of type K8sGuestInitParams, got %T instead", params)
+		}
+		operationMode = guestInitParams.OperationMode
+	} else {
+		return nil, fmt.Errorf("wrong orchestrator params type")
+	}
 
-			k8sOrchestratorInstance.informerManager.Listen()
-			atomic.StoreUint32(&k8sOrchestratorInstanceInitialized, 1)
-			log.Info("k8sOrchestratorInstance initialized")
+	// Add the snapshot informer factory only for guest clusters where ImprovedVolumeVisibility is
+	// enabled. This must be done after initFSS so the FSS state is known.
+	if controllerClusterFlavor == cnstypes.CnsClusterFlavorGuest &&
+		k8sOrchestratorInstance.IsFSSEnabled(ctx, common.ImprovedVolumeVisibility) {
+		k8sOrchestratorInstance.informerManager.SetSnapshotInformerFactory(snapshotterClient)
+	}
+
+	if (controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload ||
+		(controllerClusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
+			k8sOrchestratorInstance.IsFSSEnabled(ctx, common.ListVolumes))) &&
+		(operationMode != operationModeWebHookServer) {
+		err := initVolumeHandleToPvcMap(ctx, controllerClusterFlavor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create volume handle to PVC map. Error: %v", err)
 		}
 	}
+
+	// check capabilities CR reading for workload cluster
+	if controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		err := checkCapabilitiesCR(ctx, controllerClusterFlavor)
+		if err != nil {
+			log.Errorf("Failed to fetch the capabilities CR. Error: %v", err)
+			os.Exit(1)
+		}
+	}
+
+	if (controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload) &&
+		(operationMode != operationModeWebHookServer) {
+		// Initialize the map for volumeName to nodes, as it is needed for WCP detach volume handling
+		err := initVolumeNameToNodesMap(ctx, controllerClusterFlavor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create PV name to node names map. Error: %v", err)
+		}
+		err = initNodeIDToNameMap(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create node ID to name map. Error: %v", err)
+		}
+	} else if operationMode != operationModeWebHookServer {
+		// Initialize the map for volumeName to nodes, for non-WCP flavors and when ListVolume FSS is on
+		if k8sOrchestratorInstance.IsFSSEnabled(ctx, common.ListVolumes) {
+			err := initVolumeNameToNodesMap(ctx, controllerClusterFlavor)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create PV name to node names map. Error: %v", err)
+			}
+		}
+	}
+
+	k8sOrchestratorInstance.informerManager.Listen()
+	atomic.StoreUint32(&k8sOrchestratorInstanceInitialized, 1)
+	log.Info("k8sOrchestratorInstance initialized")
 	return k8sOrchestratorInstance, nil
 }
 

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -620,11 +620,11 @@ const (
 	// can disable the additional API traffic if needed.
 	SupervisorPVCWorkloadTypeAnnotation = "supervisor-pvc-workload-type-annotation"
 
-	// ImprovedVolumeVisiblity is the FSS that gates improved volume
-	// visibility in guest cluster, when enable it enabled guest cluster
-	// related annotations and other visiblity enhanchment for better
-	// visiblity of the guest cluster resources in the supervisor.
-	ImprovedVolumeVisiblity = "improved-volume-visibility"
+	// ImprovedVolumeVisibility is the FSS that gates improved volume
+	// visibility in guest cluster, when enabled it enables guest cluster
+	// related annotations and other visibility enhancements for better
+	// visibility of the guest cluster resources in the supervisor.
+	ImprovedVolumeVisibility = "improved-volume-visibility"
 
 	// VMPVCStoragePolicyMutability is the WCP capability for the DevOps storage-policy
 	// change feature on VMs and PVCs. When enabled on the supervisor, the CSI driver

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -536,7 +536,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					}
 					annotations[common.AnnGuestClusterRequestedTopology] = topologyAnnotation
 				}
-				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
+				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisibility) {
 					guestPvcAnnotJSON, err := json.Marshal(guestPvcAnnot)
 					if err != nil {
 						log.Errorf("failed to marshal guest cluster annotation: %+v", err)
@@ -620,7 +620,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
 		}
 
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisibility) {
 			guestPvcAnnot[common.GuestClusterAnnotKeyVolumeName] = boundPVC.Spec.VolumeName
 			err := patchSupervisorPVCAnnotation(ctx, c.supervisorClient, guestPvcAnnot, supervisorPVCName, c.supervisorNamespace)
 			if err != nil {
@@ -1832,7 +1832,7 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 				// the supervisor cluster to indicate that snapshot creation is initiated from Guest cluster
 				annotation := make(map[string]string)
 				annotation[common.SupervisorVolumeSnapshotAnnotationKey] = "true"
-				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
+				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisibility) {
 					// The guest-cluster VolumeSnapshotContent name is injected into the
 					// CreateSnapshot parameters by the external-snapshotter sidecar running
 					// in the guest cluster.

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -991,7 +991,7 @@ func TestCreateVolumeAnnotationLogic(t *testing.T) {
 	require.NoError(t, coErr)
 
 	// Enable the ImprovedVolumeVisibility feature switch
-	err := fakeOrchestrator.EnableFSS(ctx, common.ImprovedVolumeVisiblity)
+	err := fakeOrchestrator.EnableFSS(ctx, common.ImprovedVolumeVisibility)
 	require.NoError(t, err)
 
 	commonco.ContainerOrchestratorUtility = fakeOrchestrator
@@ -1164,7 +1164,7 @@ func TestCreateVolumeUpdatesVolumeNameAnnotation(t *testing.T) {
 	supervisorClient := testclient.NewClientset()
 	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
 	require.NoError(t, err)
-	require.NoError(t, co.EnableFSS(tCtx, common.ImprovedVolumeVisiblity))
+	require.NoError(t, co.EnableFSS(tCtx, common.ImprovedVolumeVisibility))
 
 	oldCO := commonco.ContainerOrchestratorUtility
 	commonco.ContainerOrchestratorUtility = co
@@ -1291,7 +1291,7 @@ func TestCreateSnapshotWithAnnotations(t *testing.T) {
 	oldCO := commonco.ContainerOrchestratorUtility
 	commonco.ContainerOrchestratorUtility = spy
 	defer func() { commonco.ContainerOrchestratorUtility = oldCO }()
-	require.NoError(t, spy.EnableFSS(ctx, common.ImprovedVolumeVisiblity))
+	require.NoError(t, spy.EnableFSS(ctx, common.ImprovedVolumeVisibility))
 
 	// Use isolated fake clients so this test does not interfere with the shared
 	// singleton controller used by the other tests in this package.

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	snapclientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
+	"github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions"
 	"k8s.io/client-go/informers"
 	v1 "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -74,18 +76,24 @@ func NewInformerFromFactory(
 func NewInformer(ctx context.Context, client clientset.Interface) *InformerManager {
 	log := logger.GetLogger(ctx)
 
+	if informerManagerInstance != nil {
+		return informerManagerInstance
+	}
+
 	informerInstanceLock.Lock()
 	defer informerInstanceLock.Unlock()
 
-	if informerManagerInstance == nil {
-		informerManagerInstance = &InformerManager{
-			client:          client,
-			stopCh:          signals.SetupSignalHandler().Done(),
-			informerFactory: informers.NewSharedInformerFactory(client, noResyncPeriodFunc()),
-		}
-		log.Info("Created new informer factory")
+	if informerManagerInstance != nil {
+		return informerManagerInstance
 	}
 
+	informerManagerInstance = &InformerManager{
+		client:          client,
+		stopCh:          signals.SetupSignalHandler().Done(),
+		informerFactory: informers.NewSharedInformerFactory(client, noResyncPeriodFunc()),
+	}
+
+	log.Info("Created new informer factory")
 	return informerManagerInstance
 }
 
@@ -268,6 +276,46 @@ func (im *InformerManager) AddVolumeAttachmentListener(ctx context.Context, add 
 	return nil
 }
 
+// SetSnapshotInformerFactory initialises the snapshot informer factory on an existing
+// InformerManager. No-op if the factory is already set or snapshotClient is nil.
+// This allows callers to defer the snapshot factory setup until after the FSS state is known.
+func (im *InformerManager) SetSnapshotInformerFactory(snapshotClient snapclientset.Interface) {
+	if im.snapshotInformerFactory != nil || snapshotClient == nil {
+		return
+	}
+	im.snapshotInformerFactory = externalversions.NewSharedInformerFactory(snapshotClient, noResyncPeriodFunc())
+}
+
+// AddSnapshotListener hooks up add, update, delete callbacks.
+// Returns an error if the snapshot informer factory was not initialised (i.e. no snapshot client
+// was provided when the InformerManager was created).
+func (im *InformerManager) AddSnapshotListener(ctx context.Context,
+	add func(obj any),
+	update func(oldObj, newObj any),
+	remove func(obj any)) error {
+	log := logger.GetLogger(ctx)
+	if im.snapshotInformerFactory == nil {
+		return logger.LogNewErrorf(log, "snapshot informer factory is not initialised; "+
+			"ensure a snapshot client was provided when creating the InformerManager")
+	}
+	if im.snapshotInformer == nil {
+		im.snapshotInformer = im.snapshotInformerFactory.
+			Snapshot().V1().VolumeSnapshots().Informer()
+	}
+
+	_, err := im.snapshotInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    add,
+		UpdateFunc: update,
+		DeleteFunc: remove,
+	})
+	if err != nil {
+		return logger.LogNewErrorf(
+			log, "failed to add event handler on snapshot listener. Error: %v", err)
+	}
+
+	return nil
+}
+
 // GetPVLister returns PV Lister for the calling informer manager.
 func (im *InformerManager) GetPVLister() corelisters.PersistentVolumeLister {
 	return im.informerFactory.Core().V1().PersistentVolumes().Lister()
@@ -334,6 +382,17 @@ func (im *InformerManager) Listen() (stopCh <-chan struct{}) {
 			return
 		}
 	}
+
+	if im.snapshotInformerFactory != nil {
+		go im.snapshotInformerFactory.Start(im.stopCh)
+		cacheSync := im.snapshotInformerFactory.WaitForCacheSync(im.stopCh)
+		for _, isSynced := range cacheSync {
+			if !isSynced {
+				return
+			}
+		}
+	}
+
 	return im.stopCh
 }
 

--- a/pkg/kubernetes/informers_test.go
+++ b/pkg/kubernetes/informers_test.go
@@ -1,0 +1,247 @@
+package kubernetes
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	snapshotfake "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sinformers "k8s.io/client-go/informers"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNewInformer(t *testing.T) {
+	t.Run("CreateNewInformerManager", func(tt *testing.T) {
+		// Reset global state.
+		informerInstanceLock.Lock()
+		informerManagerInstance = nil
+		informerInstanceLock.Unlock()
+
+		ctx := context.Background()
+		k8sClient := testclient.NewSimpleClientset()
+
+		informerMgr := NewInformer(ctx, k8sClient)
+
+		assert.NotNil(tt, informerMgr)
+		assert.NotNil(tt, informerMgr.client)
+		assert.NotNil(tt, informerMgr.informerFactory)
+		assert.NotNil(tt, informerMgr.stopCh)
+		assert.Equal(tt, k8sClient, informerMgr.client)
+		assert.Nil(tt, informerMgr.snapshotInformerFactory,
+			"snapshotInformerFactory should be nil until SetSnapshotInformerFactory is called")
+	})
+
+	t.Run("SnapshotFactorySetViaSetSnapshotInformerFactory", func(tt *testing.T) {
+		im := &InformerManager{
+			client:          testclient.NewSimpleClientset(),
+			informerFactory: k8sinformers.NewSharedInformerFactory(testclient.NewSimpleClientset(), 0),
+		}
+		assert.Nil(tt, im.snapshotInformerFactory)
+
+		im.SetSnapshotInformerFactory(snapshotfake.NewSimpleClientset())
+		assert.NotNil(tt, im.snapshotInformerFactory,
+			"snapshotInformerFactory should be set after SetSnapshotInformerFactory")
+	})
+
+	t.Run("SetSnapshotInformerFactoryNoOpIfAlreadySet", func(tt *testing.T) {
+		im := &InformerManager{
+			client:          testclient.NewSimpleClientset(),
+			informerFactory: k8sinformers.NewSharedInformerFactory(testclient.NewSimpleClientset(), 0),
+		}
+		im.SetSnapshotInformerFactory(snapshotfake.NewSimpleClientset())
+		first := im.snapshotInformerFactory
+
+		// Second call should be a no-op.
+		im.SetSnapshotInformerFactory(snapshotfake.NewSimpleClientset())
+		assert.Equal(tt, first, im.snapshotInformerFactory, "factory should not be replaced on second call")
+	})
+
+	t.Run("ReturnExistingInformerManagerOnSecondCall", func(tt *testing.T) {
+		ctx := context.Background()
+		k8sClient1 := testclient.NewSimpleClientset()
+
+		informerMgr1 := NewInformer(ctx, k8sClient1)
+
+		k8sClient2 := testclient.NewSimpleClientset()
+		informerMgr2 := NewInformer(ctx, k8sClient2)
+
+		assert.Equal(tt, informerMgr1, informerMgr2, "Should return the same singleton instance")
+	})
+
+	t.Run("ThreadSafeInitialization", func(tt *testing.T) {
+		ctx := context.Background()
+		k8sClient := testclient.NewSimpleClientset()
+
+		const numGoroutines = 10
+		results := make([]*InformerManager, numGoroutines)
+		done := make(chan bool, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(index int) {
+				results[index] = NewInformer(ctx, k8sClient)
+				done <- true
+			}(i)
+		}
+
+		for i := 0; i < numGoroutines; i++ {
+			<-done
+		}
+
+		firstInstance := results[0]
+		assert.NotNil(tt, firstInstance)
+		for i := 1; i < numGoroutines; i++ {
+			assert.Equal(tt, firstInstance, results[i],
+				"All concurrent calls should return the same instance")
+		}
+	})
+
+	t.Run("VerifyInformerManagerFields", func(tt *testing.T) {
+		ctx := context.Background()
+		k8sClient := testclient.NewSimpleClientset()
+
+		informerMgr := NewInformer(ctx, k8sClient)
+
+		assert.NotNil(tt, informerMgr)
+		assert.NotNil(tt, informerMgr.client, "client should be set")
+		assert.NotNil(tt, informerMgr.informerFactory, "informerFactory should be set")
+		assert.NotNil(tt, informerMgr.stopCh, "stopCh should be set")
+		assert.NotNil(tt, informerMgr.informerFactory.Core(), "Core informer factory should be accessible")
+
+		// Attach snapshot factory and verify it is usable.
+		informerMgr.SetSnapshotInformerFactory(snapshotfake.NewSimpleClientset())
+		assert.NotNil(tt, informerMgr.snapshotInformerFactory, "snapshotInformerFactory should be set")
+		assert.NotNil(tt, informerMgr.snapshotInformerFactory.Snapshot(),
+			"Snapshot informer factory should be accessible")
+	})
+}
+
+func TestInformerManager_AddSnapshotListener_NilFactory(t *testing.T) {
+	im := &InformerManager{
+		client:          testclient.NewSimpleClientset(),
+		informerFactory: k8sinformers.NewSharedInformerFactory(testclient.NewSimpleClientset(), 0),
+	}
+
+	err := im.AddSnapshotListener(context.Background(), nil, nil, nil)
+
+	assert.Error(t, err, "AddSnapshotListener should fail when snapshot factory is nil")
+}
+
+func TestInformerManager_AddSnapshotListener(t *testing.T) {
+	createSnapshot := func(name, namespace, pvcName string) *snapshotv1.VolumeSnapshot {
+		return &snapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: snapshotv1.VolumeSnapshotSpec{
+				Source: snapshotv1.VolumeSnapshotSource{
+					PersistentVolumeClaimName: &pvcName,
+				},
+			},
+		}
+	}
+
+	newInformerWithSnapshot := func(tt *testing.T) *InformerManager {
+		tt.Helper()
+		im := &InformerManager{
+			client:          testclient.NewSimpleClientset(),
+			informerFactory: k8sinformers.NewSharedInformerFactory(testclient.NewSimpleClientset(), 0),
+		}
+		im.SetSnapshotInformerFactory(snapshotfake.NewSimpleClientset())
+		return im
+	}
+
+	t.Run("AddSnapshotListenerWithNilHandlers", func(tt *testing.T) {
+		informerMgr := newInformerWithSnapshot(tt)
+
+		err := informerMgr.AddSnapshotListener(context.Background(), nil, nil, nil)
+
+		assert.NoError(tt, err)
+		assert.NotNil(tt, informerMgr.snapshotInformer, "snapshotInformer should be initialized")
+	})
+
+	t.Run("HandlersIgnoreInvalidObjectTypes", func(tt *testing.T) {
+		informerMgr := newInformerWithSnapshot(tt)
+
+		processedCount := 0
+		addFunc := func(obj any) {
+			snap, ok := obj.(*snapshotv1.VolumeSnapshot)
+			if ok && snap != nil {
+				processedCount++
+			}
+		}
+
+		err := informerMgr.AddSnapshotListener(context.Background(), addFunc, nil, nil)
+		assert.NoError(tt, err)
+
+		addFunc("not-a-snapshot")
+		addFunc(123)
+		addFunc(nil)
+		assert.Equal(tt, 0, processedCount, "Handler should ignore invalid object types")
+
+		snap := createSnapshot("snap1", "default", "pvc1")
+		addFunc(snap)
+		assert.Equal(tt, 1, processedCount, "Handler should process valid snapshot")
+	})
+
+	t.Run("EventHandlersTrackSnapshots", func(tt *testing.T) {
+		informerMgr := newInformerWithSnapshot(tt)
+
+		addedSnapshots := make(map[string]*snapshotv1.VolumeSnapshot)
+		updatedSnapshots := make(map[string]*snapshotv1.VolumeSnapshot)
+		deletedSnapshots := make(map[string]*snapshotv1.VolumeSnapshot)
+		var mu sync.Mutex
+
+		addFunc := func(obj any) {
+			mu.Lock()
+			defer mu.Unlock()
+			snap, ok := obj.(*snapshotv1.VolumeSnapshot)
+			if ok && snap != nil {
+				addedSnapshots[snap.Name] = snap
+			}
+		}
+
+		updateFunc := func(oldObj, newObj any) {
+			mu.Lock()
+			defer mu.Unlock()
+			snap, ok := newObj.(*snapshotv1.VolumeSnapshot)
+			if ok && snap != nil {
+				updatedSnapshots[snap.Name] = snap
+			}
+		}
+
+		deleteFunc := func(obj any) {
+			mu.Lock()
+			defer mu.Unlock()
+			snap, ok := obj.(*snapshotv1.VolumeSnapshot)
+			if ok && snap != nil {
+				deletedSnapshots[snap.Name] = snap
+			}
+		}
+
+		err := informerMgr.AddSnapshotListener(context.Background(), addFunc, updateFunc, deleteFunc)
+
+		assert.NoError(tt, err)
+		assert.NotNil(tt, informerMgr.snapshotInformer)
+
+		snap1 := createSnapshot("snap1", "default", "pvc1")
+		addFunc(snap1)
+		mu.Lock()
+		assert.Contains(tt, addedSnapshots, "snap1", "Add handler should track snapshot")
+		mu.Unlock()
+
+		snap2 := createSnapshot("snap2", "default", "pvc2")
+		updateFunc(nil, snap2)
+		mu.Lock()
+		assert.Contains(tt, updatedSnapshots, "snap2", "Update handler should track snapshot")
+		mu.Unlock()
+
+		deleteFunc(snap1)
+		mu.Lock()
+		assert.Contains(tt, deletedSnapshots, "snap1", "Delete handler should track snapshot")
+		mu.Unlock()
+	})
+}

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes
 
 import (
+	"github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -50,8 +51,11 @@ type InformerManager struct {
 	client clientset.Interface
 	// main shared informer factory
 	informerFactory informers.SharedInformerFactory
+	// snapshot informer factory
+	snapshotInformerFactory externalversions.SharedInformerFactory
+
 	// main signal
-	stopCh (<-chan struct{})
+	stopCh <-chan struct{}
 
 	// node informer
 	nodeInformer cache.SharedInformer
@@ -85,4 +89,7 @@ type InformerManager struct {
 	volumeAttachmentInformer cache.SharedInformer
 	// Function to determine if volumeAttachmentInformer has been synced
 	volumeAttachmentSynced cache.InformerSynced
+
+	// snapshot informer
+	snapshotInformer cache.SharedInformer
 }

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-co-op/gocron"
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -784,6 +785,24 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		})
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to listen on pods. Error: %v", err)
+	}
+
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest &&
+		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeVisibility) {
+		snapshotterClient, err := k8s.NewSnapshotterClient(ctx)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to create snapshotter client. Error: %v", err)
+		}
+
+		metadataSyncer.k8sInformerManager.SetSnapshotInformerFactory(snapshotterClient)
+		err = metadataSyncer.k8sInformerManager.AddSnapshotListener(
+			ctx, nil, nil,
+			func(obj any) {
+				snapshotDeleted(obj, metadataSyncer)
+			})
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to listen on snapshot delete events. Error: %v", err)
+		}
 	}
 
 	stopCh := metadataSyncer.k8sInformerManager.Listen()
@@ -2829,6 +2848,28 @@ func pvcUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer
 		}
 		csiPVCUpdated(ctx, newPvc, pv, metadataSyncer)
 	}
+}
+
+func snapshotDeleted(obj interface{}, _ *metadataSyncInformer) {
+	_, log := logger.GetNewContextWithLogger()
+	log = log.With("func", "snapshotDeleted")
+	snap, ok := obj.(*snapshotv1.VolumeSnapshot)
+	if snap == nil || !ok {
+		log.Warnf("Unrecognised object %+v", obj)
+		return
+	}
+
+	log = log.With("snapshot", snap.Name)
+	if snap.Status == nil ||
+		snap.Status.BoundVolumeSnapshotContentName == nil ||
+		*snap.Status.BoundVolumeSnapshotContentName == "" {
+		// nothing to do here
+		log.Info("snapshot doesn't have any content object created")
+		return
+	}
+
+	log.Warnf("unimplemented")
+	// TODO: implement this in a subsequent PR
 }
 
 // pvcDeleted deletes pvc metadata on VC when pvc has been deleted on K8s

--- a/pkg/syncer/metadatasyncer_test.go
+++ b/pkg/syncer/metadatasyncer_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"testing"
 
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -2121,4 +2123,62 @@ func contains(slice []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func TestSnapshotDeleted(t *testing.T) {
+	syncer := &metadataSyncInformer{}
+
+	t.Run("NonSnapshotObject", func(tt *testing.T) {
+		assert.NotPanics(tt, func() {
+			snapshotDeleted("bad-object", syncer)
+		})
+	})
+
+	t.Run("NilObject", func(tt *testing.T) {
+		assert.NotPanics(tt, func() {
+			snapshotDeleted(nil, syncer)
+		})
+	})
+
+	t.Run("NilTypedPointer", func(tt *testing.T) {
+		var nilSnap *snapshotv1.VolumeSnapshot
+		assert.NotPanics(tt, func() {
+			snapshotDeleted(nilSnap, syncer)
+		})
+	})
+
+	t.Run("SnapshotWithNilStatus", func(tt *testing.T) {
+		snap := &snapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{Name: "snap1", Namespace: "ns1"},
+		}
+		assert.NotPanics(tt, func() {
+			snapshotDeleted(snap, syncer)
+		})
+	})
+
+	t.Run("SnapshotWithEmptyBoundContentName", func(tt *testing.T) {
+		empty := ""
+		snap := &snapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{Name: "snap1", Namespace: "ns1"},
+			Status: &snapshotv1.VolumeSnapshotStatus{
+				BoundVolumeSnapshotContentName: &empty,
+			},
+		}
+		assert.NotPanics(tt, func() {
+			snapshotDeleted(snap, syncer)
+		})
+	})
+
+	t.Run("SnapshotWithValidContentName", func(tt *testing.T) {
+		contentName := "snapcontent-xyz"
+		snap := &snapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{Name: "snap1", Namespace: "ns1"},
+			Status: &snapshotv1.VolumeSnapshotStatus{
+				BoundVolumeSnapshotContentName: &contentName,
+			},
+		}
+		assert.NotPanics(tt, func() {
+			snapshotDeleted(snap, syncer)
+		})
+	})
 }

--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -38,8 +39,6 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
-
-	"slices"
 
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -178,7 +177,7 @@ func PvcsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) er
 	// backfill the guest-cluster-snapshot annotation (ImprovedVolumeVisiblity FSS) on the Supervisor
 	// VolumeSnapshot which is requested from the TKC Cluster.
 	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.SVPVCSnapshotProtectionFinalizer) ||
-		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
+		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeVisibility) {
 		err = setGuestClusterDetailsOnSupervisorSnapshot(ctx, metadataSyncer, supervisorNamespace)
 		if err != nil {
 			log.Warnf("FullSync: Failed to set Guest Cluster data on SupervisorSnapshot. Err: %v", err)
@@ -528,7 +527,7 @@ func setGuestClusterDetailsOnSupervisorPVC(ctx context.Context, metadataSyncer *
 				svPVC.Labels[key] = metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID
 			}
 
-			if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
+			if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeVisibility) {
 				if _, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; !ok {
 					guestPvcAnnot := common.BuildGuestPvcAnnotation(
 						metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID,
@@ -723,7 +722,7 @@ func setGuestClusterDetailsOnSupervisorSnapshot(ctx context.Context, metadataSyn
 	snapshotProtectionEnabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx,
 		common.SVPVCSnapshotProtectionFinalizer)
 	improvedVisibilityEnabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx,
-		common.ImprovedVolumeVisiblity)
+		common.ImprovedVolumeVisibility)
 
 	// Define the processor for supervisor snapshots. Label and finalizer mutations
 	// are gated by SVPVCSnapshotProtectionFinalizer; the guest-cluster annotation

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -30,7 +30,7 @@ import (
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
-	commonco "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
@@ -118,7 +118,7 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 				needsCleanup = true
 			}
 
-			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
+			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisibility) {
 				if annVal, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; ok {
 					// Selectively remove PVC-specific fields from the JSON annotation so
 					// that cluster-identity fields (clusterId, clusterName) are preserved


### PR DESCRIPTION
## Summary
- This PR introduces snapshot informer cache for guest cluster gated on `ImprovedVolumeVisibility` FSS and wires up a `VolumeSnapshot` delete listener in the guest CSI syncer. 
- When a snapshot is deleted in a guest cluster the syncer's `snapshotDeleted` handler fires. 
- The handler is a stub with a TODO for the full implementation in a follow-up PR.

## Which issue this PR fixes
N/A

## Testing
### Manual testing
#### Environment
Guest cluster version: v1.35.5
FSS `improved-volume-visibility` enabled in both guest and supervisor configmaps.
Deployed images with my changes on the guest cluster
| Scenario | Result |
|----------|--------|
| `NewSnapshotterClient` called at syncer init (`kubernetes.go:208` log present) | PASS |
| `AddSnapshotListener` registered without error | PASS |
| Delete snapshot (readyToUse, bound content) → `WARN unimplemented` log at `metadatasyncer.go:2868` | PASS |
| Create + delete snapshot → same `WARN unimplemented` log | PASS |

```log
2026-06-17T16:16:04.094Z  WARN  syncer/metadatasyncer.go:2868  unimplemented  {"func": "snapshotDeleted", "snapshot": "fss-test-snapshot"}
2026-06-17T16:16:51.192Z  WARN  syncer/metadatasyncer.go:2868  unimplemented  {"func": "snapshotDeleted", "snapshot": "fss-test-snapshot-2"}
```

## Special notes for your reviewer
- `vsphere-csi-controller-role` is missing `watch` on `volumesnapshots` by default. Added it to the ClusterRole in manifests for versions 1.33–1.36 (from earlier in this PR).
- `snapshotDeleted` is intentionally a stub — the actual VC-side deletion logic is scoped to a subsequent PR.

## Precheckins
### [WCP](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1697/)
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```
### [VKS](https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1280/)
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```

**Release note**:
```release-note
Add VolumeSnapshot delete listener in the guest CSI syncer, gated on ImprovedVolumeVisibility FSS
```