### PR TITLE
Spec bump CSI provisioner image

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -307,7 +307,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.10
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.11
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -307,7 +307,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.10
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.11
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -307,7 +307,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.10
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.11
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update csi-provisioner sidecar version to include changes done for adding backing disk type as PVC annotation.

**Testing done**:
Testing done as part of this PR: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3802

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/768/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/703/