### PR TITLE
re-initializing resourcQuota after update

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2436,7 +2436,7 @@ func setResourceQuota(client clientset.Interface, namespace string, size string)
 			ctx, requestStorageQuota, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("ResourceQuota details: %+v", testResourceQuota))
-		existingResourceQuota, err := client.CoreV1().ResourceQuotas(namespace).Get(ctx, namespace, metav1.GetOptions{})
+		existingResourceQuota, _ := client.CoreV1().ResourceQuotas(namespace).Get(ctx, namespace, metav1.GetOptions{})
 		err = checkResourceQuota(client, namespace, existingResourceQuota.GetName(), size)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
@@ -7189,8 +7189,8 @@ func setStoragePolicyQuota(ctx context.Context, restClientConfig *rest.Config,
 	err = cnsOperatorClient.Update(ctx, spq)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	spq = &storagepolicyv1alpha2.StoragePolicyQuota{}
 	time.Sleep(3 * storagePolicyUsagePollInterval)
+	spq = &storagepolicyv1alpha2.StoragePolicyQuota{}
 	quotaValue := spq.Spec.Limit.String()
 	framework.Logf("Updated StoragePolicyQuota value for %s in namespace %s: %s", scName, namespace, quotaValue)
 }


### PR DESCRIPTION
What this PR does / why we need it:
test util fix for setting resource quota as intermittent failure observed in UTS runs.

ResourceQuota object was updated by another process between the time we performed the Get and the time you called Update.

Testing done:
Done

@sipriyaa @kavyashree-r @rpanduranga Please review & approve the changes.