### PR TITLE
handle CnsNotRegisteredFault, re-register volume and continue volume operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vmware-tanzu/vm-operator/api v1.9.1-0.20250923172217-bf5a74e51c65
 	github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa
-	github.com/vmware/govmomi v0.53.0-alpha.0.0.20251203163802-5ce652387dac
+	github.com/vmware/govmomi v0.53.0-alpha.0.0.20251203213634-99f18b71ea8e
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/vmware-tanzu/vm-operator/api v1.9.1-0.20250923172217-bf5a74e51c65 h1:
 github.com/vmware-tanzu/vm-operator/api v1.9.1-0.20250923172217-bf5a74e51c65/go.mod h1:nWTPpxfe4gHuuYuFcrs86+NMxfkqPk3a3IlvI8TCWak=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa h1:4MKu14YJ7J54O6QKmT4ds5EUpysWLLtQRMff73cVkmU=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20250509154507-b93e51fc90fa/go.mod h1:8tiuyYslzjLIUmOlXZuGKQdQP2ZgWGCVhVeyptmZYnk=
-github.com/vmware/govmomi v0.53.0-alpha.0.0.20251203163802-5ce652387dac h1:E3W+2J1I0B5LyIillKYVQHIb6CpslGcogt7Q+8FHT3c=
-github.com/vmware/govmomi v0.53.0-alpha.0.0.20251203163802-5ce652387dac/go.mod h1:FM3GTg002dFFN7l2/hNS0YWC4f78HTw4kvgUwAE52cM=
+github.com/vmware/govmomi v0.53.0-alpha.0.0.20251203213634-99f18b71ea8e h1:TG9xuPu9N29Ak1gNs85VsMImNv1bd2l0yNfAMc3imOU=
+github.com/vmware/govmomi v0.53.0-alpha.0.0.20251203213634-99f18b71ea8e/go.mod h1:FM3GTg002dFFN7l2/hNS0YWC4f78HTw4kvgUwAE52cM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 h1:S2dVYn90KE98chqDkyE9Z4N61UnQd+KOfgp5Iu53llk=

--- a/pkg/common/cns-lib/volume/manager_mock.go
+++ b/pkg/common/cns-lib/volume/manager_mock.go
@@ -199,3 +199,11 @@ func (m MockManager) SyncVolume(ctx context.Context, syncVolumeSpecs []cnstypes.
 	//TODO implement me
 	panic("implement me")
 }
+
+func (m MockManager) ReRegisterVolume(ctx context.Context, volumeID string) error {
+	if m.failRequest {
+		return m.err
+	}
+
+	return nil
+}

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -632,3 +632,17 @@ func IsCnsVolumeAlreadyExistsFault(ctx context.Context, faultType string) bool {
 	log.Infof("Checking fault type: %q is vim.fault.CnsVolumeAlreadyExistsFault", faultType)
 	return faultType == "vim.fault.CnsVolumeAlreadyExistsFault"
 }
+
+// IsCnsNotRegisteredFault checks if the fault is CnsNotRegisteredFault
+func IsCnsNotRegisteredFault(ctx context.Context, fault *types.LocalizedMethodFault) bool {
+	log := logger.GetLogger(ctx)
+	if fault == nil || fault.Fault == nil {
+		log.Infof("fault is nil or fault.Fault is nil. Not a CnsNotRegisteredFault")
+		return false
+	}
+	if _, ok := fault.Fault.(*cnstypes.CnsNotRegisteredFault); ok {
+		log.Infof("observed CnsNotRegisteredFault")
+		return true
+	}
+	return false
+}

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -227,3 +227,7 @@ func (m *MockVolumeManager) SyncVolume(ctx context.Context,
 	syncVolumeSpecs []cnstypes.CnsSyncVolumeSpec) (string, error) {
 	return "", nil
 }
+
+func (m *MockVolumeManager) ReRegisterVolume(ctx context.Context, volumeID string) error {
+	return nil
+}

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -139,7 +139,7 @@ func getCommonUtilsTest(t *testing.T) *commonUtilsTest {
 			t.Fatal(err)
 		}
 
