### PR TITLE
Fix RWO upgrade attachment issue

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -379,6 +379,10 @@ const (
 	// It is added on the PVC during static volume provisioning
 	// and is used to specify the `CnsBackingType` during volume attachment.
 	AnnKeyBackingDiskType = "cns.vmware.com.protected/disk-backing"
+
+	// PvcUIDLabelKey is a label which gets added to CnsNodeVMAttachment instances
+	// to indicate the PVC that it has attached.
+	PvcUIDLabelKey = "cns.vmware.com/pvc-uid"
 )
 
 // Supported container orchestrators.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

This PR takes care of the upgrade case where if after 9.1, someone tries to attach an RWO PVC to a new VM, the attach will succeed but VM power on will fail. As part of attach, batch attach will apply used-by annotation.

If this PVC is then detached from the second VM, batchattach will end up removing the finalizer from the PVC. Which means PVC will get deleted even though it is still attached to the first VM.

To ensure such a situation does not happen, on upgrade to 9.1, CSI will apply a label on CnsNodeVMAttachment CRs as part of the reconcilier which will indicate the PVC that is attached to the VM using the old CnsNodeVMAttachment CR.

In batchattach controller, CSI will first ensure that no such CnsNodeVMAttachment CR exists before removing the finalizer from the PVC.

**Testing done**:

Label got added to CnsNodeVmAttachment after enabling capability:

```
Name:         vm-test-upgrade-pv-upgrade-1
Namespace:    test
Labels:       cns.vmware.com/pvc-uid=9520698d-e4a4-43d2-b541-78da92b06abe
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsNodeVmAttachment
```


Attached the same PVC to another VM, PVC got used-by annotation:

```
Name:          pv-upgrade-1
Namespace:     test
StorageClass:  vsan-default-storage-policy
Status:        Bound
Volume:        pvc-9520698d-e4a4-43d2-b541-78da92b06abe
Labels:        <none>
Annotations:   cns.vmware.com/usedby-vm-09c9142a-140a-47e3-a254-29a76699f4b3: 
               csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Fri Dec  5 10:26:15 UTC 2025
Finalizers:    [kubernetes.io/pvc-protection cns.vmware.com/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                          Message
  ----    ------                 ----               ----                                                                                          -------
  Normal  Provisioning           17m                csi.vsphere.vmware.com_422ba6cf5f02e97607746192d4ed4b17_ec7019b3-b52a-466a-b470-dc1d2e28d195  External provisioner is provisioning volume for claim "test/pv-upgrade-1"
  Normal  ProvisioningSucceeded  16m                csi.vsphere.vmware.com_422ba6cf5f02e97607746192d4ed4b17_ec7019b3-b52a-466a-b470-dc1d2e28d195  Successfully provisioned volume pvc-9520698d-e4a4-43d2-b541-78da92b06abe
  Normal  ExternalProvisioning   16m (x8 over 18m)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.

```


Detached the PVC from the second VM.
Used by annotation is removed, CNS finalizer is still present

```
Name:          pv-upgrade-1
Namespace:     test
StorageClass:  vsan-default-storage-policy
Status:        Bound
Volume:        pvc-9520698d-e4a4-43d2-b541-78da92b06abe
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Fri Dec  5 10:26:15 UTC 2025
Finalizers:    [kubernetes.io/pvc-protection cns.vmware.com/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                          Message
  ----    ------                 ----               ----                                                                                          -------
  Normal  Provisioning           17m                csi.vsphere.vmware.com_422ba6cf5f02e97607746192d4ed4b17_ec7019b3-b52a-466a-b470-dc1d2e28d195  External provisioner is provisioning volume for claim "test/pv-upgrade-1"
  Normal  ProvisioningSucceeded  17m                csi.vsphere.vmware.com_422ba6cf5f02e97607746192d4ed4b17_ec7019b3-b52a-466a-b470-dc1d2e28d195  Successfully provisioned volume pvc-9520698d-e4a4-43d2-b541-78da92b06abe

```

