### PR TITLE
Skip encryption for attached PVCs to enable atomic VM encryption

### DIFF
--- a/pkg/common/cns-lib/crypto/kubernetes.go
+++ b/pkg/common/cns-lib/crypto/kubernetes.go
@@ -20,9 +20,11 @@ import (
 	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 )
 
-// NewK8sScheme creates a Kubernetes runtime schema for interacting with EncryptionClass entities.
+// NewK8sScheme creates a Kubernetes runtime schema for interacting with EncryptionClass entities
+// and CNS operator resources.
 func NewK8sScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
 
@@ -31,6 +33,11 @@ func NewK8sScheme() (*runtime.Scheme, error) {
 	}
 
 	if err := byokv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	// Register CNS operator types (CnsNodeVmAttachment, CnsNodeVMBatchAttachment, etc.)
+	if err := cnsoperatorapis.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 

--- a/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller.go
+++ b/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller.go
@@ -29,9 +29,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	cnsv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
+	cnsbatchv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/crypto"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	commonco "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	ctrlcommoon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/common"
 )
@@ -125,6 +128,22 @@ func (r *reconciler) reconcileNormal(ctx context.Context, pvc *corev1.Persistent
 		return nil
 	}
 
+	// Check if PVC is attached to a VM
+	isAttached, vmUUID, err := r.isPVCAttachedToVM(ctx, pvc)
+	if err != nil {
+		r.logger.Errorf("Failed to check PVC attachment status for PVC %s/%s: %v", pvc.Namespace, pvc.Name, err)
+		return err
+	}
+
+	if isAttached {
+		// PVC is attached - skip encryption and defer to VM Operator
+		r.logger.Infof("Skipping encryption for PVC %s/%s as it is attached to VM with UUID %s. "+
+			"Deferring to VM Operator for atomic encryption operation. "+
+			"EncryptionClass: %s, KeyProvider: %s, KeyID: %s",
+			pvc.Namespace, pvc.Name, vmUUID, encClass.Name, encClass.Spec.KeyProvider, encClass.Spec.KeyID)
+		return nil
+	}
+
 	var cryptoSpec vimtypes.BaseCryptoSpec
 	if existingKeyID != nil {
 		cryptoSpec = &vimtypes.CryptoSpecShallowRecrypt{NewKeyId: newKeyID}
@@ -179,4 +198,55 @@ func (r *reconciler) findVolume(ctx context.Context, pvc *corev1.PersistentVolum
 	}
 
 	return &result.Volumes[0], nil
+}
+
+// isPVCAttachedToVM checks if the PVC is currently attached to a VM by looking for
+// CnsNodeVmAttachment or CnsNodeVMBatchAttachment CRs.
+// Returns (isAttached, vmUUID, error) where vmUUID is the NodeUUID or InstanceUUID of the VM.
+func (r *reconciler) isPVCAttachedToVM(ctx context.Context, pvc *corev1.PersistentVolumeClaim) (bool, string, error) {
+	log := r.logger.With("pvc", pvc.Name, "namespace", pvc.Namespace)
+
+	// Check for CnsNodeVmAttachment CRs
+	var attachmentList cnsv1alpha1.CnsNodeVmAttachmentList
+	if err := r.List(ctx, &attachmentList, client.InNamespace(pvc.Namespace)); err != nil {
+		log.Errorf("Failed to list CnsNodeVmAttachment CRs: %v", err)
+		return false, "", err
+	}
+
+	for _, attachment := range attachmentList.Items {
+		if attachment.Spec.VolumeName == pvc.Spec.VolumeName && attachment.Status.Attached {
+			log.Infof("Found CnsNodeVmAttachment CR %s with status.attached=true", attachment.Name)
+			// Use NodeUUID from spec as VM identifier
+			return true, attachment.Spec.NodeUUID, nil
+		}
+	}
+
+	// Check for CnsNodeVMBatchAttachment CRs (only if SharedDiskFss is enabled)
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, csicommon.SharedDiskFss) {
+		var batchAttachmentList cnsbatchv1alpha1.CnsNodeVMBatchAttachmentList
+		if err := r.List(ctx, &batchAttachmentList, client.InNamespace(pvc.Namespace)); err != nil {
+			log.Errorf("Failed to list CnsNodeVMBatchAttachment CRs: %v", err)
+			return false, "", err
+		}
+
+		for _, batchAttachment := range batchAttachmentList.Items {
+			// Check if PVC is in the spec
+			for _, volumeSpec := range batchAttachment.Spec.Volumes {
+				if volumeSpec.PersistentVolumeClaim.ClaimName == pvc.Name {
+					// Check if it's attached in the status
+					for _, volumeStatus := range batchAttachment.Status.VolumeStatus {
+						if volumeStatus.PersistentVolumeClaim.ClaimName == pvc.Name &&
+							volumeStatus.PersistentVolumeClaim.Attached {
+							log.Infof("Found CnsNodeVMBatchAttachment CR %s with PVC attached", batchAttachment.Name)
+							// Use InstanceUUID from spec as VM identifier
+							return true, batchAttachment.Spec.InstanceUUID, nil
+						}
+					}
+				}
+			}
+		}
+	}
+
+	log.Infof("PVC %s/%s is not attached to any VM", pvc.Namespace, pvc.Name)
+	return false, "", nil
 }

