### PR TITLE
Default to FlatVer2 if backing disk annotation is missing on PVC

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -176,7 +176,31 @@ func (c *FakeK8SOrchestrator) GetPvcObjectByName(ctx context.Context,
 			},
 			Spec: v1.PersistentVolumeClaimSpec{
 				AccessModes: []v1.PersistentVolumeAccessMode{
-					v1.ReadWriteMany, // Set the access mode to RWO (ReadWriteOnce)
+					v1.ReadWriteOnce, // Set the access mode to RWO (ReadWriteOnce)
+				},
+				Resources: v1.VolumeResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: *resource.NewQuantity(5*1024*1024*1024, resource.BinarySI), // 5Gi of storage
+					},
+				},
+				VolumeMode: &mode,
+			},
+		}
+		return pvc, nil
+	}
+
+	if pvcName == "with-sparse-backing-type" {
+		mode := v1.PersistentVolumeBlock
+
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        pvcName,   // Name of the PVC
+				Namespace:   namespace, // Namespace to create the PVC in
+				Annotations: map[string]string{common.AnnKeyBackingDiskType: "Sparse"},
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{
+					v1.ReadWriteOnce, // Set the access mode to RWO (ReadWriteOnce)
 				},
 				Resources: v1.VolumeResourceRequirements{
 					Requests: v1.ResourceList{


### PR DESCRIPTION
**What this PR does / why we need it**:

In case backing disk annotation is missing on a PVC during batch attach, default it to FlatVer2.


**Testing done**:

Created a dynamic PVC:
Ensured that PVC did not have backingTypeAnnotation

```
{"level":"info","time":"2025-12-19T07:23:27.904099075Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:559","msg":"Setting backing disk type to FlatVer2BackingInfo for PVC pvc-2","TraceId":"9bc765d9-60de-4605-9d33-190defe0875a"}
```

CNS logs confirm that FlatVer2BackingInfo was obtained during attach.
```
2025-12-19T07:23:27.122Z INFO vsanvcmgmtd 66340 [vc@4413 sub="CnsVolMgr" opId="99adf35a"] Attaching volume with spec: (vim.cns.VolumeAttachDetachSpec) [
-->    (vim.cns.VolumeAttachDetachSpec) {
-->       volumeId = (vim.cns.VolumeId) { 
-->          id = "afbde1cc-b34c-470c-8250-8192999bd136" 
-->       }, 
-->       vm = 'vim.VirtualMachine:vm-160', 
-->       diskMode = "persistent", 
-->       sharing = "sharingNone", 
-->       controllerKey = 1000, 
-->       unitNumber = 1, 
-->       backingTypeName = "FlatVer2BackingInfo", 
-->       volumeEncrypted = false
-->    }
--> ]
```

Created a static PVC without backingDiskType:

{"level":"info","time":"2025-12-19T07:32:59.865252939Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:559","msg":"Setting backing disk type to FlatVer2BackingInfo for PVC rwo-block","TraceId":"d6377438-8fe2-43d9-a2b9-6c702151ae6d"}

CNS logs confirm that FlatVer2BackingInfo was obtained during attach.
```
2025-12-19T07:33:00.677Z INFO vsanvcmgmtd 63225 [vc@4413 sub="CnsVolMgr" opId="99adf69f"] Attaching volume with spec: (vim.cns.VolumeAttachDetachSpec) [
-->    (vim.cns.VolumeAttachDetachSpec) {
-->       volumeId = (vim.cns.VolumeId) {
-->          id = "cefbaef7-017c-4ea2-97ba-61f97c61468f"
-->       },    
-->       vm = 'vim.VirtualMachine:vm-160', 
-->       diskMode = "persistent", 
-->       sharing = "sharingNone",  
-->       controllerKey = 1000,
-->       unitNumber = 2,
-->       backingTypeName = "FlatVer2BackingInfo", 
-->       volumeEncrypted = false
-->    }  
--> ]  
```

Created a static PVC with SparseVer2BackingInfo backing type:

```
{"level":"info","time":"2025-12-19T07:39:37.168677244Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:559","msg":"Setting backing disk type to SparseVer2BackingInfo for PVC rwo-block-2","TraceId":"f2014a47-6636-483f-8c10-f9ad32df6c17"}
```

CNS logs confirm that SparseVer2BackingInfo was obtained during attach.
```
2025-12-19T07:39:37.983Z INFO vsanvcmgmtd 63225 [vc@4413 sub="CnsVolMgr" opId="99adfc2f"] Attaching volume with spec: (vim.cns.VolumeAttachDetachSpec) [
-->    (vim.cns.VolumeAttachDetachSpec) { 
-->       volumeId = (vim.cns.VolumeId) { 
-->          id = "5850e064-125a-418d-b243-81211c09fd0c" 
-->       }, 
-->       vm = 'vim.VirtualMachine:vm-160', 
-->       diskMode = "persistent", 
-->       sharing = "sharingNone", 
-->       controllerKey = 1000, 
-->       unitNumber = 3, 
-->       backingTypeName = "SparseVer2BackingInfo", 
-->       volumeEncrypted = false
-->    }  
--> ]        

```

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/779/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/711/
