### PR TITLE
Remove error and attached fields from batch attach API as they are no…

### DIFF
--- a/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
+++ b/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
@@ -127,10 +127,6 @@ type CnsNodeVMBatchAttachmentStatus struct {
 
 	// Conditions describes any conditions associated with this CnsNodeVMBatchAttachment instance.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
-
-	// TODO: remove this field once VM op changes are ready.
-	// Error is the overall error status for the instance.
-	Error string `json:"error,omitempty"`
 }
 
 type VolumeStatus struct {
@@ -155,17 +151,6 @@ type PersistentVolumeClaimStatus struct {
 
 	// Conditions describes any conditions associated with this volume.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
-
-	// TODO: remove this field once VM op changes are ready.
-	// Error indicates the error which may have occurred during attach/detach.
-	Error string `json:"error,omitempty"`
-
-	// TODO: remove this field once VM op changes are ready.
-	// Attached indicates the attach status of a PVC.
-	// If volume is not attached, Attached will be set to false.
-	// If volume is attached, Attached will be set to true.
-	// If volume is detached successfully, its entry will be removed from VolumeStatus.
-	Attached bool `json:"attached"`
 }
 
 // +genclient

--- a/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
@@ -183,11 +183,6 @@ spec:
                   - type
                   type: object
                 type: array
-              error:
-                description: |-
-                  TODO: remove this field once VM op changes are ready.
-                  Error is the overall error status for the instance.
-                type: string
               volumes:
                 description: VolumeStatus reflects the status for each volume.
                 items:
@@ -199,14 +194,6 @@ spec:
                       description: PersistentVolumeClaim contains details about the
                         volume's current state.
                       properties:
-                        attached:
-                          description: |-
-                            TODO: remove this field once VM op changes are ready.
-                            Attached indicates the attach status of a PVC.
-                            If volume is not attached, Attached will be set to false.
-                            If volume is attached, Attached will be set to true.
-                            If volume is detached successfully, its entry will be removed from VolumeStatus.
-                          type: boolean
                         claimName:
                           description: ClaimName is the PVC name.
                           type: string
@@ -291,13 +278,7 @@ spec:
                           description: DiskUUID is the ID obtained when volume is
                             attached to a VM.
                           type: string
-                        error:
-                          description: |-
-                            TODO: remove this field once VM op changes are ready.
-                            Error indicates the error which may have occurred during attach/detach.
-                          type: string
                       required:
-                      - attached
                       - claimName
                       type: object
                   required:

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -611,7 +611,7 @@ func recordEvent(ctx context.Context, r *Reconciler,
 		Namespace: instance.Namespace,
 	}
 
-	log.Debugf("Event type %s", eventtype)
+	log.Infof("Event type %s", eventtype)
 	switch eventtype {
 	case v1.EventTypeWarning:
 		// Double backOff duration.
@@ -635,7 +635,6 @@ func (r *Reconciler) completeReconciliationWithSuccess(ctx context.Context, inst
 	log := logger.GetLogger(ctx)
 
 	conditions.MarkTrue(instance, v1alpha1.ConditionReady)
-	instance.Status.Error = ""
 
 	updateErr := updateInstanceStatus(ctx, r.client, instance)
 	if updateErr != nil {
@@ -661,7 +660,6 @@ func (r *Reconciler) completeReconciliationWithError(ctx context.Context, instan
 
 	trimmedError := trimMessage(err)
 	conditions.MarkError(instance, v1alpha1.ConditionReady, v1alpha1.ReasonFailed, trimmedError)
-	instance.Status.Error = err.Error()
 
 	updateErr := updateInstanceStatus(ctx, r.client, instance)
 	if updateErr != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

As part of this change, we added K8s conditions to batch attach CRD: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3734

However, attached and error fields were left out to ensure that compatibility with VM service is not broken until they make their changes.

This PR removes those fields.

**Testing done**:

Successfully attached volumes:


```
apiVersion: cns.vmware.com/v1alpha1
kind: CnsNodeVMBatchAttachment
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsNodeVMBatchAttachment","metadata":{"annotations":{},"name":"test-new-1","namespace":"test"},"spec":{"instanceUUID":"7270a6f3-49e8-4923-9211-68c5b8351c0b","volumes":[{"name":"disk-1","persistentVolumeClaim":{"claimName":"pvc-2","controllerKey":1000,"diskMode":"independent_persistent","sharingMode":"sharingNone","unitNumber":1}},{"name":"disk-2","persistentVolumeClaim":{"claimName":"pvc-3","controllerKey":1000,"diskMode":"independent_persistent","sharingMode":"sharingNone","unitNumber":2}}]}}
  creationTimestamp: "2025-12-29T10:42:58Z"
  finalizers:
  - cns.vmware.com
  generation: 4
  name: test-new-1
  namespace: test
  resourceVersion: "1325232"
  uid: 597b1692-77c6-4c28-90cc-f1df671568cd
spec:
  instanceUUID: 7270a6f3-49e8-4923-9211-68c5b8351c0b
  volumes:
  - name: disk-1
    persistentVolumeClaim:
      claimName: pvc-2
      controllerKey: 1000
      diskMode: independent_persistent
      sharingMode: sharingNone
      unitNumber: 1
  - name: disk-2
    persistentVolumeClaim:
      claimName: pvc-3
      controllerKey: 1000
      diskMode: independent_persistent
      sharingMode: sharingNone
      unitNumber: 2
status:
  conditions:
  - lastTransitionTime: "2025-12-30T13:10:37Z"
    message: ""
    reason: "True"
    status: "True"
    type: Ready
  volumes:
  - name: disk-1
    persistentVolumeClaim:
      claimName: pvc-2
      cnsVolumeId: cd03c037-73fd-46ce-bd17-4eea2a8928d7
      conditions:
      - lastTransitionTime: "2025-12-29T10:43:54Z"
        message: ""
        reason: "True"
        status: "True"
        type: VolumeAttached
      diskUUID: 6000C298-47b9-3195-a2eb-3a5b8df3b586
  - name: disk-2
    persistentVolumeClaim:
      claimName: pvc-3
      cnsVolumeId: 72a29bc9-69fd-4286-8cd0-aced44d4a476
      conditions:
      - lastTransitionTime: "2025-12-30T13:10:37Z"
        message: ""
        reason: "True"
        status: "True"
        type: VolumeAttached
      diskUUID: 6000C29c-e0fd-d472-b532-cde77373d0f4
```

Successfully detached volumes too.

In case of failure in **attach**, ensured that PVC with error in status got the correct state in pvcsInStatus map:

```
{"level":"info","time":"2025-12-30T13:13:20.539977069Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:204","msg":"Test log - PVCs in status map[pvc-2:false pvc-3:true]","TraceId":"41c6212c-7ca8-456c-9265-b70faae34e38"}
```


In case of failure in **detach**, ensured that PVC with error in status got the correct state in pvcsInStatus map:


```
{"level":"info","time":"2025-12-30T13:25:39.726104014Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:204","msg":"Test log - PVCs in status map[pvc-2:false pvc-3:false]","TraceId":"bcccff36-15eb-4dd4-b916-448c2914b8b9"}
```

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/902/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/809/
