### PR TITLE
Fix warnings for deprecated node selector and duplicate port name

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -217,9 +217,10 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/controlplane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
+            # uncomment below matchExpressions if you are on a older version of kubernetes and you are using master nodes
+            # - matchExpressions:
+            #   - key: node-role.kubernetes.io/master
+            #     operator: Exists
       serviceAccountName: vsphere-csi-controller
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -352,7 +353,7 @@ spec:
           imagePullPolicy: "Always"
           ports:
             - containerPort: 2113
-              name: prometheus
+              name: prometheus-sync
               protocol: TCP
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Summary:
Fixed: Deprecated node selector removed
Fixed: Duplicate port name resolved

1. Removed deprecated node-role.kubernetes.io/master node selector 
Commented the third nodeSelectorTerms entry that used the deprecated master label
Kept node-role.kubernetes.io/control-plane and node-role.kubernetes.io/controlplane (for compatibility)
Note: The toleration for master is kept for backward compatibility with older clusters

2. Renamed duplicate prometheus port 
Changed vsphere-syncer container's port name from prometheus to prometheus-syncer
This resolves the conflict with vsphere-csi-controller container's prometheus port
The Service definition already exposes both ports correctly by port number

The manifest should now apply without warnings. The changes maintain backward compatibility while following Kubernetes best practices for modern clusters (v1.20+).


**Testing done**:
Before:
```
 kubectl apply -f vsphere-csi-driver.yaml 
csidriver.storage.k8s.io/csi.vsphere.vmware.com unchanged
serviceaccount/vsphere-csi-controller unchanged
clusterrole.rbac.authorization.k8s.io/vsphere-csi-controller-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-controller-binding unchanged
serviceaccount/vsphere-csi-node unchanged
clusterrole.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role-binding unchanged
role.rbac.authorization.k8s.io/vsphere-csi-node-role unchanged
rolebinding.rbac.authorization.k8s.io/vsphere-csi-node-binding unchanged
configmap/internal-feature-states.csi.vsphere.vmware.com unchanged
service/vsphere-csi-controller unchanged
Warning: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[2].matchExpressions[0].key: node-role.kubernetes.io/master is use "node-role.kubernetes.io/control-plane" instead
Warning: spec.template.spec.containers[4].ports[0]: duplicate port name "prometheus" with spec.template.spec.containers[2].ports[1], services and probes that select ports by name will use spec.template.spec.containers[2].ports[1]
deployment.apps/vsphere-csi-controller configured
daemonset.apps/vsphere-csi-node configured
daemonset.apps/vsphere-csi-node-windows configured
```

After:
```
kubectl apply -f driver.yaml 
csidriver.storage.k8s.io/csi.vsphere.vmware.com unchanged
serviceaccount/vsphere-csi-controller unchanged
clusterrole.rbac.authorization.k8s.io/vsphere-csi-controller-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-controller-binding unchanged
serviceaccount/vsphere-csi-node unchanged
clusterrole.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role-binding unchanged
role.rbac.authorization.k8s.io/vsphere-csi-node-role unchanged
rolebinding.rbac.authorization.k8s.io/vsphere-csi-node-binding unchanged
configmap/internal-feature-states.csi.vsphere.vmware.com unchanged
service/vsphere-csi-controller unchanged
daemonset.apps/vsphere-csi-node configured
daemonset.apps/vsphere-csi-node-windows configured
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix warnings for deprecated node selector and duplicate port name 
```
