### PR TITLE
Improve logging and comments in batch attach reconciler

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -310,7 +310,7 @@ func (r *Reconciler) Reconcile(ctx context.Context,
 
 		// For every PVC mentioned in instance.Spec and in instance.Status, remove finalizer from it.
 		// It is important to remove the finalizer from PVCs in instance.Status also as it is possible
-		// that someone removes the PVC from spec after trriggering deletion of VM.
+		// that someone removes the PVC from spec after triggering deletion of VM.
 		for pvcName, volumeName := range pvcsInSpecAndStatus {
 			err := removePvcFinalizer(ctx, r.client, k8sClient, r.cnsOperatorClient,
 				pvcName, instance.Namespace,
@@ -610,6 +610,8 @@ func recordEvent(ctx context.Context, r *Reconciler,
 		Name:      instance.Name,
 		Namespace: instance.Namespace,
 	}
+
+	log.Debugf("Event type %s", eventtype)
 	switch eventtype {
 	case v1.EventTypeWarning:
 		// Double backOff duration.
@@ -618,14 +620,12 @@ func recordEvent(ctx context.Context, r *Reconciler,
 			cnsoperatortypes.MaxBackOffDurationForReconciler)
 		backOffDurationMapMutex.Unlock()
 		r.recorder.Event(instance, v1.EventTypeWarning, "NodeVmBatchAttachFailed", msg)
-		log.Error(msg)
 	case v1.EventTypeNormal:
 		// Reset backOff duration to one second.
 		backOffDurationMapMutex.Lock()
 		backOffDuration[namespacedName] = time.Second
 		backOffDurationMapMutex.Unlock()
 		r.recorder.Event(instance, v1.EventTypeNormal, "NodeVmBatchAttachSucceeded", msg)
-		log.Info(msg)
 	}
 }
 

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -319,8 +319,8 @@ func GetVMFromVcenter(ctx context.Context, nodeUUID string,
 	for _, dc := range dcList {
 		vm, err := dc.GetVirtualMachineByUUID(ctx, nodeUUID, true)
 		if err != nil {
-			log.Errorf("failed to find the VM with UUID: %s Err: %+v",
-				nodeUUID, err)
+			log.Errorf("failed to find the VM with UUID: %s on datacenter: %s Err: %+v",
+				nodeUUID, dc.Name(), err)
 			continue
 		}
 		return vm, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This change fixes some spelling mistakes in comments/logs of batch attach controller.

I have also removed a couple of logs from recordEvent because they're already being printed at the place where the error is coming from. Having double logs for the same thing will overflow syncer container.


**Testing done**:
Perfoemed the following tests successfully:
1. Attached 1 volume to VM.
2. Attached 2 volume to VM.
3. Detached 1 volume from VM.
4. Detached 2 volumes from VM.
5. Delete the batch attach CR itself.

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/849
VKS precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/788/