--- a/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
+++ b/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	cnsoperator "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	cnsv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
+	cnsbatchv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	commonco "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// Test helper to create a scheme with required types
+func createTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = byokv1.AddToScheme(scheme)
+	// Register CnsNodeVmAttachment and CnsNodeVMBatchAttachment
+	scheme.AddKnownTypes(cnsoperator.SchemeGroupVersion,
+		&cnsv1alpha1.CnsNodeVmAttachment{},
+		&cnsv1alpha1.CnsNodeVmAttachmentList{},
+		&cnsbatchv1alpha1.CnsNodeVMBatchAttachment{},
+		&cnsbatchv1alpha1.CnsNodeVMBatchAttachmentList{},
+	)
+	metav1.AddToGroupVersion(scheme, cnsoperator.SchemeGroupVersion)
+	return scheme
+}
+
+func TestIsPVCAttachedToVM_NotAttached(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	// Initialize fake CO interface
+	fakeCO, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commonco.ContainerOrchestratorUtility = fakeCO
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmUUID, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.False(t, isAttached, "PVC should not be attached")
+	assert.Empty(t, vmUUID, "VM UUID should be empty when not attached")
+}
+
+func TestIsPVCAttachedToVM_AttachedViaCnsNodeVmAttachment(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	// Initialize fake CO interface
+	fakeCO, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commonco.ContainerOrchestratorUtility = fakeCO
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	attachment := &cnsv1alpha1.CnsNodeVmAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-attachment",
+			Namespace: "default",
+		},
+		Spec: cnsv1alpha1.CnsNodeVmAttachmentSpec{
+			VolumeName: "pv-test",
+			NodeUUID:   "node-uuid-123",
+		},
+		Status: cnsv1alpha1.CnsNodeVmAttachmentStatus{
+			Attached: true,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, attachment).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmUUID, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.True(t, isAttached, "PVC should be attached")
+	assert.Equal(t, "node-uuid-123", vmUUID, "VM UUID should match NodeUUID from spec")
+}
+
+func TestIsPVCAttachedToVM_AttachedViaCnsNodeVmAttachment_NotAttachedStatus(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	// Initialize fake CO interface
+	fakeCO, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commonco.ContainerOrchestratorUtility = fakeCO
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	attachment := &cnsv1alpha1.CnsNodeVmAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-attachment",
+			Namespace: "default",
+		},
+		Spec: cnsv1alpha1.CnsNodeVmAttachmentSpec{
+			VolumeName: "pv-test",
+			NodeUUID:   "node-uuid",
+		},
+		Status: cnsv1alpha1.CnsNodeVmAttachmentStatus{
+			Attached: false, // Not attached
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, attachment).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmUUID, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.False(t, isAttached, "PVC should not be attached when status.attached is false")
+	assert.Empty(t, vmUUID, "VM UUID should be empty when not attached")
+}
+
+func TestIsPVCAttachedToVM_AttachedViaBatchAttachment(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	// Initialize fake CO interface and enable SharedDiskFss
+	fakeCO, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commonco.ContainerOrchestratorUtility = fakeCO
+	// Enable SharedDiskFss feature for batch attachment testing
+	err = fakeCO.EnableFSS(ctx, "supports_shared_disks_with_VM_service_VMs")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	controllerKey := int32(1000)
+	unitNumber := int32(0)
+
+	batchAttachment := &cnsbatchv1alpha1.CnsNodeVMBatchAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-batch-attachment",
+			Namespace: "default",
+		},
+		Spec: cnsbatchv1alpha1.CnsNodeVMBatchAttachmentSpec{
+			InstanceUUID: "vm-uuid",
+			Volumes: []cnsbatchv1alpha1.VolumeSpec{
+				{
+					Name: "volume-1",
+					PersistentVolumeClaim: cnsbatchv1alpha1.PersistentVolumeClaimSpec{
+						ClaimName:     "test-pvc",
+						DiskMode:      cnsbatchv1alpha1.Persistent,
+						SharingMode:   cnsbatchv1alpha1.SharingMultiWriter,
+						ControllerKey: &controllerKey,
+						UnitNumber:    &unitNumber,
+					},
+				},
+			},
+		},
+		Status: cnsbatchv1alpha1.CnsNodeVMBatchAttachmentStatus{
+			VolumeStatus: []cnsbatchv1alpha1.VolumeStatus{
+				{
+					Name: "volume-1",
+					PersistentVolumeClaim: cnsbatchv1alpha1.PersistentVolumeClaimStatus{
+						ClaimName: "test-pvc",
+						Attached:  true,
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, batchAttachment).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	// SharedDiskFss is enabled, so batch attachments should be checked
+	isAttached, vmUUID, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.True(t, isAttached, "PVC should be attached via batch attachment when SharedDiskFss is enabled")
+	assert.Equal(t, "vm-uuid", vmUUID, "VM UUID should match InstanceUUID from batch attachment spec")
+}
+
+func TestIsPVCAttachedToVM_MultipleAttachments(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	// Initialize fake CO interface
+	fakeCO, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commonco.ContainerOrchestratorUtility = fakeCO
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	// Create multiple attachments, only one with attached=true
+	attachment1 := &cnsv1alpha1.CnsNodeVmAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-attachment-1",
+			Namespace: "default",
+		},
+		Spec: cnsv1alpha1.CnsNodeVmAttachmentSpec{
+			VolumeName: "pv-other",
+			NodeUUID:   "node-uuid-1",
+		},
+		Status: cnsv1alpha1.CnsNodeVmAttachmentStatus{
+			Attached: true,
+		},
+	}
+
+	attachment2 := &cnsv1alpha1.CnsNodeVmAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-attachment-2",
+			Namespace: "default",
+		},
+		Spec: cnsv1alpha1.CnsNodeVmAttachmentSpec{
+			VolumeName: "pv-test",
+			NodeUUID:   "node-uuid-2",
+		},
+		Status: cnsv1alpha1.CnsNodeVmAttachmentStatus{
+			Attached: true,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, attachment1, attachment2).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmUUID, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.True(t, isAttached, "PVC should be attached when matching attachment exists")
+	assert.Equal(t, "node-uuid-2", vmUUID, "VM UUID should match the NodeUUID of the attachment with matching volume")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Changing the key provider type using BYOK requires an atomic operation for VMs and their disks, as there is no support for mixed-mode configurations where a VM uses one key provider and its disks use another.

