### PR TITLE
During batch attach, send VolumeEncrypted as true if PVC is encrypted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vmware-tanzu/vm-operator/api v1.9.1-0.20250923172217-bf5a74e51c65
 	github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa
-	github.com/vmware/govmomi v0.53.0-alpha.0.0.20251129033841-75fed5cec5e3
+	github.com/vmware/govmomi v0.53.0-alpha.0.0.20251203163802-5ce652387dac
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.43.0
 	golang.org/x/sync v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/vmware-tanzu/vm-operator/api v1.9.1-0.20250923172217-bf5a74e51c65 h1:
 github.com/vmware-tanzu/vm-operator/api v1.9.1-0.20250923172217-bf5a74e51c65/go.mod h1:nWTPpxfe4gHuuYuFcrs86+NMxfkqPk3a3IlvI8TCWak=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa h1:4MKu14YJ7J54O6QKmT4ds5EUpysWLLtQRMff73cVkmU=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa/go.mod h1:8tiuyYslzjLIUmOlXZuGKQdQP2ZgWGCVhVeyptmZYnk=
-github.com/vmware/govmomi v0.53.0-alpha.0.0.20251129033841-75fed5cec5e3 h1:KLwKVR0VvvDwAFkkJH11DhS/+acTSFTka7Iob3ZSD2U=
-github.com/vmware/govmomi v0.53.0-alpha.0.0.20251129033841-75fed5cec5e3/go.mod h1:FM3GTg002dFFN7l2/hNS0YWC4f78HTw4kvgUwAE52cM=
+github.com/vmware/govmomi v0.53.0-alpha.0.0.20251203163802-5ce652387dac h1:E3W+2J1I0B5LyIillKYVQHIb6CpslGcogt7Q+8FHT3c=
+github.com/vmware/govmomi v0.53.0-alpha.0.0.20251203163802-5ce652387dac/go.mod h1:FM3GTg002dFFN7l2/hNS0YWC4f78HTw4kvgUwAE52cM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 h1:S2dVYn90KE98chqDkyE9Z4N61UnQd+KOfgp5Iu53llk=

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -3532,6 +3532,7 @@ func constructBatchAttachSpecList(ctx context.Context, vm *cnsvsphere.VirtualMac
 			Sharing:         volume.SharingMode,
 			DiskMode:        volume.DiskMode,
 			BackingTypeName: cnstypes.CnsVolumeBackingType(volume.BackingType),
+			VolumeEncrypted: volume.VolumeEncrypted,
 		}
 
 		// Set controllerKey and unitNumber only if they are provided by the user.

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -51,6 +51,8 @@ type BatchAttachRequest struct {
 	UnitNumber *int32
 	// BackingType enumerates types of backing for batch attach operations.
 	BackingType string
+
+	VolumeEncrypted *bool
 }
 
 // BatchAttachResult is the result of calling batch CNS Attach for multiple volumes.

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -1212,6 +1212,48 @@ func TestGetVolumesToAttach(t *testing.T) {
 	}
 }
 
+func TestIsPvcEncrypted(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			want:        false,
+		},
+		{
+			name:        "empty map",
+			annotations: map[string]string{},
+			want:        false,
+		},
+		{
+			name: "annotation present",
+			annotations: map[string]string{
+				PVCEncryptionClassAnnotationName: "true",
+			},
+			want: true,
+		},
+		{
+			name: "other annotations present but not encryption",
+			annotations: map[string]string{
+				"other": "value",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPvcEncrypted(tt.annotations)
+			if got != tt.want {
+				t.Errorf("isPvcEncrypted() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func MockGetVMFromVcenter(ctx context.Context, nodeUUID string,
 	configInfo config.ConfigurationInfo) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Send an additional field in CnsAttachSpec to indicate whether the PVC is encrypted or not. This will help CNS understand if they need to pick encryption path or not during attach.


**Testing done**:

With encrypted PVC:

```
{"level":"info","time":"2025-12-03T09:22:01.62312318Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:587","msg":"PVC pvc1 has encryption enabled: true","TraceId":"48ed9236-db1a-401c-8f05-6dd73b205133"}

```

```
2025-12-04T03:00:05.262Z INFO vsanvcmgmtd 1235371 [vc@4413 sub="CnsVolMgr" opId="fb3309f0"] Attaching volume with spec: (vim.cns.VolumeAttachDetachSpec) [
-->    (vim.cns.VolumeAttachDetachSpec) {
-->       volumeId = (vim.cns.VolumeId) { 
-->          id = "12a65eb2-08e3-4e86-a156-544dcf4563ce"
-->       },
-->       vm = 'vim.VirtualMachine:vm-1001', 
-->       diskMode = "persistent",
-->       sharing = "sharingNone", 
-->       controllerKey = 1001, 
-->       unitNumber = 0,
-->       volumeEncrypted = true, 
-->    }
--> ]
```

Without encrypted PVC:

```
{"level":"info","time":"2025-12-03T09:38:20.415135568Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:587","msg":"PVC pv-no-encrypt has encryption enabled: false","TraceId":"7e4d8bf5-1f86-4598-bdf4-31f4e86ab394"}
```

```
2025-12-04T03:02:20.506Z INFO vsanvcmgmtd 1235384 [vc@4413 sub="CnsVolMgr" opId="fb330c5f"] Attaching volume with spec: (vim.cns.VolumeAttachDetachSpec) [
-->    (vim.cns.VolumeAttachDetachSpec) {
-->       volumeId = (vim.cns.VolumeId) { 
-->          id = "d3171b93-a492-49f8-b39b-ae489a99aac9"
-->       },
-->       vm = 'vim.VirtualMachine:vm-1002', 
-->       diskMode = "persistent",
-->       sharing = "sharingNone", 
-->       controllerKey = 1000, 
-->       unitNumber = 11,
-->       volumeEncrypted = false,
-->    }
--> ]
```

Observed that attach was successful in both the cases.
