### PR TITLE
Use Patch() to update status of CnsRegisterVolume CR instead of Update()

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -59,7 +59,7 @@ rules:
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes", "cnsregistervolumes/status", "cnsunregistervolumes", "cnsunregistervolumes/status"]
-    verbs: ["get", "list", "watch", "update", "delete"]
+    verbs: ["get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]
     verbs: ["create", "get", "update", "watch", "list"]

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -59,7 +59,7 @@ rules:
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes", "cnsregistervolumes/status", "cnsunregistervolumes", "cnsunregistervolumes/status"]
-    verbs: ["get", "list", "watch", "update", "delete"]
+    verbs: ["get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]
     verbs: ["create", "get", "update", "watch", "list"]

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -59,7 +59,7 @@ rules:
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes", "cnsregistervolumes/status", "cnsunregistervolumes", "cnsunregistervolumes/status"]
-    verbs: ["get", "list", "watch", "update", "delete"]
+    verbs: ["get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]
     verbs: ["create", "get", "update", "watch", "list"]

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -59,7 +59,7 @@ rules:
     verbs: ["get", "list", "update", "create", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes", "cnsregistervolumes/status", "cnsunregistervolumes", "cnsunregistervolumes/status"]
-    verbs: ["get", "list", "watch", "update", "delete"]
+    verbs: ["get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["triggercsifullsyncs"]
     verbs: ["create", "get", "update", "watch", "list"]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds changes to use Patch() method to update status of CnsRegisterVolume CR, instead of Update(), since Update() fails sometimes due to error as below, that causes further issue such as double quota accounting if update to mark success fails.

`2025-11-13T10:25:57.869570556Z stderr F {"level":"error","time":"2025-11-13T10:25:57.86932921Z","caller":"kubernetes/kubernetes.go:787","msg":"Failed to update status. err: Operation cannot be fulfilled on cnsregistervolumes.cns.vmware.com \"cnsregvol-8cxcl\": the object has been modified; please apply your changes to the latest version and try again","kind":"CnsRegisterVolume","name":"e2e-test-namespace-274/cnsregvol-8cxcl","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes.UpdateStatus\n\t/build/mts/release/sb-91958690/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/kubernetes/kubernetes.go:787\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume.setInstanceSuccess\n\t/build/mts/release/sb-91958690/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go:1071\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume.(*ReconcileCnsRegisterVolume).Reconcile\n\t/build/mts/release/sb-91958690/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go:802\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/build/mts/release/sb-91958690/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/[controller-runtime@v0.19.1](mailto:controller-runtime@v0.19.1)/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/build/mts/release/sb-91958690/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/[controller-runtime@v0.19.1](mailto:controller-runtime@v0.19.1)/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/build/mts/release/sb-91958690/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/[controller-runtime@v0.19.1](mailto:controller-runtime@v0.19.1)/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/build/mts/release/sb-91958690/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/sigs.k8s.io/[controller-runtime@v0.19.1](mailto:controller-runtime@v0.19.1)/pkg/internal/controller/controller.go:224"}`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP precheckin pipeline : https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/724/ - passed
VKS precheckin pipeline : https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/668/ -passed
Manual testing: 

Error case: CnsRegisterVolume for non-existing volume ID

```
root@42026f8c18cfe986a6078f15efe59749 [ ~ ]# k get pods -n vmware-system-csi -o yaml | grep image: | grep syncer
      image: cns-docker-dev-local.packages.vcfd.broadcom.net/pansea/syncer:cnsregistervolume_4dec-3
     
root@42026f8c18cfe986a6078f15efe59749 [ ~ ]# cat cnsregistervolume.yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: example-register-volume-cr
  namespace: e2e-test-namespace-747
spec:
  volumeID: "5e27e93e-eda6-489c-8bdd-95ee5804b8be" # The internal vSphere CNS Volume ID (UUID)
  pvcName: "example-pvc-name"                 # Desired name for the resulting Kubernetes PVC
  volumeMode: "Block"
  accessMode: "ReadWriteOnce"
root@42026f8c18cfe986a6078f15efe59749 [ ~ ]#

root@42026f8c18cfe986a6078f15efe59749 [ ~ ]# k create -f cnsregistervolume.yaml
cnsregistervolume.cns.vmware.com/example-register-volume-cr created
root@42026f8c18cfe986a6078f15efe59749 [ ~ ]#

root@42026f8c18cfe986a6078f15efe59749 [ ~ ]# k get cnsregistervolume -A -oyaml
...
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-12-04T08:47:54Z"
    generation: 1
    name: example-register-volume-cr
    namespace: e2e-test-namespace-747
    resourceVersion: "9369943"
    uid: a550946f-738c-4c98-b223-8a9c6d432329
  spec:
    accessMode: ReadWriteOnce
    pvcName: example-pvc-name
    volumeID: 5e27e93e-eda6-489c-8bdd-95ee5804b8be
    volumeMode: Block
  status:
    error: 'failed to create CNS volume. Error: ServerFaultCode: The object or item      <<< status updated with patch operation successful
      referred to could not be found.'
    registered: false
```

success case: 

```
root@42026f8c18cfe986a6078f15efe59749 [ ~ ]# k create -f cnsregistervolume.yaml
cnsregistervolume.cns.vmware.com/example-register-volume-cr created
root@42026f8c18cfe986a6078f15efe59749 [ ~ ]#

root@42026f8c18cfe986a6078f15efe59749 [ ~ ]# k get cnsregistervolume -A -oyaml
...
- apiVersion: cns.vmware.com/v1alpha1
  kind: CnsRegisterVolume
  metadata:
    creationTimestamp: "2025-12-04T09:17:33Z"
    generation: 1
    name: example-register-volume-cr
    namespace: e2e-test-namespace-747
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: PersistentVolumeClaim
      name: example-pvc-name
      uid: 2499d87a-6ea8-4873-ac23-1202e78de190
    resourceVersion: "9397808"
    uid: 7f0a8e71-77d9-4dca-afdc-7e85023db211
  spec:
    accessMode: ReadWriteOnce
    pvcName: example-pvc-name
    volumeID: 1226ff2e-12b6-4f95-bc13-08bc7ab775ed
    volumeMode: Block
  status:
    registered: true
      
```
      
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use Patch() to update status of CnsRegisterVolume CR instead of Update()
```
