### PR TITLE
Use PATCH API for CnsVolumeMetadata and CnsFileAccessConfig updates

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -19,6 +19,7 @@ package kubernetes
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net"
@@ -26,6 +27,7 @@ import (
 	"strconv"
 	"time"
 
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	v1 "k8s.io/api/core/v1"
@@ -37,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	clientset "k8s.io/client-go/kubernetes"
@@ -826,4 +829,47 @@ func RemoveFinalizer(ctx context.Context, c client.Client, obj client.Object, fi
 
 	log.Info("Removing finalizer from object.")
 	return c.Update(ctx, obj)
+}
+
+// PatchObject patches a Kubernetes object using strategic merge patch.
+// This function creates a patch between the original and modified objects and applies it using the client.
+// It returns an error if the patch operation fails.
+func PatchObject(ctx context.Context, k8sClient client.Client, original, modified client.Object) error {
+	log := logger.GetLogger(ctx)
+
+	// Marshal the original object
+	oldData, err := json.Marshal(original)
+	if err != nil {
+		log.Errorf("PatchObject: Failed to marshal original object %s/%s: %v",
+			original.GetNamespace(), original.GetName(), err)
+		return err
+	}
+
+	// Marshal the modified object
+	newData, err := json.Marshal(modified)
+	if err != nil {
+		log.Errorf("PatchObject: Failed to marshal modified object %s/%s: %v",
+			modified.GetNamespace(), modified.GetName(), err)
+		return err
+	}
+
+	// Create merge patch (compatible with both native K8s resources and CRDs)
+	patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
+	if err != nil {
+		log.Errorf("PatchObject: Error creating merge patch for object %s/%s: %v",
+			original.GetNamespace(), original.GetName(), err)
+		return err
+	}
+
+	// Apply the patch
+	patch := client.RawPatch(apitypes.MergePatchType, patchBytes)
+	if err := k8sClient.Patch(ctx, original, patch); err != nil {
+		log.Errorf("PatchObject: Failed to patch object %s/%s: %v",
+			original.GetNamespace(), original.GetName(), err)
+		return err
+	}
+
+	log.Debugf("PatchObject: Successfully patched object %s/%s",
+		original.GetNamespace(), original.GetName())
+	return nil
 }

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -526,12 +526,13 @@ func addPvcFinalizer(ctx context.Context,
 		return nil
 	}
 
+	original := pvc.DeepCopy()
 	if !controllerutil.AddFinalizer(pvc, cnsoperatortypes.CNSPvcFinalizer) {
 		return fmt.Errorf("failed to add CNS finalizer to PVC %s in namespace %s", pvc.Name,
 			pvc.Namespace)
 	}
 
-	err = client.Update(ctx, pvc)
+	err = k8s.PatchObject(ctx, client, original, pvc)
 	if err != nil {
 		return fmt.Errorf("failed to add finalizer %s on PVC %s in namespace %s", cnsoperatortypes.CNSPvcFinalizer,
 			instance.Spec.PvcName, instance.Namespace)
@@ -597,6 +598,7 @@ func removeFinalizerFromPVC(ctx context.Context, client client.Client,
 		return nil
 	}
 
+	original := pvc.DeepCopy()
 	if !controllerutil.RemoveFinalizer(pvc, cnsoperatortypes.CNSPvcFinalizer) {
 		err := fmt.Errorf("failed to remove finalizer %s from PVC %s in namespace %s",
 			cnsoperatortypes.CNSPvcFinalizer, pvcName, pvc.Namespace)
@@ -604,7 +606,7 @@ func removeFinalizerFromPVC(ctx context.Context, client client.Client,
 		return err
 	}
 
-	err = client.Update(ctx, pvc)
+	err = k8s.PatchObject(ctx, client, original, pvc)
 	if err != nil {
 		return fmt.Errorf("failed to remove finalizer %s from PVC %s in namespace %s",
 			cnsoperatortypes.CNSPvcFinalizer, pvcName, pvc.Namespace)
@@ -872,9 +874,10 @@ func setInstanceError(ctx context.Context, r *ReconcileCnsFileAccessConfig,
 func updateCnsFileAccessConfig(ctx context.Context, client client.Client,
 	instance *v1a1.CnsFileAccessConfig) error {
 	log := logger.GetLogger(ctx)
-	err := client.Update(ctx, instance)
+	original := instance.DeepCopy()
+	err := k8s.PatchObject(ctx, client, original, instance)
 	if err != nil {
-		log.Errorf("failed to update CnsFileAccessConfig instance: %q on namespace: %q. Error: %+v",
+		log.Errorf("failed to patch CnsFileAccessConfig instance: %q on namespace: %q. Error: %+v",
 			instance.Name, instance.Namespace, err)
 	}
 	return err

--- a/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller_test.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnsvolumemetadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
+)
+
+func TestCnsVolumeMetadata_PatchOperations(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup scheme
+	testScheme := runtime.NewScheme()
+	err := cnsoperatorapis.AddToScheme(testScheme)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		setupFunc func() (client.Client, *cnsvolumemetadatav1alpha1.CnsVolumeMetadata,
+			*cnsvolumemetadatav1alpha1.CnsVolumeMetadata)
+		expectError  bool
+		validateFunc func(t *testing.T, client client.Client, original *cnsvolumemetadatav1alpha1.CnsVolumeMetadata)
+	}{
+		{
+			name: "Patch finalizer addition",
+			setupFunc: func() (client.Client, *cnsvolumemetadatav1alpha1.CnsVolumeMetadata,
+				*cnsvolumemetadatav1alpha1.CnsVolumeMetadata) {
+				original := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-volume",
+						Namespace: "test-namespace",
+					},
+					Spec: cnsvolumemetadatav1alpha1.CnsVolumeMetadataSpec{
+						VolumeNames:    []string{"volume1"},
+						EntityType:     cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV,
+						GuestClusterID: "test-cluster",
+						EntityName:     "test-entity",
+						EntityReferences: []cnsvolumemetadatav1alpha1.CnsOperatorEntityReference{
+							{
+								EntityType: "PERSISTENT_VOLUME",
+								EntityName: "test-pv",
+								ClusterID:  "test-cluster",
+							},
+						},
+					},
+				}
+
+				fakeClient := ctrlruntimefake.NewClientBuilder().
+					WithScheme(testScheme).
+					WithObjects(original).
+					Build()
+
+				modified := original.DeepCopy()
+				modified.Finalizers = append(modified.Finalizers, cnsoperatortypes.CNSFinalizer)
+
+				return fakeClient, original, modified
+			},
+			expectError: false,
+			validateFunc: func(t *testing.T, client client.Client, original *cnsvolumemetadatav1alpha1.CnsVolumeMetadata) {
+				// Retrieve the updated instance
+				retrieved := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}
+				key := types.NamespacedName{Name: original.Name, Namespace: original.Namespace}
+				err := client.Get(ctx, key, retrieved)
+				assert.NoError(t, err)
+
+				// Verify finalizer was added
+				assert.Contains(t, retrieved.Finalizers, cnsoperatortypes.CNSFinalizer)
+			},
+		},
+		{
+			name: "Patch status update",
+			setupFunc: func() (client.Client, *cnsvolumemetadatav1alpha1.CnsVolumeMetadata,
+				*cnsvolumemetadatav1alpha1.CnsVolumeMetadata) {
+				original := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-volume-status",
+						Namespace: "test-namespace",
+					},
+					Spec: cnsvolumemetadatav1alpha1.CnsVolumeMetadataSpec{
+						VolumeNames:    []string{"volume1"},
+						EntityType:     cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV,
+						GuestClusterID: "test-cluster",
+						EntityName:     "test-entity",
+						EntityReferences: []cnsvolumemetadatav1alpha1.CnsOperatorEntityReference{
+							{
+								EntityType: "PERSISTENT_VOLUME",
+								EntityName: "test-pv",
+								ClusterID:  "test-cluster",
+							},
+						},
+					},
+					Status: cnsvolumemetadatav1alpha1.CnsVolumeMetadataStatus{
+						VolumeStatus: []cnsvolumemetadatav1alpha1.CnsVolumeMetadataVolumeStatus{
+							{
+								VolumeName: "volume1",
+								Updated:    false,
+							},
+						},
+					},
+				}
+
+				fakeClient := ctrlruntimefake.NewClientBuilder().
+					WithScheme(testScheme).
+					WithObjects(original).
+					Build()
+
+				modified := original.DeepCopy()
+				modified.Status.VolumeStatus[0].Updated = true
+				modified.Status.VolumeStatus[0].ErrorMessage = "Test error message"
+
+				return fakeClient, original, modified
+			},
+			expectError: false,
+			validateFunc: func(t *testing.T, client client.Client, original *cnsvolumemetadatav1alpha1.CnsVolumeMetadata) {
+				// Retrieve the updated instance
+				retrieved := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}
+				key := types.NamespacedName{Name: original.Name, Namespace: original.Namespace}
+				err := client.Get(ctx, key, retrieved)
+				assert.NoError(t, err)
+
+				// Verify status was updated
+				assert.True(t, retrieved.Status.VolumeStatus[0].Updated)
+				assert.Equal(t, "Test error message", retrieved.Status.VolumeStatus[0].ErrorMessage)
+			},
+		},
+		{
+			name: "Patch finalizer removal",
+			setupFunc: func() (client.Client, *cnsvolumemetadatav1alpha1.CnsVolumeMetadata,
+				*cnsvolumemetadatav1alpha1.CnsVolumeMetadata) {
+				original := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test-volume-finalizer-remove",
+						Namespace:  "test-namespace",
+						Finalizers: []string{cnsoperatortypes.CNSFinalizer, "other-finalizer"},
+					},
+					Spec: cnsvolumemetadatav1alpha1.CnsVolumeMetadataSpec{
+						VolumeNames:    []string{"volume1"},
+						EntityType:     cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV,
+						GuestClusterID: "test-cluster",
+						EntityName:     "test-entity",
+						EntityReferences: []cnsvolumemetadatav1alpha1.CnsOperatorEntityReference{
+							{
+								EntityType: "PERSISTENT_VOLUME",
+								EntityName: "test-pv",
+								ClusterID:  "test-cluster",
+							},
+						},
+					},
+				}
+
+				fakeClient := ctrlruntimefake.NewClientBuilder().
+					WithScheme(testScheme).
+					WithObjects(original).
+					Build()
+
+				modified := original.DeepCopy()
+				// Remove the CNS finalizer
+				for i, finalizer := range modified.Finalizers {
+					if finalizer == cnsoperatortypes.CNSFinalizer {
+						modified.Finalizers = append(modified.Finalizers[:i], modified.Finalizers[i+1:]...)
+						break
+					}
+				}
+
+				return fakeClient, original, modified
+			},
+			expectError: false,
+			validateFunc: func(t *testing.T, client client.Client, original *cnsvolumemetadatav1alpha1.CnsVolumeMetadata) {
+				// Retrieve the updated instance
+				retrieved := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}
+				key := types.NamespacedName{Name: original.Name, Namespace: original.Namespace}
+				err := client.Get(ctx, key, retrieved)
+				assert.NoError(t, err)
+
+				// Verify CNS finalizer was removed but other finalizer remains
+				assert.NotContains(t, retrieved.Finalizers, cnsoperatortypes.CNSFinalizer)
+				assert.Contains(t, retrieved.Finalizers, "other-finalizer")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient, original, modified := tt.setupFunc()
+
+			// Execute the patch operation using our common utility
+			err := k8s.PatchObject(ctx, fakeClient, original, modified)
+
+			// Validate results
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				// Run custom validation if provided
+				if tt.validateFunc != nil {
+					tt.validateFunc(t, fakeClient, original)
+				}
+			}
+		})
+	}
+}
+
+func TestCnsVolumeMetadata_PatchErrorHandling(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup scheme
+	testScheme := runtime.NewScheme()
+	err := cnsoperatorapis.AddToScheme(testScheme)
+	assert.NoError(t, err)
+
+	t.Run("Patch non-existent object", func(t *testing.T) {
+		// Create fake client without the object
+		fakeClient := ctrlruntimefake.NewClientBuilder().
+			WithScheme(testScheme).
+			Build()
+
+		original := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "non-existent-volume",
+				Namespace: "test-namespace",
+			},
+		}
+
+		modified := original.DeepCopy()
+		modified.Finalizers = append(modified.Finalizers, cnsoperatortypes.CNSFinalizer)
+
+		// Execute the patch operation - should fail
+		err := k8s.PatchObject(ctx, fakeClient, original, modified)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("Patch with invalid object", func(t *testing.T) {
+		// Create an object with invalid data that would cause marshaling issues
+		original := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-volume",
+				Namespace: "test-namespace",
+			},
+		}
+
+		fakeClient := ctrlruntimefake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(original).
+			Build()
+
+		// Create a modified version
+		modified := original.DeepCopy()
+		modified.Status.VolumeStatus = []cnsvolumemetadatav1alpha1.CnsVolumeMetadataVolumeStatus{
+			{
+				VolumeName: "volume1",
+				Updated:    true,
+			},
+		}
+
+		// This should succeed as the objects are valid
+		err := k8s.PatchObject(ctx, fakeClient, original, modified)
+		assert.NoError(t, err)
+
+		// Verify the patch was applied
+		retrieved := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}
+		key := types.NamespacedName{Name: original.Name, Namespace: original.Namespace}
+		err = fakeClient.Get(ctx, key, retrieved)
+		assert.NoError(t, err)
+		assert.True(t, retrieved.Status.VolumeStatus[0].Updated)
+	})
+}

