### PR TITLE
Fix - Prevent account lockout during password rotation in WCP cluster

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -2,10 +2,12 @@ package vsphere
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -60,4 +62,102 @@ func TestFilterSuspendedDatastoresWhenDatastoreIsNotSuspended(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(outputDsInfo))
 
+}
+
+func TestIsInvalidLoginError(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("WhenNilErr", func(tt *testing.T) {
+		// Setup - empty error
+		var err error
+
+		// Execute
+		result := IsInvalidLoginError(ctx, err)
+
+		// Verify
+		assert.False(tt, result)
+	})
+
+	t.Run("WhenSoapFaultWithInvalidLogin", func(tt *testing.T) {
+		// Setup - soap.soapFaultError containing InvalidLogin
+		// This mimics the actual error type returned by govmomi from vCenter
+		fault := &soap.Fault{
+			Code:   "ServerFaultCode",
+			String: "Cannot complete login due to an incorrect user name or password",
+			Detail: struct {
+				Fault types.AnyType "xml:\",any,typeattr\""
+			}{
+				Fault: &types.InvalidLogin{
+					VimFault: types.VimFault{
+						MethodFault: types.MethodFault{
+							FaultCause: &types.LocalizedMethodFault{
+								Fault:            nil,
+								LocalizedMessage: "Cannot complete login due to an incorrect user name or password",
+							},
+							FaultMessage: []types.LocalizableMessage{},
+						},
+					},
+				},
+			},
+		}
+		soapFault := soap.WrapSoapFault(fault)
+
+		// Execute
+		result := IsInvalidLoginError(ctx, soapFault)
+
+		// Verify
+		assert.True(tt, result)
+	})
+
+	t.Run("WhenSoapFaultWithDifferentVimFault", func(tt *testing.T) {
+		// Setup - SoapFault with a different VimFault type that is not InvalidLogin
+		fault := &soap.Fault{
+			Code:   "ServerFaultCode",
+			String: "Invalid locale",
+			Detail: struct {
+				Fault types.AnyType "xml:\",any,typeattr\""
+			}{
+				Fault: &types.InvalidLocale{
+					VimFault: types.VimFault{
+						MethodFault: types.MethodFault{
+							FaultCause: &types.LocalizedMethodFault{
+								Fault:            nil,
+								LocalizedMessage: "invalid locale",
+							},
+							FaultMessage: []types.LocalizableMessage{},
+						},
+					},
+				},
+			},
+		}
+		soapFault := soap.WrapSoapFault(fault)
+
+		// Execute
+		result := IsInvalidLoginError(ctx, soapFault)
+
+		// Verify
+		assert.False(tt, result)
+	})
+
+	t.Run("WhenErrorMessageContainsInvalidLoginText", func(tt *testing.T) {
+		// Setup - error message contains InvalidLogin text (fallback check)
+		err := errors.New("ServerFaultCode: Cannot complete login due to an incorrect user name or password")
+
+		// Execute
+		result := IsInvalidLoginError(ctx, err)
+
+		// Verify
+		assert.True(tt, result)
+	})
+
+	t.Run("WhenGenericError", func(tt *testing.T) {
+		// Setup - any other error that is not InvalidLogin
+		err := errors.New("some random connection error")
+
+		// Execute
+		result := IsInvalidLoginError(ctx, err)
+
+		// Verify
+		assert.False(tt, result)
+	})
 }


### PR DESCRIPTION
## Summary

Implements a retry mechanism with flat 3-minute delay for vCenter connection failures caused by `InvalidLogin` errors, preventing CSI driver crashes during WCP password rotation scenarios.
Addresses this issue which benefits the overall health of the Deployment by handling the login failures in both Syncer and Controller containers.

## Problem

During WCP password rotation, CSI Driver and syncer containers can fail to connect to vCenter when containers restart at the exact moment when credentials are being rotated. This causes:

1. **Immediate Container Crashes**: Containers crash with `InvalidLogin` errors without any retry attempts
2. **Service Disruption**: CSI operations become unavailable during password rotation window
3. **Account Lockout Risk**: Multiple concurrent connection attempts with wrong credentials can lock the service account

### Root Cause

WCP service rotates passwords for storage service accounts periodically. The rotation process involves:
1. WCP changes the password in vCenter
2. WCP updates the `vsphere-config-secret` in Kubernetes

