### PR TITLE
Fix nil pointer exception while fetching VM network status

### DIFF
--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -177,6 +177,12 @@ func GetTKGVMIP(ctx context.Context, vmOperatorClient client.Client, dc dynamic.
 				ip, vmNamespace, vmName)
 		}
 	} else if network_provider_type == VDSNetworkProvider {
+
+		if virtualMachineInstance.Status.Network == nil {
+			log.Errorf("virtualMachineInstance.Status.Network is nil for VM %s", vmName)
+			return "", fmt.Errorf("virtualMachineInstance.Status.Network is nil for VM %s", vmName)
+		}
+
 		ip = virtualMachineInstance.Status.Network.PrimaryIP4
 		if ip == "" {
 			ip = virtualMachineInstance.Status.Network.PrimaryIP6


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Recently a bug was opened which causes panic in syncer container when fileservices is disabled. This PR fixes the same by checking if VM status has a nil network field.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Ensured that new file share volumes are getting created and mounted to VM service VMs.

WCP pipeline (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/816
VKS pipeline (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/796/