### PR TITLE
Enhancement - Periodically cleanup PVCs left behind by CnsNodeVmBatchAttachment reconciler

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -68,6 +68,10 @@ const (
 	// interval after which successful CnsRegisterVolumes will be cleaned up.
 	// Current default value is set to 12 hours
 	DefaultCnsRegisterVolumesCleanupIntervalInMin = 720
+	// DefaultCnsPVCProtectionCleanupIntervalInMin is the default time interval after which
+	// orphaned PVCs will be cleaned up.
+	// Current default value is set to 10 minutes
+	DefaultCnsPVCProtectionCleanupIntervalInMin = 10
 	// DefaultVolumeMigrationCRCleanupIntervalInMin is the default time interval
 	// after which stale CnsVSphereVolumeMigration CRs will be cleaned up.
 	// Current default value is set to 2 hours.
@@ -450,6 +454,9 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 
 	if cfg.Global.CnsRegisterVolumesCleanupIntervalInMin == 0 {
 		cfg.Global.CnsRegisterVolumesCleanupIntervalInMin = DefaultCnsRegisterVolumesCleanupIntervalInMin
+	}
+	if cfg.Global.CnsPVCProtectionCleanupIntervalInMin == 0 {
+		cfg.Global.CnsPVCProtectionCleanupIntervalInMin = DefaultCnsPVCProtectionCleanupIntervalInMin
 	}
 	if cfg.Global.VolumeMigrationCRCleanupIntervalInMin == 0 {
 		cfg.Global.VolumeMigrationCRCleanupIntervalInMin = DefaultVolumeMigrationCRCleanupIntervalInMin

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -51,6 +51,9 @@ type Config struct {
 		// CnsRegisterVolumesCleanupIntervalInMin specifies the interval after which
 		// successful CnsRegisterVolumes will be cleaned up.
 		CnsRegisterVolumesCleanupIntervalInMin int `gcfg:"cnsregistervolumes-cleanup-intervalinmin"`
+		// CnsPVCProtectionCleanupIntervalInMin specifies the interval after which
+		// orphaned PVCs will be cleaned up.
+		CnsPVCProtectionCleanupIntervalInMin int `gcfg:"cnspvcprotection-cleanup-intervalinmin"`
 		// VolumeMigrationCRCleanupIntervalInMin specifies the interval after which
 		// stale CnsVSphereVolumeMigration CRs will be cleaned up.
 		VolumeMigrationCRCleanupIntervalInMin int `gcfg:"volumemigration-cr-cleanup-intervalinmin"`

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -24,6 +24,7 @@ import (
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
@@ -47,6 +48,8 @@ type FakeK8SOrchestrator struct {
 	featureStates     map[string]string
 	// CSINodeTopology instances for topology testing
 	csiNodeTopologyInstances []interface{}
+	// PVCs for testing
+	pvcs []*v1.PersistentVolumeClaim
 }
 
 // volumeMigration holds mocked migrated volume information

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -547,6 +547,27 @@ func (c *FakeK8SOrchestrator) SetCSINodeTopologyInstances(instances []interface{
 	c.csiNodeTopologyInstances = instances
 }
 
+func (c *FakeK8SOrchestrator) ListPVCs(ctx context.Context, namespace string) []*v1.PersistentVolumeClaim {
+	if namespace == "" {
+		// Return all PVCs
+		return c.pvcs
+	}
+
+	// Filter by namespace
+	var filteredPVCs []*v1.PersistentVolumeClaim
+	for _, pvc := range c.pvcs {
+		if pvc.Namespace == namespace {
+			filteredPVCs = append(filteredPVCs, pvc)
+		}
+	}
+	return filteredPVCs
+}
+
+// SetPVCs sets the PVCs for testing
+func (c *FakeK8SOrchestrator) SetPVCs(pvcs []*v1.PersistentVolumeClaim) {
+	c.pvcs = pvcs
+}
+
 // configFromVCSim starts a vcsim instance and returns config for use against the
 // vcsim instance. The vcsim instance is configured with an empty tls.Config.
 func configFromVCSim(vcsimParams VcsimParams, isTopologyEnv bool) (*config.Config, func()) {

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -128,6 +128,7 @@ type COCommonInterface interface {
 	// GetPVCNamespacedNameByUID returns the PVC's namespaced name (namespace/name) for the given UID.
 	// If the PVC is not found in the cache, it returns an empty string and false.
 	GetPVCNamespacedNameByUID(uid string) (k8stypes.NamespacedName, bool)
+	ListPVCs(ctx context.Context, namespace string) []*v1.PersistentVolumeClaim
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -47,6 +47,11 @@ type MockCOCommonInterface struct {
 	mock.Mock
 }
 
+func (m *MockCOCommonInterface) ListPVCs(ctx context.Context, namespace string) []*corev1.PersistentVolumeClaim {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *MockCOCommonInterface) GetPVCNamespacedNameByUID(uid string) (apitypes.NamespacedName, bool) {
 	//TODO implement me
 	panic("implement me")

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -226,6 +226,11 @@ func (m *mockVolumeManager) SyncVolume(ctx context.Context,
 
 type mockCOCommon struct{}
 
+func (m *mockCOCommon) ListPVCs(ctx context.Context, namespace string) []*corev1.PersistentVolumeClaim {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockCOCommon) GetPVCNamespacedNameByUID(uid string) (types.NamespacedName, bool) {
 	//TODO implement me
 	panic("implement me")

--- a/pkg/syncer/cnsoperator/manager/cleanupcustomresources_test.go
+++ b/pkg/syncer/cnsoperator/manager/cleanupcustomresources_test.go
@@ -1,0 +1,501 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
+)
+
+// createTestPVC creates a test PVC with optional finalizer, deletion timestamp, and annotations
+func createTestPVC(name, namespace string, withFinalizer bool) *corev1.PersistentVolumeClaim {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	}
+
+	if withFinalizer {
+		pvc.Finalizers = []string{cnsoperatortypes.CNSPvcFinalizer}
+	}
+
+	return pvc
+}
+
+// createTestPVCWithDeletion creates a test PVC with deletion timestamp
+func createTestPVCWithDeletion(name, namespace string, withFinalizer bool,
+	withBatchAttachAnnotation bool) *corev1.PersistentVolumeClaim {
+	pvc := createTestPVC(name, namespace, withFinalizer)
+	now := metav1.Now()
+	pvc.DeletionTimestamp = &now
+
+	if withBatchAttachAnnotation {
+		pvc.Annotations = map[string]string{
+			"cns.vmware.com/usedby-vm-ae6c8201-b485-462c-a93b-d4342b16cd68": "",
+		}
+	}
+
+	return pvc
+}
+
+// createTestBatchAttachCR creates a test CnsNodeVMBatchAttachment CR
+func createTestBatchAttachCR(name, namespace string, pvcNames []string) *v1alpha1.CnsNodeVMBatchAttachment {
+	var volumes []v1alpha1.VolumeSpec
+	for _, pvcName := range pvcNames {
+		volumes = append(volumes, v1alpha1.VolumeSpec{
+			Name: pvcName,
+			PersistentVolumeClaim: v1alpha1.PersistentVolumeClaimSpec{
+				ClaimName: pvcName,
+			},
+		})
+	}
+
+	return &v1alpha1.CnsNodeVMBatchAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.CnsNodeVMBatchAttachmentSpec{
+			Volumes: volumes,
+		},
+	}
+}
+
+// createTestBatchAttachCRWithStatus creates a test CnsNodeVMBatchAttachment CR with status
+func createTestBatchAttachCRWithStatus(name, namespace string, specPVCNames []string,
+	statusPVCNames []string) *v1alpha1.CnsNodeVMBatchAttachment {
+	cr := createTestBatchAttachCR(name, namespace, specPVCNames)
+
+	var volumeStatus []v1alpha1.VolumeStatus
+	for _, pvcName := range statusPVCNames {
+		volumeStatus = append(volumeStatus, v1alpha1.VolumeStatus{
+			Name: pvcName,
+			PersistentVolumeClaim: v1alpha1.PersistentVolumeClaimStatus{
+				ClaimName: pvcName,
+			},
+		})
+	}
+	cr.Status.VolumeStatus = volumeStatus
+
+	return cr
+}
+
+func TestCleanupPVCs(t *testing.T) {
+	// Save original function variables
+	coUtilOrig := commonco.ContainerOrchestratorUtility
+	newClientForGroupOrig := newClientForGroup
+	newForConfigOrig := newForConfig
+	defer func() {
+		commonco.ContainerOrchestratorUtility = coUtilOrig
+		newClientForGroup = newClientForGroupOrig
+		newForConfig = newForConfigOrig
+	}()
+
+	setup := func(t *testing.T, pvcs []*corev1.PersistentVolumeClaim,
+		batchAttachCRs []client.Object) *k8sfake.Clientset {
+		t.Helper()
+
+		// Setup fake k8s client for PVCs
+		var k8sObjects []runtime.Object
+		for _, pvc := range pvcs {
+			k8sObjects = append(k8sObjects, pvc)
+		}
+		fakeK8sClient := k8sfake.NewSimpleClientset(k8sObjects...)
+
+		// Setup fake controller-runtime client for batch attach CRs
+		scheme := runtime.NewScheme()
+		_ = cnsoperatorapis.AddToScheme(scheme)
+		_ = corev1.AddToScheme(scheme)
+		fakeCtrlClient := runtimefake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(batchAttachCRs...).
+			Build()
+
+		// Setup fake orchestrator
+		fakeOrch := &unittestcommon.FakeK8SOrchestrator{}
+		fakeOrch.SetPVCs(pvcs)
+		commonco.ContainerOrchestratorUtility = fakeOrch
+
+		// Override function variables to return our fake clients
+		newClientForGroup = func(ctx context.Context, config *rest.Config, groupName string) (client.Client, error) {
+			return fakeCtrlClient, nil
+		}
+		newForConfig = func(config *rest.Config) (kubernetes.Interface, error) {
+			// Return the fake clientset as kubernetes.Interface
+			return fakeK8sClient, nil
+		}
+
+		return fakeK8sClient
+	}
+
+	// Helper function to assert the complete state of all PVCs.
+	// This ensures PVCs are not accidentally deleted or modified.
+	assertPVCState := func(t *testing.T, k8sClient *k8sfake.Clientset,
+		expectedPVCs map[string]map[string]bool) {
+		t.Helper()
+
+		// expectedPVCs format: map[namespace]map[pvcName]hasFinalizer
+		// This allows us to verify the complete state of all PVCs
+
+		// Get all PVCs from the fake k8s client
+		pvcList, err := k8sClient.CoreV1().PersistentVolumeClaims("").List(
+			context.Background(), metav1.ListOptions{})
+		assert.NoError(t, err)
+
+		// Build actual state
+		actualPVCs := make(map[string]map[string]bool)
+		for _, pvc := range pvcList.Items {
+			if _, ok := actualPVCs[pvc.Namespace]; !ok {
+				actualPVCs[pvc.Namespace] = make(map[string]bool)
+			}
+			actualPVCs[pvc.Namespace][pvc.Name] = controllerutil.ContainsFinalizer(&pvc, cnsoperatortypes.CNSPvcFinalizer)
+		}
+
+		// Compare expected vs actual
+		for ns, expectedPVCsInNS := range expectedPVCs {
+			actualPVCsInNS, ok := actualPVCs[ns]
+			if !ok {
+				t.Errorf("Namespace %s: expected %d PVCs but found none", ns, len(expectedPVCsInNS))
+				continue
+			}
+
+			for pvcName, expectedHasFinalizer := range expectedPVCsInNS {
+				actualHasFinalizer, exists := actualPVCsInNS[pvcName]
+				if !exists {
+					t.Errorf("Namespace %s: PVC %s expected but not found", ns, pvcName)
+					continue
+				}
+
+				assert.Equal(t, expectedHasFinalizer, actualHasFinalizer,
+					"Namespace %s: PVC %s finalizer state mismatch", ns, pvcName)
+			}
+
+			// Check for unexpected PVCs
+			for pvcName := range actualPVCsInNS {
+				if _, expected := expectedPVCsInNS[pvcName]; !expected {
+					t.Errorf("Namespace %s: PVC %s found but not expected", ns, pvcName)
+				}
+			}
+		}
+
+		// Check for unexpected namespaces
+		for ns := range actualPVCs {
+			if _, expected := expectedPVCs[ns]; !expected {
+				t.Errorf("Namespace %s: found but not expected", ns)
+			}
+		}
+	}
+
+	t.Run("WhenNoPVCsExist", func(tt *testing.T) {
+		// Setup
+		k8sClient := setup(tt, nil, nil)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert - no PVCs should exist
+		pvcList, err := k8sClient.CoreV1().PersistentVolumeClaims("").List(
+			context.Background(), metav1.ListOptions{})
+		assert.NoError(tt, err)
+		assert.Empty(tt, pvcList.Items, "No PVCs should exist")
+	})
+
+	t.Run("WhenAllPVCsWithoutDeletionTimestamp", func(tt *testing.T) {
+		// Setup - PVCs without deletion timestamp should be ignored
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVC("pvc-1", "ns-1", true),
+			createTestPVC("pvc-2", "ns-1", true),
+		}
+		k8sClient := setup(tt, pvcs, nil)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert - PVCs should keep their finalizers (not being deleted)
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-1": true,
+				"pvc-2": true,
+			},
+		})
+	})
+
+	t.Run("WhenPVCsWithoutFinalizer", func(tt *testing.T) {
+		// Setup - PVCs without CNS finalizer should be ignored
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVCWithDeletion("pvc-1", "ns-1", false, true),
+			createTestPVCWithDeletion("pvc-2", "ns-1", false, true),
+		}
+		k8sClient := setup(tt, pvcs, nil)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert - PVCs should remain without finalizers
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-1": false,
+				"pvc-2": false,
+			},
+		})
+	})
+
+	t.Run("WhenPVCsWithoutBatchAttachAnnotation", func(tt *testing.T) {
+		// Setup - PVCs without batch attach annotation should be ignored
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVCWithDeletion("pvc-1", "ns-1", true, false),
+			createTestPVCWithDeletion("pvc-2", "ns-1", true, false),
+		}
+		k8sClient := setup(tt, pvcs, nil)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert - PVCs should keep their finalizers (not batch attach PVCs)
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-1": true,
+				"pvc-2": true,
+			},
+		})
+	})
+
+	t.Run("WhenOrphanedBatchAttachPVCsExist", func(tt *testing.T) {
+		// Setup - PVCs with deletion timestamp, finalizer, and batch attach annotation but no CRs
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVCWithDeletion("pvc-1", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-2", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-3", "ns-2", true, true),
+		}
+		k8sClient := setup(tt, pvcs, nil)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert - all PVCs should have finalizers removed (orphaned)
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-1": false,
+				"pvc-2": false,
+			},
+			"ns-2": {
+				"pvc-3": false,
+			},
+		})
+	})
+
+	t.Run("WhenPVCsReferencedInBatchAttachCRSpec", func(tt *testing.T) {
+		// Setup - PVCs referenced in CR spec should keep finalizers
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVCWithDeletion("pvc-1", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-2", "ns-1", true, true),
+		}
+		batchAttachCRs := []client.Object{
+			createTestBatchAttachCR("batch-1", "ns-1", []string{"pvc-1", "pvc-2"}),
+		}
+		k8sClient := setup(tt, pvcs, batchAttachCRs)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert - PVCs should keep their finalizers (referenced in CR spec)
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-1": true,
+				"pvc-2": true,
+			},
+		})
+	})
+
+	t.Run("WhenPVCsReferencedInBatchAttachCRStatus", func(tt *testing.T) {
+		// Setup - PVCs referenced in CR status should keep finalizers
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVCWithDeletion("pvc-1", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-2", "ns-1", true, true),
+		}
+		batchAttachCRs := []client.Object{
+			createTestBatchAttachCRWithStatus("batch-1", "ns-1", []string{}, []string{"pvc-1", "pvc-2"}),
+		}
+		k8sClient := setup(tt, pvcs, batchAttachCRs)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert - PVCs should keep their finalizers (referenced in CR status)
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-1": true,
+				"pvc-2": true,
+			},
+		})
+	})
+
+	t.Run("WhenPartialPVCsReferencedInBatchAttachCRs", func(tt *testing.T) {
+		// Setup - Some PVCs are referenced in batch attach CRs, others are orphaned
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVCWithDeletion("pvc-1", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-2", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-3", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-4", "ns-2", true, true),
+			createTestPVCWithDeletion("pvc-5", "ns-2", true, true),
+		}
+		// Only reference pvc-1 and pvc-4 in batch attach CRs
+		batchAttachCRs := []client.Object{
+			createTestBatchAttachCR("batch-1", "ns-1", []string{"pvc-1"}),
+			createTestBatchAttachCR("batch-2", "ns-2", []string{"pvc-4"}),
+		}
+		k8sClient := setup(tt, pvcs, batchAttachCRs)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert - only pvc-1 and pvc-4 should keep finalizers, others should have them removed
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-1": true,  // Referenced in CR, keeps finalizer
+				"pvc-2": false, // Not referenced, finalizer removed
+				"pvc-3": false, // Not referenced, finalizer removed
+			},
+			"ns-2": {
+				"pvc-4": true,  // Referenced in CR, keeps finalizer
+				"pvc-5": false, // Not referenced, finalizer removed
+			},
+		})
+	})
+
+	t.Run("WhenMultipleCRsInSameNamespace", func(tt *testing.T) {
+		// Setup - Multiple CRs in the same namespace
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVCWithDeletion("pvc-1", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-2", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-3", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-4", "ns-1", true, true),
+		}
+		batchAttachCRs := []client.Object{
+			createTestBatchAttachCR("batch-1", "ns-1", []string{"pvc-1"}),
+			createTestBatchAttachCR("batch-2", "ns-1", []string{"pvc-2"}),
+			createTestBatchAttachCRWithStatus("batch-3", "ns-1", []string{}, []string{"pvc-3"}),
+		}
+		k8sClient := setup(tt, pvcs, batchAttachCRs)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert - pvc-1, pvc-2, pvc-3 should keep finalizers, pvc-4 should have it removed
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-1": true,  // Referenced in batch-1 spec
+				"pvc-2": true,  // Referenced in batch-2 spec
+				"pvc-3": true,  // Referenced in batch-3 status
+				"pvc-4": false, // Not referenced, finalizer removed
+			},
+		})
+	})
+
+	t.Run("WhenMixedPVCStates", func(tt *testing.T) {
+		// Setup - Mix of different PVC states
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVC("pvc-no-deletion", "ns-1", true),                      // No deletion timestamp
+			createTestPVCWithDeletion("pvc-no-finalizer", "ns-1", false, true),  // No finalizer
+			createTestPVCWithDeletion("pvc-no-annotation", "ns-1", true, false), // No batch attach annotation
+			createTestPVCWithDeletion("pvc-orphaned", "ns-1", true, true),       // Orphaned
+			createTestPVCWithDeletion("pvc-referenced", "ns-1", true, true),     // Referenced in CR
+		}
+		batchAttachCRs := []client.Object{
+			createTestBatchAttachCR("batch-1", "ns-1", []string{"pvc-referenced"}),
+		}
+		k8sClient := setup(tt, pvcs, batchAttachCRs)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-no-deletion":   true,  // No deletion timestamp, keeps finalizer
+				"pvc-no-finalizer":  false, // No finalizer to begin with
+				"pvc-no-annotation": true,  // No batch attach annotation, keeps finalizer
+				"pvc-orphaned":      false, // Orphaned, finalizer removed
+				"pvc-referenced":    true,  // Referenced in CR, keeps finalizer
+			},
+		})
+	})
+
+	t.Run("WhenMultipleNamespacesWithMixedStates", func(tt *testing.T) {
+		// Setup - Multiple namespaces with different states
+		pvcs := []*corev1.PersistentVolumeClaim{
+			createTestPVCWithDeletion("pvc-1", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-2", "ns-1", true, true),
+			createTestPVCWithDeletion("pvc-3", "ns-2", true, true),
+			createTestPVCWithDeletion("pvc-4", "ns-2", true, true),
+			createTestPVCWithDeletion("pvc-5", "ns-3", true, true),
+		}
+		batchAttachCRs := []client.Object{
+			createTestBatchAttachCR("batch-1", "ns-1", []string{"pvc-1"}),
+			// ns-2 has no CRs - all PVCs are orphaned
+			createTestBatchAttachCR("batch-3", "ns-3", []string{"pvc-5"}),
+		}
+		k8sClient := setup(tt, pvcs, batchAttachCRs)
+
+		// Execute
+		cleanupOrphanedBatchAttachPVCs(context.Background(), rest.Config{})
+
+		// Assert
+		assertPVCState(tt, k8sClient, map[string]map[string]bool{
+			"ns-1": {
+				"pvc-1": true,  // Referenced in CR
+				"pvc-2": false, // Orphaned
+			},
+			"ns-2": {
+				"pvc-3": false, // Orphaned
+				"pvc-4": false, // Orphaned
+			},
+			"ns-3": {
+				"pvc-5": true, // Referenced in CR
+			},
+		})
+	})
+}


