### PR TITLE
Enhancement - Set resource requirements for syncer container

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -445,6 +445,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 65534
             runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -510,6 +515,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 65534
             runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -448,6 +448,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 65534
             runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -513,6 +518,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 65534
             runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -448,6 +448,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 65534
             runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -513,6 +518,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 65534
             runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -448,6 +448,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 65534
             runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -513,6 +518,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 65534
             runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements memory resource limits for the vsphere-syncer and vsphere-csi-controller containers in the CSI driver deployment to prevent unbounded memory consumption and protect other critical workloads on control plane nodes.

**Background:**
- Scale testing revealed memory leaks in Syncer where consumption reached 20GB
- After implementing logger optimization fixes, memory consumption was dramatically reduced by 165x (from ~11.5GB to ~70MB at 25k volumes + 25k snapshots)
- Despite the optimization, setting memory limits provides a safety guardrail against potential memory leaks or unexpected workload growth

**Changes:**
- Added memory resource limits to vsphere-syncer container: `requests: 100Mi, limits: 5Gi`
- Added memory resource limits to vsphere-csi-controller container: `requests: 100Mi, limits: 5Gi`
- Applied consistently across Kubernetes versions 1.29, 1.30, 1.31, and 1.32

**Rationale:**
- **Request (100Mi)**: Set low to ensure pods can be scheduled on control plane nodes without consuming excessive reserved resources
- **Limit (5Gi)**: Provides conservative headroom (~98.6% above current usage) while accounting for ~64Gi total memory on control plane nodes
- **QoS Class**: Pods will be classified as `Burstable` since only syncer and controller containers have limits set

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Manual testing**:

Deployed and tested memory limits (100Mi request, 5Gi limit) on WCP Supervisor Cluster with comprehensive profiling:

**Baseline (Idle State):**
- Controller: 5.8 MB memory, 0.27% CPU
- Syncer: 5.4 MB memory, 0.1% CPU

**After Workload (200 storage objects: 50 PVCs + 50 CnsNodeVmAttachment + 50 CnsRegisterVolume + 50 CnsUnregisterVolume):**
- Controller: 5.8 MB memory (no change), 0% CPU
- Syncer: 5.6 MB memory (+0.2 MB), 0% CPU

**Stability:**
- Uptime: 2+ hours with zero restarts across all containers
- Memory utilization: 0.11% of 5Gi limit (99.89% headroom available)
- No errors or OOM events observed

**Precheckin pipelines:**

[**WCP**](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/772/)
```
Ran 14 of 1850 Specs
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 1836 Skipped | 0 Flaked
```

[**VKS**](https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/708/)
```
Ran 6 of 1850 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 1844 Skipped | 0 Flaked
```

**Special notes for your reviewer**:

- Memory limits are based on comprehensive heap profile analysis from scaled production environments
- Current worst-case usage: ~70MB (25k volumes + 25k snapshots post-optimization)
- 5Gi limit provides ~71x multiplier above current usage, allowing significant scale growth
- Container restarts due to OOM are unlikely but handled gracefully via leader election (2 replicas)
- Each container runs in its own cgroup, so only the OOM-killed container would restart, not the entire pod
- Both Syncer and Controller are stateless, so restarts don't cause data loss

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add memory resource limits (100Mi request, 5Gi limit) to vsphere-syncer and vsphere-csi-controller containers to prevent unbounded memory consumption on control plane nodes
```
