### PR TITLE
Add Volume Attribute for backing disk type

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -383,6 +383,9 @@ const (
 	// PvcUIDLabelKey is a label which gets added to CnsNodeVMAttachment instances
 	// to indicate the PVC that it has attached.
 	PvcUIDLabelKey = "cns.vmware.com/pvc-uid"
+
+	// DefaultBackingTypeForDynamicBlockVolume is FlatVer2BackingInfo.
+	DefaultBackingTypeForDynamicBlockVolume = "FlatVer2BackingInfo"
 )
 
 // Supported container orchestrators.

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -908,6 +908,10 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		attributes[common.VolumeContextAttributeLinkedCloneVolumeSnapshotSourceUID] = volumeSnapshotUID
 	}
 
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SharedDiskFss) {
+		attributes[common.AnnKeyBackingDiskType] = common.DefaultBackingTypeForDynamicBlockVolume
+	}
+
 	resp := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      volumeInfo.VolumeID.Id,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For WCP cluster, as part of create block volume, add an attribute for backing disktype PVC annotation.
This annotation will be detected by external provisioner and added by it on the PVC.

For all dynamic volumes, the default backing disktype is flatVer2.


**Testing done**:

Dynamically created PVC got backing disk type annotation:
```
k describe pvc -n test k8s-pvc-4
Name:          k8s-pvc-4
Namespace:     test
StorageClass:  vsan-default-storage-policy
Status:        Bound
Volume:        pvc-2c53a147-793a-47e4-a6dc-d6b3a1467a81
Labels:        <none>
Annotations:   cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
               csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      64Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                          Message
  ----    ------                 ----               ----                                                                                          -------
  Normal  Provisioning           15s                csi.vsphere.vmware.com_422b906cbff38bdbb22b04e091fcc346_9e1dbddc-a523-418a-99a1-d51bb1eb66c5  External provisioner is provisioning volume for claim "test/k8s-pvc-4"
  Normal  ExternalProvisioning   12s (x5 over 16s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  11s                csi.vsphere.vmware.com_422b906cbff38bdbb22b04e091fcc346_9e1dbddc-a523-418a-99a1-d51bb1eb66c5  Successfully provisioned volume pvc-2c53a147-793a-47e4-a6dc-d6b3a1467a81
```

Statically created PVC did not get backing disk type annotation:
```
root@422ba6cf5f02e97607746192d4ed4b17 [ ~ ]# k describe pvc -n test static-pvc-2
Name:          static-pvc-2
Namespace:     test
StorageClass:  vsan-default-storage-policy
Status:        Bound
Volume:        static-pv-1cc8906c-dc36-40f5-8d10-38c597250f98
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      64Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:        <none>
```

Blueprint PVC did not get backing disk type annotation:

```
Name:          static-blueprint-1
Namespace:     test
StorageClass:  vsan-default-storage-policy
Status:        Bound
Volume:        static-pv-6cc786f9-81d4-481f-8cdc-c694c1005040
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      64Mi
Access Modes:  RWO
VolumeMode:    Filesystem
DataSource:
  APIGroup:  vmoperator.vmware.com
  Kind:      VirtualMachine
  Name:      new-vm-1
Used By:     <none>
Events:
  Type    Reason                Age                   From                                                                                          Message
  ----    ------                ----                  ----                                                                                          -------
  Normal  ExternalProvisioning  47s (x14 over 3m48s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  Provisioning          46s (x2 over 3m47s)   csi.vsphere.vmware.com_422b906cbff38bdbb22b04e091fcc346_9e1dbddc-a523-418a-99a1-d51bb1eb66c5  External provisioner is provisioning volume for claim "test/static-blueprint-1"
  Normal  Provisioning          46s (x2 over 3m47s)   external-provisioner                                                                          Assuming an external populator will provision the volume
```

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/743/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/690/