With this change, when a PVC's encryption class is updated (either via PVC annotation or EncryptionClass resource update), CSI checks if the PVC is attached to a VM. If attached, CSI skips the encryption operation and defers to VM Operator, which will aggregate all PVCs and VM encryption changes and issue atomic reconfig API call to vCenter.

This ensures VMs and their attached disks are always encrypted with the same key provider, preventing unsupported mixed-mode encryption states.

Changes:
- Add `isPVCAttachedToVM()` method to detect attachment via CnsNodeVmAttachment or CnsNodeVMBatchAttachment CRs
- Skip UpdateVolumeCrypto API call when PVC is attached to a VM
- Add unit tests covering various attachment scenarios


**Testing done**:

Manual testing done

```
# kubectl get encryptionclasses.encryption.vmware.com -n test-gc-e2e-demo-ns
NAME           KEYPROVIDER   KEYID
encclass-kms   kms2          1270
encclass-nkp   nkp           Ag4AAAEABAAMABAAIAAxMjY5Ml2JK61SFBECg7QrsdKBTKrefKCw+pCXdH6+rIduMFiBjurhxDQ7d6DUyDC44UF/theCvtHyvVk7GPqA


# kubectl get encryptionclasses.encryption.vmware.com -n test-gc-e2e-demo-ns encclass-kms
NAME           KEYPROVIDER   KEYID
encclass-kms   kms2          1270


# cat encryptedpvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: encrypted-pvc1
  namespace: test-gc-e2e-demo-ns
  annotations:
    csi.vsphere.volume-requested-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
    csi.vsphere.encryption-class: encclass-kms
spec:
  resources:
    requests:
      storage: 10Mi
  storageClassName: vm-encryption-policy
  accessModes:
    - ReadWriteOnce
  volumeMode: Block


# kubectl create -f encryptedpvc.yaml
persistentvolumeclaim/encrypted-pvc1 created


# kubectl get pvc encrypted-pvc1 -n test-gc-e2e-demo-ns
NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           VOLUMEATTRIBUTESCLASS   AGE
encrypted-pvc1   Bound    pvc-49596f2b-e02b-4f35-b162-8b28ec3d0478   10Mi       RWO            vm-encryption-policy   <unset>                 87s



# cat encryptedvm.yaml
apiVersion: vmoperator.vmware.com/v1alpha5
kind: VirtualMachine
metadata:
  name: encryptedvm
  namespace: test-gc-e2e-demo-ns
  labels:
    topology.kubernetes.io/zone: az1
spec:
  crypto:
    encryptionClassName: encclass-kms
  imageName: vmi-9faed8382c3441255
  className: best-effort-xsmall
  powerState: PoweredOn
  storageClass: vm-encryption-policy
  volumes:
    - name: my-disk
      persistentVolumeClaim:
        claimName: encrypted-pvc1



# kubectl create -f encryptedvm.yaml
virtualmachine.vmoperator.vmware.com/encryptedvm created

# kubectl get vm encryptedvm -n test-gc-e2e-demo-ns
NAME          POWER-STATE   AGE
encryptedvm   PoweredOn     6m51s

kubectl annotate pvc encrypted-pvc1 -n test-gc-e2e-demo-ns csi.vsphere.encryption-class=encclass-nkp --overwrite

```