### PR DESCRIPTION
## Summary

Implements a periodic cleanup routine to remove orphaned CNS finalizers from PVCs when CnsNodeVMBatchAttachment CRs are deleted before removing PVC finalizers, preventing stuck PVCs and blocked namespace deletions.

## Problem

During namespace deletion or manual disk detachment scenarios, the CnsNodeVMBatchAttachment reconciler can remove the finalizer from the CRD before removing finalizers from associated PVCs. This causes:

1. **Stuck PVCs**: PVCs remain in terminating state indefinitely with `cns.vmware.com/pvc-protection` finalizer
2. **Blocked Namespace Deletion**: Namespaces cannot be deleted due to stuck PVCs
3. **Resource Leaks**: Orphaned resources requiring manual intervention

### Root Cause

The issue manifests in scenarios where a volume entry is removed from the CnsNodeVmBatchAttach spec and the underlying VM is deleted simulatenously.
In such scenarios, the finalizer from the LOST PVC never gets removed leaving it perpetually stuck in terminating state.

## Solution

Introduced `cleanupOrphanedBatchAttachPVCs()` cleanup routine that:

1. **Identifies Orphaned PVCs**: Lists all PVCs with `cns.vmware.com/pvc-protection` finalizer
2. **Validates Against Active CRs**: Checks if PVC is still referenced in any CnsNodeVMBatchAttachment CR spec
3. **Removes Orphaned Finalizers**: Safely removes finalizers from PVCs not referenced in any active CR

