### PR TITLE
Update Periodic sync to calculate reserved for vmsnapshot spu

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -141,7 +141,8 @@ const (
 	ResourceKindSnapshot                 = "VolumeSnapshot"
 	PVCQuotaExtensionServiceName         = "volume.cns.vsphere.vmware.com"
 	SnapQuotaExtensionServiceName        = "snapshot.cns.vsphere.vmware.com"
-	VMServiceExtensionServiceName        = "vmware-system-vmop-webhook-service"
+	VMExtensionServiceName               = "vmware-system-vmop-webhook-service"
+	VMSnapshotExtensionServiceName       = "snapshot-vmware-system-vmop-webhook-service"
 	scParamStoragePolicyID               = "storagePolicyID"
 	StorageQuotaPeriodicSyncInstanceName = "storage-quota-periodic-sync"
 	FileVolumePrefix                     = "file:"
@@ -1196,7 +1197,8 @@ func calculateVMServiceStoragePolicyUsageReservedForNamespace(ctx context.Contex
 	}
 	storagePolicyToReservedMap := make(map[string]*resource.Quantity)
 	for _, storagePolicyUsage := range supList.Items {
-		if storagePolicyUsage.Spec.ResourceExtensionName == VMServiceExtensionServiceName {
+		if storagePolicyUsage.Spec.ResourceExtensionName == VMExtensionServiceName ||
+			storagePolicyUsage.Spec.ResourceExtensionName == VMSnapshotExtensionServiceName {
 			log.Debugf("calculateVMServiceStoragePolicyUsageReservedForNamespace: Processing StoragePolicyUsage"+
 				" Name: %q, Namespace: %q", storagePolicyUsage.Name, storagePolicyUsage.Namespace)
 			if storagePolicyUsage.DeletionTimestamp != nil {

--- a/pkg/syncer/metadatasyncer_test.go
+++ b/pkg/syncer/metadatasyncer_test.go
@@ -23,6 +23,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
 )
 
@@ -213,4 +217,546 @@ func quantitiesEqual(a, b map[string]*resource.Quantity) bool {
 		}
 	}
 	return true
+}
+
+// errorClient is a wrapper around a fake client that returns errors on List operations
+type errorClient struct {
+	client.Client
+	err error
+}
+
+func (e *errorClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return e.err
+}
+
+func TestCalculateVMServiceStoragePolicyUsageReservedForNamespace(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test-namespace"
+
+	tests := []struct {
+		name           string
+		setupClient    func() client.Client
+		expectedResult map[string]*resource.Quantity
+		expectError    bool
+	}{
+		{
+			name: "Success with single StoragePolicyUsage for VM extension",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				tenGi := resource.MustParse("10Gi")
+				spu := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &tenGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu).
+					Build()
+			},
+			expectedResult: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": resource.NewQuantity(tenGi.Value(), resource.BinarySI),
+				}
+			}(),
+			expectError: false,
+		},
+		{
+			name: "Success with single StoragePolicyUsage for VM snapshot extension",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				fiveGi := resource.MustParse("5Gi")
+				spu := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-2",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-2",
+						ResourceExtensionName: VMSnapshotExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &fiveGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu).
+					Build()
+			},
+			expectedResult: func() map[string]*resource.Quantity {
+				fiveGi := resource.MustParse("5Gi")
+				return map[string]*resource.Quantity{
+					"policy-2": resource.NewQuantity(fiveGi.Value(), resource.BinarySI),
+				}
+			}(),
+			expectError: false,
+		},
+		{
+			name: "Success with multiple StoragePolicyUsage objects for same policy",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				tenGi := resource.MustParse("10Gi")
+				fiveGi := resource.MustParse("5Gi")
+				spu1 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &tenGi,
+						},
+					},
+				}
+				spu2 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-2",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMSnapshotExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &fiveGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu1, spu2).
+					Build()
+			},
+			expectedResult: func() map[string]*resource.Quantity {
+				fifteenGi := resource.MustParse("15Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": resource.NewQuantity(fifteenGi.Value(), resource.BinarySI),
+				}
+			}(),
+			expectError: false,
+		},
+		{
+			name: "Success with multiple StoragePolicyUsage objects for different policies",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				tenGi := resource.MustParse("10Gi")
+				fiveGi := resource.MustParse("5Gi")
+				spu1 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &tenGi,
+						},
+					},
+				}
+				spu2 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-2",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-2",
+						ResourceExtensionName: VMSnapshotExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &fiveGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu1, spu2).
+					Build()
+			},
+			expectedResult: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				fiveGi := resource.MustParse("5Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": resource.NewQuantity(tenGi.Value(), resource.BinarySI),
+					"policy-2": resource.NewQuantity(fiveGi.Value(), resource.BinarySI),
+				}
+			}(),
+			expectError: false,
+		},
+		{
+			name: "Success with empty list",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build()
+			},
+			expectedResult: map[string]*resource.Quantity{},
+			expectError:    false,
+		},
+		{
+			name: "Success with StoragePolicyUsage filtered out - wrong ResourceExtensionName",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				tenGi := resource.MustParse("10Gi")
+				spu := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: "other-extension",
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &tenGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu).
+					Build()
+			},
+			expectedResult: map[string]*resource.Quantity{},
+			expectError:    false,
+		},
+		{
+			name: "Success with StoragePolicyUsage filtered out - marked for deletion",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				now := metav1.Now()
+				tenGi := resource.MustParse("10Gi")
+				spu := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "spu-1",
+						Namespace:         namespace,
+						DeletionTimestamp: &now,
+						Finalizers:        []string{"test-finalizer"},
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &tenGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu).
+					Build()
+			},
+			expectedResult: map[string]*resource.Quantity{},
+			expectError:    false,
+		},
+		{
+			name: "Success with StoragePolicyUsage filtered out - missing ResourceTypeLevelQuotaUsage",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				spu := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: nil,
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu).
+					Build()
+			},
+			expectedResult: map[string]*resource.Quantity{},
+			expectError:    false,
+		},
+		{
+			name: "Success with mixed valid and invalid StoragePolicyUsage objects",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				now := metav1.Now()
+				tenGi := resource.MustParse("10Gi")
+				fiveGi := resource.MustParse("5Gi")
+
+				// Valid SPU
+				spu1 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &tenGi,
+						},
+					},
+				}
+
+				// Invalid SPU - wrong extension name
+				spu2 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-2",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-2",
+						ResourceExtensionName: "other-extension",
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &fiveGi,
+						},
+					},
+				}
+
+				// Invalid SPU - marked for deletion
+				spu3 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "spu-3",
+						Namespace:         namespace,
+						DeletionTimestamp: &now,
+						Finalizers:        []string{"test-finalizer"},
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-3",
+						ResourceExtensionName: VMSnapshotExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &fiveGi,
+						},
+					},
+				}
+
+				// Invalid SPU - missing status
+				spu4 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-4",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-4",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: nil,
+					},
+				}
+
+				// Valid SPU
+				spu5 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-5",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMSnapshotExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &fiveGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu1, spu2, spu3, spu4, spu5).
+					Build()
+			},
+			expectedResult: func() map[string]*resource.Quantity {
+				fifteenGi := resource.MustParse("15Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": resource.NewQuantity(fifteenGi.Value(), resource.BinarySI),
+				}
+			}(),
+			expectError: false,
+		},
+		{
+			name: "Error when List fails",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				baseClient := fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build()
+
+				return &errorClient{
+					Client: baseClient,
+					err:    errors.New("list error"),
+				}
+			},
+			expectedResult: nil,
+			expectError:    true,
+		},
+		{
+			name: "Success with zero reserved quantity",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				zero := resource.MustParse("0Gi")
+				spu := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &zero,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu).
+					Build()
+			},
+			expectedResult: map[string]*resource.Quantity{
+				"policy-1": resource.NewQuantity(0, resource.BinarySI),
+			},
+			expectError: false,
+		},
+		{
+			name: "Success with StoragePolicyUsage in different namespace",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				tenGi := resource.MustParse("10Gi")
+				// SPU in different namespace
+				spu1 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: "other-namespace",
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &tenGi,
+						},
+					},
+				}
+
+				// SPU in target namespace
+				fiveGi := resource.MustParse("5Gi")
+				spu2 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-2",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-2",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &fiveGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu1, spu2).
+					Build()
+			},
+			expectedResult: func() map[string]*resource.Quantity {
+				fiveGi := resource.MustParse("5Gi")
+				return map[string]*resource.Quantity{
+					"policy-2": resource.NewQuantity(fiveGi.Value(), resource.BinarySI),
+				}
+			}(),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := tt.setupClient()
+			result, err := calculateVMServiceStoragePolicyUsageReservedForNamespace(ctx, fakeClient, namespace)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("calculateVMServiceStoragePolicyUsageReservedForNamespace() expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("calculateVMServiceStoragePolicyUsageReservedForNamespace() returned error: %v", err)
+				}
+				if !quantitiesEqual(result, tt.expectedResult) {
+					t.Errorf("calculateVMServiceStoragePolicyUsageReservedForNamespace() result = %v; want %v",
+						result, tt.expectedResult)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update Periodic sync to calculate reserved for vmsnapshot storagepolicyusage
Periodic sync calculate the reserved values across storage policies and updates the storagequota reserved value.
This VMSnapshot StoragePolicyUsage instroduced with vmsnashot feature in 9.1.

Similar to other SPUs like pvc, vm, volume snapshot we need to update periodic sync to include calculation of vmsnapshot reserved values. 
This change was missed earlier as assumption was vm and vmsnapshot will use same extension service, but vmsnapshot have different extension service name than virtualmachine only in SPU CR so we need to handle it seperately.

 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Pre-checkins Pipelines Passed:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/669/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/726/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/731/

Manual Testing 

```
root@4212231af159a62604cbf47a66ea1de1 [ ~ ]# k get pvc -n test-ns
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
sample-claim   Bound    pvc-1f5c9f9c-10c4-4a43-98d3-27286454640c   5Gi        RWO            wcpglobal-storage-profile   <unset>                 34m
root@4212231af159a62604cbf47a66ea1de1 [ ~ ]# k get vm -n test-ns     sample-vm 
NAME        POWER-STATE   AGE
sample-vm   PoweredOn     33m
root@4212231af159a62604cbf47a66ea1de1 [ ~ ]# k get vmsnapshot -n test-ns     
NAME                   AGE
sample-vm-1-snapshot   31m
root@4212231af159a62604cbf47a66ea1de1 [ ~ ]# k get StorageQuotaPeriodicSync -n vmware-system-csi   storage-quota-periodic-sync  
NAME                          AGE
storage-quota-periodic-sync   20h
root@4212231af159a62604cbf47a66ea1de1 [ ~ ]# k get vmsnapshot -n test-ns      -o yaml
apiVersion: v1
items:
- apiVersion: vmoperator.vmware.com/v1alpha5
  kind: VirtualMachineSnapshot
  metadata:
    annotations:
      csi.vsphere.volume.sync: completed
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"vmoperator.vmware.com/v1alpha5","kind":"VirtualMachineSnapshot","metadata":{"annotations":{},"name":"sample-vm-1-snapshot","namespace":"test-ns"},"spec":{"memory":false,"vmName":"sample-vm"}}
    creationTimestamp: "2025-12-10T17:34:04Z"
    finalizers:
    - vmoperator.vmware.com/virtualmachinesnapshot
    - cns.vmware.com/syncvolume
    generation: 1
    labels:
      snapshot.vmoperator.vmware.com/vm-name: sample-vm
    name: sample-vm-1-snapshot
    namespace: test-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha5
      kind: VirtualMachine
      name: sample-vm
      uid: 9bfde6fc-f093-43aa-83d5-521ac6e3495b
    resourceVersion: "739968"
    uid: bee56806-d712-4274-bd19-8a7971a6764c
  spec:
    vmName: sample-vm
  status:
    conditions:
    - lastTransitionTime: "2025-12-10T17:34:06Z"
      message: ""
      reason: "True"
      status: "True"
      type: VirtualMachineSnapshotCSISynced
    - lastTransitionTime: "2025-12-10T17:34:06Z"
      message: ""
      reason: "True"
      status: "True"
      type: VirtualMachineSnapshotCreated
    - lastTransitionTime: "2025-12-10T17:34:06Z"
      message: ""
      reason: "True"
      status: "True"
      type: VirtualMachineSnapshotReady
    powerState: PoweredOff
    storage:
      requested:
      - storageClass: wcpglobal-storage-profile
        total: 25Gi
      used: "8783160871"
    uniqueID: snapshot-266
kind: List
metadata:
  resourceVersion: ""
root@4212231af159a62604cbf47a66ea1de1 [ ~ ]# k get StorageQuotaPeriodicSync -n vmware-system-csi   storage-quota-periodic-sync   -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StorageQuotaPeriodicSync
metadata:
  creationTimestamp: "2025-12-09T21:56:08Z"
  generation: 1
  name: storage-quota-periodic-sync
  namespace: vmware-system-csi
  resourceVersion: "757585"
  uid: 2f9caba7-dded-4389-ac68-3b37c30d6da5
spec:
  syncIntervalInMinutes: 10
status:
  expectedReservedValues:
  - namespace: svc-cci-ns-1ghah
    reserved:
      4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
      61fa0b2a-a4be-4cfd-b704-1164aaa611f1: "0"
  - namespace: svc-example-ljuh4
    reserved:
      4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
      61fa0b2a-a4be-4cfd-b704-1164aaa611f1: "0"
      579e1c15-3bf6-40b0-b387-f5f68c76d6ee: "0"
      cb66f23a-59d8-4b44-83aa-5da6085b101a: "0"
      fcbe7c8e-f669-41b6-8078-08e05675deea: "0"
  - namespace: svc-tkg-9svi8
    reserved:
      4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
      61fa0b2a-a4be-4cfd-b704-1164aaa611f1: "0"
  - namespace: svc-velero-qh79y
    reserved:
      4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
      61fa0b2a-a4be-4cfd-b704-1164aaa611f1: "0"
  - namespace: test-mobility-relocate-ns
    reserved:
      579e1c15-3bf6-40b0-b387-f5f68c76d6ee: "0"
  - namespace: test-ns
    reserved:
      61fa0b2a-a4be-4cfd-b704-1164aaa611f1: "0"
      fcbe7c8e-f669-41b6-8078-08e05675deea: "0"
  - namespace: storage-policy-test
    reserved:
      fcbe7c8e-f669-41b6-8078-08e05675deea: "0"
  lastSyncTimestamp: "2025-12-10T18:02:26Z"
root@4212231af159a62604cbf47a66ea1de1 [ ~ ]# 

```
[manual_test_periodic_sync.log](https://github.com/user-attachments/files/24085340/manual_test_periodic_sync.log)
[syncer.log](https://github.com/user-attachments/files/24085343/syncer.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update Periodic sync to calculate reserved for vmsnapshot storagepolicyusage
```
