### PR TITLE
batchAttach CR validation in GC test fix

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -41,6 +41,7 @@ const (
 	contollerClusterKubeConfig                 = "CONTROLLER_CLUSTER_KUBECONFIG"
 	controlPlaneLabel                          = "node-role.kubernetes.io/control-plane"
 	crdCNSNodeVMAttachment                     = "cnsnodevmattachments"
+	crdCNSNodeVMBatchAttachment                = "cnsnodevmbatchattachments"
 	crdCNSVolumeMetadatas                      = "cnsvolumemetadatas"
 	crdCNSFileAccessConfig                     = "cnsfileaccessconfigs"
 	crdtriggercsifullsyncsName                 = "csifullsync"

--- a/tests/e2e/vmc_scale_gc_workers.go
+++ b/tests/e2e/vmc_scale_gc_workers.go
@@ -158,7 +158,7 @@ var _ = ginkgo.Describe("Scale TKG Worker nodes", func() {
 
 					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
-					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+pv.Spec.CSI.VolumeHandle,
+					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName, pv.Spec.CSI.VolumeHandle,
 						crdVersion, crdGroup)
 
 				}
@@ -243,7 +243,7 @@ var _ = ginkgo.Describe("Scale TKG Worker nodes", func() {
 
 					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
-					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+pv.Spec.CSI.VolumeHandle,
+					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName, pv.Spec.CSI.VolumeHandle,
 						crdVersion, crdGroup)
 
 				}
@@ -294,7 +294,7 @@ var _ = ginkgo.Describe("Scale TKG Worker nodes", func() {
 
 					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
-					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+pv.Spec.CSI.VolumeHandle,
+					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName, pv.Spec.CSI.VolumeHandle,
 						crdVersion, crdGroup)
 
 				}
@@ -320,7 +320,7 @@ var _ = ginkgo.Describe("Scale TKG Worker nodes", func() {
 						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
-						verifyIsDetachedInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+pv.Spec.CSI.VolumeHandle,
+						verifyIsDetachedInSupervisor(ctx, f, sspod.Spec.NodeName, pv.Spec.CSI.VolumeHandle,
 							crdVersion, crdGroup)
 					}
 				}

--- a/tests/e2e/vmc_upgrade_tkg.go
+++ b/tests/e2e/vmc_upgrade_tkg.go
@@ -192,7 +192,7 @@ var _ = ginkgo.Describe("Upgrade TKG", func() {
 
 					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
-					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+pv.Spec.CSI.VolumeHandle,
+					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName, pv.Spec.CSI.VolumeHandle,
 						crdVersion, crdGroup)
 
 				}
@@ -245,7 +245,7 @@ var _ = ginkgo.Describe("Upgrade TKG", func() {
 
 					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
-					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+pv.Spec.CSI.VolumeHandle,
+					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName, pv.Spec.CSI.VolumeHandle,
 						crdVersion, crdGroup)
 
 				}
@@ -271,7 +271,7 @@ var _ = ginkgo.Describe("Upgrade TKG", func() {
 						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
-						verifyIsDetachedInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+pv.Spec.CSI.VolumeHandle,
+						verifyIsDetachedInSupervisor(ctx, f, sspod.Spec.NodeName, pv.Spec.CSI.VolumeHandle,
 							crdVersion, crdGroup)
 					}
 				}

--- a/tests/e2e/vmc_vc_cert_rotate.go
+++ b/tests/e2e/vmc_vc_cert_rotate.go
@@ -154,7 +154,7 @@ var _ = ginkgo.Describe("VMC VC Cert Rotate", func() {
 
 					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
-					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+pv.Spec.CSI.VolumeHandle,
+					verifyIsAttachedInSupervisor(ctx, f, sspod.Spec.NodeName, pv.Spec.CSI.VolumeHandle,
 						crdVersion, crdGroup)
 
 				}
@@ -208,7 +208,7 @@ var _ = ginkgo.Describe("VMC VC Cert Rotate", func() {
 						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
-						verifyIsDetachedInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+pv.Spec.CSI.VolumeHandle,
+						verifyIsDetachedInSupervisor(ctx, f, sspod.Spec.NodeName, pv.Spec.CSI.VolumeHandle,
 							crdVersion, crdGroup)
 					}
 				}


### PR DESCRIPTION
What this PR does / why we need it:
GC regression fix for batchAttach CR

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #
batchAttach CR validation required instead of older nodeVmAttachment CR.

Testing done:
Yes
https://gist.github.com/rajguptavm/7c52e1ad78ca9ce5cae113f3471a8126

Special notes for your reviewer:
@kavyashree-r @Aishwarya-Hebbar @sipriyaa 