### PR TITLE
Fix - Incorrect volume detach watch in Guest cluster

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1100,6 +1100,13 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	return resp, err
 }
 
+// `:detaching` suffix is added by VM Operator to the volume name in the VM status
+// that is in the process of being detached.
+// removeDetachingSuffixFromVolumeName removes the suffix from the volume name.
+func removeDetachingSuffixFromVolumeName(volumeName string) string {
+	return strings.TrimSuffix(volumeName, ":detaching")
+}
+
 // controllerUnpublishForBlockVolume is helper method to handle ControllerPublishVolume for Block volumes
 func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest, c *controller) (
 	*csi.ControllerUnpublishVolumeResponse, string, error) {
@@ -1150,7 +1157,8 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 	}
 	isVolumePresentInVMStatus := false
 	for _, volume := range virtualMachine.Status.Volumes {
-		if volume.Name == req.VolumeId {
+		name := removeDetachingSuffixFromVolumeName(volume.Name)
+		if name == req.VolumeId {
 			isVolumePresentInVMStatus = true
 		}
 	}
@@ -1197,7 +1205,8 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 			case watch.Added, watch.Modified:
 				isVolumeDetached = true
 				for _, volume := range vm.Status.Volumes {
-					if volume.Name == req.VolumeId {
+					name := removeDetachingSuffixFromVolumeName(volume.Name)
+					if name == req.VolumeId {
 						log.Debugf("Volume %q still exists in VirtualMachine %q status", volume.Name, virtualMachine.Name)
 						isVolumeDetached = false
 						if volume.Attached && volume.Error != "" {


### PR DESCRIPTION
## Summary

Fixes guest cluster volume detachment bug where VM Operator's `:detaching` suffix caused premature exit from unpublish workflow. The guest CSI driver now correctly strips the suffix and waits for actual volume removal.

## Problem

VM Operator adds `:detaching` suffix to volume names during detachment (e.g., `pvc-12345:detaching`). Guest CSI driver's exact string matching in [`controllerUnpublishForBlockVolume()`](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/csi/service/wcpguest/controller.go#L1104) failed to find the volume, incorrectly assuming it was already removed, causing premature exit.

## Solution

Added `removeDetachingSuffixFromVolumeName()` helper function to strip `:detaching` suffix at two locations in `controllerUnpublishForBlockVolume()`:

- Initial volume check before watch loop
- Inside watch loop for each VM status update

## Testing done

### Test Environment

- Guest Cluster: Kubernetes v1.31.11 (TKG)
- Supervisor Cluster: vSphere 9.1

### Test Scenario

1. Created PVC and Pod in guest cluster
2. Scaled down supervisor CSI (simulating failure)
3. Deleted Pod to trigger detachment
4. Verified guest CSI continuously watches without premature exit
5. Scaled up supervisor CSI
6. Confirmed successful detachment completion

### Pre-Fix Behavior (Buggy)

- Volume detachment exited after ~1 second (premature)
- Did NOT strip `:detaching` suffix
- Result[Premature Exit]: ❌ FAILED

### Post-Fix Behavior (Corrected)

- Watched for ~3 min 18 sec until completion
- Correctly stripped `:detaching` suffix on every check
- Volume successfully removed from VM status
- Result[Waited for detach successfully]: ✅ PASSED
- Logs
     ```
  {"level":"info","time":"2025-12-03T07:28:28.510695632Z","caller":"utils/utils.go:336","msg":"PatchVirtualMachine: successfully patched the virtualmachine, name: test-detach-cluster-node-pool-01-sqk2k-rvn7h-mv4g4","TraceId":"cf05f520-d292-4ffd-bd2d-87243ddaf0c6"}
  {"level":"info","time":"2025-12-03T07:28:28.514249903Z","caller":"wcpguest/controller.go:1160","msg":"Name of the volume before split 80f09f5a-80c8-4bed-b000-5d34b9b5d3c4-785c3159-e7b1-4916-ac8c-f978c0faddb4","TraceId":"cf05f520-d292-4ffd-bd2d-87243ddaf0c6"}
  {"level":"info","time":"2025-12-03T07:28:28.515729347Z","caller":"wcpguest/controller.go:1162","msg":"Name of the volume after split 80f09f5a-80c8-4bed-b000-5d34b9b5d3c4-785c3159-e7b1-4916-ac8c-f978c0faddb4","TraceId":"cf05f520-d292-4ffd-bd2d-87243ddaf0c6"}
  -------
  {"level":"info","time":"2025-12-03T07:31:46.654603894Z","caller":"wcpguest/controller.go:1212","msg":"Name of the volume after split 80f09f5a-80c8-4bed-b000-5d34b9b5d3c4-785c3159-e7b1-4916-ac8c-f978c0faddb4","TraceId":"cf05f520-d292-4ffd-bd2d-87243ddaf0c6"}
  {"level":"info","time":"2025-12-03T07:31:46.716854693Z","caller":"wcpguest/controller.go:1232","msg":"ControllerUnpublishVolume: Volume detached successfully \"80f09f5a-80c8-4bed-b000-5d34b9b5d3c4-785c3159-e7b1-4916-ac8c-f978c0faddb4\"","TraceId":"cf05f520-d292-4ffd-bd2d-87243ddaf0c6"}
  {"level":"info","time":"2025-12-03T07:31:46.727508468Z","caller":"wcpguest/controller.go:1096","msg":"Volume \"80f09f5a-80c8-4bed-b000-5d34b9b5d3c4-785c3159-e7b1-4916-ac8c-f978c0faddb4\" detached successfully from node \"test-detach-cluster-node-pool-01-sqk2k-rvn7h-mv4g4\".","TraceId":"cf05f520-d292-4ffd-bd2d-87243ddaf0c6"}
  ```

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
Fix guest cluster volume detachment handling :detaching suffix from VM Operator
```
