### PR TITLE
Remove csi-migration fss

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -234,4 +234,6 @@ replace (
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.35.0
 	k8s.io/sample-controller => k8s.io/sample-controller v0.35.0
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.1
+	k8s.io/endpointslice => k8s.io/endpointslice v0.28.1
+	k8s.io/externaljwt => k8s.io/externaljwt v0.31.0
 )

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -63,7 +63,6 @@ var mapVolumePathToID map[string]map[string]string
 func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCommonInterface, error) {
 	if orchestratorType == common.Kubernetes {
 		defaultFSS := map[string]string{
-			"csi-migration":                     "true",
 			"file-volume":                       "true",
 			"block-volume-snapshot":             "true",
 			"tkgs-ha":                           "true",

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -401,7 +401,6 @@ func Newk8sOrchestrator(ctx context.Context, controllerClusterFlavor cnstypes.Cn
 
 func getReleasedVanillaFSS() map[string]struct{} {
 	return map[string]struct{}{
-		common.CSIMigration:                  {},
 		common.OnlineVolumeExtend:            {},
 		common.BlockVolumeSnapshot:           {},
 		common.CSIWindowsSupport:             {},
@@ -1058,9 +1057,7 @@ func pvAdded(obj interface{}) {
 	// Add VCP-CSI migrated volumes to the volumeIDToNameMap map.
 	// Since cns query will return all the volumes including the migrated ones, the map would need to be a
 	// union of migrated VCP-CSI volumes and CSI volumes, as well.
-	if pv.Spec.VsphereVolume != nil &&
-		k8sOrchestratorInstance.IsFSSEnabled(context.Background(), common.CSIMigration) &&
-		isValidMigratedvSphereVolume(context.Background(), pv.ObjectMeta) {
+	if pv.Spec.VsphereVolume != nil && isValidMigratedvSphereVolume(context.Background(), pv.ObjectMeta) {
 		if pv.Status.Phase == v1.VolumeBound {
 			k8sOrchestratorInstance.volumeIDToNameMap.add(pv.Spec.VsphereVolume.VolumePath, pv.Name)
 			log.Debugf("Migrated pvAdded: Added '%s -> %s' pair to volumeIDToNameMap", pv.Spec.VsphereVolume.VolumePath, pv.Name)
@@ -1108,9 +1105,7 @@ func pvUpdated(oldObj, newObj interface{}) {
 	// Update VCP-CSI migrated volumes to the volumeIDToNameMap map.
 	// Since cns query will return all the volumes including the migrated ones, the map would need to be a
 	// union of migrated VCP-CSI volumes and CSI volumes, as well.
-	if newPv.Spec.VsphereVolume != nil &&
-		k8sOrchestratorInstance.IsFSSEnabled(context.Background(), common.CSIMigration) &&
-		isValidMigratedvSphereVolume(context.Background(), newPv.ObjectMeta) {
+	if newPv.Spec.VsphereVolume != nil && isValidMigratedvSphereVolume(context.Background(), newPv.ObjectMeta) {
 		if oldPv.Status.Phase != v1.VolumeBound && newPv.Status.Phase == v1.VolumeBound {
 			k8sOrchestratorInstance.volumeIDToNameMap.add(newPv.Spec.VsphereVolume.VolumePath, newPv.Name)
 			log.Debugf("Migrated pvUpdated: Added '%s -> %s' pair to volumeIDToNameMap",
@@ -1138,7 +1133,7 @@ func pvDeleted(obj interface{}) {
 		log.Debugf("k8sorchestrator: Deleted key %s from pvcToVolumeID",
 			pv.Spec.ClaimRef.Namespace+"/"+pv.Spec.ClaimRef.Name)
 	}
-	if pv.Spec.VsphereVolume != nil && k8sOrchestratorInstance.IsFSSEnabled(context.Background(), common.CSIMigration) {
+	if pv.Spec.VsphereVolume != nil {
 		k8sOrchestratorInstance.volumeIDToNameMap.remove(pv.Spec.VsphereVolume.VolumePath)
 		log.Debugf("k8sorchestrator migrated volume: Deleted key %s from volumeIDToNameMap",
 			pv.Spec.VsphereVolume.VolumePath)

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
@@ -173,9 +173,8 @@ func TestIsFSSEnabledInGcWrongValues(t *testing.T) {
 // TestIsFSSEnabledInSV tests IsFSSEnabled in Supervisor flavor - all scenarios
 func TestIsFSSEnabledInSV(t *testing.T) {
 	svFSS := map[string]string{
-		feature_flag_1:  "true",
-		feature_flag_2:  "false",
-		"csi-migration": "enabled",
+		feature_flag_1: "true",
+		feature_flag_2: "false",
 	}
 	svFSSConfigMapInfo := FSSConfigMapInfo{
 		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
@@ -194,11 +193,6 @@ func TestIsFSSEnabledInSV(t *testing.T) {
 	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, feature_flag_2)
 	if isEnabled {
 		t.Errorf("%s feature state is enabled!", feature_flag_2)
-	}
-	// Wrong value given
-	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "csi-migration")
-	if isEnabled {
-		t.Errorf("csi-migration feature state is enabled even when it was assigned a wrong value!")
 	}
 	// Feature state missing
 	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "online-volume-extend")

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -409,8 +409,6 @@ const (
 	DefaultFeatureEnablementCheckInterval = 1 * time.Minute
 	// OnlineVolumeExtend guards the feature for online volume expansion.
 	OnlineVolumeExtend = "online-volume-extend"
-	// CSIMigration is feature flag for migrating in-tree vSphere volumes to CSI.
-	CSIMigration = "csi-migration"
 	// CSISVFeatureStateReplication is feature flag for SV feature state
 	// replication feature.
 	CSISVFeatureStateReplication = "csi-sv-feature-states-replication"

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -241,66 +241,51 @@ func IsValidVolumeCapabilities(ctx context.Context, volCaps []*csi.VolumeCapabil
 
 // ParseStorageClassParams parses the params in the CSI CreateVolumeRequest API
 // call back to StorageClassParams structure.
-func ParseStorageClassParams(ctx context.Context, params map[string]string,
-	csiMigrationFeatureState bool) (*StorageClassParams, error) {
+func ParseStorageClassParams(ctx context.Context, params map[string]string) (*StorageClassParams, error) {
 	log := logger.GetLogger(ctx)
 	scParams := &StorageClassParams{
 		DatastoreURL:      "",
 		StoragePolicyName: "",
 	}
-	if !csiMigrationFeatureState {
-		for param, value := range params {
+	otherParams := make(map[string]string)
+	for param, value := range params {
+		param = strings.ToLower(param)
+		if param == AttributeDatastoreURL {
+			scParams.DatastoreURL = value
+		} else if param == AttributeStoragePolicyName {
+			scParams.StoragePolicyName = value
+		} else if param == AttributeFsType {
+			log.Warnf("param 'fstype' is deprecated, please use 'csi.storage.k8s.io/fstype' instead")
+		} else if param == CSIMigrationParams {
+			scParams.CSIMigration = value
+		} else {
+			otherParams[param] = value
+		}
+	}
+	// check otherParams belongs to in-tree migrated Parameters.
+	if scParams.CSIMigration == "true" {
+		for param, value := range otherParams {
 			param = strings.ToLower(param)
-			if param == AttributeDatastoreURL {
-				scParams.DatastoreURL = value
-			} else if param == AttributeStoragePolicyName {
-				scParams.StoragePolicyName = value
-			} else if param == AttributeFsType {
-				log.Warnf("param 'fstype' is deprecated, please use 'csi.storage.k8s.io/fstype' instead")
+			if param == DatastoreMigrationParam {
+				scParams.Datastore = value
+			} else if param == DiskFormatMigrationParam && value == "thin" {
+				continue
+			} else if param == HostFailuresToTolerateMigrationParam ||
+				param == ForceProvisioningMigrationParam || param == CacheReservationMigrationParam ||
+				param == DiskstripesMigrationParam || param == ObjectspacereservationMigrationParam ||
+				param == IopslimitMigrationParam {
+				return nil, fmt.Errorf("vSphere CSI driver does not support creating volume using "+
+					"in-tree vSphere volume plugin parameter key:%v, value:%v", param, value)
 			} else {
-				return nil, fmt.Errorf("invalid param: %q and value: %q", param, value)
+				return nil, fmt.Errorf("invalid parameter. key:%v, value:%v", param, value)
 			}
 		}
 	} else {
-		otherParams := make(map[string]string)
-		for param, value := range params {
-			param = strings.ToLower(param)
-			if param == AttributeDatastoreURL {
-				scParams.DatastoreURL = value
-			} else if param == AttributeStoragePolicyName {
-				scParams.StoragePolicyName = value
-			} else if param == AttributeFsType {
-				log.Warnf("param 'fstype' is deprecated, please use 'csi.storage.k8s.io/fstype' instead")
-			} else if param == CSIMigrationParams {
-				scParams.CSIMigration = value
-			} else {
-				otherParams[param] = value
-			}
-		}
-		// check otherParams belongs to in-tree migrated Parameters.
-		if scParams.CSIMigration == "true" {
-			for param, value := range otherParams {
-				param = strings.ToLower(param)
-				if param == DatastoreMigrationParam {
-					scParams.Datastore = value
-				} else if param == DiskFormatMigrationParam && value == "thin" {
-					continue
-				} else if param == HostFailuresToTolerateMigrationParam ||
-					param == ForceProvisioningMigrationParam || param == CacheReservationMigrationParam ||
-					param == DiskstripesMigrationParam || param == ObjectspacereservationMigrationParam ||
-					param == IopslimitMigrationParam {
-					return nil, fmt.Errorf("vSphere CSI driver does not support creating volume using "+
-						"in-tree vSphere volume plugin parameter key:%v, value:%v", param, value)
-				} else {
-					return nil, fmt.Errorf("invalid parameter. key:%v, value:%v", param, value)
-				}
-			}
-		} else {
-			if len(otherParams) != 0 {
-				return nil, fmt.Errorf("invalid parameters :%v", otherParams)
-			}
+		if len(otherParams) != 0 {
+			return nil, fmt.Errorf("invalid parameters :%v", otherParams)
 		}
 	}
+
 	return scParams, nil
 }
 

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -382,8 +382,7 @@ func TestParseStorageClassParamsWithDeprecatedFSType(t *testing.T) {
 		"fstype": "ext4",
 	}
 	expectedScParams := &StorageClassParams{}
-	csiMigrationFeatureState := false
-	actualScParams, err := ParseStorageClassParams(ctx, params, csiMigrationFeatureState)
+	actualScParams, err := ParseStorageClassParams(ctx, params)
 	if err != nil {
 		t.Errorf("failed to parse params: %+v", params)
 	}
@@ -401,8 +400,7 @@ func TestParseStorageClassParamsWithValidParams(t *testing.T) {
 		DatastoreURL:      "ds1",
 		StoragePolicyName: "policy1",
 	}
-	csiMigrationFeatureState := false
-	actualScParams, err := ParseStorageClassParams(ctx, params, csiMigrationFeatureState)
+	actualScParams, err := ParseStorageClassParams(ctx, params)
 	if err != nil {
 		t.Errorf("failed to parse params: %+v", params)
 	}
@@ -412,7 +410,6 @@ func TestParseStorageClassParamsWithValidParams(t *testing.T) {
 }
 
 func TestParseStorageClassParamsWithMigrationEnabledNagative(t *testing.T) {
-	csiMigrationFeatureState := true
 	params := map[string]string{
 		CSIMigrationParams:                   "true",
 		DatastoreMigrationParam:              "vSANDatastore",
@@ -424,7 +421,7 @@ func TestParseStorageClassParamsWithMigrationEnabledNagative(t *testing.T) {
 		ObjectspacereservationMigrationParam: "50",
 		IopslimitMigrationParam:              "16",
 	}
-	scParam, err := ParseStorageClassParams(ctx, params, csiMigrationFeatureState)
+	scParam, err := ParseStorageClassParams(ctx, params)
 	if err == nil {
 		t.Errorf("error expected but not received. scParam received from ParseStorageClassParams: %v", scParam)
 	}
@@ -432,12 +429,11 @@ func TestParseStorageClassParamsWithMigrationEnabledNagative(t *testing.T) {
 }
 
 func TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative(t *testing.T) {
-	csiMigrationFeatureState := true
 	params := map[string]string{
 		CSIMigrationParams:       "true",
 		DiskFormatMigrationParam: "thick",
 	}
-	scParam, err := ParseStorageClassParams(ctx, params, csiMigrationFeatureState)
+	scParam, err := ParseStorageClassParams(ctx, params)
 	if err == nil {
 		t.Errorf("error expected but not received. scParam received from ParseStorageClassParams: %v", scParam)
 	}
@@ -445,7 +441,6 @@ func TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative(t *testing
 }
 
 func TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive(t *testing.T) {
-	csiMigrationFeatureState := true
 	params := map[string]string{
 		CSIMigrationParams:       "true",
 		DiskFormatMigrationParam: "thin",
@@ -453,7 +448,7 @@ func TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive(t *testing
 	expectedScParams := &StorageClassParams{
 		CSIMigration: "true",
 	}
-	scParam, err := ParseStorageClassParams(ctx, params, csiMigrationFeatureState)
+	scParam, err := ParseStorageClassParams(ctx, params)
 	if err != nil {
 		t.Errorf("failed to parse params: %+v, err: %+v", params, err)
 	}
@@ -463,7 +458,6 @@ func TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive(t *testing
 }
 
 func TestParseStorageClassParamsWithMigrationEnabledPositive(t *testing.T) {
-	csiMigrationFeatureState := true
 	params := map[string]string{
 		CSIMigrationParams:         "true",
 		DatastoreMigrationParam:    "vSANDatastore",
@@ -474,7 +468,7 @@ func TestParseStorageClassParamsWithMigrationEnabledPositive(t *testing.T) {
 		StoragePolicyName: "policy1",
 		CSIMigration:      "true",
 	}
-	scParam, err := ParseStorageClassParams(ctx, params, csiMigrationFeatureState)
+	scParam, err := ParseStorageClassParams(ctx, params)
 	if err != nil {
 		t.Errorf("failed to parse params: %+v", params)
 	}
@@ -484,14 +478,13 @@ func TestParseStorageClassParamsWithMigrationEnabledPositive(t *testing.T) {
 }
 
 func TestParseStorageClassParamsWithMigrationDisabled(t *testing.T) {
-	csiMigrationFeatureState := false
 	params := map[string]string{
 		CSIMigrationParams:                   "true",
 		DatastoreMigrationParam:              "vSANDatastore",
 		AttributeStoragePolicyName:           "policy1",
 		HostFailuresToTolerateMigrationParam: "1",
 	}
-	scParam, err := ParseStorageClassParams(ctx, params, csiMigrationFeatureState)
+	scParam, err := ParseStorageClassParams(ctx, params)
 	if err == nil {
 		t.Errorf("error expected but not received. scParam received from ParseStorageClassParams: %v", scParam)
 	}

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -57,7 +57,6 @@ var (
 	// COInitParams stores the input params required for initiating the
 	// CO agnostic orchestrator in the admission handler package.
 	COInitParams                              *interface{}
-	featureGateCsiMigrationEnabled            bool
 	featureGateBlockVolumeSnapshotEnabled     bool
 	featureGateTKGSHaEnabled                  bool
 	featureGateTopologyAwareFileVolumeEnabled bool
@@ -237,14 +236,13 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 			}
 			log.Debugf("webhook config: %v", cfg)
 		}
-		featureGateCsiMigrationEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		featureGateTopologyAwareFileVolumeEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.TopologyAwareFileVolume)
 		featureFileVolumesWithVmServiceEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.FileVolumesWithVmService)
 
-		if featureGateCsiMigrationEnabled || featureGateBlockVolumeSnapshotEnabled {
+		if featureGateBlockVolumeSnapshotEnabled {
 			certs, err := tls.LoadX509KeyPair(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile)
 			if err != nil {
 				log.Errorf("failed to load key pair. certFile: %q, keyFile: %q err: %v",

--- a/pkg/syncer/admissionhandler/validatestorageclass.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass.go
@@ -49,13 +49,6 @@ const (
 
 // validateStorageClass helps validate AdmissionReview requests for StroageClass.
 func validateStorageClass(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-	if !featureGateCsiMigrationEnabled {
-		// If CSI migration is disabled and webhook is running,
-		// skip validation for StorageClass.
-		return &admissionv1.AdmissionResponse{
-			Allowed: true,
-		}
-	}
 	log := logger.GetLogger(ctx)
 	req := ar.Request
 	var result *metav1.Status

--- a/pkg/syncer/admissionhandler/validatestorageclass_test.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass_test.go
@@ -40,7 +40,6 @@ var admissionReview = v1.AdmissionReview{
 func TestValidateStorageClassForAllowVolumeExpansion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	featureGateCsiMigrationEnabled = true
 	admissionReview.Request.Object = runtime.RawExtension{
 		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
 			"{\n    \"name\": \"sc\",\n    \"uid\": \"e5d6b37e-db23-4c1d-9aed-e38cdd0f9ec6\",\n    " +
@@ -65,7 +64,6 @@ func TestValidateStorageClassForAllowVolumeExpansion(t *testing.T) {
 func TestValidateStorageClassForMigrationParameter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	featureGateCsiMigrationEnabled = true
 	admissionReview.Request.Object = runtime.RawExtension{
 		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
 			"{\n    \"name\": \"sc\",\n    \"uid\": \"a9ed134e-aab1-4624-8de4-b9d961cad861\",\n    " +
@@ -103,7 +101,6 @@ func TestValidateStorageClassForMigrationParameter(t *testing.T) {
 func TestValidateStorageClassForValidStorageClass(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	featureGateCsiMigrationEnabled = true
 	admissionReview.Request.Object = runtime.RawExtension{
 		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
 			"{\n    \"name\": \"sc\",\n    \"uid\": \"a896f427-929a-4fc5-be95-078d99d57774\",\n    " +

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -75,8 +75,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 	var err error
 	// Fetch CSI migration feature state, before performing full sync operations.
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) &&
-			len(metadataSyncer.configInfo.Cfg.VirtualCenter) == 1 {
+		if len(metadataSyncer.configInfo.Cfg.VirtualCenter) == 1 {
 			migrationFeatureStateForFullSync = true
 		}
 	}

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -66,9 +66,8 @@ var getPVsInBoundAvailableOrReleased = func(ctx context.Context,
 		return nil, err
 	}
 	for _, pv := range allPVs {
-		if (pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csitypes.Name) ||
-			(metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil &&
-				isValidvSphereVolume(ctx, pv)) {
+		if (pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csitypes.Name) || (pv.Spec.VsphereVolume != nil &&
+			isValidvSphereVolume(ctx, pv)) {
 			log.Debugf("FullSync: pv %v is in state %v", pv.Name, pv.Status.Phase)
 			if pv.Status.Phase == v1.VolumeBound || pv.Status.Phase == v1.VolumeAvailable ||
 				pv.Status.Phase == v1.VolumeReleased {
@@ -156,14 +155,7 @@ func IsValidVolume(ctx context.Context, volume v1.Volume, pod *v1.Pod,
 		// Verify volume is a in-tree VCP volume.
 		if pv.Spec.VsphereVolume != nil {
 			// Check if migration feature switch is enabled.
-			if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
-				if !isValidvSphereVolume(ctx, pv) {
-					return false, nil, nil
-				}
-			} else {
-				log.Debugf(
-					"%s feature switch is disabled. Cannot update vSphere volume metadata %s for the pod %s in namespace %s",
-					common.CSIMigration, pv.Name, pod.Name, pod.Namespace)
+			if !isValidvSphereVolume(ctx, pv) {
 				return false, nil, nil
 			}
 		} else {
@@ -611,8 +603,7 @@ func getPVsInBoundAvailableOrReleasedForVc(ctx context.Context, metadataSyncer *
 	for _, pv := range allPvs {
 		// Check if the PV is an in-tree volume.
 		if pv.Spec.CSI == nil {
-			if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) &&
-				pv.Spec.VsphereVolume != nil {
+			if pv.Spec.VsphereVolume != nil {
 				return nil, logger.LogNewErrorf(log,
 					"In-tree volumes are not supported on a multi VC set up."+
 						"Found in-tree volume %q.", pv.Name)
@@ -797,8 +788,7 @@ func createMissingFileVolumeInfoCrs(ctx context.Context, metadataSyncer *metadat
 	fileVolumes := make([]*v1.PersistentVolume, 0)
 	for _, pv := range allPvs {
 		if pv.Spec.CSI == nil {
-			if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) &&
-				pv.Spec.VsphereVolume != nil {
+			if pv.Spec.VsphereVolume != nil {
 				log.Errorf("In-tree volumes are not supported on a multi VC set up."+
 					"Found in-tree volume %s.", pv.Name)
 				return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Remove CSI-MIGRATION FSS

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://vmw-jira.broadcom.net/browse/CNAS-7526

**Testing done**:
1. wcp precheckin
hp025209
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/988/
Ran 16 of 2324 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2308 Skipped | 0 Flaked
VC ob-25240273 
ESX null 
VC IP 172.21.1.120


2. vks precheckin
hp025209
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/885/
Ran 6 of 2324 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2318 Skipped | 0 Flaked
VC IP 172.21.1.36

3. vanilla precheckin
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vanilla-instapp-e2e-pre-checkin/282/
Ran 16 of 1264 Specs
FAILURE! -- 15 Passed | 1 Failed | 1 Pending | 0 Skipped | 0 Flaked
(Verify label updates on PVC and PV attached to a statefulset-  this test failed for 2 runs. @rajguptavm confirmed, this issue is with the setup slowness. It is waiting for statefulset replicas to match with number of pods. It is waiting for 10 mins to have all pods up n running. Same test is passing in UTS & Jenkins regular pipeline and failure is unrelated to the code changes in this PR)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