--- a/pkg/syncer/cnsoperator/util/util_test.go
+++ b/pkg/syncer/cnsoperator/util/util_test.go
@@ -22,10 +22,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
 func TestGetSnatIpFromNamespaceNetworkInfo(t *testing.T) {
@@ -185,4 +192,185 @@ func TestGetMaxWorkerThreads(t *testing.T) {
 		// Assert
 		assert.Equal(t, expVal, val)
 	})
+}
+
+func TestPatchObject(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		setupFunc   func() (client.Client, client.Object, client.Object)
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "Successful patch with status update",
+			setupFunc: func() (client.Client, client.Object, client.Object) {
+				scheme := runtime.NewScheme()
+				err := cnsoperatorapis.AddToScheme(scheme)
+				if err != nil {
+					t.Fatalf("Failed to add scheme: %v", err)
+				}
+
+				original := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-volume",
+						Namespace: "test-namespace",
+					},
+					Spec: cnsvolumemetadatav1alpha1.CnsVolumeMetadataSpec{
+						VolumeNames: []string{"volume1"},
+						EntityType:  cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV,
+					},
+					Status: cnsvolumemetadatav1alpha1.CnsVolumeMetadataStatus{
+						VolumeStatus: []cnsvolumemetadatav1alpha1.CnsVolumeMetadataVolumeStatus{
+							{
+								VolumeName: "volume1",
+								Updated:    false,
+							},
+						},
+					},
+				}
+
+				fakeClient := ctrlruntimefake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(original).
+					Build()
+
+				modified := original.DeepCopy()
+				modified.Status.VolumeStatus[0].Updated = true
+
+				return fakeClient, original, modified
+			},
+			expectError: false,
+		},
+		{
+			name: "Successful patch with finalizer addition",
+			setupFunc: func() (client.Client, client.Object, client.Object) {
+				scheme := runtime.NewScheme()
+				err := cnsoperatorapis.AddToScheme(scheme)
+				if err != nil {
+					t.Fatalf("Failed to add scheme: %v", err)
+				}
+
+				original := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-volume",
+						Namespace: "test-namespace",
+					},
+					Spec: cnsvolumemetadatav1alpha1.CnsVolumeMetadataSpec{
+						VolumeNames: []string{"volume1"},
+						EntityType:  cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV,
+					},
+				}
+
+				fakeClient := ctrlruntimefake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(original).
+					Build()
+
+				modified := original.DeepCopy()
+				modified.Finalizers = append(modified.Finalizers, "test-finalizer")
+
+				return fakeClient, original, modified
+			},
+			expectError: false,
+		},
+		{
+			name: "Error when object doesn't exist",
+			setupFunc: func() (client.Client, client.Object, client.Object) {
+				scheme := runtime.NewScheme()
+				err := cnsoperatorapis.AddToScheme(scheme)
+				if err != nil {
+					t.Fatalf("Failed to add scheme: %v", err)
+				}
+
+				original := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "non-existent-volume",
+						Namespace: "test-namespace",
+					},
+				}
+
+				// Create client without the object
+				fakeClient := ctrlruntimefake.NewClientBuilder().
+					WithScheme(scheme).
+					Build()
+
+				modified := original.DeepCopy()
+				modified.Status.VolumeStatus = []cnsvolumemetadatav1alpha1.CnsVolumeMetadataVolumeStatus{
+					{
+						VolumeName: "volume1",
+						Updated:    true,
+					},
+				}
+
+				return fakeClient, original, modified
+			},
+			expectError: true,
+		},
+		{
+			name: "No changes needed - identical objects",
+			setupFunc: func() (client.Client, client.Object, client.Object) {
+				scheme := runtime.NewScheme()
+				err := cnsoperatorapis.AddToScheme(scheme)
+				if err != nil {
+					t.Fatalf("Failed to add scheme: %v", err)
+				}
+
+				original := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-volume",
+						Namespace: "test-namespace",
+					},
+					Spec: cnsvolumemetadatav1alpha1.CnsVolumeMetadataSpec{
+						VolumeNames: []string{"volume1"},
+						EntityType:  cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV,
+					},
+				}
+
+				fakeClient := ctrlruntimefake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(original).
+					Build()
+
+				// Modified is identical to original
+				modified := original.DeepCopy()
+
+				return fakeClient, original, modified
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient, original, modified := tt.setupFunc()
+
+			err := k8s.PatchObject(ctx, fakeClient, original, modified)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				// Verify the object was actually patched by retrieving it
+				if !tt.expectError {
+					retrieved := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}
+					key := types.NamespacedName{
+						Name:      original.GetName(),
+						Namespace: original.GetNamespace(),
+					}
+					err := fakeClient.Get(ctx, key, retrieved)
+					assert.NoError(t, err)
+
+					// For successful patches, verify the changes were applied
+					if tt.name == "Successful patch with status update" {
+						assert.True(t, retrieved.Status.VolumeStatus[0].Updated)
+					} else if tt.name == "Successful patch with finalizer addition" {
+						assert.Contains(t, retrieved.Finalizers, "test-finalizer")
+					}
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use PATCH API for CnsVolumeMetadata and CnsFileAccessConfig updates since UPDATE API fails sometimes due to resource version conflicts.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
VKS pipeline:

