### PR TITLE
Host properties retrieval logging enhancements for error paths

### DIFF
--- a/pkg/common/cns-lib/vsphere/hostsystem.go
+++ b/pkg/common/cns-lib/vsphere/hostsystem.go
@@ -51,6 +51,7 @@ func (host *HostSystem) GetAllAccessibleDatastores(ctx context.Context) ([]*Data
 		log.Errorf("failed to retrieve datastores for host %v with err: %v", host, err)
 		return nil, err
 	}
+	log.Debugf("hostSystemMo Datastore: %+v", hostSystemMo.Datastore)
 	var dsRefList []types.ManagedObjectReference
 	dsRefList = append(dsRefList, hostSystemMo.Datastore...)
 
@@ -59,8 +60,9 @@ func (host *HostSystem) GetAllAccessibleDatastores(ctx context.Context) ([]*Data
 	properties := []string{"info", "customValue"}
 	err = pc.Retrieve(ctx, dsRefList, properties, &dsMoList)
 	if err != nil {
-		log.Errorf("failed to get datastore managed objects from datastore objects %v with properties %v: %v",
-			dsRefList, properties, err)
+		log.Errorf("failed to get datastore managed objects from for the host %v "+
+			" with datastore references %v, properties %v: , err : %v",
+			host.HostSystem.Name(), dsRefList, properties, err)
 		return nil, err
 	}
 	var dsObjList []*DatastoreInfo


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Observed an issue with Property Collector retrieve method, where the datastore references list is empty for few of the hosts in vsphere cluster. For such cases, it is important to log the host name/ip for storing information of the host in contention, in the final error & it also helps during debugging.

The PR is modifying the log message to store the host info in the error.

**Testing done**:
TBA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Host properties retrieval logging enhancements
```
