### PR TITLE
version specific change for batchAttach CR util

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -281,6 +281,7 @@ const (
 	selectedNodeIsZone                       = "cns.vmware.com/selected-node-is-zone"
 	selectedNodeAnnotationOnPVC              = "volume.kubernetes.io/selected-node"
 	vmZoneLabel                              = "topology.kubernetes.io/zone"
+	batchAttachSupportedVCVersion            = "9.1.0"
 )
 
 /*

--- a/tests/e2e/snapshot_vmservice_vm.go
+++ b/tests/e2e/snapshot_vmservice_vm.go
@@ -198,7 +198,7 @@ var _ bool = ginkgo.Describe("[snapshot-vmsvc] Snapshot VM Service VM", func() {
 	   11. Cleanup: Execute and verify the steps mentioned in the Delete snapshot mandatory checks
 	*/
 
-	ginkgo.It("[cf-f-wcp] Taking snapshot of a vm service vm attached to a dynamic "+
+	ginkgo.It("[cf-wcp] Taking snapshot of a vm service vm attached to a dynamic "+
 		"volume", ginkgo.Label(p0, block, wcp, snapshot, vmServiceVm, vc80), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/vmservice_vm.go
+++ b/tests/e2e/vmservice_vm.go
@@ -203,7 +203,7 @@ var _ bool = ginkgo.Describe("[vmsvc] vm service with csi vol tests", func() {
 	   8   delete pvcs
 	   9   Remove spbm policy attached to test namespace
 	*/
-	ginkgo.It("[cf-f-wcp] verify vmservice vm creation with a pvc in its spec", ginkgo.Label(p0,
+	ginkgo.It("[cf-wcp] verify vmservice vm creation with a pvc in its spec", ginkgo.Label(p0,
 		vmServiceVm, block, wcp, vc80), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
What this PR does / why we need it:
VmService VM regression fix for batchAttach CR

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #
batchAttach CR validation required instead of older nodeVmAttachment CR.

Testing done:
Yes
https://gist.github.com/rajguptavm/166b0bcb525c229e032ef1a75117fc58

Special notes for your reviewer:
@kavyashree-r @Aishwarya-Hebbar
