### PR TITLE
Fix - Add iaas.vmware.com/capabilities RBAC to CSI controller role

### DIFF
--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -135,6 +135,9 @@ rules:
   - apiGroups: ["nsx.vmware.com"]
     resources: ["namespacenetworkinfos"]
     verbs: ["get", "list"]
+  - apiGroups: ["iaas.vmware.com"]
+    resources: ["capabilities"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -138,6 +138,9 @@ rules:
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachinesnapshots"]
     verbs: ["get", "list", "patch", "update", "watch"]
+  - apiGroups: ["iaas.vmware.com"]
+    resources: ["capabilities"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -138,6 +138,9 @@ rules:
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachinesnapshots"]
     verbs: ["get", "list", "patch", "update", "watch"]
+  - apiGroups: ["iaas.vmware.com"]
+    resources: ["capabilities"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -138,6 +138,9 @@ rules:
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachinesnapshots"]
     verbs: ["get", "list", "patch", "update", "watch"]
+  - apiGroups: ["iaas.vmware.com"]
+    resources: ["capabilities"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary

Adds self-managed RBAC for `iaas.vmware.com/capabilities` resource to the `vsphere-csi-controller-role` ClusterRole in supervisor manifests (1.26-1.32).

## Problem

The CSI driver reads the `supervisor-capabilities` CR from `iaas.vmware.com` API group to determine which WCP features are enabled. Currently, this access relies on an external ClusterRoleBinding (`wcp:authenticated:capabilities`) managed by WCP controller:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: wcp:authenticated:capabilities
roleRef:
  kind: ClusterRole
  name: wcp:capabilities-view
subjects:
- kind: Group
  name: system:authenticated
```

This is an anti-pattern because:
1. IaaS controllers should manage their own RBAC
2. Dependency on external RBAC creates fragile coupling
3. If the binding is removed/modified/deprecated, CSI driver fails with RBAC errors

### Error Without Proper RBAC

```
capabilities.iaas.vmware.com "supervisor-capabilities" is forbidden: 
User "system:serviceaccount:vmware-system-csi:vsphere-csi-controller" 
cannot get resource "capabilities" in API group "iaas.vmware.com" at the cluster scope
```

## Solution

Added the following RBAC rule to `vsphere-csi-controller-role` ClusterRole:

```yaml
- apiGroups: ["iaas.vmware.com"]
  resources: ["capabilities"]
  verbs: ["get", "list", "watch"]
```

This makes CSI driver self-sufficient for capabilities access without depending on WCP-managed bindings.

## Testing Done

### Phase 1: Bug Reproduction

| Step | Action | Result |
|------|--------|--------|
| 1 | Backup and delete `wcp:authenticated:capabilities` binding | Binding removed |
| 2 | Restart CSI controller | Pod enters Error state |
| 3 | Check logs | `forbidden` error confirmed |

**Error Log:**
```
2026-02-02T08:27:46.350Z ERROR k8sorchestrator/k8sorchestrator.go:1299 
failed to fetch Capabilities CR instance with name "supervisor-capabilities" 
Error: capabilities.iaas.vmware.com "supervisor-capabilities" is forbidden: 
User "system:serviceaccount:vmware-system-csi:vsphere-csi-controller" 
cannot get resource "capabilities" in API group "iaas.vmware.com" at the cluster scope
```

### Phase 2: Fix Verification

| Step | Action | Result |
|------|--------|--------|
| 1 | Patch ClusterRole with new RBAC rule | Rule added |
| 2 | Restart CSI controller | Pod `7/7 Running` |
| 3 | Verify `wcp:authenticated:capabilities` still deleted | Confirmed deleted |
| 4 | Check logs for capability errors | **None** |

**Verification:**
- CSI controller running healthy without WCP-managed binding
- No capability-related errors in syncer or controller logs
- Fix works independently of external RBAC

## Safety Considerations

- **Minimal Permissions**: Read-only access (`get`, `list`, `watch`)
- **Backward Compatible**: Adding new RBAC rule doesn't affect existing permissions

## Precheckin runs
### [WCP](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/932/)
```
Ran 16 of 2324 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2308 Skipped | 0 Flaked
```

## Special Notes for Reviewer

- Changes applied to all supervisor manifests (1.29-1.32) for consistency
- This change allows CSI to work even if WCP removes the `wcp:authenticated:capabilities` binding in future
- Precheckin runs for Vanilla and VKS are not required as the change is only specific to WCP

## Release Note

```release-note
Add self-managed RBAC for iaas.vmware.com/capabilities to CSI controller role in supervisor manifests
```
