### PR TITLE
Validate volumeMode in CnsRegisterVolume

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -267,13 +267,12 @@ func getPersistentVolumeSpec(volumeName string, volumeID string, capacity int64,
 		Status: v1.PersistentVolumeStatus{},
 	}
 
-	if isSharedDiskEnabled {
-		if volumeMode == "" {
-			// For both RWO and RWX volumes, default volumeMode is Filesystem.
-			volumeMode = v1.PersistentVolumeFilesystem
-		}
-		pv.Spec.VolumeMode = &volumeMode
+	// Set volumeMode if specified or default to Filesystem
+	if volumeMode == "" {
+		// For both RWO and RWX volumes, default volumeMode is Filesystem.
+		volumeMode = v1.PersistentVolumeFilesystem
 	}
+	pv.Spec.VolumeMode = &volumeMode
 
 	annotations := make(map[string]string)
 	annotations["pv.kubernetes.io/provisioned-by"] = cnsoperatortypes.VSphereCSIDriverName


### PR DESCRIPTION
**What this PR does / why we need it**:
If a pre-existing PVC has volumeMode but CnsRegisterVolume does not have volumeMode set, CnsRegisterVolume controller should set volumeMode in PV based on what is set in PVC.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/665/ (passed)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/617/ (passed)

The following are tested manually:
```
- Create a PVC with volumeMode Block and CnsRegisterVolume volumeMode not set:  Successful
- Create a PVC with volumeMode Block and CnsRegisterVolume volumeMode Block: Successful
- Create a PVC with volumeMode Block and CnsRegisterVolume volumeMode Filesystem: Failed
- Create a PVC with volumeMode Filesystem and CnsRegisterVolume volumeMode unset: Successful
```
```
root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# cat pop.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pop-pvc
  namespace: storage-policy-test
spec:
  storageClassName: wcpglobal-storage-profile
  dataSourceRef:
    apiGroup: vmoperator.vmware.com
    kind: VirtualMachine
    name: my-vm-1
  accessModes:
    - ReadWriteOnce
  volumeMode: Block
  resources:
    requests:
      storage: 1Gi

root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl create -f pop.yaml
persistentvolumeclaim/pop-pvc created

root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl get pvc pop-pvc -n storage-policy-test
NAME      STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pop-pvc   Pending                                      wcpglobal-storage-profile   <unset>                 15s

root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# cat register.yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: static-volume
  namespace: storage-policy-test
spec:
  volumeID: a43ec9c9-236d-4217-8366-70c2bb47fc51
  accessMode: ReadWriteOnce
  pvcName: pop-pvc

Without my fix:
root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl create -f register.yaml
cnsregistervolume.cns.vmware.com/static-volume created

root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl get cnsregistervolume static-volume -n storage-policy-test -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  creationTimestamp: "2025-11-27T16:46:50Z"
  generation: 1
  name: static-volume
  namespace: storage-policy-test
  resourceVersion: "7118477"
  uid: 3f2e73a4-8b87-45e8-b6f3-fa050be644a1
spec:
  accessMode: ReadWriteOnce
  pvcName: pop-pvc
  volumeID: a43ec9c9-236d-4217-8366-70c2bb47fc51
status:
  error: 'PVC: pop-pvc is not bound'  ⇐ PVC is not bound
  registered: false

root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl get pv static-pv-a43ec9c9-236d-4217-8366-70c2bb47fc51 -o yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
  creationTimestamp: "2025-11-27T16:46:51Z"
  finalizers:
  - kubernetes.io/pv-protection
  name: static-pv-a43ec9c9-236d-4217-8366-70c2bb47fc51
  resourceVersion: "7117695"
  uid: 56682401-ccd4-49f1-a5a2-71aae0eb1f49
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: pop-pvc
    namespace: storage-policy-test
  csi:
    driver: csi.vsphere.vmware.com
    fsType: ext4
    volumeHandle: a43ec9c9-236d-4217-8366-70c2bb47fc51
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: topology.kubernetes.io/zone
          operator: In
          values:
          - domain-c36
  persistentVolumeReclaimPolicy: Delete
  storageClassName: wcpglobal-storage-profile
  volumeMode: Filesystem ⇐ This PV can’t be bound with PVC because of volumeMode mismatch
status:
  lastPhaseTransitionTime: "2025-11-27T16:46:51Z"
  phase: Available

Testing with my image:

root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl get cnsregistervolume -n storage-policy-test -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-11-27T16:46:50Z"
    generation: 2
    name: static-volume
    namespace: storage-policy-test
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: PersistentVolumeClaim
      name: pop-pvc
      uid: 81bacc5f-7bcb-41d8-9171-cd64a742b07f
    resourceVersion: "7216450"
    uid: 3f2e73a4-8b87-45e8-b6f3-fa050be644a1
  spec:
    accessMode: ReadWriteOnce
    pvcName: pop-pvc
    volumeID: a43ec9c9-236d-4217-8366-70c2bb47fc51
    volumeMode: Block
  status:
    registered: true
kind: List
metadata:
  resourceVersion: ""

root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl get pvc pop-pvc -n storage-policy-test
NAME      STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pop-pvc   Bound    static-pv-a43ec9c9-236d-4217-8366-70c2bb47fc51   1Gi        RWO            wcpglobal-storage-profile   <unset>                 158m

root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl get pv static-pv-a43ec9c9-236d-4217-8366-70c2bb47fc51 -o yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
  creationTimestamp: "2025-11-27T19:22:46Z"
  finalizers:
  - kubernetes.io/pv-protection
  name: static-pv-a43ec9c9-236d-4217-8366-70c2bb47fc51
  resourceVersion: "7216421"
  uid: 9c48439d-66f4-450d-90d9-6e04f6efaa3f
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: pop-pvc
    namespace: storage-policy-test
    resourceVersion: "7117690"
    uid: 81bacc5f-7bcb-41d8-9171-cd64a742b07f
  csi:
    driver: csi.vsphere.vmware.com
    fsType: ext4
    volumeHandle: a43ec9c9-236d-4217-8366-70c2bb47fc51
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: topology.kubernetes.io/zone
          operator: In
          values:
          - domain-c36
  persistentVolumeReclaimPolicy: Delete
  storageClassName: wcpglobal-storage-profile
  volumeMode: Block <= PV re-created with the correct Mode
status:
  lastPhaseTransitionTime: "2025-11-27T19:22:50Z"
  phase: Bound

Negative test - create PVC with block volumeMode and CnsRegisterVolume with filesystem volumeMode get a mismatch error.
root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl get cnsregistervolume -A -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-11-27T19:38:25Z"
    generation: 1
    name: static-volume
    namespace: storage-policy-test
    resourceVersion: "7226410"
    uid: ed7687a6-45c9-4599-bad6-bfd1b2cf426a
  spec:
    accessMode: ReadWriteOnce
    pvcName: pop-pvc
    volumeID: a43ec9c9-236d-4217-8366-70c2bb47fc51
    volumeMode: filesystem
  status:
    error: 'VolumeMode mismatch: existing PVC pop-pvc in namespace storage-policy-test
      has volumeMode Block, but CnsRegisterVolume specifies volumeMode filesystem'
    registered: false
kind: List
metadata:
  resourceVersion: ""

Create PVC with filesystem volumeMode and CnsRegisterVolume volumeMode unset. Successfully registered.
root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# cat pop.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pop-pvc
  namespace: storage-policy-test
spec:
  storageClassName: wcpglobal-storage-profile
  dataSourceRef:
    apiGroup: vmoperator.vmware.com
    kind: VirtualMachine
    name: my-vm-1
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  resources:
    requests:
      storage: 1Gi

root@4211cbeca6d80eaf07891886434b7917 [ ~ ]# kubectl get cnsregistervolume -A -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-11-27T19:43:15Z"
    generation: 2
    name: static-volume
    namespace: storage-policy-test
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: PersistentVolumeClaim
      name: pop-pvc
      uid: 7e0597b1-1c0e-4956-ae9d-11bdcb2e2892
    resourceVersion: "7229738"
    uid: 2257200f-0a5e-4bdb-b82a-930bbb0abde1
  spec:
    accessMode: ReadWriteOnce
    pvcName: pop-pvc
    volumeID: a43ec9c9-236d-4217-8366-70c2bb47fc51
    volumeMode: Filesystem
  status:
    registered: true
kind: List
metadata:
  resourceVersion: ""
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
If a pre-existing PVC has volumeMode but CnsRegisterVolume does not have volumeMode set, CnsRegisterVolume controller should set volumeMode in PV based on what is set in PVC.
```
