### PR TITLE
Revert "Add Volume Attribute for backing disk type"

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -395,9 +395,6 @@ const (
 	// PvcUIDLabelKey is a label which gets added to CnsNodeVMAttachment instances
 	// to indicate the PVC that it has attached.
 	PvcUIDLabelKey = "cns.vmware.com/pvc-uid"
-
-	// DefaultBackingTypeForDynamicBlockVolume is FlatVer2BackingInfo.
-	DefaultBackingTypeForDynamicBlockVolume = "FlatVer2BackingInfo"
 )
 
 // Supported container orchestrators.

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -974,10 +974,6 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		attributes[common.VolumeContextAttributeLinkedCloneVolumeSnapshotSourceUID] = volumeSnapshotUID
 	}
 
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SharedDiskFss) {
-		attributes[common.AnnKeyBackingDiskType] = common.DefaultBackingTypeForDynamicBlockVolume
-	}
-
 	resp := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      volumeInfo.VolumeID.Id,


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit a192fcd869f9389fd1fa65569b4fe8d8bdfd10a1.

If no backing type is provided, we will be falling back to FlatV2 version. So there is no need to add this change.

**Testing done**:

Created a PVC and observed that it did not get backing disk annotation on it:

```
Name:          pvc-1
Namespace:     test
StorageClass:  vsan-default-storage-policy
Status:        Bound
Volume:        pvc-12cffbe0-acb3-4411-a066-fa6d03eaacd4
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"domain-c79"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      100Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                   From                                                                                          Message
  ----    ------                 ----                  ----                                                                                          -------
  Normal  Provisioning           3m55s                 csi.vsphere.vmware.com_42001b21a1c4dea32663549f732f0c56_42434b6d-7f25-4b90-a5db-40206b9c53b2  External provisioner is provisioning volume for claim "test/pvc-1"
  Normal  Provisioning           103s                  csi.vsphere.vmware.com_42001b21a1c4dea32663549f732f0c56_a9fa80f4-a856-43f2-b6f3-9d406d412d8a  External provisioner is provisioning volume for claim "test/pvc-1"
  Normal  ExternalProvisioning   52s (x14 over 3m55s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  52s                   csi.vsphere.vmware.com_42001b21a1c4dea32663549f732f0c56_a9fa80f4-a856-43f2-b6f3-9d406d412d8a  Successfully provisioned volume pvc-12cffbe0-acb3-4411-a066-fa6d03eaacd4
```

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/771/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/706/


