### PR TITLE
revert resizer to v1.12.0

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -375,7 +375,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v2.0.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.12.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -375,7 +375,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v2.0.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.12.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -375,7 +375,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v2.0.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.12.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We bumped resizer with this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3846
but it broke ability to resize volume back to back in the supervisor cluster.
We have decided to revert resizer to avoid any further regression.



**Testing done**:

replaced image `docker.io/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.12.0_vmware.1` on the supervisor cluster and performed following test.

```
Create PVC

# kubectl create -f pvc.yaml -n test
persistentvolumeclaim/pvc-4 created

# kubectl get pvc pvc-4  -n test
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pvc-4   Bound    pvc-356c3e35-f726-4386-bfce-7cc85a40942b   500Mi      RWO            wcpglobal-storage-profile   <unset>                 102s

Create Pod

# kubectl create -f pod.yaml -n test
pod/pod4 created

# kubectl get pod pod4 -n test
NAME   READY   STATUS    RESTARTS   AGE
pod4   1/1     Running   0          93s


Edit PVC and changed   resources -> requests -> storage to 600Mi

# kubectl edit pvc pvc-4 -n test
persistentvolumeclaim/pvc-4 edited

verified volume is expanded

# kubectl get pvc pvc-4  -n test
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pvc-4   Bound    pvc-356c3e35-f726-4386-bfce-7cc85a40942b   600Mi      RWO            wcpglobal-storage-profile   <unset>                 3m18s


Edit PVC and changed   resources -> requests -> storage to 800Mi

Verified volume is expanded

# kubectl get pvc pvc-4  -n test
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pvc-4   Bound    pvc-356c3e35-f726-4386-bfce-7cc85a40942b   800Mi      RWO            wcpglobal-storage-profile   <unset>                 6m49s

```

**Special notes for your reviewer**:

pre-checkin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/890/
All test passed except for resize volume which will get fixed after spec bump as mentioned by @chethanv28 here - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3861#issuecomment-3748206583

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
revert resizer to v1.12.0
```
