### PR TITLE
Reconcile Sync period modifications & ListVolume enhancements to support 120k CNS Volumes

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -2413,7 +2413,7 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 			volumeIDs = append(volumeIDs, cnsVolumeIDs[i])
 		}
 
-		response, err := getVolumeIDToVMMap(ctx, volumeIDs, vmMoidToHostMoid, volumeIDToVMMap)
+		response, err := getVolumeIDToVMMap(ctx, c.k8sClient, volumeIDs, vmMoidToHostMoid, volumeIDToVMMap)
 		if err != nil {
 			log.Errorf("Error while generating ListVolume response, err:%v", err)
 			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, "Error while generating ListVolume response")

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -48,6 +49,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
 )
@@ -585,10 +587,129 @@ func (c *controller) GetVolumeToHostMapping(ctx context.Context,
 	return vmMoIDToHostMoID, volumeIDVMMap, nil
 }
 
-// getVolumeIDToVMMap returns the csi list volume response by computing the volumeID to nodeNames map for
-// fake attached volumes and non-fake attached volumes.
-func getVolumeIDToVMMap(ctx context.Context, volumeIDs []string, vmMoidToHostMoid,
-	volumeIDToVMMap map[string]string) (*csi.ListVolumesResponse, error) {
+// getPublishedNodesFromVolumeAttachments queries the Kubernetes API for all
+// VolumeAttachment objects belonging to the vSphere CSI driver and returns a
+// map of CSI volumeHandle → list of node names on which the volume is
+// currently published (i.e. VA.Status.Attached == true).
+//
+// For Pod VM workloads the Kubernetes node that is recorded on the
+// VolumeAttachment is the supervisor node (ESXi host), not the individual
+// Pod VM. The VA.Status.AttachmentMetadata["vmUUID"] field carries the
+// instance UUID of the Pod VM that actually consumed the volume. Both cases
+// are captured here so that the ListVolumes response correctly reflects the
+// published node for every attach path:
+//
+//   - Regular TKG / supervisor VMs  → Spec.NodeName (ESXi host name)
+//   - Pod VMs                        → AttachmentMetadata["vmUUID"] if present,
+//     otherwise falls back to Spec.NodeName
+func getPublishedNodesFromVolumeAttachments(
+	ctx context.Context,
+	k8sClient kubernetes.Interface,
+	volumeIDs []string,
+) (map[string][]string, error) {
+	log := logger.GetLogger(ctx)
+
+	// Build a set of volumeIDs we care about for O(1) lookup.
+	volumeIDSet := make(map[string]struct{}, len(volumeIDs))
+	for _, id := range volumeIDs {
+		volumeIDSet[id] = struct{}{}
+	}
+
+	vaList, err := k8sClient.StorageV1().VolumeAttachments().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list VolumeAttachments: %v", err)
+	}
+
+	volumeIDToNodes := make(map[string][]string)
+	nodesSeen := make(map[string]map[string]struct{}) // volumeID → set of nodes (dedup)
+
+	for i := range vaList.Items {
+		va := &vaList.Items[i]
+		if !isPodVMVolumeAttachment(va) {
+			continue
+		}
+		if !va.Status.Attached {
+			continue
+		}
+		if va.Spec.Source.PersistentVolumeName == nil {
+			continue
+		}
+
+		// Resolve PV name → CSI volumeHandle via the PV object.
+		pvName := *va.Spec.Source.PersistentVolumeName
+		pv, err := k8sClient.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+		if err != nil {
+			log.Warnf("getPublishedNodesFromVolumeAttachments: failed to get PV %q: %v", pvName, err)
+			continue
+		}
+		if pv.Spec.CSI == nil {
+			continue
+		}
+		volumeHandle := pv.Spec.CSI.VolumeHandle
+		if _, ok := volumeIDSet[volumeHandle]; !ok {
+			// Not in the page of volumes we are building a response for.
+			continue
+		}
+
+		// Determine the node identifier to report.
+		// For Pod VMs the AttachmentMetadata carries the VM instance UUID;
+		// use that when present so the caller can correlate to the Pod VM.
+		// For all other cases report the Kubernetes node name (ESXi host).
+		nodeName := va.Spec.NodeName
+		if vmUUID, ok := va.Status.AttachmentMetadata[common.AttributeVmUUID]; ok && vmUUID != "" {
+			log.Debugf("getPublishedNodesFromVolumeAttachments: volume %q is attached to Pod VM UUID %q "+
+				"on node %q", volumeHandle, vmUUID, nodeName)
+			nodeName = vmUUID
+		}
+
+		if _, exists := nodesSeen[volumeHandle]; !exists {
+			nodesSeen[volumeHandle] = make(map[string]struct{})
+		}
+		if _, dup := nodesSeen[volumeHandle][nodeName]; !dup {
+			nodesSeen[volumeHandle][nodeName] = struct{}{}
+			volumeIDToNodes[volumeHandle] = append(volumeIDToNodes[volumeHandle], nodeName)
+		}
+	}
+
+	log.Debugf("getPublishedNodesFromVolumeAttachments: volumeID→nodes map: %v", volumeIDToNodes)
+	return volumeIDToNodes, nil
+}
+
+// isPodVMVolumeAttachment returns true when the VolumeAttachment was created
+// by the vSphere CSI driver for a Pod VM workload. A VA is considered to be a
+// Pod VM VA when:
+//   - its attacher field matches the vSphere CSI driver name, AND
+//   - its Status.AttachmentMetadata contains a "vmUUID" key (populated by the
+//     driver during ControllerPublishVolume for Pod VMs).
+//
+// Note: regular supervisor-VM VAs also have the same attacher but will NOT
+// have the "vmUUID" metadata key, so this predicate is safe to use without
+// additional filtering. The caller must decide how to handle regular VAs.
+func isPodVMVolumeAttachment(va *storagev1.VolumeAttachment) bool {
+	if va.Spec.Attacher != csitypes.Name {
+		return false
+	}
+	_, hasPodVMUUID := va.Status.AttachmentMetadata[common.AttributeVmUUID]
+	return hasPodVMUUID
+}
+
+// getVolumeIDToVMMap returns the csi list volume response by computing the
+// volumeID to nodeNames map for fake-attached, regular, and Pod VM volumes.
+//
+// Pod VM PVCs are attached to ephemeral VMs that run inside the supervisor
+// cluster namespace. Their attachment path does not go through the standard
+// VM → ESXi host mapping used for regular TKG node VMs. Instead, each Pod VM
+// creates a VolumeAttachment whose Status.AttachmentMetadata["vmUUID"] holds
+// the instance UUID of the Pod VM. This function queries all VolumeAttachment
+// objects to discover Pod VM published nodes and merges them into the response
+// alongside the host-based published nodes for regular volumes.
+func getVolumeIDToVMMap(
+	ctx context.Context,
+	k8sClient kubernetes.Interface,
+	volumeIDs []string,
+	vmMoidToHostMoid map[string]string,
+	volumeIDToVMMap map[string]string,
+) (*csi.ListVolumesResponse, error) {
 	log := logger.GetLogger(ctx)
 	response := &csi.ListVolumesResponse{}
 
@@ -600,7 +721,7 @@ func getVolumeIDToVMMap(ctx context.Context, volumeIDs []string, vmMoidToHostMoi
 		}
 	}
 
