### PR TITLE
Enhance storageclass validation for linkedclone volume creation

### DIFF
--- a/pkg/syncer/admissionhandler/validatepvc_test.go
+++ b/pkg/syncer/admissionhandler/validatepvc_test.go
@@ -15,10 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
@@ -619,6 +621,528 @@ func TestValidatePVC(t *testing.T) {
 
 			actualResponse := validatePVC(ctx, test.admissionReview.Request)
 			assert.Equal(t, test.expectedResponse, actualResponse)
+		})
+	}
+}
+
+func TestValidateGuestPVCOperation_LinkedClone_StorageClass(t *testing.T) {
+	// Store the original feature gate value and restore it after the test
+	originalFeatureGate := featureIsLinkedCloneSupportEnabled
+	defer func() {
+		featureIsLinkedCloneSupportEnabled = originalFeatureGate
+	}()
+	featureIsLinkedCloneSupportEnabled = true
+
+	const (
+		testLinkedCloneNamespace     = "test-ns"
+		testLinkedClonePVCName       = "test-lc-pvc"
+		testSourcePVCName            = "test-source-pvc"
+		testSnapshotName             = "test-snapshot"
+		testStorageClassA            = "storage-class-a"
+		testStorageClassB            = "storage-class-b"
+		testSvStorageClass1          = "wcpglobal-storage-profile"
+		testSvStorageClass2          = "wcpglobal-storage-profile-2"
+		testLinkedCloneSnapshotClass = "test-snapshot-class"
+	)
+
+	stringPtr := func(s string) *string {
+		return &s
+	}
+
+	boolPtr := func(b bool) *bool {
+		return &b
+	}
+
+	tests := []struct {
+		name                   string
+		kubeObjs               []runtime.Object
+		snapshotObjs           []runtime.Object
+		pvc                    *corev1.PersistentVolumeClaim
+		expectedAllowed        bool
+		expectedMessageContain string
+	}{
+		{
+			name: "LinkedClone with matching svStorageClass should succeed",
+			kubeObjs: []runtime.Object{
+				// Source PVC StorageClass with svStorageClass1
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testStorageClassA,
+					},
+					Provisioner: "csi.vsphere.vmware.com",
+					Parameters: map[string]string{
+						common.AttributeSupervisorStorageClass: testSvStorageClass1,
+					},
+				},
+				// Source PVC
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSourcePVCName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: stringPtr(testStorageClassA),
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("5Gi"),
+							},
+						},
+					},
+				},
+			},
+			snapshotObjs: []runtime.Object{
+				// VolumeSnapshot
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSnapshotName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: stringPtr(testSourcePVCName),
+						},
+						VolumeSnapshotClassName: stringPtr(testLinkedCloneSnapshotClass),
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{
+						ReadyToUse: boolPtr(true),
+					},
+				},
+			},
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testLinkedClonePVCName,
+					Namespace: testLinkedCloneNamespace,
+					Annotations: map[string]string{
+						common.AnnKeyLinkedClone: "true",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr(testStorageClassA), // Same storage class
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("5Gi"),
+						},
+					},
+					DataSource: &corev1.TypedLocalObjectReference{
+						APIGroup: stringPtr("snapshot.storage.k8s.io"),
+						Kind:     "VolumeSnapshot",
+						Name:     testSnapshotName,
+					},
+				},
+			},
+			expectedAllowed:        true,
+			expectedMessageContain: "",
+		},
+		{
+			name: "LinkedClone with different StorageClass but same svStorageClass should succeed",
+			kubeObjs: []runtime.Object{
+				// Source PVC StorageClass with svStorageClass1
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testStorageClassA,
+					},
+					Provisioner: "csi.vsphere.vmware.com",
+					Parameters: map[string]string{
+						common.AttributeSupervisorStorageClass: testSvStorageClass1,
+					},
+				},
+				// LinkedClone PVC StorageClass with same svStorageClass1 but different name
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testStorageClassB,
+					},
+					Provisioner: "csi.vsphere.vmware.com",
+					Parameters: map[string]string{
+						common.AttributeSupervisorStorageClass: testSvStorageClass1, // Same supervisor storage class
+					},
+				},
+				// Source PVC
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSourcePVCName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: stringPtr(testStorageClassA),
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("5Gi"),
+							},
+						},
+					},
+				},
+			},
+			snapshotObjs: []runtime.Object{
+				// VolumeSnapshot
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSnapshotName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: stringPtr(testSourcePVCName),
+						},
+						VolumeSnapshotClassName: stringPtr(testLinkedCloneSnapshotClass),
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{
+						ReadyToUse: boolPtr(true),
+					},
+				},
+			},
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testLinkedClonePVCName,
+					Namespace: testLinkedCloneNamespace,
+					Annotations: map[string]string{
+						common.AnnKeyLinkedClone: "true",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr(testStorageClassB), // Different storage class
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("5Gi"),
+						},
+					},
+					DataSource: &corev1.TypedLocalObjectReference{
+						APIGroup: stringPtr("snapshot.storage.k8s.io"),
+						Kind:     "VolumeSnapshot",
+						Name:     testSnapshotName,
+					},
+				},
+			},
+			expectedAllowed:        true,
+			expectedMessageContain: "",
+		},
+		{
+			name: "LinkedClone with mismatched svStorageClass should fail",
+			kubeObjs: []runtime.Object{
+				// Source PVC StorageClass with svStorageClass1
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testStorageClassA,
+					},
+					Provisioner: "csi.vsphere.vmware.com",
+					Parameters: map[string]string{
+						common.AttributeSupervisorStorageClass: testSvStorageClass1,
+					},
+				},
+				// LinkedClone PVC StorageClass with different svStorageClass2
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testStorageClassB,
+					},
+					Provisioner: "csi.vsphere.vmware.com",
+					Parameters: map[string]string{
+						common.AttributeSupervisorStorageClass: testSvStorageClass2, // Different supervisor storage class
+					},
+				},
+				// Source PVC
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSourcePVCName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: stringPtr(testStorageClassA),
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("5Gi"),
+							},
+						},
+					},
+				},
+			},
+			snapshotObjs: []runtime.Object{
+				// VolumeSnapshot
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSnapshotName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: stringPtr(testSourcePVCName),
+						},
+						VolumeSnapshotClassName: stringPtr(testLinkedCloneSnapshotClass),
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{
+						ReadyToUse: boolPtr(true),
+					},
+				},
+			},
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testLinkedClonePVCName,
+					Namespace: testLinkedCloneNamespace,
+					Annotations: map[string]string{
+						common.AnnKeyLinkedClone: "true",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr(testStorageClassB), // Different storage class with different policy
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("5Gi"),
+						},
+					},
+					DataSource: &corev1.TypedLocalObjectReference{
+						APIGroup: stringPtr("snapshot.storage.k8s.io"),
+						Kind:     "VolumeSnapshot",
+						Name:     testSnapshotName,
+					},
+				},
+			},
+			expectedAllowed:        false,
+			expectedMessageContain: "svStorageClass mismatch",
+		},
+		{
+			name: "LinkedClone with missing svStorageClass in source StorageClass should fail",
+			kubeObjs: []runtime.Object{
+				// Source PVC StorageClass without svStorageClass
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testStorageClassA,
+					},
+					Provisioner: "csi.vsphere.vmware.com",
+					Parameters:  map[string]string{
+						// Missing common.AttributeSupervisorStorageClass
+					},
+				},
+				// LinkedClone PVC StorageClass with svStorageClass
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testStorageClassB,
+					},
+					Provisioner: "csi.vsphere.vmware.com",
+					Parameters: map[string]string{
+						common.AttributeSupervisorStorageClass: testSvStorageClass1,
+					},
+				},
+				// Source PVC
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSourcePVCName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: stringPtr(testStorageClassA),
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("5Gi"),
+							},
+						},
+					},
+				},
+			},
+			snapshotObjs: []runtime.Object{
+				// VolumeSnapshot
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSnapshotName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: stringPtr(testSourcePVCName),
+						},
+						VolumeSnapshotClassName: stringPtr(testLinkedCloneSnapshotClass),
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{
+						ReadyToUse: boolPtr(true),
+					},
+				},
+			},
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testLinkedClonePVCName,
+					Namespace: testLinkedCloneNamespace,
+					Annotations: map[string]string{
+						common.AnnKeyLinkedClone: "true",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr(testStorageClassB),
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("5Gi"),
+						},
+					},
+					DataSource: &corev1.TypedLocalObjectReference{
+						APIGroup: stringPtr("snapshot.storage.k8s.io"),
+						Kind:     "VolumeSnapshot",
+						Name:     testSnapshotName,
+					},
+				},
+			},
+			expectedAllowed:        false,
+			expectedMessageContain: "does not have svstorageclass parameter",
+		},
+		{
+			name: "LinkedClone with missing svStorageClass in LinkedClone StorageClass should fail",
+			kubeObjs: []runtime.Object{
+				// Source PVC StorageClass with svStorageClass
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testStorageClassA,
+					},
+					Provisioner: "csi.vsphere.vmware.com",
+					Parameters: map[string]string{
+						common.AttributeSupervisorStorageClass: testSvStorageClass1,
+					},
+				},
+				// LinkedClone PVC StorageClass without svStorageClass
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testStorageClassB,
+					},
+					Provisioner: "csi.vsphere.vmware.com",
+					Parameters:  map[string]string{
+						// Missing common.AttributeSupervisorStorageClass
+					},
+				},
+				// Source PVC
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSourcePVCName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: stringPtr(testStorageClassA),
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("5Gi"),
+							},
+						},
+					},
+				},
+			},
+			snapshotObjs: []runtime.Object{
+				// VolumeSnapshot
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSnapshotName,
+						Namespace: testLinkedCloneNamespace,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: stringPtr(testSourcePVCName),
+						},
+						VolumeSnapshotClassName: stringPtr(testLinkedCloneSnapshotClass),
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{
+						ReadyToUse: boolPtr(true),
+					},
+				},
+			},
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testLinkedClonePVCName,
+					Namespace: testLinkedCloneNamespace,
+					Annotations: map[string]string{
+						common.AnnKeyLinkedClone: "true",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr(testStorageClassB),
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("5Gi"),
+						},
+					},
+					DataSource: &corev1.TypedLocalObjectReference{
+						APIGroup: stringPtr("snapshot.storage.k8s.io"),
+						Kind:     "VolumeSnapshot",
+						Name:     testSnapshotName,
+					},
+				},
+			},
+			expectedAllowed:        false,
+			expectedMessageContain: "does not have svstorageclass parameter",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create fake clients
+			kubeClient := fake.NewSimpleClientset(test.kubeObjs...)
+			snapshotClient := snapshotclientfake.NewSimpleClientset(test.snapshotObjs...)
+
+			// Patch k8s client functions
+			patches := gomonkey.ApplyFunc(
+				k8s.NewClient, func(ctx context.Context) (clientset.Interface, error) {
+					return kubeClient, nil
+				})
+			defer patches.Reset()
+
+			patches = gomonkey.ApplyFunc(
+				k8s.NewSnapshotterClient, func(ctx context.Context) (snapshotterClientSet.Interface, error) {
+					return snapshotClient, nil
+				})
+			defer patches.Reset()
+
+			// Marshal the PVC to raw JSON
+			pvcBytes, err := json.Marshal(test.pvc)
+			assert.NoError(t, err)
+
+			// Create admission request
+			admissionReq := &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Kind: "PersistentVolumeClaim",
+				},
+				Operation: admissionv1.Create,
+				Namespace: testLinkedCloneNamespace,
+				Name:      testLinkedClonePVCName,
+				Object: runtime.RawExtension{
+					Raw: pvcBytes,
+				},
+			}
+
+			// Call the validation function
+			ctx := context.Background()
+			response := validateGuestPVCOperation(ctx, admissionReq)
+
+			// Verify the response
+			assert.Equal(t, test.expectedAllowed, response.Allowed,
+				"Expected allowed=%v but got allowed=%v. Message: %v",
+				test.expectedAllowed, response.Allowed, response.Result)
+
+			if !test.expectedAllowed && test.expectedMessageContain != "" {
+				assert.Contains(t, response.Result.Message, test.expectedMessageContain,
+					"Expected error message to contain '%s' but got: %s",
+					test.expectedMessageContain, response.Result.Message)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enhances LinkedClone PVC validation in guest clusters to compare supervisor storage class references instead of guest storage class names. This allows LinkedClone volumes to reference different guest storage classes as long as they point to the same supervisor storage class, providing more flexibility in storage class management.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Precheckins:
WCP(PASS): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/725/
VKS(PASS): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/665/

Modified the validation logic in `validateGuestPVCOperation` to fetch StorageClass objects and compare their `parameters.svStorageClass` values. Updated validation comments and error messages to reflect this change.

Added comprehensive unit tests covering five scenarios:
- LinkedClone with matching svStorageClass (same StorageClass)
- LinkedClone with different StorageClass names but same svStorageClass
- LinkedClone with mismatched svStorageClass
- LinkedClone with missing svStorageClass in source StorageClass
- LinkedClone with missing svStorageClass in LinkedClone StorageClass

Test results:
```
=== RUN   TestValidateGuestPVCOperation_LinkedClone_StorageClass
=== RUN   TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_matching_svStorageClass_should_succeed
=== RUN   TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_different_StorageClass_but_same_svStorageClass_should_succeed
=== RUN   TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_mismatched_svStorageClass_should_fail
=== RUN   TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_missing_svStorageClass_in_source_StorageClass_should_fail
=== RUN   TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_missing_svStorageClass_in_LinkedClone_StorageClass_should_fail
--- PASS: TestValidateGuestPVCOperation_LinkedClone_StorageClass (0.00s)
    --- PASS: TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_matching_svStorageClass_should_succeed (0.00s)
    --- PASS: TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_different_StorageClass_but_same_svStorageClass_should_succeed (0.00s)
    --- PASS: TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_mismatched_svStorageClass_should_fail (0.00s)
    --- PASS: TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_missing_svStorageClass_in_source_StorageClass_should_fail (0.00s)
    --- PASS: TestValidateGuestPVCOperation_LinkedClone_StorageClass/LinkedClone_with_missing_svStorageClass_in_LinkedClone_StorageClass_should_fail (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/admissionhandler	0.640s



Actual testbed testing:
root@localhost [ ~ ]# cat pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: src-pvc
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: wcpglobal-storage-profile

root@localhost [ ~ ]# cat vs-1.yaml
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: vs-1
spec:
  volumeSnapshotClassName: volumesnapshotclass-delete
  source:
    persistentVolumeClaimName: src-pvc
root@localhost [ ~ ]# cat lc-1.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
     csi.vsphere.volume/fast-provisioning : "true"
  name: vs1-lc-1
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  dataSource:
    name: vs-1
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  storageClassName: wcpglobal-storage-profile
root@localhost [ ~ ]# cat lc-2.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
     csi.vsphere.volume/fast-provisioning : "true"
  name: vs1-lc-2
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  dataSource:
    name: vs-1
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  storageClassName: wcpglobal-storage-profile-latebinding
root@localhost [ ~ ]# cat lc-3.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
     csi.vsphere.volume/fast-provisioning : "true"
  name: vs1-lc-3
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  dataSource:
    name: vs-1
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  storageClassName: testpol


Regression LC creation:

root@localhost [ ~ ]# kubectl -n testns apply -f lc-1.yaml
persistentvolumeclaim/vs1-lc-1 created


Create LC with different WFFC version of storageclass:
root@localhost [ ~ ]# kubectl -n testns apply -f lc-2.yaml
persistentvolumeclaim/vs1-lc-2 created

Create LC with different storageclass:
root@localhost [ ~ ]# kubectl -n testns apply -f lc-3.yaml
Error from server: error when creating "lc-3.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: StorageClass svStorageClass mismatch, Namespace: testns, LinkedClone StorageClass: testpol (svStorageClass: testpol), source PVC StorageClass: wcpglobal-storage-profile (svStorageClass: wcpglobal-storage-profile)
```


**Special notes for your reviewer**:

The validation now retrieves StorageClass objects via the Kubernetes API to access their parameters. Error messages include both StorageClass names and their svStorageClass parameter values for better troubleshooting. The change is backward compatible and only affects LinkedClone PVC validation in guest clusters.

RBAC changes needed - this is covered in standard package


**Release note**:
NONE