### PR TITLE
remove duplicate device type check for VirtualDisk

### DIFF
--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -195,13 +195,12 @@ func getBlockVolumeIDToNodeUUIDMap(ctx context.Context, c *controller,
 			devices := info.Config.Hardware.Device
 			vmDevices := object.VirtualDeviceList(devices)
 			for _, device := range vmDevices {
-				if vmDevices.TypeName(device) == "VirtualDisk" {
-					if virtualDisk, ok := device.(*types.VirtualDisk); ok {
-						if virtualDisk.VDiskId != nil {
-							volumeIDNodeUUIDMap[virtualDisk.VDiskId.Id] = info.Config.Uuid
-						}
+				if virtualDisk, ok := device.(*types.VirtualDisk); ok {
+					if virtualDisk.VDiskId != nil {
+						volumeIDNodeUUIDMap[virtualDisk.VDiskId.Id] = info.Config.Uuid
 					}
 				}
+
 			}
 		}
 	}

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -575,11 +575,9 @@ func (c *controller) GetVolumeToHostMapping(ctx context.Context,
 		devices := info.Config.Hardware.Device
 		vmDevices := object.VirtualDeviceList(devices)
 		for _, device := range vmDevices {
-			if vmDevices.TypeName(device) == "VirtualDisk" {
-				if virtualDisk, ok := device.(*vimtypes.VirtualDisk); ok {
-					if virtualDisk.VDiskId != nil {
-						volumeIDVMMap[virtualDisk.VDiskId.Id] = vmMoID
-					}
+			if virtualDisk, ok := device.(*vimtypes.VirtualDisk); ok {
+				if virtualDisk.VDiskId != nil {
+					volumeIDVMMap[virtualDisk.VDiskId.Id] = vmMoID
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing duplicate device type check for VirtualDisk

```
if vmDevices.TypeName(device) == "VirtualDisk" {
			if virtualDisk, ok := device.(*types.VirtualDisk); ok {
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #3678

**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/909/ - Pass
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/816/ - Pass


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
remove duplicate device type check for VirtualDisk
```
