### PR TITLE
Skip update volume crypto for attached pvc

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -74,7 +74,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["vmware.com"]
     resources: ["virtualnetworks"]
     verbs: ["get"]

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -74,7 +74,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["vmware.com"]
     resources: ["virtualnetworks"]
     verbs: ["get"]

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -74,7 +74,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["vmware.com"]
     resources: ["virtualnetworks"]
     verbs: ["get"]

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -74,7 +74,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["vmware.com"]
     resources: ["virtualnetworks"]
     verbs: ["get"]

--- a/pkg/common/cns-lib/crypto/kubernetes.go
+++ b/pkg/common/cns-lib/crypto/kubernetes.go
@@ -17,12 +17,13 @@ limitations under the License.
 package crypto
 
 import (
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
-// NewK8sScheme creates a Kubernetes runtime schema for interacting with EncryptionClass entities.
+// NewK8sScheme creates a Kubernetes runtime schema for interacting with EncryptionClass and VirtualMachine entities.
 func NewK8sScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
 
@@ -31,6 +32,11 @@ func NewK8sScheme() (*runtime.Scheme, error) {
 	}
 
 	if err := byokv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	// Register VM Operator types to enable listing VirtualMachines
+	if err := vmoperatortypes.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 

--- a/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
+++ b/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
@@ -1,0 +1,678 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// createTestScheme creates a scheme with all required types for testing
+func createTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = vmoperatortypes.AddToScheme(scheme)
+	return scheme
+}
+
+// TestFindVolume tests the findVolume function
+func TestFindVolume(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+	volumeHandle := "test-volume-handle"
+	pvName := "pv-test"
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: pvName,
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		pv := &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pvName,
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						Driver:       csicommon.VSphereCSIDriverName,
+						VolumeHandle: volumeHandle,
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, pv).Build()
+		r := &reconciler{
+			Client: fakeClient,
+			logger: logger.GetLoggerWithNoContext().Named("test"),
+		}
+
+		volID, err := r.findVolume(ctx, pvc)
+		assert.NoError(t, err)
+		assert.Equal(t, volumeHandle, volID)
+	})
+
+	t.Run("PVNotFound", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
+		r := &reconciler{
+			Client: fakeClient,
+			logger: logger.GetLoggerWithNoContext().Named("test"),
+		}
+
+		volID, err := r.findVolume(ctx, pvc)
+		assert.Error(t, err)
+		assert.Empty(t, volID)
+	})
+
+	t.Run("NotVSphereCSIVolume", func(t *testing.T) {
+		pv := &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pvName,
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						Driver: "other-driver",
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, pv).Build()
+		r := &reconciler{
+			Client: fakeClient,
+			logger: logger.GetLoggerWithNoContext().Named("test"),
+		}
+
+		volID, err := r.findVolume(ctx, pvc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a vSphere CSI volume")
+		assert.Empty(t, volID)
+	})
+
+	t.Run("IsFileVolume", func(t *testing.T) {
+		fileVolumeHandle := "file:test-volume-handle"
+		pv := &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pvName,
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						Driver:       csicommon.VSphereCSIDriverName,
+						VolumeHandle: fileVolumeHandle,
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, pv).Build()
+		r := &reconciler{
+			Client: fakeClient,
+			logger: logger.GetLoggerWithNoContext().Named("test"),
+		}
+
+		volID, err := r.findVolume(ctx, pvc)
+		assert.NoError(t, err)
+		assert.Empty(t, volID)
+	})
+}
+
+// TestIsPVCAttachedToVM_NotAttached tests the case where a PVC is not referenced in any VM
+func TestIsPVCAttachedToVM_NotAttached(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	// Create a VM that doesn't reference this PVC
+	vm := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vm",
+			Namespace: "default",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: "other-volume",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "other-pvc",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, vm).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.False(t, isAttached, "PVC should not be attached")
+	assert.Empty(t, vmName, "VM name should be empty when not attached")
+}
+
+// TestIsPVCAttachedToVM_Attached tests the case where a PVC is referenced in a VM
+func TestIsPVCAttachedToVM_Attached(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	// Create a VM that references this PVC
+	vm := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vm",
+			Namespace: "default",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: "my-disk",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "test-pvc",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, vm).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.True(t, isAttached, "PVC should be attached")
+	assert.Equal(t, "test-vm", vmName, "VM name should match")
+}
+
+// TestIsPVCAttachedToVM_NoVMs tests the case where no VMs exist in the namespace
+func TestIsPVCAttachedToVM_NoVMs(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.False(t, isAttached, "PVC should not be attached when no VMs exist")
+	assert.Empty(t, vmName, "VM name should be empty")
+}
+
+// TestIsPVCAttachedToVM_MultipleVMs tests the case where multiple VMs exist and one references the PVC
+func TestIsPVCAttachedToVM_MultipleVMs(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	// VM 1 - doesn't reference the PVC
+	vm1 := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm-1",
+			Namespace: "default",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: "other-volume",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "other-pvc",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// VM 2 - references the PVC
+	vm2 := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm-2",
+			Namespace: "default",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: "my-disk",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "test-pvc",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// VM 3 - doesn't reference the PVC
+	vm3 := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm-3",
+			Namespace: "default",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, vm1, vm2, vm3).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.True(t, isAttached, "PVC should be attached")
+	assert.Equal(t, "vm-2", vmName, "VM name should match the VM that references the PVC")
+}
+
+// TestIsPVCAttachedToVM_VMWithMultipleVolumes tests a VM with multiple volumes including the target PVC
+func TestIsPVCAttachedToVM_VMWithMultipleVolumes(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	// VM with multiple volumes
+	vm := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vm",
+			Namespace: "default",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: "disk-1",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "pvc-1",
+							},
+						},
+					},
+				},
+				{
+					Name: "disk-2",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "test-pvc",
+							},
+						},
+					},
+				},
+				{
+					Name: "disk-3",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "pvc-3",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, vm).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.True(t, isAttached, "PVC should be attached")
+	assert.Equal(t, "test-vm", vmName, "VM name should match")
+}
+
+// TestIsPVCAttachedToVM_DifferentNamespace tests that VMs in different namespaces are not considered
+func TestIsPVCAttachedToVM_DifferentNamespace(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "namespace-1",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	// VM in a different namespace that references a PVC with the same name
+	vm := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vm",
+			Namespace: "namespace-2",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: "my-disk",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "test-pvc",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, vm).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.False(t, isAttached, "PVC should not be attached (VM is in different namespace)")
+	assert.Empty(t, vmName, "VM name should be empty")
+}
+
+// TestIsPVCAttachedToVM_VMWithNoPVCVolumes tests a VM that has no PVC volumes
+func TestIsPVCAttachedToVM_VMWithNoPVCVolumes(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	// VM with a non-PVC volume (e.g., ConfigMap)
+	vm := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vm",
+			Namespace: "default",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: "config-volume",
+					// PersistentVolumeClaim is nil - could be a ConfigMap or other volume type
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, vm).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	assert.NoError(t, err)
+	assert.False(t, isAttached, "PVC should not be attached")
+	assert.Empty(t, vmName, "VM name should be empty")
+}
+
+// TestIsPVCAttachedToVM_PVCAnnotationChanged_AttachedToVM tests the scenario where
+// a PVC's csi.vsphere.encryption-class annotation is changed while the PVC is attached to a VM.
+// The isPVCAttachedToVM function should detect the attachment and return true.
+func TestIsPVCAttachedToVM_PVCAnnotationChanged_AttachedToVM(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	// Create PVC with NEW encryption class annotation (simulating annotation change from old-class to new-class)
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"csi.vsphere.encryption-class": "new-encryption-class", // Changed annotation
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test-123",
+		},
+	}
+
+	// Create VM that references this PVC
+	vm := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vm",
+			Namespace: "default",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: "my-disk",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "test-pvc",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, vm).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	// Execute - this simulates the reconciliation triggered by PVC annotation change
+	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	// Verify - should detect attachment and return true
+	assert.NoError(t, err)
+	assert.True(t, isAttached, "PVC should be detected as attached when annotation changes while attached to VM")
+	assert.Equal(t, "test-vm", vmName, "VM name should be returned")
+}
+
+// TestIsPVCAttachedToVM_EncryptionClassUpdated_PVCAttachedToVM tests the scenario where
+// an EncryptionClass is updated (e.g., KeyID or KeyProvider changed) and a PVC referencing
+// it is attached to a VM. The isPVCAttachedToVM function should detect the attachment.
+func TestIsPVCAttachedToVM_EncryptionClassUpdated_PVCAttachedToVM(t *testing.T) {
+	ctx := context.Background()
+	scheme := createTestScheme()
+
+	// Create PVC that references an EncryptionClass (which will be updated externally)
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"csi.vsphere.encryption-class": "my-encryption-class",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test-456",
+		},
+	}
+
+	// Create VM that references this PVC
+	vm := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prod-vm",
+			Namespace: "default",
+		},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: "data-disk",
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "test-pvc",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc, vm).
+		Build()
+
+	r := &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+
+	// Execute - this simulates the reconciliation triggered by EncryptionClass update
+	// (The EncryptionClassToPersistentVolumeClaimMapper would have triggered reconciliation of this PVC)
+	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+
+	// Verify - should detect attachment and return true
+	assert.NoError(t, err)
+	assert.True(t, isAttached,
+		"PVC should be detected as attached when EncryptionClass is updated and PVC is attached to VM")
+	assert.Equal(t, "prod-vm", vmName, "VM name should be returned")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

    Skip PVC encryption when attached to VirtualMachine

    When a PVC's encryption class annotation is changed or when an
    EncryptionClass is updated, CSI should skip calling UpdateVolumeCrypto
    for PVCs that are attached to VirtualMachines. This ensures atomic
    encryption operations where VM Operator aggregates all PVCs and VM
    encryption changes and issues a single atomic reconfig API call to
    vCenter, preventing mixed-mode scenarios where a VM and its disks are
    on different key providers.

    Changes:
    - Register VM Operator types in BYOK controller scheme to enable
      listing VirtualMachine CRs
    - Updated `findVolume` func to fetch volume ID from the PV volume handle. 
       - This is required for statically created PV. Existing logic in the `findVolume` func query CNS with PV name 
       which does not work for static PV. Also call to CNS is not required just to check volume is file volume or block volume.
    - Add isPVCAttachedToVM() function to check if PVC is referenced in
      any VM's spec.volumes in the same namespace
    - Modify reconcileNormal() to check VM attachment before calling
      UpdateVolumeCrypto and skip encryption if PVC is attached to a VM
    - Add unit tests
    - Add watch permission for virtualmachines in vmoperator.vmware.com
      API group to vsphere-csi-controller ClusterRole for supervisor
      cluster versions 1.30, 1.31, and 1.32

    When a PVC is attached to a VM, CSI logs at Info level and defers
    encryption to VM Operator, which will handle the encryption atomically
    during the VM update path.



