### PR TITLE
Removing test from WCP

### DIFF
--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -164,8 +164,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 	// 10. Delete PVC and SC
 
 	ginkgo.It("[ef-vanilla-block][pq-n1-vanilla-block][pq-n2-vanilla-block] [ef-wcp][cf-vks][csi-block-vanilla]"+
-		"[csi-guest][csi-supervisor] Verify impact on "+
-		"existing pv pvc when sc recreated with different binding mode", ginkgo.Label(p0,
+		"[csi-guest] Verify impact on existing pv pvc when sc recreated with different binding mode", ginkgo.Label(p0,
 		block, wcp, tkg, vanilla, vc70), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: removing "Verify impact on existing pv pvc when sc recreated with different binding mode"for SUpervisor


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Test is not valid for Supervisor now. step 7 Creating a SC WaitForFirstConsumer storage class on WCP is not valid.
Now any storage policy that is getting assigned to namespace is creating two storage classes, One with immediate binding more and another with latebinding (WFFC). We have coverage for both in other tests. 