```
<br> PR 3779<br>
Ran 6 of 1846 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 1840 Skipped | 0 Flaked
```

WCP Pipeline:
```
<br> PR 3779<br>
Ran 15 of 1846 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 1831 Skipped | 0 Flaked
```

Created a volume in Guest Cluster:
```
kubectl create -f pvc.yaml
```

Verified creation & patching of cnsvolumemetadata in Supervisor:
```
kubectl get cnsvolumemetadata -A
NAMESPACE             NAME                                                                        AGE
test-gc-e2e-demo-ns   eb5f3049-0be6-4b03-b8ba-71586cd74cdd-4bba74fa-e480-4070-813c-5339c84beb40   72s
test-gc-e2e-demo-ns   eb5f3049-0be6-4b03-b8ba-71586cd74cdd-727ae0f3-75b3-4465-a686-35e2b866fed4   72s
```

Created file volumes & pods to verify cnsfileaccessconfig patch operations. Pasting CSI Syncer Logs
```
2025-12-02T23:25:13.745Z	INFO	cnsvolumemetadata/cnsvolumemetadata_controller.go:527	ReconcileCnsVolumeMetadata: Successfully updated entry in CNS for instance with name "pvc-9ea201ae-4f8b-4ad9-9501-0f9e4d5aa27c" and entity type "PERSISTENT_VOLUME" in the guest cluster "eb5f3049-0be6-4b03-b8ba-71586cd74cdd".
2025-12-02T23:25:13.763Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-33589f8f-3db5-49af-ae43-735d45efb2f9
```

