### PR TITLE
Set error code to indicate timeout in pvCSI

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -469,7 +469,11 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 
 			log.Errorf("Last observed events on the pvc %q/%q in supervisor cluster: %+v",
 				c.supervisorNamespace, pvc.Name, spew.Sdump(eventList.Items))
-			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+			// Note: Set the return code to codes.DeadlineExceeded if PVC is still not bound
+			// to indicate that the volume provisioning has timed out
+			// so that external-provisioner will keep retrying and won't leave
+			// orphan volumes behind.
+			return nil, csifault.CSIInternalFault, status.Error(codes.DeadlineExceeded, msg)
 		}
 		attributes := make(map[string]string)
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) && isFileVolumeRequest {

--- a/pkg/csi/service/wcpguest/controller_timeout_test.go
+++ b/pkg/csi/service/wcpguest/controller_timeout_test.go
@@ -1,0 +1,436 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wcpguest
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+)
+
+// TestTimeoutErrorCodes verifies that timeout operations return the correct gRPC error code
+// (codes.DeadlineExceeded) instead of codes.Internal, which allows external-provisioner to
+// retry and prevents orphaned volumes.
+func TestTimeoutErrorCodes(t *testing.T) {
+	tests := []struct {
+		name         string
+		code         codes.Code
+		expectedCode codes.Code
+		shouldMatch  bool
+	}{
+		{
+			name:         "timeout returns DeadlineExceeded",
+			code:         codes.DeadlineExceeded,
+			expectedCode: codes.DeadlineExceeded,
+			shouldMatch:  true,
+		},
+		{
+			name:         "DeadlineExceeded is not Internal",
+			code:         codes.DeadlineExceeded,
+			expectedCode: codes.Internal,
+			shouldMatch:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := status.Error(tt.code, "test message")
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatal("Failed to extract gRPC status from error")
+			}
+
+			if tt.shouldMatch {
+				if st.Code() != tt.expectedCode {
+					t.Errorf("Expected code %v, got %v", tt.expectedCode, st.Code())
+				}
+			} else {
+				if st.Code() == tt.expectedCode {
+					t.Errorf("Expected code to differ from %v, but they matched", tt.expectedCode)
+				}
+			}
+		})
+	}
+}
+
+// TestPVCStateTransitions verifies PVC state transitions in the supervisor cluster,
+// which is critical for the timeout retry scenario.
+func TestPVCStateTransitions(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialPhase  v1.PersistentVolumeClaimPhase
+		targetPhase   v1.PersistentVolumeClaimPhase
+		shouldSucceed bool
+	}{
+		{
+			name:          "create pending PVC",
+			initialPhase:  v1.ClaimPending,
+			targetPhase:   v1.ClaimPending,
+			shouldSucceed: true,
+		},
+		{
+			name:          "transition pending to bound",
+			initialPhase:  v1.ClaimPending,
+			targetPhase:   v1.ClaimBound,
+			shouldSucceed: true,
+		},
+		{
+			name:          "bound remains bound",
+			initialPhase:  v1.ClaimBound,
+			targetPhase:   v1.ClaimBound,
+			shouldSucceed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			supervisorClient := testclient.NewSimpleClientset()
+			supervisorNamespace := "supervisor-ns"
+			pvcName := "test-pvc-" + tt.name
+
+			// Create PVC with initial phase
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: supervisorNamespace,
+					Annotations: map[string]string{
+						common.AnnDynamicallyProvisioned: "csi.vsphere.vmware.com",
+					},
+				},
+				Spec: v1.PersistentVolumeClaimSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+					Resources: v1.VolumeResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+					StorageClassName: stringPtr("test-sc"),
+				},
+				Status: v1.PersistentVolumeClaimStatus{
+					Phase: tt.initialPhase,
+				},
+			}
+
+			// Create PVC
+			createdPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).Create(
+				ctx, pvc, metav1.CreateOptions{})
+			if err != nil {
+				if tt.shouldSucceed {
+					t.Fatalf("Failed to create PVC: %v", err)
+				}
+				return
+			}
+
+			// Verify initial phase
+			if createdPVC.Status.Phase != tt.initialPhase {
+				t.Errorf("Expected initial phase %v, got %v", tt.initialPhase, createdPVC.Status.Phase)
+			}
+
+			// Update to target phase if different
+			if tt.targetPhase != tt.initialPhase {
+				createdPVC.Status.Phase = tt.targetPhase
+				if tt.targetPhase == v1.ClaimBound {
+					createdPVC.Status.Capacity = v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("10Gi"),
+					}
+					createdPVC.Spec.VolumeName = "pv-" + pvcName
+				}
+
+				updatedPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).Update(
+					ctx, createdPVC, metav1.UpdateOptions{})
+				if err != nil {
+					if tt.shouldSucceed {
+						t.Fatalf("Failed to update PVC: %v", err)
+					}
+					return
+				}
+
+				// Verify target phase
+				if updatedPVC.Status.Phase != tt.targetPhase {
+					t.Errorf("Expected target phase %v, got %v", tt.targetPhase, updatedPVC.Status.Phase)
+				}
+			}
+		})
+	}
+}
+
+// TestPVCLifecycle verifies the complete PVC lifecycle: create, update, delete.
+// This simulates the full timeout and cleanup scenario.
+func TestPVCLifecycle(t *testing.T) {
+	tests := []struct {
+		name           string
+		pvcName        string
+		initialPhase   v1.PersistentVolumeClaimPhase
+		updateToPhase  v1.PersistentVolumeClaimPhase
+		shouldDelete   bool
+		verifyDeletion bool
+	}{
+		{
+			name:           "pending PVC can be deleted",
+			pvcName:        "pending-pvc",
+			initialPhase:   v1.ClaimPending,
+			updateToPhase:  v1.ClaimPending,
+			shouldDelete:   true,
+			verifyDeletion: true,
+		},
+		{
+			name:           "bound PVC can be deleted for cleanup",
+			pvcName:        "bound-pvc",
+			initialPhase:   v1.ClaimPending,
+			updateToPhase:  v1.ClaimBound,
+			shouldDelete:   true,
+			verifyDeletion: true,
+		},
+		{
+			name:           "verify PVC creation only",
+			pvcName:        "create-only-pvc",
+			initialPhase:   v1.ClaimPending,
+			updateToPhase:  v1.ClaimPending,
+			shouldDelete:   false,
+			verifyDeletion: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			supervisorClient := testclient.NewSimpleClientset()
+			supervisorNamespace := "supervisor-ns"
+
+			// Create PVC
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.pvcName,
+					Namespace: supervisorNamespace,
+					Annotations: map[string]string{
+						common.AnnDynamicallyProvisioned: "csi.vsphere.vmware.com",
+					},
+				},
+				Spec: v1.PersistentVolumeClaimSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+					Resources: v1.VolumeResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+					StorageClassName: stringPtr("test-sc"),
+				},
+				Status: v1.PersistentVolumeClaimStatus{
+					Phase: tt.initialPhase,
+				},
+			}
+
+			createdPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).Create(
+				ctx, pvc, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create PVC: %v", err)
+			}
+
+			// Update phase if needed
+			if tt.updateToPhase != tt.initialPhase {
+				createdPVC.Status.Phase = tt.updateToPhase
+				if tt.updateToPhase == v1.ClaimBound {
+					createdPVC.Status.Capacity = v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("10Gi"),
+					}
+					createdPVC.Spec.VolumeName = "pv-" + tt.pvcName
+				}
+
+				_, err = supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).Update(
+					ctx, createdPVC, metav1.UpdateOptions{})
+				if err != nil {
+					t.Fatalf("Failed to update PVC: %v", err)
+				}
+			}
+
+			// Delete if requested
+			if tt.shouldDelete {
+				err = supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).Delete(
+					ctx, tt.pvcName, metav1.DeleteOptions{})
+				if err != nil {
+					t.Fatalf("Failed to delete PVC: %v", err)
+				}
+			}
+
+			// Verify deletion if requested
+			if tt.verifyDeletion {
+				_, err = supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).Get(
+					ctx, tt.pvcName, metav1.GetOptions{})
+				if err == nil {
+					t.Error("Expected PVC to be deleted, but it still exists")
+				}
+			}
+		})
+	}
+}
+
+// TestIdempotentOperations verifies that operations can be safely retried.
+func TestIdempotentOperations(t *testing.T) {
+	tests := []struct {
+		name          string
+		pvcName       string
+		createTwice   bool
+		expectSuccess bool
+		expectedPhase v1.PersistentVolumeClaimPhase
+	}{
+		{
+			name:          "create PVC once",
+			pvcName:       "single-create-pvc",
+			createTwice:   false,
+			expectSuccess: true,
+			expectedPhase: v1.ClaimBound,
+		},
+		{
+			name:          "idempotent get after create",
+			pvcName:       "idempotent-pvc",
+			createTwice:   true,
+			expectSuccess: true,
+			expectedPhase: v1.ClaimBound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			supervisorClient := testclient.NewSimpleClientset()
+			supervisorNamespace := "supervisor-ns"
+
+			// Create PVC
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.pvcName,
+					Namespace: supervisorNamespace,
+				},
+				Spec: v1.PersistentVolumeClaimSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+					Resources: v1.VolumeResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+					StorageClassName: stringPtr("test-sc"),
+					VolumeName:       "pv-" + tt.pvcName,
+				},
+				Status: v1.PersistentVolumeClaimStatus{
+					Phase: tt.expectedPhase,
+					Capacity: v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("10Gi"),
+					},
+				},
+			}
+
+			_, err := supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).Create(
+				ctx, pvc, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create PVC: %v", err)
+			}
+
+			// Get PVC (simulates retry/idempotent check)
+			if tt.createTwice {
+				retrievedPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).Get(
+					ctx, tt.pvcName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to get PVC: %v", err)
+				}
+
+				if retrievedPVC.Status.Phase != tt.expectedPhase {
+					t.Errorf("Expected phase %v, got %v", tt.expectedPhase, retrievedPVC.Status.Phase)
+				}
+
+				// Verify we got the same PVC
+				if retrievedPVC.Name != tt.pvcName {
+					t.Errorf("Expected PVC name %s, got %s", tt.pvcName, retrievedPVC.Name)
+				}
+			}
+		})
+	}
+}
+
+// TestErrorCodeBehavior verifies external-provisioner behavior with different error codes.
+func TestErrorCodeBehavior(t *testing.T) {
+	tests := []struct {
+		name                     string
+		errorCode                codes.Code
+		expectRetry              bool
+		expectedProvisionerState string
+	}{
+		{
+			name:                     "DeadlineExceeded allows retry",
+			errorCode:                codes.DeadlineExceeded,
+			expectRetry:              true,
+			expectedProvisionerState: "ProvisioningInBackground",
+		},
+		{
+			name:                     "Internal stops retry",
+			errorCode:                codes.Internal,
+			expectRetry:              false,
+			expectedProvisionerState: "ProvisioningFinished",
+		},
+		{
+			name:                     "Unavailable allows retry",
+			errorCode:                codes.Unavailable,
+			expectRetry:              true,
+			expectedProvisionerState: "ProvisioningInBackground",
+		},
+		{
+			name:                     "Aborted allows retry",
+			errorCode:                codes.Aborted,
+			expectRetry:              true,
+			expectedProvisionerState: "ProvisioningInBackground",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := status.Error(tt.errorCode, "test error")
+			st, _ := status.FromError(err)
+
+			if st.Code() != tt.errorCode {
+				t.Errorf("Expected error code %v, got %v", tt.errorCode, st.Code())
+			}
+
+			// Verify error codes match expected retry behavior
+			// (codes 1-4 allow retry: Canceled, Unknown, InvalidArgument, DeadlineExceeded)
+			// (codes 13+ typically stop retry: Internal, Unavailable, etc. - but Unavailable/Aborted allow retry)
+			retryableCodes := map[codes.Code]bool{
+				codes.Canceled:         true,
+				codes.DeadlineExceeded: true,
+				codes.Unavailable:      true,
+				codes.Aborted:          true,
+			}
+
+			shouldRetry := retryableCodes[tt.errorCode]
+			if shouldRetry != tt.expectRetry {
+				t.Errorf("Expected retry=%v for code %v, but got %v", tt.expectRetry, tt.errorCode, shouldRetry)
+			}
+		})
+	}
+}
+
+// Helper function
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR changes the return code to a non-final error if supervisor PVC is not in bound state within the timeout limit. This allows external-provisioner to continue with retries and eventually deletes the volume when it is finally created.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/661/ (failed but unrelated to my change as I only modified pvCSI)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/615/ (passed)

