### PR TITLE
Fix invalid reserved values 

### DIFF
--- a/pkg/syncer/metadatasyncer_test.go
+++ b/pkg/syncer/metadatasyncer_test.go
@@ -21,13 +21,18 @@ import (
 	"errors"
 	"testing"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	testclient "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
+	sqperiodicsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagequotaperiodicsync/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 )
 
 // fake implementation for fetchStorageClassToStoragePolicyMapping
@@ -757,6 +762,761 @@ func TestCalculateVMServiceStoragePolicyUsageReservedForNamespace(t *testing.T) 
 						result, tt.expectedResult)
 				}
 			}
+		})
+	}
+}
+
+func TestSyncStorageQuotaReserved(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name                string
+		setupClient         func() client.Client
+		setupMetadataSyncer func(t *testing.T) *metadataSyncInformer
+		expectError         bool
+	}{
+		{
+			name: "Error when StoragePolicyQuota List fails",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				baseClient := fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build()
+
+				return &errorClient{
+					Client: baseClient,
+					err:    errors.New("list error"),
+				}
+			},
+			setupMetadataSyncer: func(t *testing.T) *metadataSyncInformer {
+				// Create a fake k8s client and informer factory to get listers
+				// Note: We create a new informer factory directly instead of using
+				// the singleton InformerManager to avoid interference with other tests.
+				// The listers work fine without starting the informers.
+				k8sClient := testclient.NewSimpleClientset()
+				informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+				return &metadataSyncInformer{
+					pvLister:  informerFactory.Core().V1().PersistentVolumes().Lister(),
+					pvcLister: informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
+				}
+			},
+			expectError: false, // Function returns early, doesn't return error
+		},
+		{
+			name: "Success with empty StoragePolicyQuota list",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+				_ = sqperiodicsyncv1alpha1.AddToScheme(scheme)
+
+				sqPeriodicSync := &sqperiodicsyncv1alpha1.StorageQuotaPeriodicSync{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      StorageQuotaPeriodicSyncInstanceName,
+						Namespace: "vmware-system-csi",
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sqPeriodicSync).
+					Build()
+			},
+			setupMetadataSyncer: func(t *testing.T) *metadataSyncInformer {
+				// Create a fake k8s client and informer factory to get listers
+				// Note: We create a new informer factory directly instead of using
+				// the singleton InformerManager to avoid interference with other tests.
+				// The listers work fine without starting the informers.
+				k8sClient := testclient.NewSimpleClientset()
+				informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+				return &metadataSyncInformer{
+					pvLister:  informerFactory.Core().V1().PersistentVolumes().Lister(),
+					pvcLister: informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
+				}
+			},
+			expectError: false,
+		},
+		{
+			name: "Success with single StoragePolicyQuota",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+				_ = sqperiodicsyncv1alpha1.AddToScheme(scheme)
+
+				spq := &storagepolicyv1alpha2.StoragePolicyQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spq-1",
+						Namespace: "test-ns",
+					},
+				}
+
+				sqPeriodicSync := &sqperiodicsyncv1alpha1.StorageQuotaPeriodicSync{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      StorageQuotaPeriodicSyncInstanceName,
+						Namespace: "vmware-system-csi",
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spq, sqPeriodicSync).
+					Build()
+			},
+			setupMetadataSyncer: func(t *testing.T) *metadataSyncInformer {
+				// Create a fake k8s client and informer factory to get listers
+				// Note: We create a new informer factory directly instead of using
+				// the singleton InformerManager to avoid interference with other tests.
+				// The listers work fine without starting the informers.
+				k8sClient := testclient.NewSimpleClientset()
+				informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+				return &metadataSyncInformer{
+					pvLister:  informerFactory.Core().V1().PersistentVolumes().Lister(),
+					pvcLister: informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
+				}
+			},
+			expectError: false,
+		},
+		{
+			name: "Success with multiple StoragePolicyQuota namespaces",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+				_ = sqperiodicsyncv1alpha1.AddToScheme(scheme)
+
+				spq1 := &storagepolicyv1alpha2.StoragePolicyQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spq-1",
+						Namespace: "test-ns-1",
+					},
+				}
+				spq2 := &storagepolicyv1alpha2.StoragePolicyQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spq-2",
+						Namespace: "test-ns-2",
+					},
+				}
+
+				sqPeriodicSync := &sqperiodicsyncv1alpha1.StorageQuotaPeriodicSync{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      StorageQuotaPeriodicSyncInstanceName,
+						Namespace: "vmware-system-csi",
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spq1, spq2, sqPeriodicSync).
+					Build()
+			},
+			setupMetadataSyncer: func(t *testing.T) *metadataSyncInformer {
+				// Create a fake k8s client and informer factory to get listers
+				// Note: We create a new informer factory directly instead of using
+				// the singleton InformerManager to avoid interference with other tests.
+				// The listers work fine without starting the informers.
+				k8sClient := testclient.NewSimpleClientset()
+				informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+				return &metadataSyncInformer{
+					pvLister:  informerFactory.Core().V1().PersistentVolumes().Lister(),
+					pvcLister: informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
+				}
+			},
+			expectError: false,
+		},
+		{
+			name: "Negative value update skipped - StoragePolicyUsage with negative reserved",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+				_ = sqperiodicsyncv1alpha1.AddToScheme(scheme)
+
+				spq := &storagepolicyv1alpha2.StoragePolicyQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spq-1",
+						Namespace: "test-ns",
+					},
+				}
+
+				// Create StoragePolicyUsage with negative reserved value
+				negTenGi := resource.MustParse("-10Gi")
+				spu := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: "test-ns",
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &negTenGi,
+						},
+					},
+				}
+
+				sqPeriodicSync := &sqperiodicsyncv1alpha1.StorageQuotaPeriodicSync{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      StorageQuotaPeriodicSyncInstanceName,
+						Namespace: "vmware-system-csi",
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spq, spu, sqPeriodicSync).
+					Build()
+			},
+			setupMetadataSyncer: func(t *testing.T) *metadataSyncInformer {
+				// Save original function
+				origFetchStorageClassToStoragePolicyMapping := fetchStorageClassToStoragePolicyMapping
+				t.Cleanup(func() {
+					fetchStorageClassToStoragePolicyMapping = origFetchStorageClassToStoragePolicyMapping
+				})
+				// Mock fetchStorageClassToStoragePolicyMapping
+				fetchStorageClassToStoragePolicyMapping = fakeFetchStorageClassToStoragePolicyMapping
+
+				k8sClient := testclient.NewSimpleClientset()
+				informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+				return &metadataSyncInformer{
+					pvLister:  informerFactory.Core().V1().PersistentVolumes().Lister(),
+					pvcLister: informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
+				}
+			},
+			expectError: false, // Function should skip negative values and continue
+		},
+		{
+			name: "PVC with same name but different size in different namespaces",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+				_ = sqperiodicsyncv1alpha1.AddToScheme(scheme)
+
+				spq1 := &storagepolicyv1alpha2.StoragePolicyQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spq-1",
+						Namespace: "test-ns-1",
+					},
+				}
+				spq2 := &storagepolicyv1alpha2.StoragePolicyQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spq-2",
+						Namespace: "test-ns-2",
+					},
+				}
+
+				sqPeriodicSync := &sqperiodicsyncv1alpha1.StorageQuotaPeriodicSync{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      StorageQuotaPeriodicSyncInstanceName,
+						Namespace: "vmware-system-csi",
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spq1, spq2, sqPeriodicSync).
+					Build()
+			},
+			setupMetadataSyncer: func(t *testing.T) *metadataSyncInformer {
+				// Save original function
+				origFetchStorageClassToStoragePolicyMapping := fetchStorageClassToStoragePolicyMapping
+				t.Cleanup(func() {
+					fetchStorageClassToStoragePolicyMapping = origFetchStorageClassToStoragePolicyMapping
+				})
+				// Mock fetchStorageClassToStoragePolicyMapping
+				fetchStorageClassToStoragePolicyMapping = fakeFetchStorageClassToStoragePolicyMapping
+
+				// Create PVCs with same name but different sizes in different namespaces
+				scName := "sc1"
+				pvc1 := &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pvc",
+						Namespace: "test-ns-1",
+					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						StorageClassName: &scName,
+						Resources: v1.VolumeResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+					Status: v1.PersistentVolumeClaimStatus{
+						Phase: v1.ClaimPending,
+					},
+				}
+
+				pvc2 := &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pvc", // Same name as pvc1
+						Namespace: "test-ns-2",
+					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						StorageClassName: &scName,
+						Resources: v1.VolumeResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceStorage: resource.MustParse("20Gi"), // Different size
+							},
+						},
+					},
+					Status: v1.PersistentVolumeClaimStatus{
+						Phase: v1.ClaimPending,
+					},
+				}
+
+				k8sClient := testclient.NewSimpleClientset(pvc1, pvc2)
+				informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+				// Start the informer factory to populate the cache
+				stopCh := make(chan struct{})
+				informerFactory.Start(stopCh)
+				// Wait for cache sync - this ensures PVCs are available in the lister
+				cacheSynced := informerFactory.WaitForCacheSync(stopCh)
+				allSynced := true
+				for _, synced := range cacheSynced {
+					if !synced {
+						allSynced = false
+						break
+					}
+				}
+				if !allSynced {
+					t.Fatal("Failed to sync informer cache")
+				}
+				// Note: We don't close stopCh here as the test will complete and cleanup
+				// The informer will stop when the test ends
+
+				return &metadataSyncInformer{
+					pvLister:  informerFactory.Core().V1().PersistentVolumes().Lister(),
+					pvcLister: informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
+				}
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Execute function - this test verifies the function doesn't panic
+			// and handles errors gracefully. Full unit testing would require
+			// refactoring to use dependency injection for helper functions.
+			fakeClient := tt.setupClient()
+			metadataSyncer := tt.setupMetadataSyncer(t)
+
+			// The function doesn't return errors, it logs them and continues
+			// This test verifies it doesn't panic on various error conditions
+			syncStorageQuotaReserved(ctx, fakeClient, metadataSyncer)
+
+			// If we expected an error path, verify the function handled it gracefully
+			// (by not panicking and completing execution)
+		})
+	}
+}
+
+func TestValidateReservedValues(t *testing.T) {
+	tests := []struct {
+		name           string
+		reservedValues map[string]*resource.Quantity
+		expectedResult bool
+	}{
+		{
+			name: "All positive values",
+			reservedValues: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				fiveGi := resource.MustParse("5Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+					"policy-2": &fiveGi,
+				}
+			}(),
+			expectedResult: true,
+		},
+		{
+			name: "Zero values",
+			reservedValues: map[string]*resource.Quantity{
+				"policy-1": resource.NewQuantity(0, resource.BinarySI),
+			},
+			expectedResult: true,
+		},
+		{
+			name:           "Empty map",
+			reservedValues: map[string]*resource.Quantity{},
+			expectedResult: true,
+		},
+		{
+			name: "Negative value",
+			reservedValues: func() map[string]*resource.Quantity {
+				negTenGi := resource.MustParse("-10Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &negTenGi,
+				}
+			}(),
+			expectedResult: false,
+		},
+		{
+			name: "Mixed positive and negative",
+			reservedValues: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				negFiveGi := resource.MustParse("-5Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+					"policy-2": &negFiveGi,
+				}
+			}(),
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateReservedValues(tt.reservedValues)
+			if result != tt.expectedResult {
+				t.Errorf("validateReservedValues() = %v; want %v", result, tt.expectedResult)
+			}
+		})
+	}
+}
+
+func TestMergeStoragePolicyReserved(t *testing.T) {
+	tests := []struct {
+		name                       string
+		storagePolicyReserved      map[string]*resource.Quantity
+		totalStoragePolicyReserved map[string]*resource.Quantity
+		expectedResult             map[string]*resource.Quantity
+	}{
+		{
+			name: "Merge new policy into empty map",
+			storagePolicyReserved: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+				}
+			}(),
+			totalStoragePolicyReserved: map[string]*resource.Quantity{},
+			expectedResult: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+				}
+			}(),
+		},
+		{
+			name: "Merge new policy into existing map",
+			storagePolicyReserved: func() map[string]*resource.Quantity {
+				fiveGi := resource.MustParse("5Gi")
+				return map[string]*resource.Quantity{
+					"policy-2": &fiveGi,
+				}
+			}(),
+			totalStoragePolicyReserved: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+				}
+			}(),
+			expectedResult: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				fiveGi := resource.MustParse("5Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+					"policy-2": &fiveGi,
+				}
+			}(),
+		},
+		{
+			name: "Merge same policy - should add values",
+			storagePolicyReserved: func() map[string]*resource.Quantity {
+				fiveGi := resource.MustParse("5Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &fiveGi,
+				}
+			}(),
+			totalStoragePolicyReserved: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+				}
+			}(),
+			expectedResult: func() map[string]*resource.Quantity {
+				fifteenGi := resource.MustParse("15Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &fifteenGi,
+				}
+			}(),
+		},
+		{
+			name: "Merge multiple policies",
+			storagePolicyReserved: func() map[string]*resource.Quantity {
+				threeGi := resource.MustParse("3Gi")
+				sevenGi := resource.MustParse("7Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &threeGi,
+					"policy-2": &sevenGi,
+				}
+			}(),
+			totalStoragePolicyReserved: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+				}
+			}(),
+			expectedResult: func() map[string]*resource.Quantity {
+				thirteenGi := resource.MustParse("13Gi")
+				sevenGi := resource.MustParse("7Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &thirteenGi,
+					"policy-2": &sevenGi,
+				}
+			}(),
+		},
+		{
+			name:                  "Merge empty map",
+			storagePolicyReserved: map[string]*resource.Quantity{},
+			totalStoragePolicyReserved: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+				}
+			}(),
+			expectedResult: func() map[string]*resource.Quantity {
+				tenGi := resource.MustParse("10Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": &tenGi,
+				}
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeStoragePolicyReserved(tt.storagePolicyReserved, tt.totalStoragePolicyReserved)
+			if !quantitiesEqual(result, tt.expectedResult) {
+				t.Errorf("mergeStoragePolicyReserved() = %v; want %v", result, tt.expectedResult)
+			}
+		})
+	}
+}
+
+func TestCalculateSPRReservedForNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	// Save original function
+	origFetchStorageClassToStoragePolicyMapping := fetchStorageClassToStoragePolicyMapping
+	defer func() {
+		fetchStorageClassToStoragePolicyMapping = origFetchStorageClassToStoragePolicyMapping
+	}()
+
+	// Mock fetchStorageClassToStoragePolicyMapping
+	fetchStorageClassToStoragePolicyMapping = fakeFetchStorageClassToStoragePolicyMapping
+
+	tests := []struct {
+		name           string
+		setupClient    func() client.Client
+		namespace      string
+		expectedResult map[string]*resource.Quantity
+		expectError    bool
+	}{
+		{
+			name: "Success with single SPR",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				tenGi := resource.MustParse("10Gi")
+				fiveGi := resource.MustParse("5Gi")
+				spr := &storagepolicyv1alpha2.StoragePolicyReservation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spr-1",
+						Namespace: "test-ns",
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyReservationSpec{
+						Requested: []storagepolicyv1alpha2.Requested{
+							{
+								ReservationRequests: []storagepolicyv1alpha2.ReservationRequest{
+									{
+										StorageClassName: "sc1",
+										Request:          &tenGi,
+									},
+								},
+							},
+						},
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyReservationStatus{
+						Approved: []storagepolicyv1alpha2.StorageObject{
+							{
+								StorageClassName: "sc1",
+								Request:          &fiveGi,
+							},
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spr).
+					Build()
+			},
+			namespace: "test-ns",
+			expectedResult: func() map[string]*resource.Quantity {
+				fiveGi := resource.MustParse("5Gi")
+				return map[string]*resource.Quantity{
+					"policy1": &fiveGi,
+				}
+			}(),
+			expectError: false,
+		},
+		{
+			name: "Success with empty SPR list",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build()
+			},
+			namespace:      "test-ns",
+			expectedResult: nil,
+			expectError:    false,
+		},
+		{
+			name: "Error when List fails",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				baseClient := fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build()
+
+				return &errorClient{
+					Client: baseClient,
+					err:    errors.New("list error"),
+				}
+			},
+			namespace:      "test-ns",
+			expectedResult: nil,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := tt.setupClient()
+			result, err := calculateSPRReservedForNamespace(ctx, fakeClient, tt.namespace)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("calculateSPRReservedForNamespace() expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("calculateSPRReservedForNamespace() returned error: %v", err)
+				}
+				if tt.expectedResult == nil {
+					if result != nil {
+						t.Errorf("calculateSPRReservedForNamespace() result = %v; want nil", result)
+					}
+				} else {
+					if !quantitiesEqual(result, tt.expectedResult) {
+						t.Errorf("calculateSPRReservedForNamespace() result = %v; want %v", result, tt.expectedResult)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateStorageQuotaPeriodicSyncCR(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name                   string
+		setupClient            func() client.Client
+		expectedReservedValues []sqperiodicsyncv1alpha1.ExpectedReservedValues
+		expectError            bool
+	}{
+		{
+			name: "Success with valid CR",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+				_ = sqperiodicsyncv1alpha1.AddToScheme(scheme)
+
+				sqPeriodicSync := &sqperiodicsyncv1alpha1.StorageQuotaPeriodicSync{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      StorageQuotaPeriodicSyncInstanceName,
+						Namespace: common.GetCSINamespace(),
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sqPeriodicSync).
+					Build()
+			},
+			expectedReservedValues: func() []sqperiodicsyncv1alpha1.ExpectedReservedValues {
+				tenGi := resource.MustParse("10Gi")
+				return []sqperiodicsyncv1alpha1.ExpectedReservedValues{
+					{
+						Namespace: "test-ns",
+						Reserved: map[string]*resource.Quantity{
+							"policy-1": &tenGi,
+						},
+					},
+				}
+			}(),
+			expectError: false,
+		},
+		{
+			name: "Error when CR not found",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+				_ = sqperiodicsyncv1alpha1.AddToScheme(scheme)
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build()
+			},
+			expectedReservedValues: []sqperiodicsyncv1alpha1.ExpectedReservedValues{},
+			expectError:            false, // Function logs error and returns, doesn't return error
+		},
+		{
+			name: "Success with empty reserved values",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+				_ = sqperiodicsyncv1alpha1.AddToScheme(scheme)
+
+				sqPeriodicSync := &sqperiodicsyncv1alpha1.StorageQuotaPeriodicSync{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      StorageQuotaPeriodicSyncInstanceName,
+						Namespace: common.GetCSINamespace(),
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sqPeriodicSync).
+					Build()
+			},
+			expectedReservedValues: []sqperiodicsyncv1alpha1.ExpectedReservedValues{},
+			expectError:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := tt.setupClient()
+			lastSyncTime := metav1.NewTime(metav1.Now().Time)
+
+			// The function doesn't return errors, it logs them
+			// This test verifies it doesn't panic
+			// Note: The fake client has limitations with status subresource patching,
+			// so we just verify the function executes without panicking
+			updateStorageQuotaPeriodicSyncCR(ctx, fakeClient, tt.expectedReservedValues, lastSyncTime)
+
+			// The function handles errors gracefully by logging them
+			// We verify it completes execution without panicking
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix the logic to fetch the pv and related pvc to include pvc namespace, as it is possible to have pvc with same name in different namespaces.
Also includes other code improvements

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual testing logs:
```
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get pvc -n test-ns
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pvc1           Bound    pvc-d86f5cb1-4b7f-42d0-95b6-52cc7374d152   5Gi        RWO            wcpglobal-storage-profile   <unset>                 24m
pvc2           Bound    pvc-6f3ac061-e7fb-45f1-a102-be199be15e30   5Gi        RWO            wcpglobal-storage-profile   <unset>                 24m
sample-claim   Bound    pvc-9f0143d1-9a93-4e69-a022-bbe44be74ece   5Gi        RWO            wcpglobal-storage-profile   <unset>                 20m
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get pvc -n test-ns2
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pvc1           Bound    pvc-b4dcaadb-df8a-457d-ac88-b737d4723271   5Gi        RWO            wcpglobal-storage-profile   <unset>                 24m
pvc2           Bound    pvc-e9d243d1-5f4c-4aa3-a5e9-ff6d7e9ba752   5Gi        RWO            wcpglobal-storage-profile   <unset>                 24m
sample-claim   Bound    pvc-3f0a8b01-6dfc-427a-9817-2aa61e166ac3   5Gi        RWO            wcpglobal-storage-profile   <unset>                 18m
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get volumesnapshot -n test-ns
NAME            READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
pvc-snapshot1   true         pvc1                                5Gi           volumesnapshotclass-delete   snapcontent-b3eaef81-ac63-44c6-a887-7963cb1dbe72   11m            11m
pvc-snapshot2   true         pvc2                                5Gi           volumesnapshotclass-delete   snapcontent-5efe582a-0005-44c9-829e-6158383be82e   11m            11m
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get volumesnapshot -n test-ns2
NAME            READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
pvc-snapshot1   true         pvc1                                5Gi           volumesnapshotclass-delete   snapcontent-5c9973b7-e660-4ba7-8ced-78beee168186   11m            11m
pvc-snapshot2   true         pvc2                                5Gi           volumesnapshotclass-delete   snapcontent-9293cdd0-cb7d-4bfd-af14-bdb10cfb5910   11m            11m
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get vm -n test-ns
NAME        POWER-STATE   AGE
sample-vm   PoweredOn     21m
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get vm -n test-ns2
NAME        POWER-STATE   AGE
sample-vm   PoweredOn     17m
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get vmsnapshot  -n test-ns     
NAME                   AGE
sample-vm-1-snapshot   8m28s
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get vmsnapshot  -n test-ns2
NAME                   AGE
sample-vm-1-snapshot   8m33s
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# 

root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k apply -f pvcs.yaml 
persistentvolumeclaim/pvc11 created
persistentvolumeclaim/pvc21 created
persistentvolumeclaim/pvc11 created
persistentvolumeclaim/pvc21 created
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get pvc -n test-ns2
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pvc1           Bound    pvc-b4dcaadb-df8a-457d-ac88-b737d4723271   5Gi        RWO            wcpglobal-storage-profile   <unset>                 2d22h
pvc11          Bound    pvc-8b1a9cd1-2349-4183-8067-3fa262339dce   6Gi        RWO            wcpglobal-storage-profile   <unset>                 13s
pvc2           Bound    pvc-e9d243d1-5f4c-4aa3-a5e9-ff6d7e9ba752   5Gi        RWO            wcpglobal-storage-profile   <unset>                 2d22h
pvc21          Bound    pvc-74c5028b-d097-4731-9d67-5c22d8adf715   7Gi        RWO            wcpglobal-storage-profile   <unset>                 13s
sample-claim   Bound    pvc-3f0a8b01-6dfc-427a-9817-2aa61e166ac3   5Gi        RWO            wcpglobal-storage-profile   <unset>                 2d22h
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k apply -f pvc.yaml 
persistentvolumeclaim/pvc-exp created
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k get pvc -n test-ns
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pvc-exp        Bound    pvc-26545468-41eb-4983-90f2-1f7fc3fbe28c   5Gi        RWO            wcpglobal-storage-profile   <unset>                 6s
pvc1           Bound    pvc-d86f5cb1-4b7f-42d0-95b6-52cc7374d152   5Gi        RWO            wcpglobal-storage-profile   <unset>                 2d22h
pvc11          Bound    pvc-e1eb3a5f-d932-4fe1-9a60-4902d9dc914c   3Gi        RWO            wcpglobal-storage-profile   <unset>                 37s
pvc2           Bound    pvc-6f3ac061-e7fb-45f1-a102-be199be15e30   5Gi        RWO            wcpglobal-storage-profile   <unset>                 2d22h
pvc21          Bound    pvc-8250691a-e928-4ca0-a027-f4d1e748ca3c   4Gi        RWO            wcpglobal-storage-profile   <unset>                 36s
sample-claim   Bound    pvc-9f0143d1-9a93-4e69-a022-bbe44be74ece   5Gi        RWO            wcpglobal-storage-profile   <unset>                 2d22h
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]#  k get pvc -n test-ns pvc-exp
NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pvc-exp   Bound    pvc-26545468-41eb-4983-90f2-1f7fc3fbe28c   5Gi        RWO            wcpglobal-storage-profile   <unset>                 20s
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]#  k get pv pvc-26545468-41eb-4983-90f2-1f7fc3fbe28c -n test-ns 
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM             STORAGECLASS                VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-26545468-41eb-4983-90f2-1f7fc3fbe28c   5Gi        RWO            Delete           Bound    test-ns/pvc-exp   wcpglobal-storage-profile   <unset>                          30s
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k edit pvc pvc-exp -n test-ns
persistentvolumeclaim/pvc-exp edited
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# k apply -f pod.yaml 
pod/pod-exp created
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]#  k get pod -n test-ns
NAME      READY   STATUS    RESTARTS   AGE
pod-exp   1/1     Running   0          16s
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]#  k get pvc -n test-ns pvc-exp
NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pvc-exp   Bound    pvc-26545468-41eb-4983-90f2-1f7fc3fbe28c   8Gi        RWO            wcpglobal-storage-profile   <unset>                 80s
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]#  k get pv pvc-26545468-41eb-4983-90f2-1f7fc3fbe28c -n test-ns 
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM             STORAGECLASS                VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-26545468-41eb-4983-90f2-1f7fc3fbe28c   8Gi        RWO            Delete           Bound    test-ns/pvc-exp   wcpglobal-storage-profile   <unset>                          85s
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]# 
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]#  k get storagequotaperiodicsyncs -n vmware-system-csi
NAME                          AGE
storage-quota-periodic-sync   5d9h
root@421fda5708535a2b6f3b79d5dd5d3967 [ ~ ]#  k get storagequotaperiodicsyncs -n vmware-system-csi -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StorageQuotaPeriodicSync
  metadata:
    creationTimestamp: "2025-12-12T08:47:28Z"
    generation: 1
    name: storage-quota-periodic-sync
    namespace: vmware-system-csi
    resourceVersion: "4874764"
    uid: ed39d5b3-db68-4a47-b826-ad1b0bf8f3e2
  spec:
    syncIntervalInMinutes: 10
  status:
    expectedReservedValues:
    - namespace: storage-policy-test
      reserved:
        8da079a3-e0bc-4fab-ac3b-0ef426a01878: "0"
    - namespace: svc-cci-ns-hm2et
      reserved:
        4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
        9f52a495-6548-4c0a-bef7-52df06236d6b: "0"
    - namespace: svc-example-i4eh0
      reserved:
        441542de-6cec-40df-8ebb-c206b3160ef0: "0"
        4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
        8da079a3-e0bc-4fab-ac3b-0ef426a01878: "0"
        9f52a495-6548-4c0a-bef7-52df06236d6b: "0"
        e6c2e45f-7431-44b7-9e93-dedbf347a424: "0"
    - namespace: svc-tkg-jf5sp
      reserved:
        4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
        9f52a495-6548-4c0a-bef7-52df06236d6b: "0"
    - namespace: test-mobility-relocate-ns
      reserved:
        441542de-6cec-40df-8ebb-c206b3160ef0: "0"
    - namespace: test-ns
      reserved:
        8da079a3-e0bc-4fab-ac3b-0ef426a01878: "0"
        9f52a495-6548-4c0a-bef7-52df06236d6b: "0"
    - namespace: svc-velero-p6xh8
      reserved:
        4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
        9f52a495-6548-4c0a-bef7-52df06236d6b: "0"
    - namespace: test-ns2
      reserved:
        8da079a3-e0bc-4fab-ac3b-0ef426a01878: "0"
        9f52a495-6548-4c0a-bef7-52df06236d6b: "0"
    lastSyncTimestamp: "2025-12-17T18:12:18Z"
kind: List
metadata:
  resourceVersion: ""

```
[reserve_fix_syncer.log](https://github.com/user-attachments/files/24219468/reserve_fix_syncer.log)
[reserve_fix_vsphere-csi-controller.log](https://github.com/user-attachments/files/24219469/reserve_fix_vsphere-csi-controller.log)



Pipelines: 
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/693/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/747/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix invalid reserved values 
```
