### PR TITLE
 Revert "Prevent account lockout during password rotation in WCP cluster (#3787)

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -602,32 +602,3 @@ func FilterSuspendedDatastores(ctx context.Context, datastoreInfoList []*Datasto
 	log.Infof("Filtered list of datastores after removing suspended ones are: %+v", filteredList)
 	return filteredList, nil
 }
-
-// IsInvalidLoginError checks if the error is due to invalid credentials (*types.InvalidLogin).
-//
-// The govmomi client returns a soap.soapFaultError containing *types.InvalidLogin as the
-// underlying VimFault. We also check the error message as a fallback.
-func IsInvalidLoginError(ctx context.Context, err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// Check if it's a soap.soapFaultError containing InvalidLogin
-	// This is the primary check that catches the actual error from vCenter
-	if soap.IsSoapFault(err) {
-		soapFault := soap.ToSoapFault(err)
-		if soapFault != nil && soapFault.VimFault() != nil {
-			if _, ok := soapFault.VimFault().(*types.InvalidLogin); ok {
-				return true
-			}
-		}
-	}
-
-	// Fallback: check if the error message contains the InvalidLogin text
-	// This handles edge cases where type checking doesn't work
-	if strings.Contains(err.Error(), "Cannot complete login due to an incorrect user name or password") {
-		return true
-	}
-
-	return false
-}

--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -2,12 +2,10 @@ package vsphere
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -62,102 +60,4 @@ func TestFilterSuspendedDatastoresWhenDatastoreIsNotSuspended(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(outputDsInfo))
 
-}
-
-func TestIsInvalidLoginError(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("WhenNilErr", func(tt *testing.T) {
-		// Setup - empty error
-		var err error
-
-		// Execute
-		result := IsInvalidLoginError(ctx, err)
-
-		// Verify
-		assert.False(tt, result)
-	})
-
-	t.Run("WhenSoapFaultWithInvalidLogin", func(tt *testing.T) {
-		// Setup - soap.soapFaultError containing InvalidLogin
-		// This mimics the actual error type returned by govmomi from vCenter
-		fault := &soap.Fault{
-			Code:   "ServerFaultCode",
-			String: "Cannot complete login due to an incorrect user name or password",
-			Detail: struct {
-				Fault types.AnyType "xml:\",any,typeattr\""
-			}{
-				Fault: &types.InvalidLogin{
-					VimFault: types.VimFault{
-						MethodFault: types.MethodFault{
-							FaultCause: &types.LocalizedMethodFault{
-								Fault:            nil,
-								LocalizedMessage: "Cannot complete login due to an incorrect user name or password",
-							},
-							FaultMessage: []types.LocalizableMessage{},
-						},
-					},
-				},
-			},
-		}
-		soapFault := soap.WrapSoapFault(fault)
-
-		// Execute
-		result := IsInvalidLoginError(ctx, soapFault)
-
-		// Verify
-		assert.True(tt, result)
-	})
-
-	t.Run("WhenSoapFaultWithDifferentVimFault", func(tt *testing.T) {
-		// Setup - SoapFault with a different VimFault type that is not InvalidLogin
-		fault := &soap.Fault{
-			Code:   "ServerFaultCode",
-			String: "Invalid locale",
-			Detail: struct {
-				Fault types.AnyType "xml:\",any,typeattr\""
-			}{
-				Fault: &types.InvalidLocale{
-					VimFault: types.VimFault{
-						MethodFault: types.MethodFault{
-							FaultCause: &types.LocalizedMethodFault{
-								Fault:            nil,
-								LocalizedMessage: "invalid locale",
-							},
-							FaultMessage: []types.LocalizableMessage{},
-						},
-					},
-				},
-			},
-		}
-		soapFault := soap.WrapSoapFault(fault)
-
-		// Execute
-		result := IsInvalidLoginError(ctx, soapFault)
-
-		// Verify
-		assert.False(tt, result)
-	})
-
-	t.Run("WhenErrorMessageContainsInvalidLoginText", func(tt *testing.T) {
-		// Setup - error message contains InvalidLogin text (fallback check)
-		err := errors.New("ServerFaultCode: Cannot complete login due to an incorrect user name or password")
-
-		// Execute
-		result := IsInvalidLoginError(ctx, err)
-
-		// Verify
-		assert.True(tt, result)
-	})
-
-	t.Run("WhenGenericError", func(tt *testing.T) {
-		// Setup - any other error that is not InvalidLogin
-		err := errors.New("some random connection error")
-
-		// Execute
-		result := IsInvalidLoginError(ctx, err)
-
-		// Verify
-		assert.False(tt, result)
-	})
 }

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -60,16 +60,6 @@ const (
 	statusSuccess = "success"
 	// failed request
 	statusFailUnknown = "fail-unknown"
-
-	// Retry configuration for InvalidLogin errors during connection establishment.
-	// These constants define the retry behavior when authentication fails,
-	// which can happen during password rotation by WCP service.
-	// Uses a flat 3-minute (180s) delay matching vCenter's SSO lockout window
-	// (5 attempts in 180s). After one retry, the function returns an error,
-	// allowing Kubernetes to restart the container for fresh attempts.
-	// This approach is lockout-proof and leverages Kubernetes' restart mechanism.
-	maxLoginRetries = 2 // Initial attempt + 1 retry after 180s
-	retryDelay      = 3 * time.Minute
 )
 
 // VirtualCenter holds details of a virtual center instance.