Logs after updating encryption-class on attached PVC
-----

> {"level":"info","time":"2026-01-15T01:17:07.096920656Z","logger":"controllers.PersistentVolumeClaim","caller":"persistentvolumeclaim/persistentvolumeclaim_controller.go:240","msg":"Found CnsNodeVMBatchAttachment CR encryptedvm with PVC attached","pvc":"encrypted-pvc1","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-15T01:17:07.097323316Z","logger":"controllers.PersistentVolumeClaim","caller":"persistentvolumeclaim/persistentvolumeclaim_controller.go:140","msg":"Skipping encryption for PVC test-gc-e2e-demo-ns/encrypted-pvc1 as it is attached to VM with UUID 53fe3f70-60bf-456e-9e46-07403579b249. Deferring to VM Operator for atomic encryption operation. EncryptionClass: encclass-nkp, KeyProvider: nkp, KeyID: Ag4AAAEABAAMABAAIAAxMjY5Ml2JK61SFBECg7QrsdKBTKrefKCw+pCXdH6+rIduMFiBjurhxDQ7d6DUyDC44UF/theCvtHyvVk7GPqA"}


```
Reverted PVC annotation back to original and updated key in the encryptionclass
kubectl annotate pvc encrypted-pvc1 -n test-gc-e2e-demo-ns csi.vsphere.encryption-class=encclass-kms --overwrite

# kubectl edit encryptionclasses.encryption.vmware.com encclass-kms -n test-gc-e2e-demo-ns
encryptionclass.encryption.vmware.com/encclass-kms edited

```

Logs after updating encryption-class key
-----