It runs periodically similar to existing CnsRegisterVolume and CnsUnregisterVolume cleanup routines.

## Testing Done

### Test Summary

Validated the cleanup routine across upgrade path and various attachment scenarios:

| Phase | Scenario | Expected Behavior | Result |
|-------|----------|------------------|--------|
| Before enabling supports_shared_disks_with_VM_service_VMs | Legacy VM with CnsNodeVmAttachment | PVCs ignored (no batch annotation) | PASS |
| After enabling supports_shared_disks_with_VM_service_VMs | PVC attached to Pod | PVC ignored (no batch annotation) | PASS |
| After enabling supports_shared_disks_with_VM_service_VMs | PVC actively attached to VM | Finalizer preserved (in CR spec) | PASS |
| After enabling supports_shared_disks_with_VM_service_VMs | Orphaned PVCs (5 total) | Finalizers removed, PVCs deleted | PASS |

### Test Scenarios

#### Before enabling supports_shared_disks_with_VM_service_VMs (Legacy CnsNodeVmAttachment)
- Created VM with volumes using legacy CnsNodeVmAttachment (singular CRs)
- Verified PVCs have finalizer but NO batch attach annotation
- **Result**: Cleanup correctly ignored legacy PVCs

#### After enabling supports_shared_disks_with_VM_service_VMs (CnsNodeVmBatchAttachment Enabled)