@@ -272,83 +262,30 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) erro
 	return client.SessionManager.LoginByToken(client.Client.WithHeader(ctx, header))
 }
 
-// cleanupVCClient logs out and clears the VC client to ensure a clean state.
-// This helper is used during error handling and retry logic.
-func (vc *VirtualCenter) cleanupVCClient(ctx context.Context) {
-	log := logger.GetLogger(ctx)
-	if vc.Client == nil {
-		return
-	}
-
-	if err := vc.Client.Logout(ctx); err != nil {
-		log.With("err", err).Warn("Could not logout of VC session")
-	}
-	vc.Client = nil
-}
-
 // Connect establishes a new connection with vSphere with updated credentials.
-// If credentials are invalid due to password rotation, it retries with a flat 3-minute delay
-// to avoid account lockout. The delay matches vCenter's SSO lockout window (5 attempts in 180s),
-// ensuring each retry happens after the previous lockout window expires.
-// For any other failure, it fails immediately without retry.
-// After each login attempt, the client is cleaned up to avoid resource leaks.
+// If credentials are invalid then it fails the connection.
 func (vc *VirtualCenter) Connect(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 
 	vc.ClientMutex.Lock()
 	defer vc.ClientMutex.Unlock()
 
-	var err error
-	for attempt := 1; attempt <= maxLoginRetries; attempt++ {
-		err = vc.connect(ctx)
-		if err == nil {
-			// Connection successful
-			log.With("attempt", attempt).Debug("Successfully connected to vCenter")
-			return nil
-		}
-
-		// Check if this is an InvalidLogin error that we should retry
-		if !IsInvalidLoginError(ctx, err) {
-			// Not an authentication error - fail immediately without retry
-			log.With("err", err).Error("Cannot connect to vCenter")
-			break
-		}
-
-		// If this is the last attempt, don't wait - just exit
-		if attempt >= maxLoginRetries {
-			log.With("attempts", maxLoginRetries, "err", err).
-				Warn("Cannot connect to vCenter after all retry attempts with InvalidLogin error")
-			break
-		}
-
-		// Log the retry attempt
-		log.With("attempt", attempt, "retryDelay", retryDelay, "maxAttempts", maxLoginRetries).
-			Warn("Unable to login to VC with invalid login error, retrying (possibly due to credential rotation)")
-
-		// Cleanup before retrying to ensure clean state
-		vc.cleanupVCClient(ctx)
-
-		// Wait before retrying.
-		// Since defer in not a good practice in loops, we stop the timer explicitly.
-		retryTimer := time.NewTimer(retryDelay)
-		select {
-		case <-ctx.Done():
-			retryTimer.Stop()
-			log.With("err", ctx.Err()).Error("Context cancelled during retry backoff")
-			return ctx.Err()
-		case <-retryTimer.C:
-			retryTimer.Stop()
-			// Continue to next attempt
-		}
+	// Set up the vc connection.
+	err := vc.connect(ctx)
+	if err != nil {
+		log.Errorf("Cannot connect to vCenter with err: %v", err)
+		// Logging out of the current session to make sure the retry create
+		// a new client in the next attempt.
+		defer func() {
+			if vc.Client != nil {
+				logoutErr := vc.Client.Logout(ctx)
+				if logoutErr != nil {
+					log.Errorf("Could not logout of VC session. Error: %v", logoutErr)
+				}
+			}
+		}()
 	}
-
-	// We reach here in one of the following cases:
-	// 1. All retry attempts failed with InvalidLogin errors.
-	// 2. The context was cancelled.
-	// 3. Some other error occurred while creating a new client.
-	// In all these cases, we need to clean up the client before returning the error.
-	vc.cleanupVCClient(ctx)
-	return fmt.Errorf("failed to connect to vCenter: %w", err)
+	return err
 }
 
 // connect creates a connection to the virtual center host.


### PR DESCRIPTION
This reverts commit 7592a837485c4d72b90a8624c395e706b8ec001c.

## Summary
The logic introduced in #3858 fixes the password rotation issue during restarts but it's not handling session invalidated issues correctly. This PR reverts this fix to avoid this regression while we handle this correctly in another PR.


## Testing done
Before the revert was applied all the volumes were in Pending state.
After revering this fix all the volumes got provisioned.

## Precheckin runs
### [WCP](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/895/)
In progress

### [VKS](https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/805/)
In progress

### [Vanilla](https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vanilla-instapp-e2e-pre-checkin/240/)
In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```


