### PR TITLE
Fix - NotAuthenticated errors after service disruptions

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -2,10 +2,12 @@ package vsphere
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -60,4 +62,102 @@ func TestFilterSuspendedDatastoresWhenDatastoreIsNotSuspended(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(outputDsInfo))
 
+}
+
+func TestIsInvalidLoginError(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("WhenNilErr", func(tt *testing.T) {
+		// Setup - empty error
+		var err error
+
+		// Execute
+		result := IsInvalidLoginError(ctx, err)
+
+		// Verify
+		assert.False(tt, result)
+	})
+
+	t.Run("WhenSoapFaultWithInvalidLogin", func(tt *testing.T) {
+		// Setup - soap.soapFaultError containing InvalidLogin
+		// This mimics the actual error type returned by govmomi from vCenter
+		fault := &soap.Fault{
+			Code:   "ServerFaultCode",
+			String: "Cannot complete login due to an incorrect user name or password",
+			Detail: struct {
+				Fault types.AnyType "xml:\",any,typeattr\""
+			}{
+				Fault: &types.InvalidLogin{
+					VimFault: types.VimFault{
+						MethodFault: types.MethodFault{
+							FaultCause: &types.LocalizedMethodFault{
+								Fault:            nil,
+								LocalizedMessage: "Cannot complete login due to an incorrect user name or password",
+							},
+							FaultMessage: []types.LocalizableMessage{},
+						},
+					},
+				},
+			},
+		}
+		soapFault := soap.WrapSoapFault(fault)
+
+		// Execute
+		result := IsInvalidLoginError(ctx, soapFault)
+
+		// Verify
+		assert.True(tt, result)
+	})
+
+	t.Run("WhenSoapFaultWithDifferentVimFault", func(tt *testing.T) {
+		// Setup - SoapFault with a different VimFault type that is not InvalidLogin
+		fault := &soap.Fault{
+			Code:   "ServerFaultCode",
+			String: "Invalid locale",
+			Detail: struct {
+				Fault types.AnyType "xml:\",any,typeattr\""
+			}{
+				Fault: &types.InvalidLocale{
+					VimFault: types.VimFault{
+						MethodFault: types.MethodFault{
+							FaultCause: &types.LocalizedMethodFault{
+								Fault:            nil,
+								LocalizedMessage: "invalid locale",
+							},
+							FaultMessage: []types.LocalizableMessage{},
+						},
+					},
+				},
+			},
+		}
+		soapFault := soap.WrapSoapFault(fault)
+
+		// Execute
+		result := IsInvalidLoginError(ctx, soapFault)
+
+		// Verify
+		assert.False(tt, result)
+	})
+
+	t.Run("WhenErrorMessageContainsInvalidLoginText", func(tt *testing.T) {
+		// Setup - error message contains InvalidLogin text (fallback check)
+		err := errors.New("ServerFaultCode: Cannot complete login due to an incorrect user name or password")
+
+		// Execute
+		result := IsInvalidLoginError(ctx, err)
+
+		// Verify
+		assert.True(tt, result)
+	})
+
+	t.Run("WhenGenericError", func(tt *testing.T) {
+		// Setup - any other error that is not InvalidLogin
+		err := errors.New("some random connection error")
+
+		// Execute
+		result := IsInvalidLoginError(ctx, err)
+
+		// Verify
+		assert.False(tt, result)
+	})
 }

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -60,6 +60,16 @@ const (
 	statusSuccess = "success"
 	// failed request
 	statusFailUnknown = "fail-unknown"
+
+	// Retry configuration for InvalidLogin errors during connection establishment.
+	// These constants define the retry behavior when authentication fails,
+	// which can happen during password rotation by WCP service.
+	// Uses a flat 3-minute (180s) delay matching vCenter's SSO lockout window
+	// (5 attempts in 180s). After one retry, the function returns an error,
+	// allowing Kubernetes to restart the container for fresh attempts.
+	// This approach is lockout-proof and leverages Kubernetes' restart mechanism.
+	maxLoginRetries = 2 // Initial attempt + 1 retry after 180s
+	retryDelay      = 3 * time.Minute
 )
 
 // VirtualCenter holds details of a virtual center instance.