> {"level":"info","time":"2026-01-15T01:20:28.320556453Z","caller":"persistentvolumeclaim/util.go:51","msg":"Reconciling all PVCs referencing an EncryptionClass","name":"encclass-kms","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-15T01:20:28.321025021Z","caller":"persistentvolumeclaim/util.go:88","msg":"Reconciling PVCs due to EncryptionClass watchrequests[test-gc-e2e-demo-ns/encrypted-pvc1]","name":"encclass-kms","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-15T01:20:28.321247867Z","caller":"persistentvolumeclaim/util.go:51","msg":"Reconciling all PVCs referencing an EncryptionClass","name":"encclass-kms","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-15T01:20:28.32169377Z","caller":"persistentvolumeclaim/util.go:88","msg":"Reconciling PVCs due to EncryptionClass watchrequests[test-gc-e2e-demo-ns/encrypted-pvc1]","name":"encclass-kms","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-15T01:20:30.382255762Z","caller":"volume/listview.go:200","msg":"AddTask called for Task:task-7390"}
{"level":"info","time":"2026-01-15T01:20:30.387299757Z","caller":"volume/listview.go:218","msg":"client is valid. trying to add task to listview object"}
{"level":"info","time":"2026-01-15T01:20:30.394110035Z","caller":"volume/listview.go:241","msg":"task Task:task-7390 added to listView"}
{"level":"info","time":"2026-01-15T01:20:30.39899967Z","caller":"volume/listview.go:427","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-7390 Task:Task:task-7390 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.queryvolumeinfo Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc001fbd8f0 QueueTime:2026-01-15 01:20:33.043322 +0000 UTC StartTime:2026-01-15 01:20:33.063133 +0000 UTC CompleteTime:<nil> EventChainId:41463 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:5a71a247}}","TraceId":"ad9cad62-94e8-4346-86ca-051bd37e2f44"}
{"level":"info","time":"2026-01-15T01:20:31.31394648Z","caller":"volume/listview.go:427","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-7390 Task:Task:task-7390 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.queryvolumeinfo Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:success Cancelled:false Cancelable:false Error:<nil> Result:{DynamicData:{} VolumeResults:[0xc00180c720]} Progress:0 ProgressDetails:[] Reason:0xc0024ab0f0 QueueTime:2026-01-15 01:20:33.043322 +0000 UTC StartTime:2026-01-15 01:20:33.063133 +0000 UTC CompleteTime:2026-01-15 01:20:33.996415 +0000 UTC EventChainId:41463 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:5a71a247}}","TraceId":"ad9cad62-94e8-4346-86ca-051bd37e2f44"}
{"level":"info","time":"2026-01-15T01:20:31.31401876Z","caller":"volume/listview.go:455","msg":"Successfully sent task result for task Task:task-7390","TraceId":"ad9cad62-94e8-4346-86ca-051bd37e2f44"}
{"level":"info","time":"2026-01-15T01:20:31.332438295Z","caller":"volume/listview.go:267","msg":"client is valid. trying to remove task from listview object"}
{"level":"info","time":"2026-01-15T01:20:31.337658779Z","caller":"volume/listview.go:273","msg":"task Task:task-7390 removed from listView"}
{"level":"info","time":"2026-01-15T01:20:31.337805225Z","caller":"volume/manager.go:2366","msg":"QueryVolumeInfo: volumeIDList: [{{} 49596f2b-e02b-4f35-b162-8b28ec3d0478}], opId: \"5a71a247\""}
{"level":"info","time":"2026-01-15T01:20:31.33782354Z","caller":"volume/manager.go:2384","msg":"QueryVolumeInfo successfully returned volumeInfo volumeIDList [{{} 49596f2b-e02b-4f35-b162-8b28ec3d0478}]:, opId: \"5a71a247\""}
{"level":"info","time":"2026-01-15T01:20:31.34014606Z","logger":"controllers.PersistentVolumeClaim","caller":"persistentvolumeclaim/persistentvolumeclaim_controller.go:240","msg":"Found CnsNodeVMBatchAttachment CR encryptedvm with PVC attached","pvc":"encrypted-pvc1","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-15T01:20:31.340236919Z","logger":"controllers.PersistentVolumeClaim","caller":"persistentvolumeclaim/persistentvolumeclaim_controller.go:140","msg":"Skipping encryption for PVC test-gc-e2e-demo-ns/encrypted-pvc1 as it is attached to VM with UUID 53fe3f70-60bf-456e-9e46-07403579b249. Deferring to VM Operator for atomic encryption operation. EncryptionClass: encclass-kms, KeyProvider: kms2, KeyID: 1271"}





**Special notes for your reviewer**:
Pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/894/

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Skip encryption for attached PVCs to enable atomic VM encryption
```