**Testing done**:

Updated "csi.vsphere.encryption-class" annotation on the PVC attached to VM

> {"level":"info","time":"2026-01-18T17:22:56.743754665Z","caller":"utils/utils.go:53","msg":"Successfully listed 11 virtual machines in namespace test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-18T17:22:56.744225992Z","logger":"controllers.PersistentVolumeClaim","caller":"persistentvolumeclaim/persistentvolumeclaim_controller.go:225","msg":"Found VirtualMachine encryptedvm in namespace test-gc-e2e-demo-ns referencing PVC encrypted-pvc1","pvc":"encrypted-pvc1","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-18T17:22:56.744372964Z","logger":"controllers.PersistentVolumeClaim","caller":"persistentvolumeclaim/persistentvolumeclaim_controller.go:110","msg":"Skipping encryption for PVC test-gc-e2e-demo-ns/encrypted-pvc1 as it is referenced in VirtualMachine encryptedvm. Deferring to VM Operator which will aggregate all PVCs and VM encryption changes and issue atomic reconfig API call to vCenter. EncryptionClass: encclass-nkp, KeyProvider: nkp, KeyID: "}


Updated  encryptionclass with PVC created using it and attached to VM

> {"level":"info","time":"2026-01-18T18:06:03.658732185Z","caller":"persistentvolumeclaim/util.go:51","msg":"Reconciling all PVCs referencing an EncryptionClass","name":"encclass-nkp","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-18T18:06:03.679557901Z","caller":"persistentvolumeclaim/util.go:88","msg":"Reconciling PVCs due to EncryptionClass watchrequests[test-gc-e2e-demo-ns/encrypted-pvc1]","name":"encclass-nkp","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-18T18:06:03.686715762Z","caller":"persistentvolumeclaim/util.go:51","msg":"Reconciling all PVCs referencing an EncryptionClass","name":"encclass-nkp","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-18T18:06:03.692233523Z","caller":"persistentvolumeclaim/util.go:88","msg":"Reconciling PVCs due to EncryptionClass watchrequests[test-gc-e2e-demo-ns/encrypted-pvc1]","name":"encclass-nkp","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-18T18:06:03.714442765Z","caller":"utils/utils.go:53","msg":"Successfully listed 11 virtual machines in namespace test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-18T18:06:03.714639443Z","logger":"controllers.PersistentVolumeClaim","caller":"persistentvolumeclaim/persistentvolumeclaim_controller.go:225","msg":"Found VirtualMachine encryptedvm in namespace test-gc-e2e-demo-ns referencing PVC encrypted-pvc1","pvc":"encrypted-pvc1","namespace":"test-gc-e2e-demo-ns"}
{"level":"info","time":"2026-01-18T18:06:03.714706737Z","logger":"controllers.PersistentVolumeClaim","caller":"persistentvolumeclaim/persistentvolumeclaim_controller.go:110","msg":"Skipping encryption for PVC test-gc-e2e-demo-ns/encrypted-pvc1 as it is referenced in VirtualMachine encryptedvm. Deferring to VM Operator which will aggregate all PVCs and VM encryption changes and issue atomic reconfig API call to vCenter. EncryptionClass: encclass-nkp, KeyProvider: nkp2, KeyID: "}


**Special notes for your reviewer**:
VM service team has also verified by patching their environment with this CSI change.

Pre-checkin pipeline:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/975/ 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Skip update volume crypto for attached pvc
```