-		volumeManager, err := cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, "")
+		volumeManager, err := cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, "", "", "")
 		if err != nil {
 			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -131,6 +131,11 @@ func (m *mockVolumeManager) SyncVolume(ctx context.Context,
 	syncVolumeSpecs []cnstypes.CnsSyncVolumeSpec) (string, error) {
 	return "", nil
 }
+
+func (m *mockVolumeManager) ReRegisterVolume(ctx context.Context, volumeID string) error {
+	return nil
+}
+
 func TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsCnsVolumeNotFoundFault(t *testing.T) {
 	// Skip test on ARM64 due to gomonkey limitations
 	if runtime.GOARCH == "arm64" {

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -243,7 +243,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 
 		volumeManager, err := cnsvolume.GetManager(ctx, vcenter,
 			fakeOpStore, true, false,
-			false, cnstypes.CnsClusterFlavorVanilla)
+			false, cnstypes.CnsClusterFlavorVanilla, "", "")
 		if err != nil {
 			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/csi/service/vanilla/controller_topology_test.go
+++ b/pkg/csi/service/vanilla/controller_topology_test.go
@@ -415,7 +415,7 @@ func getControllerTestWithTopology(t *testing.T) *controllerTestTopology {
 
 		volumeManager, err := cnsvolume.GetManager(ctxtopology, vcenter,
 			fakeOpStore, true, false,
-			false, cnstypes.CnsClusterFlavorVanilla)
+			false, cnstypes.CnsClusterFlavorVanilla, "", "")
 		if err != nil {
 			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -118,7 +118,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 
 		volumeManager, err := cnsvolume.GetManager(ctx, vcenter,
 			fakeOpStore, true, false,
-			false, cnstypes.CnsClusterFlavorWorkload)
+			false, cnstypes.CnsClusterFlavorWorkload, "", "")
 		if err != nil {
 			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/syncer/byokoperator/manager.go
+++ b/pkg/syncer/byokoperator/manager.go
@@ -76,7 +76,8 @@ func NewManager(
 		return nil, err
 	}
 
-	volumeManager, err := volume.GetManager(ctx, vcClient, nil, false, false, false, clusterFlavor)
+	volumeManager, err := volume.GetManager(ctx, vcClient, nil, false,
+		false, false, clusterFlavor, configInfo.Cfg.Global.SupervisorID, configInfo.Cfg.Global.ClusterDistribution)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create an instance of volume manager: %w", err)
 	}

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -224,6 +224,10 @@ func (m *mockVolumeManager) SyncVolume(ctx context.Context,
 	return "", nil
 }
 
+func (m *mockVolumeManager) ReRegisterVolume(ctx context.Context, volumeID string) error {
+	return nil
+}
+
 type mockCOCommon struct{}
 
 func (m *mockCOCommon) ListPVCs(ctx context.Context, namespace string) []*corev1.PersistentVolumeClaim {

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -89,7 +89,14 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			return err
 		}
 
-		volumeManager, err = volumes.GetManager(ctx, vCenter, nil, false, false, false, clusterFlavor)
+		var clusterId string
+		if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+			clusterId = cnsOperator.configInfo.Cfg.Global.SupervisorID
+		} else {
+			clusterId = cnsOperator.configInfo.Cfg.Global.ClusterID
+		}
+		volumeManager, err = volumes.GetManager(ctx, vCenter, nil, false, false, false,
+			clusterFlavor, clusterId, cnsOperator.configInfo.Cfg.Global.ClusterDistribution)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -438,7 +438,8 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
 
 		volumeManager, err := volumes.GetManager(ctx, vCenter,
-			nil, false, false, false, metadataSyncer.clusterFlavor)
+			nil, false, false, false,
+			metadataSyncer.clusterFlavor, configInfo.Cfg.Global.SupervisorID, configInfo.Cfg.Global.ClusterDistribution)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 		}
@@ -509,7 +510,8 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			}
 			volumeManager, err := volumes.GetManager(ctx, vCenter,
 				nil, false, true,
-				multivCenterTopologyDeployment, metadataSyncer.clusterFlavor)
+				multivCenterTopologyDeployment, metadataSyncer.clusterFlavor, configInfo.Cfg.Global.ClusterID,
+				configInfo.Cfg.Global.ClusterDistribution)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 			}
@@ -2475,7 +2477,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 				return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 			}
 			volumeManager, err := volumes.GetManager(ctx, vcenter, nil, false, false, false,
-				metadataSyncer.clusterFlavor)
+				metadataSyncer.clusterFlavor, cfg.Global.SupervisorID, cfg.Global.ClusterDistribution)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 			}

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -103,7 +103,13 @@ func (w *DiskDecommController) detachVolumes(ctx context.Context, storagePoolNam
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to get cluster flavor. Error: %v", err)
 	}
-	volManager, err := volume.GetManager(ctx, &vc, nil, false, false, false, clusterFlavor)
+	cfg, err := config.GetConfig(ctx)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to get config. Error: %v", err)
+	}
+	volManager, err := volume.GetManager(ctx, &vc, nil, false,
+		false, false,
+		clusterFlavor, cfg.Global.SupervisorID, cfg.Global.ClusterDistribution)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
 	}

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -144,7 +144,7 @@ func TestSyncerWorkflows(t *testing.T) {
 		}
 	}()
 
-	volumeManager, err = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, "")
+	volumeManager, err = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, "", "", "")
 	if err != nil {
 		t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This commit adds handling for CnsNotRegisteredFault in various CNS volume
operations for the WORKLOAD cluster flavor. When a volume operation fails
with CnsNotRegisteredFault, the driver now attempts to re-register the
volume with CNS and retries the operation.

Changes include:
- Add clusterId and clusterDistribution parameters to GetManager() for
  volume re-registration
- Add ReRegisterVolume() public method to re-register unregistered volumes
- Add IsCnsNotRegisteredFault() helper to detect the fault type
- Add IsCnsVolumeAlreadyExistsFault() helper for idempotent re-registration
- Handle CnsNotRegisteredFault in:
  - AttachVolume
  - DetachVolume
  - DeleteVolume (with improved idempotency)
  - UpdateVolumeMetadata
  - UpdateVolumeCrypto
  - ExpandVolume (with improved idempotency)
  - CreateSnapshot (with improved idempotency and with transaction)
  - DeleteSnapshot
  - RelocateVolume (in migrationController)

The re-registration is only attempted once per operation to prevent
infinite loops. If re-registration fails or the retry fails, the
original error is returned.


**Testing done**:

Refer to tests and logs here - https://gist.github.com/divyenpatel/c48fddcc2bb7323fbbd168d4e035ff6a

pre-checkin runs:

- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/858/ - passed



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
handle CnsNotRegisteredFault and re-register volume
```
