### PR TITLE
Add dynamic BackingType detection via VirtualDiskManager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-co-op/gocron v1.37.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/golang/protobuf v1.5.4
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kubernetes-csi/csi-proxy/v2 v2.0.0-alpha.1
@@ -100,7 +101,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cadvisor v0.52.1 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect

--- a/pkg/common/cns-lib/volume/manager_mock.go
+++ b/pkg/common/cns-lib/volume/manager_mock.go
@@ -199,3 +199,9 @@ func (m MockManager) SyncVolume(ctx context.Context, syncVolumeSpecs []cnstypes.
 	//TODO implement me
 	panic("implement me")
 }
+
+func (m MockManager) QueryBackingTypeFromVirtualDiskInfo(ctx context.Context,
+	volumeID string) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/pkg/common/cns-lib/volume/util_test.go
+++ b/pkg/common/cns-lib/volume/util_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertDiskTypeToBackingType(t *testing.T) {
+	tests := []struct {
+		name     string
+		diskType string
+		want     string
+	}{
+		{
+			name:     "thin disk type",
+			diskType: "thin",
+			want:     "FlatVer2BackingInfo",
+		},
+		{
+			name:     "preallocated disk type",
+			diskType: "preallocated",
+			want:     "FlatVer2BackingInfo",
+		},
+		{
+			name:     "thick disk type",
+			diskType: "thick",
+			want:     "FlatVer2BackingInfo",
+		},
+		{
+			name:     "eagerZeroedThick disk type",
+			diskType: "eagerZeroedThick",
+			want:     "FlatVer2BackingInfo",
+		},
+		{
+			name:     "sparse2Gb disk type",
+			diskType: "sparse2Gb",
+			want:     "SparseVer2BackingInfo",
+		},
+		{
+			name:     "sparseMonolithic disk type",
+			diskType: "sparseMonolithic",
+			want:     "SparseVer2BackingInfo",
+		},
+		{
+			name:     "delta disk type",
+			diskType: "delta",
+			want:     "SparseVer2BackingInfo",
+		},
+		{
+			name:     "vmfsSparse disk type",
+			diskType: "vmfsSparse",
+			want:     "SparseVer2BackingInfo",
+		},
+		{
+			name:     "thick2Gb disk type",
+			diskType: "thick2Gb",
+			want:     "FlatVer2BackingInfo",
+		},
+		{
+			name:     "flatMonolithic disk type",
+			diskType: "flatMonolithic",
+			want:     "FlatVer2BackingInfo",
+		},
+		{
+			name:     "seSparse disk type",
+			diskType: "seSparse",
+			want:     "SeSparseBackingInfo",
+		},
+		{
+			name:     "rdm disk type",
+			diskType: "rdm",
+			want:     "RawDiskMappingVer1BackingInfo",
+		},
+		{
+			name:     "rdmp disk type",
+			diskType: "rdmp",
+			want:     "RawDiskMappingVer1BackingInfo",
+		},
+		{
+			name:     "unknown disk type",
+			diskType: "unknown",
+			want:     "",
+		},
+		{
+			name:     "empty disk type",
+			diskType: "",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertDiskTypeToBackingType(tt.diskType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -224,3 +224,8 @@ func (m *MockVolumeManager) SyncVolume(ctx context.Context,
 	syncVolumeSpecs []cnstypes.CnsSyncVolumeSpec) (string, error) {
 	return "", nil
 }
+
+func (m *MockVolumeManager) QueryBackingTypeFromVirtualDiskInfo(ctx context.Context,
+	volumeID string) (string, error) {
+	return "", nil
+}

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -131,6 +131,12 @@ func (m *mockVolumeManager) SyncVolume(ctx context.Context,
 	syncVolumeSpecs []cnstypes.CnsSyncVolumeSpec) (string, error) {
 	return "", nil
 }
+
+func (m *mockVolumeManager) QueryBackingTypeFromVirtualDiskInfo(ctx context.Context,
+	volumeID string) (string, error) {
+	return "", nil
+}
+
 func TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsCnsVolumeNotFoundFault(t *testing.T) {
 	// Skip test on ARM64 due to gomonkey limitations
 	if runtime.GOARCH == "arm64" {

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -538,7 +538,7 @@ func (r *Reconciler) processBatchAttach(ctx context.Context, k8sClient kubernete
 
 	// Construct batch attach request
 	pvcsInAttachList, volumeIdsInAttachList, batchAttachRequest, err := constructBatchAttachRequest(ctx,
-		volumesToAttach, instance)
+		volumesToAttach, instance, r.volumeManager, k8sClient)
 	if err != nil {
 		log.Errorf("failed to construct batch attach request. Err: %s", err)
 		return err

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -224,6 +224,11 @@ func (m *mockVolumeManager) SyncVolume(ctx context.Context,
 	return "", nil
 }
 
+func (m *mockVolumeManager) QueryBackingTypeFromVirtualDiskInfo(ctx context.Context,
+	volumeID string) (string, error) {
+	return "", nil
+}
+
 type mockCOCommon struct{}
 
 func (m *mockCOCommon) GetPVCNamespacedNameByUID(uid string) (types.NamespacedName, bool) {


### PR DESCRIPTION
**What this PR does / why we need it**:

When the disk-backing annotation is not present on a PVC, dynamically query the backing type from vSphere VirtualDiskManager API and cache it on the PVC annotation for future attach operations.

Changes:
- Add queryBackingTypeFromVirtualDiskInfo() to query disk type via CNS QueryVolume API and VirtualDiskManager.QueryVirtualDiskInfo()
- Add convertDiskTypeToBackingType() to map vSphere disk types (thin, preallocated, eagerZeroedThick, etc.) to backing types
- Add patchPVCBackingTypeAnnotation() to persist queried backing type on PVC annotation for caching
- Update constructBatchAttachRequest() to query and cache backing type when annotation is missing
- Add unit tests for convertDiskTypeToBackingType and patchPVCBackingTypeAnnotation functions

<!-- Thanks for sending a pull request! -->


**Testing done**:
Verified Creating Dynamic PVC and attaching it to VM. When PVC does not have `cns.vmware.com.protected/disk-backing` annotation set, cnsnodevmbatchattachment reconciler is setting this annotation after querying backing type.


> {"level":"info","time":"2025-12-13T16:13:42.151459229Z","caller":"volume/manager.go:2473","msg":"QueryVolumeAsync successfully returned CnsQueryResult, opId: \"56aa5c18\"","TraceId":"b5fab59c-178c-4c7c-90aa-7ce25b1b5921"}
{"level":"info","time":"2025-12-13T16:13:42.203838795Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:568","msg":"Successfully retrieved BackingType FlatVer2BackingInfo for PVC vm-dj5y-pvc-0 from VirtualDiskManager","TraceId":"b5fab59c-178c-4c7c-90aa-7ce25b1b5921"}
{"level":"info","time":"2025-12-13T16:13:42.204150985Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:802","msg":"Setting BackingType annotation cns.vmware.com.protected/disk-backing=FlatVer2BackingInfo on PVC vm-dj5y-pvc-0","TraceId":"b5fab59c-178c-4c7c-90aa-7ce25b1b5921"}
{"level":"info","time":"2025-12-13T16:13:42.204341388Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:819","msg":"Patching PVC vm-dj5y-pvc-0 with BackingType annotation","TraceId":"b5fab59c-178c-4c7c-90aa-7ce25b1b5921"}
{"level":"info","time":"2025-12-13T16:13:42.224495615Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:833","msg":"Successfully patched PVC: vm-dj5y-pvc-0 with BackingType annotation map[cns.vmware.com.protected/disk-backing:FlatVer2BackingInfo csi.vsphere.volume-accessible-topology:[{\"topology.kubernetes.io/zone\":\"domain-c36\"}] csi.vsphere.volume-requested-topology:[{\"topology.kubernetes.io/zone\":\"domain-c36\"}] pv.kubernetes.io/bind-completed:yes pv.kubernetes.io/bound-by-controller:yes volume.beta.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com volume.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com]","TraceId":"b5fab59c-178c-4c7c-90aa-7ce25b1b5921"}
{"level":"info","time":"2025-12-13T16:13:42.224673309Z","caller":"volume/manager.go:3571","msg":"Starting batch attach for VM 694a5650-07df-49be-a8e2-30180e4f2a1a","TraceId":"b5fab59c-178c-4c7c-90aa-7ce25b1b5921"}


Pre-checkin pipelines are not available at the moment. I have validated this change, by replacing the syncer image with this change.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add dynamic BackingType detection via VirtualDiskManager
```