Manual tests with my fix:
```
Changed timeout in pvCSI to 1 min:
env:
- name: PROVISION_TIMEOUT_MINUTES
 value: "1"  ⇐ decreased from 4 minutes to 1 minute

Create a 50Gi PVC.
root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# cat pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-pvc
  namespace: test-ns
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 50Gi
  storageClassName: wcpglobal-storage-profile

Wrote data (>29G) to the volume.
root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# kubectl exec data-writer -n test-ns -- sh -c "df -h /data && du -sh /data"
Filesystem                Size      Used Available Use% Mounted on
/dev/sdb                 48.9G     29.3G     17.1G  63% /data
29.3G	/data

Create a VolumeSnapshot on Guest:
root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# kubectl create -f snapshot.yaml
volumesnapshot.snapshot.storage.k8s.io/test-snapshot created
root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# kubectl get vs -n test-ns
NAME            READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
test-snapshot   true         test-pvc                            50Gi          volumesnapshotclass-delete   snapcontent-fc744924-87b9-4ecc-82df-1e42616bf3a8   <invalid>      6s

Supervisor:
root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# kubectl get vs -n svc-tkg-827eq
NAME                                                                        READYTOUSE   SOURCEPVC                                                                   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
9ba071c6-f073-4302-93be-8c7bf8169354-fc744924-87b9-4ecc-82df-1e42616bf3a8   true         9ba071c6-f073-4302-93be-8c7bf8169354-58880e37-c08c-47b4-9821-620e282f600a                           50Gi          volumesnapshotclass-delete   snapcontent-4775f562-a865-4ff8-a3b2-5d26bb21eb31   8s             17s

Guest:
Create a PVC from VolumeSnapshot.

root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# cat restore.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-restore
  namespace: test-ns
spec:
  storageClassName: wcpglobal-storage-profile
  dataSource:
    name: test-snapshot
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 50Gi

Guest:
root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# kubectl get pvc -n test-ns
NAME           STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-pvc       Bound     pvc-58880e37-c08c-47b4-9821-620e282f600a   50Gi       RWO            wcpglobal-storage-profile   <unset>                 11h
test-restore   Pending                                                                        wcpglobal-storage-profile   <unset>                 3m6s

vsphere csi controller logs with timeout error:

{"level":"info","time":"2025-11-25T03:06:56.637592064Z","caller":"wcpguest/controller.go:304","msg":"CreateVolume: called with args name:\"pvc-192bff8d-2437-4aa2-a300-91ba3f6ffff5\" capacity_range:{required_bytes:53687091200} volume_capabilities:{mount:{fs_type:\"ext4\"} access_mode:{mode:SINGLE_NODE_WRITER}} parameters:{key:\"svStorageClass\" value:\"wcpglobal-storage-profile\"} volume_content_source:{snapshot:{snapshot_id:\"9ba071c6-f073-4302-93be-8c7bf8169354-9ee67a09-5fc7-4413-b370-c2aa43335275\"}} accessibility_requirements:{requisite:{segments:{key:\"topology.kubernetes.io/zone\" value:\"domain-c52\"}} preferred:{segments:{key:\"topology.kubernetes.io/zone\" value:\"domain-c52\"}}}","TraceId":"0836c3bd-af58-41fc-b414-9bdc7b7c2201"}

{"level":"info","time":"2025-11-25T03:06:56.938820871Z","caller":"wcpguest/controller_helper.go:370","msg":"provisionTimeout is set to 1 minutes","TraceId":"0836c3bd-af58-41fc-b414-9bdc7b7c2201"}

{"level":"info","time":"2025-11-25T03:06:56.939861911Z","caller":"wcpguest/controller_helper.go:324","msg":"Waiting up to 60 seconds for PersistentVolumeClaim 9ba071c6-f073-4302-93be-8c7bf8169354-192bff8d-2437-4aa2-a300-91ba3f6ffff5 in namespace svc-tkg-827eq to have phase Bound","TraceId":"0836c3bd-af58-41fc-b414-9bdc7b7c2201"}

{"level":"error","time":"2025-11-25T03:07:56.969531765Z","caller":"wcpguest/controller.go:445","msg":"failed to create volume on namespace: svc-tkg-827eq in supervisor cluster. Error: persistentVolumeClaim 9ba071c6-f073-4302-93be-8c7bf8169354-192bff8d-2437-4aa2-a300-91ba3f6ffff5 in namespace svc-tkg-827eq not in phase Bound within 60 seconds","TraceId":"0836c3bd-af58-41fc-b414-9bdc7b7c2201","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcpguest.(*controller).CreateVolume.func1\n\t/build/pkg/csi/service/wcpguest/controller.go:445\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcpguest.(*controller).CreateVolume\n\t/build/pkg/csi/service/wcpguest/controller.go:553\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.11.0/lib/go/csi/csi_grpc.pb.go:444\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go:1405\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go:1815\ngoogle.golang.org/grpc.(*Server).serveStreams.func2.1\n\t/go/pkg/mod/google.golang.org/grpc@v1.72.1/server.go:1035"}

Delete PVC being created from VolumeSnapshot without deleting the VolumeSnapshot.
root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# kubectl delete pvc test-restore -n test-ns
persistentvolumeclaim "test-restore" deleted

Supervisor:
PVC in Supervisor was pending. Eventually it got deleted after it was created.

root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# kubectl get pvc -n svc-tkg-827eq
NAME                                                                        STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
9ba071c6-f073-4302-93be-8c7bf8169354-192bff8d-2437-4aa2-a300-91ba3f6ffff5   Pending                                                                        wcpglobal-storage-profile   <unset>                 3m42s
9ba071c6-f073-4302-93be-8c7bf8169354-58880e37-c08c-47b4-9821-620e282f600a   Bound     pvc-4bb82950-fc50-42ae-827f-cb37e5db0589   50Gi       RWO            wcpglobal-storage-profile   <unset>                 11h
root@422c5ad9cdf63ebf0f433aecddad9ff7 [ ~ ]# kubectl get pvc -n svc-tkg-827eq
NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
9ba071c6-f073-4302-93be-8c7bf8169354-58880e37-c08c-47b4-9821-620e282f600a   Bound    pvc-4bb82950-fc50-42ae-827f-cb37e5db0589   50Gi       RWO            wcpglobal-storage-profile   <unset>                 11h
```

**Special notes for your reviewer**:
I also submitted a fix in external-provisioner: https://github.com/kubernetes-csi/external-provisioner/pull/1448
With the provisioner fix, the PVC in supervisor will also be deleted after it is finally created from VolumeSnapshot if the VolumeSnapshot itself is also being deleted. VolumeSnapshot will be deleted as well.

Note: The fix in pvCSI is independent of the fix in external-provisioner. Without the provisioner fix, the PVC in supervisor will be deleted after it is finally created from VolumeSnapshot if the VolumeSnapshot itself is not being deleted.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set error code to indicate timeout in pvCSI to avoid leaking volumes.
```