@@ -262,30 +272,89 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) erro
 	return client.SessionManager.LoginByToken(client.Client.WithHeader(ctx, header))
 }
 
+// cleanupVCClient logs out and clears the VC client to ensure a clean state.
+// This helper is used during error handling and retry logic.
+func (vc *VirtualCenter) cleanupVCClient(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+	if vc.Client == nil {
+		return
+	}
+
+	if err := vc.Client.Logout(ctx); err != nil {
+		log.With("err", err).Warn("Could not logout of VC session")
+	}
+
+	// nullifies all the clients so that they are created anew during next Connection attempt
+	vc.Client = nil
+	vc.PbmClient = nil
+	vc.CnsClient = nil
+	vc.VsanClient = nil
+	vc.VslmClient = nil
+}
+
 // Connect establishes a new connection with vSphere with updated credentials.
-// If credentials are invalid then it fails the connection.
+// If credentials are invalid due to password rotation, it retries with a flat 3-minute delay
+// to avoid account lockout. The delay matches vCenter's SSO lockout window (5 attempts in 180s),
+// ensuring each retry happens after the previous lockout window expires.
+// For any other failure, it fails immediately without retry.
+// After each login attempt, the client is cleaned up to avoid resource leaks.
 func (vc *VirtualCenter) Connect(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 
 	vc.ClientMutex.Lock()
 	defer vc.ClientMutex.Unlock()
 
-	// Set up the vc connection.
-	err := vc.connect(ctx)
-	if err != nil {
-		log.Errorf("Cannot connect to vCenter with err: %v", err)
-		// Logging out of the current session to make sure the retry create
-		// a new client in the next attempt.
-		defer func() {
-			if vc.Client != nil {
-				logoutErr := vc.Client.Logout(ctx)
-				if logoutErr != nil {
-					log.Errorf("Could not logout of VC session. Error: %v", logoutErr)
-				}
-			}
-		}()
+	var err error
+	for attempt := 1; attempt <= maxLoginRetries; attempt++ {
+		err = vc.connect(ctx)
+		if err == nil {
+			// Connection successful
+			log.With("attempt", attempt).Debug("Successfully connected to vCenter")
+			return nil
+		}
+
+		// Check if this is an InvalidLogin error that we should retry
+		if !IsInvalidLoginError(ctx, err) {
+			// Not an authentication error - fail immediately without retry
+			log.With("err", err).Error("Cannot connect to vCenter")
+			break
+		}
+
+		// If this is the last attempt, don't wait - just exit
+		if attempt >= maxLoginRetries {
+			log.With("attempts", maxLoginRetries, "err", err).
+				Warn("Cannot connect to vCenter after all retry attempts with InvalidLogin error")
+			break
+		}
+
+		// Log the retry attempt
+		log.With("attempt", attempt, "retryDelay", retryDelay, "maxAttempts", maxLoginRetries).
+			Warn("Unable to login to VC with invalid login error, retrying (possibly due to credential rotation)")
+
+		// Cleanup before retrying to ensure clean state
+		vc.cleanupVCClient(ctx)
+
+		// Wait before retrying.
+		// Since defer in not a good practice in loops, we stop the timer explicitly.
+		retryTimer := time.NewTimer(retryDelay)
+		select {
+		case <-ctx.Done():
+			retryTimer.Stop()
+			log.With("err", ctx.Err()).Error("Context cancelled during retry backoff")
+			return ctx.Err()
+		case <-retryTimer.C:
+			retryTimer.Stop()
+			// Continue to next attempt
+		}
 	}
-	return err
+
+	// We reach here in one of the following cases:
+	// 1. All retry attempts failed with InvalidLogin errors.
+	// 2. The context was cancelled.
+	// 3. Some other error occurred while creating a new client.
+	// In all these cases, we need to clean up the client before returning the error.
+	vc.cleanupVCClient(ctx)
+	return fmt.Errorf("failed to connect to vCenter: %w", err)
 }
 
 // connect creates a connection to the virtual center host.


### PR DESCRIPTION
## Summary
#3787 introduced retry mechanism to handle container restarts during WCP password rotation. But, the [cleanup routine](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/7592a837485c4d72b90a8624c395e706b8ec001c/pkg/common/cns-lib/vsphere/virtualcenter.go#L277) that this PR introduced violates an undocumented assumption that `Client` of the virtual center should not be nullified.
#3864 reverted this broken password rotation change.

### Root Cause

The `cleanupVCClient()` function was nullifying `vc.Client` during error recovery. This broke the intended reconnection flow:

1. After service disruption, `cleanupVCClient()` nullified `vc.Client`
2. Next `connect()` call created a new client with a valid session
3. Operations using dependent clients failed with NotAuthenticated

This PR cherry-picks the password rotation back to main with the correct cleanup routine on top. Fixes #3787.

## Testing Done

### Test Summary

Validated fix across service disruption and password rotation scenarios:

| Test | Scenario | Expected Behavior | Result |
|------|----------|------------------|--------|
| Bug Reproduction | vpxd restart with buggy code | NotAuthenticated on VsanClient | PASS |
| Fix Validation | vpxd restart with fix | All operations succeed(new clients created) | PASS |
| Password Rotation 1 | WCP down + secret change + restart | 3-min backoff → success | PASS |
| Password Rotation 2 | Secret change + vpxd restart(service disruption) | 3-min backoff → success | PASS |

### Test Scenarios

#### Bug Reproduction (Buggy Code)

**Setup**: Deployed buggy code, enabled DEBUG logging, restarted vpxd

**Timeline**:

```
08:02:10 - New vCenter session created successfully
08:03:40 - Auth manager refresh triggered
08:03:40 - HasUserPrivilegeOnEntities: SUCCESS (main SDK works)
08:03:40 - VsanClusterGetConfig: FAILED NotAuthenticated (VsanClient fails)
```

**Result**: Successfully reproduced exact bug

#### Fix Validation (Fixed Code)

**Setup**: Deployed fix, enabled DEBUG logging, restarted vpxd

**Timeline**:
```
08:49:06 - New vCenter session created successfully  
08:50:39 - Auth manager refresh triggered
08:50:39 - HasUserPrivilegeOnEntities: SUCCESS (main SDK works)
08:50:39 - vsan cluster config: SUCCESS (no NotAuthenticated errors)
```

**Result**: No NotAuthenticated errors after service disruption

#### Password Rotation Test 1: WCP Service Down

**Scenario**: Simulate password rotation with WCP service maintenance

**Steps**:
1. Stopped WCP service
2. Updated secret with wrong password
3. Restarted CSI deployment
4. Started WCP service (auto-updated secret)
5. Observed backoff and retry

**Timeline**:
```
10:45:35 - InvalidLogin detected, 3-minute backoff started
10:47:58 - WCP auto-updated secret with correct password
10:48:35 - Retry after backoff → SUCCESS
```

**Result**: Automatic recovery after backoff

#### Password Rotation Test 2: vpxd Restart

**Scenario**: Simulate password rotation with service restart (no pod restart)

**Steps**:
1. Updated secret with wrong password (pod still running)
2. Restarted vpxd (forced re-authentication)
3. Observed InvalidLogin and backoff
4. Restored correct password
5. Observed successful connection after backoff

**Timeline**:
```
10:52:04 - InvalidLogin detected, 3-minute backoff started
10:53:34 - Secret restored with correct password
10:55:07 - Retry after backoff → SUCCESS
```

**Result**: No pod restart needed, automatic recovery

## Precheckin runs
### [WCP](https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/921/)
```
Ran 16 of 2324 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2308 Skipped | 0 Flaked
```
### [VKS](https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/821/)
```
Ran 5 of 2324 Specs
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 2319 Skipped | 0 Flaked
```
### Vanilla

## Special Notes for Reviewer

- The existing `vc.connect` code had an implicit assumption that `vc.Client` should persist across reconnection attempts, but this was never documented
- This fix makes the implicit assumption explicit through code comments
- This pattern is critical for proper session management but was not obvious from the code

## Release Note

```release-note
Fix NotAuthenticated errors on dependent client operations after vCenter service disruptions by correcting error recovery logic
```
