### PR TITLE
Bump golangci-lint from v1.64.8 to v2.7.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,59 @@
+version: "2"
+
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
     - misspell
     - lll
+  exclusions:
+    rules:
+      # Exclude errcheck for Close, Unsetenv, Setenv, Remove calls
+      # These are commonly ignored in deferred cleanup operations
+      - linters:
+          - errcheck
+        text: "Error return value of .*(Close|Unsetenv|Setenv|Remove).*is not checked"
+      # Exclude QF1001 (could apply De Morgan's law) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1001"
+      # Exclude QF1002 (could use tagged switch) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1002"
+      # Exclude QF1003 (could use tagged switch) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1003"
+      # Exclude QF1004 (could use strings.ReplaceAll) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1004"
+      # Exclude QF1007 (could merge conditional assignment) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1007"
+      # Exclude QF1008 (could remove embedded field from selector) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1008"
+      # Exclude QF1010 (could convert argument to string) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1010"
+      # Exclude QF1011 (could omit type from declaration) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1011"
+      # Exclude ST1023 (should omit type from declaration) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "ST1023"
+
 linters-settings:
   lll:
     # max line length, lines longer will be reported. Default is 120.

--- a/hack/check-golangci-lint.sh
+++ b/hack/check-golangci-lint.sh
@@ -53,8 +53,8 @@ shift $((OPTIND-1))
 
 export GOOS=linux
 if [ ! "${DO_DOCKER-}" ]; then
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.64.8
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v2.7.2
   "$(go env GOPATH)"/bin/golangci-lint run -v --timeout=1200s
 else
-  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.64.8 golangci-lint run -v --timeout=1200s
+  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v2.7.2 golangci-lint run -v --timeout=1200s
 fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Upgrade golangci-lint to v2.7.2 to support Go 1.25
- Update .golangci.yml configuration for v2 format:
  - Add required version field
  - Change 'disable-all' to 'default: none'
  - Remove deprecated linters (gosimple merged into staticcheck, typecheck is automatic)

**Which issue this PR fixes** 

due to recent golang bump to 1.25 in this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3811
observing following golangci linter failure on the repo.


```
level=info msg="[config_reader] Used config file .golangci.yml"
Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
Failed executing command with error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
make: *** [Makefile:379: golangci-lint] Error 3
```

**Testing done**:
executed linter check locally.
https://prow.k8s.io/log?container=test&id=2001900536458121216&job=pull-vsphere-csi-driver-verify-golangci-lint

pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/773/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump golangci-lint from v1.64.8 to v2.7.2
```
