### PR TITLE
Ensure that it is not possible to attach volumes across namespaces

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -3549,7 +3549,7 @@ func constructBatchAttachSpecList(ctx context.Context, vm *cnsvsphere.VirtualMac
 		cnsAttachSpecList = append(cnsAttachSpecList, cnsAttachDetachSpec)
 	}
 
-	log.Infof("Constucted CnsVolumeAttachDetachSpec for VM %s", vm.UUID)
+	log.Infof("Constructed CnsVolumeAttachDetachSpec for VM %s", vm.UUID)
 	return cnsAttachSpecList, nil
 
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a possible security issue with batch attach where a volume from another namespace may get attached to a VM in another namespace.

As the only consumer for this API is VM op, it is highly unlikely to run into this issue, however, we still need to fix this.

As part of this change, during attach, we first ensure that a VM with the given instance UUID exists in the same namespace as the batchattach instance.

As we already obtain PVC object in that namespace, we don't need the same check for PVCs also.

Also observed in logs that we're printing the same error message multiple times, so this PR contains that change also.


**Testing done**:

Create 2 namespaces - test and test2.
Created vm-1 and pvc-1 in both the namespaces.

Created batch attach CR manually and tried to attach vm-1 in test2 namespace with pvc-1 in test namespace. Observed that it failed:

```
Name:         test-new-1
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsNodeVMBatchAttachment
Metadata:
  Creation Timestamp:  2025-12-29T10:42:58Z
  Finalizers:
    cns.vmware.com
  Generation:        1
  Resource Version:  176893
  UID:               597b1692-77c6-4c28-90cc-f1df671568cd
Spec:
  Instance UUID:  de70cbaa-0234-4aba-a30a-3391c8bdc152
  Volumes:
    Name:  disk-1
    Persistent Volume Claim:
      Claim Name:      pvc-1
      Controller Key:  1000
      Disk Mode:       independent_persistent
      Sharing Mode:    sharingNone
      Unit Number:     1
Status:
  Conditions:
    Last Transition Time:  2025-12-29T10:42:59Z
    Message:               failed to find VM with instance UUID de70cbaa-0234-4aba-a30a-3391c8bdc152 in namespace test
    Reason:                Failed
    Status:                False
    Type:                  Ready
  Error:                   failed to find VM with instance UUID de70cbaa-0234-4aba-a30a-3391c8bdc152 in namespace test
Events:
  Type     Reason                   Age              From            Message
  ----     ------                   ----             ----            -------
  Warning  NodeVmBatchAttachFailed  2s (x3 over 5s)  cns.vmware.com  failed to find VM with instance UUID de70cbaa-0234-4aba-a30a-3391c8bdc152 in namespace test
```

Attempted to attach vm-1 in test namespace and pvc-1 in test namespace and it succeeded:

```
Name:         test-new-1
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsNodeVMBatchAttachment
Metadata:
  Creation Timestamp:  2025-12-29T10:42:58Z
  Finalizers:
    cns.vmware.com
  Generation:        2
  Resource Version:  177473
  UID:               597b1692-77c6-4c28-90cc-f1df671568cd
Spec:
  Instance UUID:  7270a6f3-49e8-4923-9211-68c5b8351c0b
  Volumes:
    Name:  disk-1
    Persistent Volume Claim:
      Claim Name:      pvc-1
      Controller Key:  1000
      Disk Mode:       independent_persistent
      Sharing Mode:    sharingNone
      Unit Number:     1
Status:
  Conditions:
    Last Transition Time:  2025-12-29T10:43:54Z
    Message:               
    Reason:                True
    Status:                True
    Type:                  Ready
  Volumes:
    Name:  disk-1
    Persistent Volume Claim:
      Attached:       true
      Claim Name:     pvc-1
      Cns Volume Id:  f79ae143-58ad-437f-9c87-03211932330d
      Conditions:
        Last Transition Time:  2025-12-29T10:43:54Z
        Message:               
        Reason:                True
        Status:                True
        Type:                  VolumeAttached
      Disk UUID:               6000C293-4e5e-63c0-b219-cea727e529b7
Events:
  Type     Reason                      Age                From            Message
  ----     ------                      ----               ----            -------
  Warning  NodeVmBatchAttachFailed     24s (x6 over 55s)  cns.vmware.com  failed to find VM with instance UUID de70cbaa-0234-4aba-a30a-3391c8bdc152 in namespace test
  Normal   NodeVmBatchAttachSucceeded  0s                 cns.vmware.com  ReconcileCnsNodeVMBatchAttachment: Successfully processed instance test/test-new-1 in namespace "test/test-new-1".
```

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/807/
VKS precheckin (failure unrelated to my change): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/768/