**Scenario 1: PVC attached to Pod**
- PVC used by Pod (no batch attach annotation)
- **Result**: Cleanup correctly ignored

**Scenario 2: PVC actively attached to VM**
- PVC with batch attach annotation and referenced in CnsNodeVmBatchAttachment CR
- **Result**: Finalizer preserved, PVC not touched

**Scenario 3: Orphaned PVCs**
- Created 5 PVCs with finalizer and batch attach annotation
- Deleted PVCs → stuck in Terminating state
- **Result**: All 5 finalizers removed, PVCs successfully deleted

### Cleanup Logs

```
Successfully removed finalizer from PVC cns-batch-attach-bug/test-pvc-orphaned-1
Successfully removed finalizer from PVC cns-batch-attach-bug/test-pvc-orphaned-2
Successfully removed finalizer from PVC cns-batch-attach-bug/test-pvc-orphaned-3
Successfully removed finalizer from PVC cns-batch-attach-bug/test-pvc-orphaned-4
Successfully removed finalizer from PVC cns-batch-attach-bug/test-pvc-orphaned-5
```

### Verification

All test scenarios passed with 100% success rate:
- Legacy PVCs without batch annotations are not touched
- Pod-attached PVCs are correctly ignored
- Active VM-attached PVCs keep their finalizers
- Orphaned PVCs are cleaned up and deleted


## Safety Considerations

- **Conservative Approach**: Only removes finalizers from PVCs NOT in any active CR spec
- **No False Positives**: PVCs actively being processed by reconciler are preserved
- **Idempotent**: Safe to run multiple times(no effect during container restarts)
- **Cluster-Wide Scan**: Processes all namespaces to catch orphaned PVCs anywhere

## Precheckin runs
### [VKS](https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/716/)
```
Ran 6 of 1850 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 1844 Skipped | 0 Flaked
```
### [WCP](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/782)
```
Ran 13 of 1850 Specs
FAILURE! -- 12 Passed | 1 Failed | 0 Pending | 1837 Skipped | 0 Flaked
```

## Special Notes for Reviewer

- This is a safety net mechanism for edge cases, not a replacement for proper finalizer management in the reconciler
- The cleanup routine follows the exact same pattern as existing `cleanUpCnsRegisterVolumeInstances` and `cleanUpCnsUnregisterVolumeInstances` routines (infinite loop with sleep intervals)
- Tested across upgrade path to ensure backward compatibility with legacy CnsNodeVmAttachment

## Release Note

```release-note
Add periodic cleanup routine to remove orphaned CNS finalizers from PVCs when CnsNodeVMBatchAttachment CRs are deleted prematurely
```