```
kubectl logs vsphere-csi-controller-7fc7df7864-hg57b -c vsphere-syncer -n vmware-system-csi | grep "PatchObject: Successfully patched object"
2025-12-02T23:24:53.169Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-4bba74fa-e480-4070-813c-5339c84beb40
2025-12-02T23:24:53.246Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-727ae0f3-75b3-4465-a686-35e2b866fed4
2025-12-02T23:24:54.156Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-9e88e7e0-77a7-4db6-b310-0801a7b5d56c
2025-12-02T23:24:54.156Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-b6b6291f-a6f3-4e80-b975-a03b77256da6
2025-12-02T23:24:54.341Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-dbcb5e02-de4d-48b3-9131-e8d415fcc6d8
2025-12-02T23:25:06.037Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-4bba74fa-e480-4070-813c-5339c84beb40
2025-12-02T23:25:09.950Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-727ae0f3-75b3-4465-a686-35e2b866fed4
2025-12-02T23:25:10.934Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-33589f8f-3db5-49af-ae43-735d45efb2f9
2025-12-02T23:25:10.971Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-9ea201ae-4f8b-4ad9-9501-0f9e4d5aa27c
2025-12-02T23:25:12.987Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-9ea201ae-4f8b-4ad9-9501-0f9e4d5aa27c
2025-12-02T23:25:13.763Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-33589f8f-3db5-49af-ae43-735d45efb2f9
2025-12-02T23:35:19.542Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-4466d061-d18b-4c1f-9f28-f335dd677486
2025-12-02T23:35:19.556Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-15af5960-cad4-4e98-a343-8a70d366180a
2025-12-02T23:35:32.988Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-4466d061-d18b-4c1f-9f28-f335dd677486
2025-12-02T23:35:39.631Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-15af5960-cad4-4e98-a343-8a70d366180a
2025-12-02T23:39:50.480Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/test-cluster-e2e-script-node-pool-1-cbsfb-vdmfq-9mktl-eb5f3049-0be6-4b03-b8ba-71586cd74cdd-15af5960-cad4-4e98-a343-8a70d366180a
2025-12-02T23:39:50.489Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/test-cluster-e2e-script-node-pool-1-cbsfb-vdmfq-j588g-eb5f3049-0be6-4b03-b8ba-71586cd74cdd-15af5960-cad4-4e98-a343-8a70d366180a
2025-12-02T23:39:50.703Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-15af5960-cad4-4e98-a343-8a70d366180a
2025-12-02T23:39:50.708Z	DEBUG	kubernetes/kubernetes.go:872	PatchObject: Successfully patched object test-gc-e2e-demo-ns/eb5f3049-0be6-4b03-b8ba-71586cd74cdd-15af5960-cad4-4e98-a343-8a70d366180a
root@421b5ae3d13950bcdb6eaedb2de2bae3 [ ~ ]# kubectl get cnsfileaccessconfig -A
NAMESPACE             NAME                                                                                                                              AGE
test-gc-e2e-demo-ns   test-cluster-e2e-script-node-pool-1-cbsfb-vdmfq-9mktl-eb5f3049-0be6-4b03-b8ba-71586cd74cdd-15af5960-cad4-4e98-a343-8a70d366180a   2m44s
test-gc-e2e-demo-ns   test-cluster-e2e-script-node-pool-1-cbsfb-vdmfq-j588g-eb5f3049-0be6-4b03-b8ba-71586cd74cdd-15af5960-cad4-4e98-a343-8a70d366180a   2m44s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use PATCH API for CnsVolumeMetadata and CnsFileAccessConfig updates
```
