### PR TITLE
Update sidecar versions for csi-resizer, csi-attacher and liveness-probe in supervisor YAMLs

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -347,7 +347,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.7.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -375,7 +375,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.12.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v2.0.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -462,7 +462,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.14.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           securityContext:

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -347,7 +347,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.7.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -375,7 +375,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.12.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v2.0.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -462,7 +462,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.14.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           securityContext:

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -347,7 +347,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.7.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -375,7 +375,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.12.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v2.0.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -462,7 +462,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.14.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           securityContext:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update sidecar versions for csi-resizer, csi-attacher and liveness-probe in supervisor YAMLs for 9.1 release.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Updated sidecar images manually on testbed for testing and verified that basic sanity is working fine.
```
# kubectl get pods -n vmware-system-csi -l app=vsphere-csi-controller -o json | jq -r '.items[].spec.containers[] | select(.name=="csi-attacher" or .name=="csi-resizer" or .name=="liveness-probe") | "\(.name): \(.image)"'
csi-attacher: cns-docker-dev-local.packages.vcfd.broadcom.net/vkotkar:attacher_4.10.0
csi-resizer: cns-docker-dev-local.packages.vcfd.broadcom.net/vkotkar:resizer_2.0.0
liveness-probe: cns-docker-dev-local.packages.vcfd.broadcom.net/vkotkar:liveness_2.17.0
```

Basic workflows like create volume, attach volume, expand volume etc. are tested and working good.
```
Create Volume:
# k apply -f pvc.yaml -n svc-velero-domain-c10
persistentvolumeclaim/example-pvc created

# k get pvc -n svc-velero-domain-c10
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-pvc   Bound    pvc-7461ad37-c14b-4346-a533-00e50c79df3f   1Gi        RWO            wcpglobal-storage-profile   <unset>                 9s

Volume Mount:
# k apply -f pod.yaml -n svc-velero-domain-c10
pod/example-pod created

# k get pods -n svc-velero-domain-c10
NAME                                               READY   STATUS    RESTARTS   AGE
example-pod                                        1/1     Running   0          30s

Expand volume:
# k edit pvc example-pvc -n svc-velero-domain-c10
persistentvolumeclaim/example-pvc edited

# k get pvc -n svc-velero-domain-c10 
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-pvc   Bound    pvc-7461ad37-c14b-4346-a533-00e50c79df3f   2Gi        RWO            wcpglobal-storage-profile   <unset>                 4m49s

Volume unmount:
# k delete pod example-pod   -n svc-velero-domain-c10
pod "example-pod" deleted


Volume deletion:
# k delete pvc example-pvc  -n svc-velero-domain-c10 
persistentvolumeclaim "example-pvc" deleted

# k get pvc -n svc-velero-domain-c10 
No resources found in svc-velero-domain-c10 namespace.
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Update sidecar versions for csi-resizer, csi-attacher and liveness-probe in supervisor YAMLs
```
