### PR TITLE
change vsphere-csi-controller service type to ClusterIP

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -620,7 +620,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -620,7 +620,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -620,7 +620,7 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR updates the vSphere CSI Controller Service type from LoadBalancer to ClusterIP.

Previously, we attempted to change the vSphere CSI Controller Service to ClusterIP in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3519

However, that change was reverted due to an issue in netoperator where the
netoperator.vmware.com/service finalizer was not being removed when the Service was deleted. At that time, netoperator only removed this finalizer for Services of type ClusterIP, and not for LoadBalancer, which caused Service deletion to hang and thus upgrade was not happening.

The underlying netoperator bug has now been fixed, and the netoperator.vmware.com/service finalizer is correctly removed regardless of the Service type.




**Testing done**:

Deployed service with LoadBalancer.

```
# kubectl get  service vsphere-csi-controller -n vmware-system-csi -o json
{
    "apiVersion": "v1",
    "kind": "Service",
    "metadata": {
        "annotations": {
            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"vsphere-csi-controller\"},\"name\":\"vsphere-csi-controller\",\"namespace\":\"vmware-system-csi\"},\"spec\":{\"ports\":[{\"name\":\"ctlr\",\"port\":2112,\"protocol\":\"TCP\",\"targetPort\":2112},{\"name\":\"syncer\",\"port\":2113,\"protocol\":\"TCP\",\"targetPort\":2113}],\"selector\":{\"app\":\"vsphere-csi-controller\"},\"type\":\"LoadBalancer\"}}\n",
            "lbapi.run.tanzu.vmware.com/ip-address": "166.168.0.1"
        },
        "creationTimestamp": "2026-01-07T00:18:05Z",
        "finalizers": [
            "netoperator.vmware.com/service"
        ],
        "labels": {
            "app": "vsphere-csi-controller",
            "service.route.lbapi.run.tanzu.vmware.com/gateway-name": "vsphere-csi-controller",
            "service.route.lbapi.run.tanzu.vmware.com/gateway-namespace": "vmware-system-csi",
            "service.route.lbapi.run.tanzu.vmware.com/type": "direct"
        },
        "name": "vsphere-csi-controller",
        "namespace": "vmware-system-csi",
        "resourceVersion": "2720",
        "uid": "5e8ce348-d446-413e-942c-4ead1279cc71"
    },
    "spec": {
        "allocateLoadBalancerNodePorts": true,
        "clusterIP": "10.96.245.186",
        "clusterIPs": [
            "10.96.245.186"
        ],
        "externalTrafficPolicy": "Cluster",
        "internalTrafficPolicy": "Cluster",
        "ipFamilies": [
            "IPv4"
        ],
        "ipFamilyPolicy": "SingleStack",
apiVersion: v1
        "ports": [
            {
                "name": "ctlr",
                "nodePort": 31272,
                "port": 2112,
                "protocol": "TCP",
                "targetPort": 2112
            },
            {
                "name": "syncer",
                "nodePort": 30430,
                "port": 2113,
                "protocol": "TCP",
                "targetPort": 2113
            }
        ],
        "selector": {
            "app": "vsphere-csi-controller"
        },
        "sessionAffinity": "None",
        "type": "LoadBalancer"
    },
    "status": {
        "loadBalancer": {
            "ingress": [
                {
                    "ip": "166.168.0.1",
                    "ipMode": "VIP"
                }
            ]
        }
    }
}
```

Deleted service and confirmed service is not stuck in terminating state due to finalizer not getting removed.

```
# kubectl delete service vsphere-csi-controller -n vmware-system-csi
service "vsphere-csi-controller" deleted


# kubectl get  service vsphere-csi-controller -n vmware-system-csi
Error from server (NotFound): services "vsphere-csi-controller" not found
```


re-created service with type ClusterIP

```
# kubectl create -f service.yaml
service/vsphere-csi-controller created
root@42050969df500b79150b1338640e3abf [ ~ ]# kubectl get  service vsphere-csi-controller -n vmware-system-csi
NAME                     TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
vsphere-csi-controller   ClusterIP   10.96.45.209   <none>        2112/TCP,2113/TCP   8s


# kubectl get  service vsphere-csi-controller -n vmware-system-csi -o json
{
    "apiVersion": "v1",
    "kind": "Service",
    "metadata": {
        "creationTimestamp": "2026-01-09T18:41:11Z",
        "labels": {
            "app": "vsphere-csi-controller"
        },
        "name": "vsphere-csi-controller",
        "namespace": "vmware-system-csi",
        "resourceVersion": "2471784",
        "uid": "d5b5ec9f-2f27-442d-af40-6cc41c4e5a1c"
    },
    "spec": {
        "clusterIP": "10.96.45.209",
        "clusterIPs": [
            "10.96.45.209"
        ],
        "internalTrafficPolicy": "Cluster",
        "ipFamilies": [
            "IPv4"
        ],
        "ipFamilyPolicy": "SingleStack",
        "ports": [
            {
                "name": "ctlr",
                "port": 2112,
                "protocol": "TCP",
                "targetPort": 2112
            },
            {
                "name": "syncer",
                "port": 2113,
                "protocol": "TCP",
                "targetPort": 2113
            }
        ],
        "selector": {
            "app": "vsphere-csi-controller"
        },
        "sessionAffinity": "None",
        "type": "ClusterIP"
    },
    "status": {
        "loadBalancer": {}
    }
}
```


**Special notes for your reviewer**:
pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/859/
executed with `REPLACE_LATEST_CNS_CSI_YAML` flag.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
change vsphere-csi-controller service type to ClusterIP
```
