### PR TITLE
Remove csi-internal-generated-cluster-id FSS

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -275,8 +275,7 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 		}
 		var configInfo *config.ConfigurationInfo
 		var err error
-		if clusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
-			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIInternalGeneratedClusterID) {
+		if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 			configInfo, err = syncer.SyncerInitConfigInfo(ctx)
 			if err != nil {
 				log.Errorf("failed to initialize the configInfo. Err: %+v", err)

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -401,12 +401,11 @@ func Newk8sOrchestrator(ctx context.Context, controllerClusterFlavor cnstypes.Cn
 
 func getReleasedVanillaFSS() map[string]struct{} {
 	return map[string]struct{}{
-		common.OnlineVolumeExtend:            {},
-		common.BlockVolumeSnapshot:           {},
-		common.CSIWindowsSupport:             {},
-		common.ListVolumes:                   {},
-		common.CnsMgrSuspendCreateVolume:     {},
-		common.CSIInternalGeneratedClusterID: {},
+		common.OnlineVolumeExtend:        {},
+		common.BlockVolumeSnapshot:       {},
+		common.CSIWindowsSupport:         {},
+		common.ListVolumes:               {},
+		common.CnsMgrSuspendCreateVolume: {},
 	}
 }
 

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -436,9 +436,6 @@ const (
 	PVtoBackingDiskObjectIdMapping = "pv-to-backingdiskobjectid-mapping"
 	// Block Create Volume for datastores that are in suspended mode
 	CnsMgrSuspendCreateVolume = "cnsmgr-suspend-create-volume"
-	// CSIInternalGeneratedClusterID enables support to generate unique cluster
-	// ID internally if user doesn't provide it in vSphere config secret.
-	CSIInternalGeneratedClusterID = "csi-internal-generated-cluster-id"
 	// PodVMOnStretchedSupervisor is the WCP FSS which determines if PodVM
 	// support is available on stretched supervisor cluster.
 	PodVMOnStretchedSupervisor = "PodVM_On_Stretched_Supervisor_Supported"

--- a/pkg/csi/service/driver.go
+++ b/pkg/csi/service/driver.go
@@ -149,8 +149,7 @@ func (driver *vsphereCSIDriver) BeforeServe(ctx context.Context) error {
 		return err
 	}
 
-	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
-		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIInternalGeneratedClusterID) {
+	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		CSINamespace := common.GetCSINamespace()
 		if cfg.Global.ClusterID == "" {
 			var clusterID string

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2348,8 +2348,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 	log.Info("Reloading Configuration")
 	var cfg *cnsconfig.Config
 	var err error
-	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
-		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIInternalGeneratedClusterID) {
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		cfg, err = getConfig(ctx)
 	} else {
 		cfg, err = cnsconfig.GetConfig(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Cleanup csi-internal-generated-cluster-id FSS related code
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://vmw-jira.broadcom.net/browse/CNAS-7536

**Testing done**:
1. vks precheckin
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/908/
hp025209
PR 3911
Ran 6 of 2324 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2318 Skipped | 0 Flaked
VC IP 172.21.1.70

2. wcp precheckin
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1031/
hp025209
PR 3911
Ran 16 of 2324 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2308 Skipped | 0 Flaked
VC ob-25260780
ESX null
VC IP 172.21.1.70

3. vanilla precheckin
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vanilla-instapp-e2e-pre-checkin/289/
bn023052
PR 3911
Ran 16 of 2324 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2308 Skipped | 0 Flaked

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