-	// Process fake attached volumes
+	// ── 1. Fake-attached volumes ──────────────────────────────────────────────
 	log.Debugf("Fake attached volumes %v", fakeAttachedVolumes)
 	volumeIDToNodesMap := commonco.ContainerOrchestratorUtility.GetNodesForVolumes(ctx, fakeAttachedVolumes)
 	for volumeID, publishedNodeIDs := range volumeIDToNodesMap {
@@ -617,6 +738,42 @@ func getVolumeIDToVMMap(ctx context.Context, volumeIDs []string, vmMoidToHostMoi
 		response.Entries = append(response.Entries, entry)
 	}
 
+	// ── 2. Pod VM volumes (VolumeAttachment-based lookup) ────────────────────
+	// Pod VMs are ephemeral VMs running inside supervisor namespaces. Their
+	// disks do not appear in the host-VM hardware scan performed by
+	// GetVolumeToHostMapping, so we must derive their published nodes directly
+	// from the VolumeAttachment status.
+	podVMPublishedNodes, err := getPublishedNodesFromVolumeAttachments(ctx, k8sClient, volumeIDs)
+	if err != nil {
+		// Non-fatal: log and continue. The regular VM path below will still
+		// populate published nodes for non-Pod VM volumes.
+		log.Warnf("getVolumeIDToVMMap: failed to get Pod VM published nodes from VolumeAttachments: %v", err)
+	}
+
+	// Track which volumes have already been added via the Pod VM path so we
+	// don't double-count them in the regular VM section below.
+	podVMHandled := make(map[string]struct{}, len(podVMPublishedNodes))
+	for volumeID, nodeIDs := range podVMPublishedNodes {
+		podVMHandled[volumeID] = struct{}{}
+		// Skip volumes that are already represented as fake-attached above.
+		if _, isFake := allFakeAttachMarkedVolumes[volumeID]; isFake {
+			continue
+		}
+		volume := &csi.Volume{
+			VolumeId: volumeID,
+		}
+		volumeStatus := &csi.ListVolumesResponse_VolumeStatus{
+			PublishedNodeIds: nodeIDs,
+		}
+		entry := &csi.ListVolumesResponse_Entry{
+			Volume: volume,
+			Status: volumeStatus,
+		}
+		log.Debugf("getVolumeIDToVMMap: Pod VM volume %q published on nodes %v", volumeID, nodeIDs)
+		response.Entries = append(response.Entries, entry)
+	}
+
+	// ── 3. Regular VM volumes (ESXi host-based lookup) ───────────────────────
 	hostNames := commonco.ContainerOrchestratorUtility.GetNodeIDtoNameMap(ctx)
 	if len(hostNames) == 0 {
 		log.Errorf("no hostnames found in the NodeIDtoName map")
@@ -625,11 +782,12 @@ func getVolumeIDToVMMap(ctx context.Context, volumeIDs []string, vmMoidToHostMoi
 
 	for volumeID, VMMoID := range volumeIDToVMMap {
 		isFakeAttached, exists := allFakeAttachMarkedVolumes[volumeID]
-		// If we do not find this entry in the input list obtained from CNS
-		//, then we do not bother adding it to the result since, CNS is not aware
-		// of this volume. Also, if it is fake attached volume we have handled it
-		// above so we will not add it to the response here.
+		// Skip volumes CNS is not aware of, or already handled via fake-attach
+		// or Pod VM paths.
 		if !exists || isFakeAttached {
+			continue
+		}
+		if _, handledByPodVM := podVMHandled[volumeID]; handledByPodVM {
 			continue
 		}
 
@@ -642,8 +800,7 @@ func getVolumeIDToVMMap(ctx context.Context, volumeIDs []string, vmMoidToHostMoi
 		if !ok {
 			continue
 		}
-		publishedNodeIDs := make([]string, 0)
-		publishedNodeIDs = append(publishedNodeIDs, hostName)
+		publishedNodeIDs := []string{hostName}
 		volume := &csi.Volume{
 			VolumeId: volumeID,
 		}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The csi-attacher sidecar's VA reconciler runs on a default interval of 1 minute, calling ListVolumes on the CSI driver at every cycle. This flooded the CSI controller logs with noise at a rate of once per minute per cluster.

Additionally, the Supervisor (wcp) ListVolumes implementation accounted for Pod VM workloads, VM Service & VKS VM Service. Pod VMs are ephemeral VMs running inside supervisor namespaces whose disks do not appear in the standard ESXi host → VM hardware scan used to derive published nodes. As a result, PVCs consumed by Pod VMs were silently omitted from ListVolumes responses, giving the csi-attacher an incomplete view of volume-to-node mappings during its reconciliation cycles.


**Testing done**:
Running e2e pipelines. Results TBA

ListVolume invocation frequency is now reduced.

Before (invoked every minute):

```
root@420a06edb013734dfdb354729733710b [ ~ ]# kubectl logs vsphere-csi-controller-7b58df5474-nvpq7 -c vsphere-csi-controller -n vmware-system-csi | grep ListVolumes called
grep: called: No such file or directory
root@420a06edb013734dfdb354729733710b [ ~ ]# kubectl logs vsphere-csi-controller-7b58df5474-nvpq7 -c vsphere-csi-controller -n vmware-system-csi | grep "ListVolumes called"
2026-02-25T22:50:40.827Z	DEBUG	wcp/controller.go:2351	ListVolumes called with args , expectedStartingIndex 0	{"TraceId": "42327418-dfa8-4fde-90b0-7542cfadb527"}
2026-02-25T22:51:41.050Z	DEBUG	wcp/controller.go:2351	ListVolumes called with args , expectedStartingIndex 0	{"TraceId": "0eb5a0d5-db6c-49d0-9806-1e78cb3ca8d7"}
2026-02-25T22:52:41.151Z	DEBUG	wcp/controller.go:2351	ListVolumes called with args , expectedStartingIndex 0	{"TraceId": "ccb6f8ed-0dd7-4620-bd54-c088b61e28e5"}
```


After (invoked every 5 minutes):
```
kubectl logs vsphere-csi-controller-674f55d64f-h6j6j -c vsphere-csi-controller -n vmware-system-csi | grep "ListVolumes called"
2026-02-25T22:57:31.207Z	DEBUG	wcp/controller.go:2351	ListVolumes called with args , expectedStartingIndex 0	{"TraceId": "dba69bcc-3f44-4dad-a60a-aeb947b258dc"}
2026-02-25T23:02:31.845Z	DEBUG	wcp/controller.go:2351	ListVolumes called with args , expectedStartingIndex 0	{"TraceId": "54339a3d-8f58-4ede-9956-2bca532905fb"}
2026-02-25T23:07:31.988Z	DEBUG	wcp/controller.go:2351	ListVolumes called with args , expectedStartingIndex 0	{"TraceId": "8d1f49d6-994f-4946-b83a-897e41c08417"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Reconcile Sync period modifications & ListVolume enhancements to support 120k CNS Volumes
```
