### PR TITLE
Do not set FS type when volumeMode on PVC is Block

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -256,7 +256,6 @@ func getPersistentVolumeSpec(volumeName string, volumeID string, capacity int64,
 					Driver:       cnsoperatortypes.VSphereCSIDriverName,
 					VolumeHandle: volumeID,
 					ReadOnly:     false,
-					FSType:       "ext4",
 				},
 			},
 			AccessModes: []v1.PersistentVolumeAccessMode{
@@ -274,6 +273,11 @@ func getPersistentVolumeSpec(volumeName string, volumeID string, capacity int64,
 		volumeMode = v1.PersistentVolumeFilesystem
 	}
 	pv.Spec.VolumeMode = &volumeMode
+
+	// FStype should be set only when volumeMode for PVC is FileSystem.
+	if *pv.Spec.VolumeMode == v1.PersistentVolumeFilesystem {
+		pv.Spec.PersistentVolumeSource.CSI.FSType = "ext4"
+	}
 
 	annotations := make(map[string]string)
 	annotations["pv.kubernetes.io/provisioned-by"] = cnsoperatortypes.VSphereCSIDriverName


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

During static volume provisioning, if volumeMode is block, do not set fsType in the PV.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Created a static PVC with volumeMode as block and observed that PV has fsType empty:

```
Name:              static-pv-76323915-673e-4996-b102-c4f6199cc19d
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection external-provisioner.volume.kubernetes.io/finalizer]
StorageClass:      vsan-default-storage-policy
Status:            Bound
Claim:             test/blockvolmode
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Block
Capacity:          64Mi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [az1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            
    VolumeHandle:      76323915-673e-4996-b102-c4f6199cc19d
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>
```

Created a static PVC with volumeMode as Filesystem and observed that PV has fsType ext4:

```
Name:              static-pv-e24bda59-ef4f-473c-a89a-b723e1f5a676
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection external-provisioner.volume.kubernetes.io/finalizer]
StorageClass:      vsan-default-storage-policy
Status:            Bound
Claim:             test/fsvolmode-3
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          64Mi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [az1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      e24bda59-ef4f-473c-a89a-b723e1f5a676
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>
```

Created a static PVC with volumeMode as empty and observed that PV has fsType ext4:

```
root@421f63f3643ee19a69e990d9f5e36229 [ ~ ]# k describe pv static-pv-cfb6d820-da03-4f4d-bec7-c15395a6dfec
Name:              static-pv-cfb6d820-da03-4f4d-bec7-c15395a6dfec
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection external-provisioner.volume.kubernetes.io/finalizer]
StorageClass:      vsan-default-storage-policy
Status:            Bound
Claim:             test/fsvolmode-4
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          64Mi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [az1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      cfb6d820-da03-4f4d-bec7-c15395a6dfec
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>
```

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/827/
VKS pipeline (failure unrelated to my change): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/778/