Syncer logs confirm that the finalizer was not removed as part of detach call:

```
{"level":"info","time":"2025-12-05T10:39:38.501360146Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:236","msg":"Acquired lock for instance test/test-upgrade","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:38.517061332Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:643","msg":"Obtained VM object for VM 09c9142a-140a-47e3-a254-29a76699f4b3 from VC","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:38.517603729Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:362","msg":"Deletion timestamp observed on instance test/test-upgrade. Detaching all volumes.","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:38.51777552Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:458","msg":"Detach call started for PVC pv-upgrade-1 with volumeID 9520698d-e4a4-43d2-b541-78da92b06abe in namespace test for instance test-upgrade","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:38.5473952Z","caller":"volume/listview.go:200","msg":"AddTask called for Task:task-2102","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:38.551753741Z","caller":"volume/listview.go:218","msg":"client is valid. trying to add task to listview object","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:38.563125573Z","caller":"volume/listview.go:241","msg":"task Task:task-2102 added to listView","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.682950659Z","caller":"volume/listview.go:267","msg":"client is valid. trying to remove task from listview object","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.688412268Z","caller":"volume/listview.go:273","msg":"task Task:task-2102 removed from listView","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.68856584Z","caller":"volume/manager.go:1263","msg":"DetachVolume: volumeID: \"9520698d-e4a4-43d2-b541-78da92b06abe\", vm: \"VirtualMachine:vm-1024 [VirtualCenterHost: lvn-dvm-10-161-106-130.dvm.lvn.broadcom.net, UUID: 09c9142a-140a-47e3-a254-29a76699f4b3, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: lvn-dvm-10-161-106-130.dvm.lvn.broadcom.net]]\", opId: \"fb388046\"","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.689527946Z","caller":"volume/manager.go:1313","msg":"DetachVolume: Volume detached successfully. volumeID: \"9520698d-e4a4-43d2-b541-78da92b06abe\", vm: \"VirtualMachine:vm-1024 [VirtualCenterHost: lvn-dvm-10-161-106-130.dvm.lvn.broadcom.net, UUID: 09c9142a-140a-47e3-a254-29a76699f4b3, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: lvn-dvm-10-161-106-130.dvm.lvn.broadcom.net]]\", opId: \"fb388046\"","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.689716391Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:889","msg":"Acquired lock for PVC test/pv-upgrade-1","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.690143791Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:755","msg":"Removing annotation cns.vmware.com/usedby-vm-09c9142a-140a-47e3-a254-29a76699f4b3 from PVC pv-upgrade-1","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.690278379Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:777","msg":"Patching PVC pv-upgrade-1 with updated annotation","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.731899786Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:920","msg":"Successfully updated annotations on PVC pv-upgrade-1 for VM 09c9142a-140a-47e3-a254-29a76699f4b3","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.747932755Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:811","msg":"PVC pv-upgrade-1 does not contain any annotations with prefix cns.vmware.com/usedby-vm-","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.754021724Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:948","msg":"PVC is attached to a VM via CnsNodeVMAttachment CR. Skip removing finalizer","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.754171576Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:892","msg":"Released lock for PVC test/pv-upgrade-1","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.754194286Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:507","msg":"Successfully detached volume pv-upgrade-1 from VM 09c9142a-140a-47e3-a254-29a76699f4b3","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.754211709Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:482","msg":"Detach call ended for PVC pv-upgrade-1 in namespace test for instance test-upgrade","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
{"level":"info","time":"2025-12-05T10:39:39.754281917Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:79","msg":"Removing \"cns.vmware.com\" finalizer from CnsNodeVMBatchAttachment instance with name: \"test-upgrade\" on namespace: \"test\"","TraceId":"07c62ee0-b59c-4178-bd36-519f30d1c057"}
```

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/732/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/680/