### PR TITLE
[release-3.6] Bump golang to 1.25.5 and golangci-lint to v2.7.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,59 @@
+version: "2"
+
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
     - misspell
     - lll
+  exclusions:
+    rules:
+      # Exclude errcheck for Close, Unsetenv, Setenv, Remove calls
+      # These are commonly ignored in deferred cleanup operations
+      - linters:
+          - errcheck
+        text: "Error return value of .*(Close|Unsetenv|Setenv|Remove).*is not checked"
+      # Exclude QF1001 (could apply De Morgan's law) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1001"
+      # Exclude QF1002 (could use tagged switch) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1002"
+      # Exclude QF1003 (could use tagged switch) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1003"
+      # Exclude QF1004 (could use strings.ReplaceAll) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1004"
+      # Exclude QF1007 (could merge conditional assignment) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1007"
+      # Exclude QF1008 (could remove embedded field from selector) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1008"
+      # Exclude QF1010 (could convert argument to string) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1010"
+      # Exclude QF1011 (could omit type from declaration) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "QF1011"
+      # Exclude ST1023 (should omit type from declaration) - stylistic suggestion
+      - linters:
+          - staticcheck
+        text: "ST1023"
+
 linters-settings:
   lll:
     # max line length, lines longer will be reported. Default is 120.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module sigs.k8s.io/vsphere-csi-driver/v3
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.5
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0

--- a/hack/check-golangci-lint.sh
+++ b/hack/check-golangci-lint.sh
@@ -53,8 +53,8 @@ shift $((OPTIND-1))
 
 export GOOS=linux
 if [ ! "${DO_DOCKER-}" ]; then
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.64.8
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v2.7.2
   "$(go env GOPATH)"/bin/golangci-lint run -v --timeout=1200s
 else
-  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.64.8 golangci-lint run -v --timeout=1200s
+  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v2.7.2 golangci-lint run -v --timeout=1200s
 fi

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -49,7 +49,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=<docker-registry>/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.24
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.25.5
 
 ARCH=amd64
 OSVERSION=1809

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.24
+ARG GOLANG_IMAGE=golang:1.25.5
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.24
+ARG GOLANG_IMAGE=golang:1.25.5
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.24
+ARG GOLANG_IMAGE=golang:1.25.5
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.24
+ARG GOLANG_IMAGE=golang:1.25.5
 ARG OSVERSION
 ARG ARCH=amd64
 

--- a/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
+++ b/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: storagepools.cns.vmware.com
 spec:
   group: cns.vmware.com


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Upgrade golang from 1.24.0 to 1.25.5
- Update golang image in all Dockerfiles (ci, driver, syncer, windows)
- Update golang image in release.sh
- Upgrade golangci-lint from v1.64.8 to v2.7.2 to support Go 1.25
- Update .golangci.yml configuration for v2 format:
  - Add required version field
  - Change 'disable-all' to 'default: none'
  - Remove deprecated linters (gosimple merged into staticcheck, typecheck is automatic)
  - Add exclusion rules for pre-existing linter issues

**Which issue this PR fixes**
fixed CVE issues

**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vanilla-instapp-e2e-pre-checkin/223/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump golang to 1.25.5 and golangci-lint to v2.7.2
```
