### PR TITLE
Fix - Prevent unnecessary reconciliations for CnsRegisterVolume instances

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -37,12 +37,12 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 
@@ -173,25 +173,17 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	maxWorkerThreads := util.GetMaxWorkerThreads(ctx,
 		workerThreadsEnvVar, defaultMaxWorkerThreads)
 	// Create a new controller.
-	c, err := controller.New("cnsregistervolume-controller", mgr,
-		controller.Options{Reconciler: r, MaxConcurrentReconciles: maxWorkerThreads})
+	err := ctrl.NewControllerManagedBy(mgr).Named("cnsregistervolume-controller").
+		For(&cnsregistervolumev1alpha1.CnsRegisterVolume{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxWorkerThreads}).
+		Complete(r)
 	if err != nil {
-		log.Errorf("Failed to create new CnsRegisterVolume controller with error: %+v", err)
+		log.Errorf("Failed to build application controller. Err: %v", err)
 		return err
 	}
 
 	backOffDuration = make(map[apitypes.NamespacedName]time.Duration)
-
-	// Watch for changes to primary resource CnsRegisterVolume.
-	err = c.Watch(source.Kind(
-		mgr.GetCache(),
-		&cnsregistervolumev1alpha1.CnsRegisterVolume{},
-		&handler.TypedEnqueueRequestForObject[*cnsregistervolumev1alpha1.CnsRegisterVolume]{},
-	))
-	if err != nil {
-		log.Errorf("Failed to watch for changes to CnsRegisterVolume resource with error: %+v", err)
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

This PR adds `GenerationChangedPredicate` to the `CnsRegisterVolume` controller to optimize reconciliation behavior and align with best practices used in other controllers within the codebase.

## Problem Statement

The `CnsRegisterVolume` controller can be triggered for updates that don't involve actual spec changes which could lead to unnecessary reconciliations which could overwhelm the VC network. We have observed similar issues with `CnsNodeVmAttachment` reconciler in the past.

## Solution

Add `GenerationChangedPredicate` to the controller builder to avoid reconciling events that do not increment the generation of CnsRegisterVolume instance.

## Testing
### Verifying backoff duration
Create a dummy CnsRegisterVolume instance and verified that the reconciliation is following the correct backoff pattern and durations -
```
11:49:40 - timeout "1s"
11:49:41 - timeout "2s"      (1s later)
11:49:43 - timeout "4s"      (2s later)
11:49:47 - timeout "8s"      (4s later)
11:49:55 - timeout "16s"     (8s later)
11:50:11 - timeout "32s"     (16s later)
11:50:43 - timeout "1m4s"    (32s later)
11:51:47 - timeout "2m8s"    (64s later)
11:53:56 - timeout "4m16s"   (128s later)
11:58:12 - timeout "5m0s"    (256s later, capped at max)
12:03:12 - timeout "5m0s"    (5m intervals continue...)
12:08:12 - timeout "5m0s"
12:13:12 - timeout "5m0s"
```

### Volume registration
**Status**: **PASSED**

**Setup**:
1. Created PVC 
2. Captured the FCD ID
3. Changed PV reclaim policy to `Retain`
4. Deleted PVC and PV, leaving FCD in backend
5. Created CnsRegisterVolume CR to register the orphaned FCD:
```yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: test2-register-fcd
spec:
  pvcName: test2-fcd-registered-pvc
  volumeID: "28181b0f-3889-48da-bec1-946b008d49b2"
  accessMode: ReadWriteOnce
```

**Result**: **SUCCESS**
- Status: `registered: true`
- PVC created: `test2-fcd-registered-pvc` (Bound, 5Gi)
- PV created: `static-pv-28181b0f-3889-48da-bec1-946b008d49b2` (Bound)
- Storage class correctly mapped: `vsan-default-storage-policy`

## Special notes for reviewer
- This change follows the same pattern we have implemented for other controllers.
- This change doesn't introduce any behavioural changes to any volume registration workflows.

## Precheckin runs
### [WCP](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/867/)
In Progress

## Release Note
```release-note
Prevent unnecessary reconciliations for CnsRegisterVolume instances
```