If CSI containers restart between steps 1 and 2, they attempt to connect with the old password (from the secret) against the new password (in vCenter), resulting in authentication failure. Currently, the CSI driver fails immediately without any retry mechanism.

## Solution

Introduced a simple retry mechanism specifically for `InvalidLogin` errors in the `Connect()` method of `virtualcenter.go`:

1. **Detects InvalidLogin Errors**: Enhanced `IsInvalidLoginError()` helper function to identify `*types.InvalidLogin` VIM fault errors, including `soap.soapFaultError` wrapping
2. **Single Retry with 3-Minute Wait**: On `InvalidLogin`, waits 3 minutes (matching vCenter's SSO lockout window) and retries once
3. **Kubernetes-Native Recovery**: After the retry, returns error to allow Kubernetes to restart the container for fresh attempts
4. **Lockout-Proof**: 180s delay ensures each attempt happens after the previous lockout window expires, even with multiple concurrent callers
5. **Config Reload**: Reloads vCenter configuration from secret before retry to pick up updated credentials
6. **Resource Cleanup**: Properly cleans up VC client sessions between attempts

### Rationale Behind Retry Configuration

**vCenter SSO Lockout Policy (Default):**
- Maximum failed attempts: 5 attempts within 180 seconds (3 minutes)
- Sources: [vSphere 7.0](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/7-0/vsphere-security-7-0/securing-vcenter-server-systems/vcenter-server-security-best-practices/vcenter-server-password-requirements-and-lockout-behavior.html), [vSphere 8.0](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security-8-0/securing-vcenter-server-systems/vcenter-server-password-requirements-and-lockout-behavior.html), [vSphere 9.0](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/9-0/vsphere-security/securing-vcenter-server-systems/vcenter-server-password-requirements-and-lockout-behavior.html)

**Why Single Retry with 3-Minute Wait:**
- Waits exactly 180 seconds (3 minutes) - matching the lockout window duration
- By the time attempt 2 occurs (at t=180s), the lockout window from attempt 1 (at t=0s) has expired
- After one retry, exits and lets Kubernetes restart the container for fresh attempts
- This approach is lockout-proof even with multiple concurrent callers and leverages Kubernetes' native restart mechanism
- Simpler than long retry loops while providing the same safety guarantees
- Result: No lockout risk even with both syncer and controller retrying simultaneously

### Retry Behavior Per Invocation

| Attempt | Delay Before | Action After |
|---------|--------------|--------------|
| 1       | 0s           | If InvalidLogin: wait 180s |
| 2       | 180s         | If still fails: return error, let K8s restart |

**Recovery Timeline:**
- **t=0s**: Container starts, attempt 1 fails
- **t=180s**: Attempt 2 (may succeed if WCP rotated password)
- **t=180s+**: If still fails, container exits and Kubernetes restarts it for fresh attempts

This approach provides a 3-minute window for WCP password rotation per container lifecycle while guaranteeing no account lockout.

## Testing Methodology

To reproduce the bug and verify the fix, the following approach was used:

1. **Stop WCP Service**: Execute `vmon-cli --stop wcp` on the vCenter host to prevent automatic secret updates
2. **Manipulate Secret**: Modify `vsphere-config-secret` in the `vmware-system-csi` namespace with invalid credentials
3. **Restart Deployment**: Restart the CSI controller deployment to trigger connection attempts with invalid credentials
4. **Observe Retry Behavior**: Monitor logs to verify retry attempts with 180s delay
5. **Restore Service**: Execute `vmon-cli --start wcp` to allow WCP to restore correct credentials in the secret
6. **Verify Recovery**: Confirm successful connection during retry window after credentials are restored

This methodology simulates the exact race condition that occurs during WCP password rotation.

## Testing Done

### Test Environment

Tested on vCenter:
```
VMware vCenter Server
Release: 9.1.0.0
Version: 9.1.0.0
Build: 25106871
```

### Testing

**Problem Reproduction (Without Fix):**
- Deployed CSI driver from master branch
- Followed testing methodology above
- Observed immediate container crashes with `InvalidLogin` errors
- Pod entered `CrashLoopBackOff` state
- Account got locked within a few seconds

**Fix Validation (With Fix):**
- Deployed CSI driver with retry mechanism (2 attempts per container lifecycle)
- Followed testing methodology above
- Observed behavior with invalid credentials (WCP service stopped):
  - Multiple container restarts occurred (30 total restarts observed)
  - Each container lifecycle: Attempt 1 failed → waited 180s → Attempt 2 failed → container exited
  - Kubernetes automatically restarted containers after each failure
- After WCP service restarted and restored credentials:
  - WCP updated secret with correct password: `$=pyJX=ZsIT5ju]0uF$1`
  - New container lifecycle reloaded config from secret
  - **SUCCESS**: Connected immediately with restored credentials
  - Pod stabilized to `7/7 Running` status
- No account lockouts observed throughout the test

**Observed Log Output (Controller Container):**

*Phase 1 - Invalid Credentials:*
```json
{"level":"error","time":"2025-12-26T16:16:12.631787826Z","msg":"failed to login to vc. err: ServerFaultCode: Cannot complete login due to an incorrect user name or password."}
{"level":"warn","time":"2025-12-26T16:16:12.63200712Z","msg":"Unable to login to VC with invalid login error, retrying (possibly due to credential rotation)","attempt":1,"retryDelay":180,"maxAttempts":2}
```

*Phase 2 - After 180s Wait (Attempt 2 with still-invalid credentials):*
```json
{"level":"warn","time":"2025-12-26T16:19:12.632Z","msg":"Cannot connect to vCenter after all retry attempts with InvalidLogin error","attempts":2}
```

*Phase 3 - After WCP Restored Credentials:*
```json
{"level":"info","time":"2025-12-26T16:25:06.072318747Z","msg":"Reloading latest VC config from vSphere Config Secret for vcenter: \"lvn-dvm-10-192-85-165.dvm.lvn.broadcom.net\""}
{"level":"info","time":"2025-12-26T16:25:06.133530565Z","msg":"New session ID for 'VSPHERE.LOCAL\\wcp-storage-user-8279fcf7-4b4d-4091-bc34-97ada5be75ac-b2f6091d-4f30-4361-88fb-bf8a631821c6' = 5208eaba-2e7e-09c8-d2f9-bdaa9c2cd3fd"}
{"level":"info","time":"2025-12-26T16:25:06.133656048Z","msg":"VirtualCenter.connect() successfully created new client"}
```

**Results:**
- Single retry with 3-minute wait working as designed
- Kubernetes restart mechanism provided continuous retry opportunities during password rotation window
- Config reload on each container restart successfully picked up updated credentials
- No account lockout occurred (guaranteed by 180s delay matching lockout window)
- Pod stabilized to `7/7 Running` after WCP restored credentials
- Both controller and syncer containers successfully used retry mechanism
- Total recovery time: ~9 minutes (from initial failure to final stabilization)

## Safety Considerations

- **Lockout-Proof Design**: 180s delay matches vCenter's SSO lockout window, **mathematically guaranteeing** no account lockout even with multiple concurrent callers
- **Kubernetes-Native Recovery**: Leverages Kubernetes restart mechanism for additional retry opportunities beyond the single in-process retry
- **Simple & Predictable**: Single retry per container lifecycle makes behavior easy to understand and debug
- **Selective Retry**: Only retries on InvalidLogin errors; other errors fail immediately
- **Resource Cleanup**: Properly logs out of failed sessions and clears client between attempts to prevent resource leaks
- **Backward Compatible**: No behavior change for non-authentication errors
- **Config Reload**: Reloads configuration from secret before retry to pick up rotated credentials

## Pre-checkin runs
### [WCP](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/804/)
```
Ran 13 of 2324 Specs
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 2311 Skipped | 0 Flaked
```

## Special Notes for Reviewer

- This fix addresses a scenario observed in performance testing where WCP password rotation caused CSI driver outage
- Single retry with 3-minute wait chosen to mathematically guarantee no account lockout while leveraging Kubernetes' restart mechanism for extended recovery
- Simpler than long retry loops: one in-process retry + Kubernetes restarts provide sufficient recovery opportunities
- Even though the same method is used to connect to the VC in **Vanilla K8s**, the credentials are manually created and no password rotation is expected. So, no negative impact.

## Release Note

```release-note
Add retry mechanism with 3-minute delay to handle WCP password rotation gracefully
```