### PR TITLE
Add finalizer to CnsRegisterVolume to ensure proper cleanup before deletion

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -239,12 +239,19 @@ func getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx context.Context
 // getPersistentVolumeSpec to create PV volume spec for the given input params.
 func getPersistentVolumeSpec(volumeName string, volumeID string, capacity int64,
 	accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode, scName string,
-	claimRef *v1.ObjectReference) *v1.PersistentVolume {
+	claimRef *v1.ObjectReference, crNamespace string, crName string) *v1.PersistentVolume {
 	capacityInMb := strconv.FormatInt(capacity, 10) + "Mi"
+	// Add labels for PV identification and direct lookup
+	labels := make(map[string]string)
+	labels[labelCnsRegisterVolumeCreatedBy] = labelCnsRegisterVolumeCreatedByValue
+	labels[labelCnsRegisterVolumeCRNamespace] = crNamespace
+	labels[labelCnsRegisterVolumeCRName] = crName
+
 	pv := &v1.PersistentVolume{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: volumeName,
+			Name:   volumeName,
+			Labels: labels,
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
@@ -226,6 +226,8 @@ func TestGetPersistentVolumeSpec_VolumeModeEmpty(t *testing.T) {
 		volumeMode,
 		scName,
 		claimRef,
+		"default",
+		"test-cr",
 	)
 
 	if pv == nil {
@@ -279,6 +281,8 @@ func TestGetPersistentVolumeSpec_VolumeModeBlock(t *testing.T) {
 		volumeMode,
 		scName,
 		claimRef,
+		"default",
+		"test-cr",
 	)
 
 	if pv == nil {
@@ -324,6 +328,8 @@ func TestGetPersistentVolumeSpec_VolumeModeFilesystem(t *testing.T) {
 		volumeMode,
 		scName,
 		claimRef,
+		"default",
+		"test-cr",
 	)
 
 	if pv == nil {

--- a/pkg/syncer/cnsoperator/types/types.go
+++ b/pkg/syncer/cnsoperator/types/types.go
@@ -44,6 +44,10 @@ const (
 	// to avoid deletion of PVCs which are in the process of being unregistered.
 	CNSUnregisterProtectionFinalizer = "cns.vmware.com/unregister-protection"
 
+	// CNSRegisterVolumeFinalizer is the finalizer added to CNSRegisterVolume CRs
+	// to handle deletion gracefully and prevent race conditions with unregister operations.
+	CNSRegisterVolumeFinalizer = "cns.vmware.com/register-volume"
+
 	// VSphereCSIDriverName is the vsphere CSI driver name
 	VSphereCSIDriverName = "csi.vsphere.vmware.com"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds a finalizer to CnsRegisterVolume CRs to ensure proper cleanup of resources before the CR is deleted from the API server. With the finalizer in place, the CR remains visible to clients until the controller completes cleanup, allowing clients to know that deletion is in progress.

Changes:
- Add finalizer (cns.vmware.com/register-volume) to CnsRegisterVolume CRs
- Implement reconcileDelete function to handle cleanup on CR deletion
- Check for deletion timestamp at reconciliation start to trigger cleanup
- Add label (cns.vmware.com/created-by: cnsregistervolume) to created PVs for efficient lookup during cleanup

Cleanup logic in reconcileDelete:
- If registration completed (PVC/PV bound): Remove finalizer immediately
- If registration incomplete: Clean up statically created PV and untag CNS volume (deleteDisk=false) before removing finalizer
-  unregister disk as FCD if DiskURLPath specified in the CNSRegisterVolume spec
- Use label selector for efficient PV lookup when searching for PVs
- Skip PV deletion if PV is bound to PVC (PVC owns lifecycle)

Testing:
Added comprehensive unit tests for reconcileDelete function:
- TestReconcileDelete/WhenAlreadyRegistered: Verifies finalizer removal when registration is already complete
- TestReconcileDelete/WhenNotRegisteredAndNoResourcesCreated: Tests cleanup when no resources were created
- TestReconcileDelete/WhenNotRegisteredAndPVExists: Tests PV deletion for unbound PV with VolumeID specified in spec
- TestReconcileDelete/WhenPVCIsBound_ShouldSkipAllCleanup: Tests early exit when PVC is bound (DiskURLPath case)
- TestReconcileDelete/WhenPVIsBoundViaSearch_ShouldSkipAllCleanup: Tests early exit when PV found via label search is bound (DiskURLPath case)
- TestReconcileDelete/WhenDiskURLPathSpecified_ShouldDeleteUnboundPV: Tests PV deletion for unbound PV with DiskURLPath specified in spec
- TestProtectInstance: Tests finalizer addition logic
- TestRemoveFinalizer: Tests finalizer removal logic


**Testing done**:
Manual testing - https://gist.github.com/divyenpatel/8fa728abfebdb924f4e28dc0e41c59bb


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add finalizer to CnsRegisterVolume to ensure proper cleanup before deletion
```
