### PR TITLE
Use PVC requested size for PV capacity when PVC has DataSourceRef

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -645,6 +645,37 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	}
 
 	capacityInMb := volume.BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
+	// pvCapacity is used for PV spec, CNSVolumeInfo and validateAndFixPVVolumeMode;
+	// When registering a disk with VM as the datasource ref, we expect VM Op to create the PVC with DataSourceRef
+	// while CSI registers the disk. So, we check  if a PVC exists and use the capacity from the PVC when
+	// creating the PV.
+	// When a PVC exists with DataSourceRef (e.g. vmoperator.vmware.com/ VirtualMachine)
+	// and spec.resources.requests.storage set, use that value for the PV capacity so PV and PVC sizes
+	// match and they can bind.
+	// When PVC not present, query the volume size from the backend and applies queried size to
+	// both the PV and the PVC.
+	var pvCapacity resource.Quantity
+	if pvc != nil && pvc.Spec.DataSourceRef != nil && pvc.Spec.Resources.Requests != nil {
+		if requestStorage, ok := pvc.Spec.Resources.Requests[v1.ResourceStorage]; ok {
+			pvCapacity = requestStorage.DeepCopy()
+			log.Infof("Using PVC requested size %s for PV capacity as DataSourceRef is set on PVC", requestStorage.String())
+			log.Infof("PVC %s/%s size in MB: %v", pvc.Namespace, pvc.Name, common.RoundUpSize(pvCapacity.Value(), 1024*1024))
+			log.Infof("FCD size in MB: %v", capacityInMb)
+			if err := validatePVCCapacityMatchesBackendFCD(pvc, capacityInMb); err != nil {
+				log.Error(err.Error())
+				setInstanceError(ctx, r, instance, err.Error())
+				return reconcile.Result{RequeueAfter: timeout}, nil
+			}
+		} else {
+			log.Errorf("PVC %s has no storage request and DataSourceRef is not supported", pvc.Namespace+"/"+pvc.Name)
+			setInstanceError(ctx, r, instance,
+				fmt.Sprintf("PVC %s has no storage request and DataSourceRef is not supported", pvc.Namespace+"/"+pvc.Name))
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+	} else {
+		log.Infof("Using backend capacity for PV: %d Mi", capacityInMb)
+		pvCapacity = *resource.NewQuantity(capacityInMb*common.MbInBytes, resource.BinarySI)
+	}
 	accessMode := instance.Spec.AccessMode
 	// Set accessMode to ReadWriteOnce if DiskURLPath is used for import.
 	if accessMode == "" && instance.Spec.DiskURLPath != "" {
@@ -661,7 +692,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 				Namespace:  instance.Namespace,
 				Name:       instance.Spec.PvcName,
 			}
-			pvSpec := getPersistentVolumeSpec(pvName, volumeID, capacityInMb,
+			pvSpec := getPersistentVolumeSpec(pvName, volumeID, pvCapacity,
 				accessMode, instance.Spec.VolumeMode, storageClassName, claimRef,
 				instance.Namespace, instance.Name)
 			pvSpec.Spec.NodeAffinity = pvNodeAffinity
@@ -682,8 +713,8 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		}
 	} else {
 		// PV exists - check if volumeMode needs correction
-		pv, err = validateAndFixPVVolumeMode(ctx, k8sclient, r, instance, pv, pvName, volumeID,
-			capacityInMb, accessMode, storageClassName, pvNodeAffinity, timeout)
+		pv, err = validateAndFixPVVolumeMode(ctx, k8sclient, r, instance, pv, pvName, volumeID, pvCapacity,
+			accessMode, storageClassName, pvNodeAffinity, timeout)
 		if err != nil {
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
@@ -767,11 +798,9 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	if isBound {
 		log.Infof("PVC: %s is bound", instance.Spec.PvcName)
 		if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
-			// Create CNSVolumeInfo CR for static pv
-			capacityInBytes := capacityInMb * common.MbInBytes
-			capacity := resource.NewQuantity(capacityInBytes, resource.BinarySI)
+			// Create CNSVolumeInfo CR for static pv (pvCapacity set earlier from PVC or backend)
 			err = r.volumeInfoService.CreateVolumeInfoWithPolicyInfo(ctx, volumeID, instance.Namespace,
-				volume.StoragePolicyId, storageClassName, vc.Config.Host, capacity, false)
+				volume.StoragePolicyId, storageClassName, vc.Config.Host, &pvCapacity, false)
 			if err != nil {
 				log.Errorf("failed to store volumeID %q namespace %s StoragePolicyID %q StorageClassName %q and vCenter %q "+
 					"in CNSVolumeInfo CR. Error: %+v", volumeID, instance.Namespace, volume.StoragePolicyId,
@@ -810,13 +839,13 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 			patchedStoragePolicyUsageCR := storagePolicyUsageCR.DeepCopy()
 			if storagePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage != nil &&
 				storagePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved != nil {
-				patchedStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Add(*capacity)
+				patchedStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Add(pvCapacity)
 			} else {
 				var (
 					usedQty     resource.Quantity
 					reservedQty resource.Quantity
 				)
-				reservedQty = *resource.NewQuantity(capacity.Value(), capacity.Format)
+				reservedQty = *resource.NewQuantity(pvCapacity.Value(), pvCapacity.Format)
 				patchedStoragePolicyUsageCR.Status = storagepolicyusagev1alpha2.StoragePolicyUsageStatus{
 					ResourceTypeLevelQuotaUsage: &storagepolicyusagev1alpha2.QuotaUsageDetails{
 						Reserved: &reservedQty,
@@ -853,14 +882,13 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 				log.Errorf("patching operation failed for StoragePolicyUsage CR: %q in namespace: %q. err: %v",
 					currentStoragePolicyUsageCR.Name, currentStoragePolicyUsageCR.Namespace, err)
 			} else {
-				log.Infof("Successfully decreased the reserved field by %v Mb "+
+				reservedQty := currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved
+				log.Infof("Successfully decreased the reserved field by %s "+
 					"for storagepolicyusage CR: %q in namespace: %q",
-					currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Value(), finalStoragePolicyUsageCR.Name,
-					finalStoragePolicyUsageCR.Namespace)
-				log.Infof("Successfully increased the used field by %v Mb "+
+					reservedQty.String(), finalStoragePolicyUsageCR.Name, finalStoragePolicyUsageCR.Namespace)
+				log.Infof("Successfully increased the used field by %s "+
 					"for storagepolicyusage CR: %q in namespace: %q",
-					currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Value(), finalStoragePolicyUsageCR.Name,
-					finalStoragePolicyUsageCR.Namespace)
+					reservedQty.String(), finalStoragePolicyUsageCR.Name, finalStoragePolicyUsageCR.Namespace)
 			}
 		}
 	} else {
@@ -1121,7 +1149,7 @@ func isBlockVolumeRegisterRequest(ctx context.Context, instance *cnsregistervolu
 // and recreates the PV with the correct volumeMode since volumeMode is immutable on PVs.
 func validateAndFixPVVolumeMode(ctx context.Context, k8sclient clientset.Interface,
 	r *ReconcileCnsRegisterVolume, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
-	pv *v1.PersistentVolume, pvName, volumeID string, capacityInMb int64,
+	pv *v1.PersistentVolume, pvName, volumeID string, pvCapacity resource.Quantity,
 	accessMode v1.PersistentVolumeAccessMode, storageClassName string,
 	pvNodeAffinity *v1.VolumeNodeAffinity, timeout time.Duration) (*v1.PersistentVolume, error) {
 	log := logger.GetLogger(ctx)
@@ -1196,7 +1224,7 @@ func validateAndFixPVVolumeMode(ctx context.Context, k8sclient clientset.Interfa
 			Namespace:  instance.Namespace,
 			Name:       instance.Spec.PvcName,
 		}
-		pvSpec := getPersistentVolumeSpec(pvName, volumeID, capacityInMb,
+		pvSpec := getPersistentVolumeSpec(pvName, volumeID, pvCapacity,
 			accessMode, instance.Spec.VolumeMode, storageClassName, claimRef,
 			instance.Namespace, instance.Name)
 		pvSpec.Spec.NodeAffinity = pvNodeAffinity
@@ -1212,6 +1240,18 @@ func validateAndFixPVVolumeMode(ctx context.Context, k8sclient clientset.Interfa
 	}
 
 	return pv, nil
+}
+
+// validatePVCCapacityMatchesBackendFCD checks that the PVC's requested storage
+// size (rounded up to MB) matches the backend FCD capacity in MB, allowing
+// capacityInMb or capacityInMb+1 (for rounding). Returns an error if they do not match.
+func validatePVCCapacityMatchesBackendFCD(pvc *v1.PersistentVolumeClaim, capacityInMb int64) error {
+	requestStorage := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+	pvcCapacityInMB := common.RoundUpSize(requestStorage.Value(), 1024*1024)
+	if pvcCapacityInMB == capacityInMb || pvcCapacityInMB == capacityInMb+1 {
+		return nil
+	}
+	return fmt.Errorf("PVC %s size is not matching with backend FCD size", pvc.Namespace+"/"+pvc.Name)
 }
 
 // setInstanceError sets error and records an event on the CnsRegisterVolume

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -850,6 +851,169 @@ var _ = Describe("checkExistingPVCDataSourceRef", func() {
 	})
 })
 
+var _ = Describe("PV capacity from PVC with DataSourceRef", func() {
+	const pvcStorageRequestBytes = int64(8529897472)
+
+	var (
+		ctx       context.Context
+		k8sclient *k8sfake.Clientset
+		namespace string
+		pvcName   string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		k8sclient = k8sfake.NewClientset()
+		namespace = "test-namespace"
+		pvcName = "test-pvc"
+	})
+
+	Context("when PVC has DataSourceRef (vmoperator.vmware.com/VirtualMachine) and storage request 8529897472", func() {
+		BeforeEach(func() {
+			apiGroup := "vmoperator.vmware.com"
+			storageRequest := resource.NewQuantity(pvcStorageRequestBytes, resource.BinarySI)
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: namespace,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					DataSourceRef: &corev1.TypedObjectReference{
+						APIGroup: &apiGroup,
+						Kind:     "VirtualMachine",
+						Name:     "test-vm",
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: *storageRequest,
+						},
+					},
+				},
+			}
+			_, err := k8sclient.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+		})
+
+		It("checkExistingPVCDataSourceRef returns the PVC with storage request 8529897472", func() {
+			pvc, err := checkExistingPVCDataSourceRef(ctx, k8sclient, pvcName, namespace)
+			Expect(err).To(BeNil())
+			Expect(pvc).ToNot(BeNil())
+			Expect(pvc.Spec.DataSourceRef).ToNot(BeNil())
+			Expect(*pvc.Spec.DataSourceRef.APIGroup).To(Equal("vmoperator.vmware.com"))
+			Expect(pvc.Spec.DataSourceRef.Kind).To(Equal("VirtualMachine"))
+			Expect(pvc.Spec.Resources.Requests).ToNot(BeNil())
+			storageReq, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+			Expect(ok).To(BeTrue())
+			Expect(storageReq.Value()).To(Equal(pvcStorageRequestBytes))
+		})
+
+		It("getPersistentVolumeSpec with PVC capacity produces PV with same capacity so PVC and PV can bind", func() {
+			pvc, err := k8sclient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(pvc.Spec.Resources.Requests).ToNot(BeNil())
+			pvcCapacity := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+
+			pvName := "static-pv-test"
+			volumeID := "volume-id-123"
+			claimRef := &corev1.ObjectReference{
+				Kind:       "PersistentVolumeClaim",
+				APIVersion: "v1",
+				Namespace:  namespace,
+				Name:       pvcName,
+			}
+			pvSpec := getPersistentVolumeSpec(pvName, volumeID, pvcCapacity,
+				corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem, "test-sc",
+				claimRef, namespace, "test-cr")
+
+			Expect(pvSpec.Spec.Capacity).ToNot(BeNil())
+			pvCapacityQty, ok := pvSpec.Spec.Capacity[corev1.ResourceStorage]
+			Expect(ok).To(BeTrue())
+			Expect(pvCapacityQty.Value()).To(Equal(pvcStorageRequestBytes),
+				"PV capacity should match PVC request (8529897472) so they can bind")
+		})
+	})
+})
+
+var _ = Describe("validatePVCCapacityMatchesBackendFCD", func() {
+	var (
+		namespace string
+		pvcName   string
+	)
+
+	BeforeEach(func() {
+		namespace = "test-namespace"
+		pvcName = "test-pvc"
+	})
+
+	Context("when PVC capacity in MB equals backend FCD size", func() {
+		It("returns nil", func() {
+			// 2048 Mi = 2048 * 1024 * 1024 bytes
+			storageRequest := resource.NewQuantity(2048*1024*1024, resource.BinarySI)
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: namespace,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: *storageRequest,
+						},
+					},
+				},
+			}
+			err := validatePVCCapacityMatchesBackendFCD(pvc, 2048)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when PVC capacity in MB equals backend FCD size + 1", func() {
+		It("returns nil (allows rounding)", func() {
+			// 2049 Mi - RoundUpSize(2049*1024*1024, 1024*1024) = 2049
+			storageRequest := resource.NewQuantity(2049*1024*1024, resource.BinarySI)
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: namespace,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: *storageRequest,
+						},
+					},
+				},
+			}
+			err := validatePVCCapacityMatchesBackendFCD(pvc, 2048)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when PVC capacity in MB does not match backend FCD size", func() {
+		It("returns error with PVC name", func() {
+			// 1000 Mi - does not match backend 2048 or 2049
+			storageRequest := resource.NewQuantity(1000*1024*1024, resource.BinarySI)
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: namespace,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: *storageRequest,
+						},
+					},
+				},
+			}
+			err := validatePVCCapacityMatchesBackendFCD(pvc, 2048)
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("size is not matching with backend FCD size"))
+			Expect(err.Error()).To(ContainSubstring(namespace + "/" + pvcName))
+		})
+	})
+})
+
 var _ = Describe("validatePVCTopologyCompatibility", func() {
 	var (
 		ctx                         context.Context
@@ -1393,7 +1557,8 @@ func TestGetPersistentVolumeSpecWhenVolumeModeIsEmpty(t *testing.T) {
 
 	isSharedDiskEnabled = true
 	commonco.ContainerOrchestratorUtility = &mockCOCommon{}
-	pv := getPersistentVolumeSpec(volumeName, volumeID, int64(capacity), accessMode, "", scName, nil, "default", "test-cr")
+	capacityQty := resource.MustParse(strconv.FormatInt(int64(capacity), 10) + "Mi")
+	pv := getPersistentVolumeSpec(volumeName, volumeID, capacityQty, accessMode, "", scName, nil, "default", "test-cr")
 	assert.Equal(t, corev1.PersistentVolumeFilesystem, *pv.Spec.VolumeMode)
 }
 
@@ -1408,8 +1573,9 @@ func TestGetPersistentVolumeSpecWithVolumeMode(t *testing.T) {
 	)
 
 	isSharedDiskEnabled = true
-	pv := getPersistentVolumeSpec(volumeName, volumeID,
-		int64(capacity), accessMode, volumeMode, scName, nil, "default", "test-cr")
+	capacityQty := resource.MustParse(strconv.FormatInt(int64(capacity), 10) + "Mi")
+	pv := getPersistentVolumeSpec(volumeName, volumeID, capacityQty, accessMode, volumeMode, scName,
+		nil, "default", "test-cr")
 	assert.Equal(t, volumeMode, *pv.Spec.VolumeMode)
 }
 
@@ -1423,7 +1589,8 @@ func TestGetPersistentVolumeSpecWhenVolumeModeIsEmptyWithoutSharedDisk(t *testin
 	)
 
 	isSharedDiskEnabled = false
-	pv := getPersistentVolumeSpec(volumeName, volumeID, int64(capacity), accessMode, "", scName, nil, "default", "test-cr")
+	capacityQty := resource.MustParse(strconv.FormatInt(int64(capacity), 10) + "Mi")
+	pv := getPersistentVolumeSpec(volumeName, volumeID, capacityQty, accessMode, "", scName, nil, "default", "test-cr")
 	// volumeMode should be set to Filesystem even when isSharedDiskEnabled is false
 	assert.NotNil(t, pv.Spec.VolumeMode, "VolumeMode should be set even when isSharedDiskEnabled is false")
 	assert.Equal(t, corev1.PersistentVolumeFilesystem, *pv.Spec.VolumeMode)
@@ -1440,11 +1607,78 @@ func TestGetPersistentVolumeSpecWithVolumeModeWithoutSharedDisk(t *testing.T) {
 	)
 
 	isSharedDiskEnabled = false
-	pv := getPersistentVolumeSpec(volumeName, volumeID,
-		int64(capacity), accessMode, volumeMode, scName, nil, "default", "test-cr")
+	capacityQty := resource.MustParse(strconv.FormatInt(int64(capacity), 10) + "Mi")
+	pv := getPersistentVolumeSpec(volumeName, volumeID, capacityQty, accessMode, volumeMode, scName,
+		nil, "default", "test-cr")
 	// volumeMode should be set to Block even when isSharedDiskEnabled is false
 	assert.NotNil(t, pv.Spec.VolumeMode, "VolumeMode should be set even when isSharedDiskEnabled is false")
 	assert.Equal(t, volumeMode, *pv.Spec.VolumeMode)
+}
+
+// TestPVCapacityFromPVCWithDataSourceRef verifies that when a PVC has DataSourceRef
+// (apiGroup: vmoperator.vmware.com, kind: VirtualMachine) and storage request 8529897472,
+// the PV spec uses the same capacity so PVC and PV can bind.
+func TestPVCapacityFromPVCWithDataSourceRef(t *testing.T) {
+	ctx := context.Background()
+	k8sclient := k8sfake.NewClientset()
+	namespace := "test-namespace"
+	pvcName := "vm-1234-c17c0bb5"
+	const pvcStorageRequestBytes = int64(8529897472)
+
+	apiGroup := "vmoperator.vmware.com"
+	storageRequest := resource.NewQuantity(pvcStorageRequestBytes, resource.BinarySI)
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     "VirtualMachine",
+				Name:     "test-vm",
+			},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *storageRequest,
+				},
+			},
+		},
+	}
+	_, err := k8sclient.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Verify checkExistingPVCDataSourceRef returns PVC with correct request
+	existingPVC, err := checkExistingPVCDataSourceRef(ctx, k8sclient, pvcName, namespace)
+	assert.NoError(t, err)
+	assert.NotNil(t, existingPVC)
+	assert.NotNil(t, existingPVC.Spec.DataSourceRef)
+	assert.Equal(t, "vmoperator.vmware.com", *existingPVC.Spec.DataSourceRef.APIGroup)
+	assert.Equal(t, "VirtualMachine", existingPVC.Spec.DataSourceRef.Kind)
+	assert.NotNil(t, existingPVC.Spec.Resources.Requests)
+	reqStorage, ok := existingPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+	assert.True(t, ok)
+	assert.Equal(t, pvcStorageRequestBytes, reqStorage.Value())
+
+	// PV spec with capacity from PVC request must have same capacity so they can bind
+	pvcCapacity := existingPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+	pvName := "static-pv-46849247-6eaa-4eb1-a143-7e9326e31195"
+	volumeID := "volume-id-123"
+	claimRef := &corev1.ObjectReference{
+		Kind:       "PersistentVolumeClaim",
+		APIVersion: "v1",
+		Namespace:  namespace,
+		Name:       pvcName,
+	}
+	pvSpec := getPersistentVolumeSpec(pvName, volumeID, pvcCapacity,
+		corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem, "test-sc",
+		claimRef, namespace, "test-cr")
+
+	assert.NotNil(t, pvSpec.Spec.Capacity)
+	pvCapacityQty, ok := pvSpec.Spec.Capacity[corev1.ResourceStorage]
+	assert.True(t, ok)
+	assert.Equal(t, pvcStorageRequestBytes, pvCapacityQty.Value(),
+		"PV capacity must match PVC request (8529897472) so they can bind")
 }
 
 func TestVolumeModeInheritanceFromExistingPVCWithDataSourceRef(t *testing.T) {
@@ -1854,12 +2088,12 @@ func TestPVRecreationWhenVolumeModeIncorrect(t *testing.T) {
 	}
 
 	// Call validateAndFixPVVolumeMode
-	capacityInMb := int64(1024)
 	accessMode := corev1.ReadWriteOnce
 	timeout := time.Second * 10
+	pvCapacity := *resource.NewQuantity(int64(1024)*common.MbInBytes, resource.BinarySI)
 
 	pvAfter, err := validateAndFixPVVolumeMode(ctx, k8sclient, reconciler, instance,
-		pvBefore, pvName, volumeID, capacityInMb, accessMode, storageClassName, nil, timeout)
+		pvBefore, pvName, volumeID, pvCapacity, accessMode, storageClassName, nil, timeout)
 
 	// Verify the function succeeded
 	assert.NoError(t, err)
@@ -1980,12 +2214,12 @@ func TestPVRecreationWithoutSharedDiskEnabled(t *testing.T) {
 	}
 
 	// Call validateAndFixPVVolumeMode
-	capacityInMb := int64(1024)
 	accessMode := corev1.ReadWriteOnce
 	timeout := time.Second * 10
+	pvCapacity := *resource.NewQuantity(int64(1024)*common.MbInBytes, resource.BinarySI)
 
 	pvAfter, err := validateAndFixPVVolumeMode(ctx, k8sclient, reconciler, instance,
-		existingPV, pvName, volumeID, capacityInMb, accessMode, storageClassName, nil, timeout)
+		existingPV, pvName, volumeID, pvCapacity, accessMode, storageClassName, nil, timeout)
 
 	// Verify the function succeeded
 	assert.NoError(t, err)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -236,11 +236,11 @@ func getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx context.Context
 	}
 }
 
-// getPersistentVolumeSpec to create PV volume spec for the given input params.
-func getPersistentVolumeSpec(volumeName string, volumeID string, capacity int64,
+// getPersistentVolumeSpec creates a PV spec for the given params. Caller supplies capacity
+// (e.g. from PVC request for DataSourceRef, or from backend capacity).
+func getPersistentVolumeSpec(volumeName string, volumeID string, capacity resource.Quantity,
 	accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode, scName string,
 	claimRef *v1.ObjectReference, crNamespace string, crName string) *v1.PersistentVolume {
-	capacityInMb := strconv.FormatInt(capacity, 10) + "Mi"
 	// Add labels for PV identification and direct lookup
 	labels := make(map[string]string)
 	labels[labelCnsRegisterVolumeCreatedBy] = labelCnsRegisterVolumeCreatedByValue
@@ -256,7 +256,7 @@ func getPersistentVolumeSpec(volumeName string, volumeID string, capacity int64,
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
 			Capacity: v1.ResourceList{
-				v1.ResourceName(v1.ResourceStorage): resource.MustParse(capacityInMb),
+				v1.ResourceName(v1.ResourceStorage): capacity,
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
@@ -19,6 +19,7 @@ package cnsregistervolume
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 )
@@ -221,7 +223,7 @@ func TestGetPersistentVolumeSpec_VolumeModeEmpty(t *testing.T) {
 	pv := getPersistentVolumeSpec(
 		volumeName,
 		volumeID,
-		capacity,
+		resource.MustParse(strconv.FormatInt(capacity, 10)+"Mi"),
 		accessMode,
 		volumeMode,
 		scName,
@@ -276,7 +278,7 @@ func TestGetPersistentVolumeSpec_VolumeModeBlock(t *testing.T) {
 	pv := getPersistentVolumeSpec(
 		volumeName,
 		volumeID,
-		capacity,
+		resource.MustParse(strconv.FormatInt(capacity, 10)+"Mi"),
 		accessMode,
 		volumeMode,
 		scName,
@@ -323,7 +325,7 @@ func TestGetPersistentVolumeSpec_VolumeModeFilesystem(t *testing.T) {
 	pv := getPersistentVolumeSpec(
 		volumeName,
 		volumeID,
-		capacity,
+		resource.MustParse(strconv.FormatInt(capacity, 10)+"Mi"),
 		accessMode,
 		volumeMode,
 		scName,


### PR DESCRIPTION
**What this PR does / why we need it**:

When a PVC already exists with DataSourceRef (e.g. vmoperator.vmware.com/ VirtualMachine) and spec.resources.requests.storage set, use that value for the PV capacity so PV and PVC sizes match and they can bind. Previously the PV used backend CapacityInMb, which could be slightly smaller and prevent binding (e.g. PVC 8529897472 bytes vs PV 8134Mi).

- Resolve capacity once into a single pvCapacity (resource.Quantity) from either PVC request (DataSourceRef path) or backend capacityInMb, and use it for PV spec, CNSVolumeInfo, StoragePolicyUsage, and volumeMode fix.
- Refactor getPersistentVolumeSpec to take a single capacity resource.Quantity instead of capacityInMb and optional pvCapacity.
- Simplify validateAndFixPVVolumeMode to take only pvCapacity (after volumeID); remove capacityInMb parameter and internal capacity branching.
- Remove getPVCapacityQuantity helper.
- Add unit tests for DataSourceRef PVC with storage request 8529897472 (Ginkgo block and TestPVCapacityFromPVCWithDataSourceRef).
- Added validation to ensure FCD size from backend is either equal to PVC size or 1 MB less


**Testing done**:
Manual testing done.

## Test:1

Created VM and additional disk and imported to supervisor.

```
# kubectl get pvc -n divyen-ns
NAME                     STATUS    VOLUME                                           CAPACITY     ACCESS MODES   STORAGECLASS                  VOLUMEATTRIBUTESCLASS   AGE
vm-56b2cblr07-1f0c5619   Bound     static-pv-bfb12515-49f4-4a76-85fc-1bbdf6edd941   9159017472   RWO            wcp-vmfs-policy               <unset>                 20m
vm-56b2cblr07-b5cec162   Bound     static-pv-1ad0bb55-54b9-44b3-94c3-81a672ffd011   16Gi         RWO            wcp-vmfs-policy               <unset>                 20m
```

Logs

```
{"level":"info","time":"2026-03-04T23:12:45.287095325Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:277","msg":"Reconciling CnsRegisterVolume with instance: \"vm-56b2cblr07-1f0c5619\" from namespace: \"divyen-ns\". timeout \"1s\" seconds","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:45.287208166Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:1515","msg":"Adding finalizer","TraceId":"54160810-2fcd-4b58-b389-47c876048068","name":"vm-56b2cblr07-1f0c5619","namespace":"divyen-ns","finalizer":"cns.vmware.com/register-volume"}
{"level":"info","time":"2026-03-04T23:12:45.305968069Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:321","msg":"Creating CNS volume: &{TypeMeta:{Kind:CnsRegisterVolume APIVersion:cns.vmware.com/v1alpha1} ObjectMeta:{Name:vm-56b2cblr07-1f0c5619 GenerateName: Namespace:divyen-ns SelfLink: UID:0426a9a5-6a82-482e-9cda-7c09b1ae0b8c ResourceVersion:1485404 Generation:1 CreationTimestamp:2026-03-04 23:12:45 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[vmoperator.vmware.com/created-by:vm-56b2cblr07] Annotations:map[] OwnerReferences:[{APIVersion:vmoperator.vmware.com/v1alpha5 Kind:VirtualMachine Name:vm-56b2cblr07 UID:a5b76017-bb76-4e21-b98e-01de1d4fd61c Controller:0xc001da06fa BlockOwnerDeletion:0xc001da06f9}] Finalizers:[cns.vmware.com/register-volume] ManagedFields:[{Manager:manager Operation:Update APIVersion:cns.vmware.com/v1alpha1 Time:2026-03-04 23:12:45 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:metadata\":{\"f:labels\":{\".\":{},\"f:vmoperator.vmware.com/created-by\":{}},\"f:ownerReferences\":{\".\":{},\"k:{\\\"uid\\\":\\\"a5b76017-bb76-4e21-b98e-01de1d4fd61c\\\"}\":{}}},\"f:spec\":{\".\":{},\"f:accessMode\":{},\"f:backingType\":{},\"f:diskURLPath\":{},\"f:pvcName\":{},\"f:volumeMode\":{}}} Subresource:} {Manager:vsphere-syncer Operation:Update APIVersion:cns.vmware.com/v1alpha1 Time:2026-03-04 23:12:45 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:metadata\":{\"f:finalizers\":{\".\":{},\"v:\\\"cns.vmware.com/register-volume\\\"\":{}}}} Subresource:}]} Spec:{PvcName:vm-56b2cblr07-1f0c5619 VolumeID: AccessMode:ReadWriteOnce DiskURLPath:https://lvn-dvm-10-161-92-251.dvm.lvn.broadcom.net:443/folder/test-vmfs-vm/test-vmfs-vm_1.vmdk?dcPath=%2Fwcp-sanity&dsName=sharedVmfs_0 VolumeMode:Block BackingType:FlatVer2BackingInfo} Status:{Registered:false Error:}} for CnsRegisterVolume request with name: \"vm-56b2cblr07-1f0c5619\" on namespace: \"divyen-ns\"","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:45.34831283Z","caller":"volume/listview.go:200","msg":"AddTask called for Task:task-1198","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:45.354549833Z","caller":"volume/listview.go:218","msg":"client is valid. trying to add task to listview object","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:45.361146042Z","caller":"volume/listview.go:241","msg":"task Task:task-1198 added to listView","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.420582589Z","caller":"volume/listview.go:267","msg":"client is valid. trying to remove task from listview object","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.425474102Z","caller":"volume/listview.go:273","msg":"task Task:task-1198 removed from listView","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.42553675Z","caller":"volume/manager.go:944","msg":"CreateVolume: VolumeName: \"static-pv-a72e0143-181f-11f1-8639-005056a3f229\", opId: \"68da4ebf\"","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.425552601Z","caller":"volume/util.go:365","msg":"Volume created successfully. VolumeName: \"static-pv-a72e0143-181f-11f1-8639-005056a3f229\", volumeID: \"bfb12515-49f4-4a76-85fc-1bbdf6edd941\"","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.426067078Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:349","msg":"Created CNS volume with volumeID: bfb12515-49f4-4a76-85fc-1bbdf6edd941","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.426400138Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:353","msg":"Querying volume: bfb12515-49f4-4a76-85fc-1bbdf6edd941 for CnsRegisterVolume request with name: \"vm-56b2cblr07-1f0c5619\" on namespace: \"divyen-ns\"","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.456189958Z","caller":"volume/listview.go:200","msg":"AddTask called for Task:task-1203","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.462011866Z","caller":"volume/listview.go:218","msg":"client is valid. trying to add task to listview object","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.467531296Z","caller":"volume/listview.go:241","msg":"task Task:task-1203 added to listView","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.602977928Z","caller":"volume/listview.go:267","msg":"client is valid. trying to remove task from listview object","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.609002734Z","caller":"volume/listview.go:273","msg":"task Task:task-1203 removed from listView","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.609148228Z","caller":"volume/manager.go:2630","msg":"QueryVolumeAsync successfully returned CnsQueryResult, opId: \"68da4ec6\"","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.612010648Z","caller":"k8sorchestrator/topology.go:1750","msg":"zone name=\"az1\" ns=\"divyen-ns\" uid=\"d0dda1c8-53ee-40c2-bcfe-8d98f5d91c5f\" rv=\"1446594\" active clusters: [domain-c9]","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.612236019Z","caller":"k8sorchestrator/topology.go:1763","msg":"active clusters: [domain-c9] for namespace: \"divyen-ns\" in requested zones: [az1]","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.675753198Z","caller":"cnsregistervolume/util.go:95","msg":"Found datastoreUrl: ds:///vmfs/volumes/69a599ab-ea656869-a80c-0200468e3199/ is accessible to cluster: domain-c9","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.791235373Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:472","msg":"Volume with storagepolicyId: 86b24710-2136-4479-a0e8-f67368f63a17 is mapping to K8S storage class: wcp-vmfs-policy and assigned to namespace: divyen-ns","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.859675182Z","caller":"k8sorchestrator/topology.go:1586","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:az1]]","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.866064909Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:1051","msg":"Existing PVC vm-56b2cblr07-1f0c5619 in namespace divyen-ns has valid DataSourceRef (apiGroup: vmoperator.vmware.com, kind: VirtualMachine), can reuse","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.86615815Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:601","msg":"PVC: vm-56b2cblr07-1f0c5619 already exists. Validate if there is topology annotation on PVC","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.93165379Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:952","msg":"Successfully added topology annotation [{\"topology.kubernetes.io/zone\":\"az1\"}] to PVC divyen-ns/vm-56b2cblr07-1f0c5619","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.931741527Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:653","msg":"Using PVC requested size 9159017472 for PV capacity as DataSourceRef is set on PVC","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.953707888Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:671","msg":"PV: static-pv-bfb12515-49f4-4a76-85fc-1bbdf6edd941 not found. Creating a new PV","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.983147705Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:691","msg":"PV: static-pv-bfb12515-49f4-4a76-85fc-1bbdf6edd941 is created successfully","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.983254222Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:745","msg":"PVC vm-56b2cblr07-1f0c5619 in namespace divyen-ns has valid DataSourceRef with apiGroup: vmoperator.vmware.com, kind: VirtualMachine, name: vm-56b2cblr07","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:47.983287932Z","caller":"cnsregistervolume/util.go:375","msg":"Waiting up to 60 seconds for PersistentVolumeClaim vm-56b2cblr07-1f0c5619 in namespace divyen-ns to have phase Bound","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:55.184700299Z","caller":"cnsregistervolume/util.go:399","msg":"PersistentVolumeClaim vm-56b2cblr07-1f0c5619 in namespace divyen-ns is in state Bound","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:55.187232665Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:783","msg":"PVC: vm-56b2cblr07-1f0c5619 is bound","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:55.187430927Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:205","msg":"creating cnsvolumeinfo for volumeID: \"bfb12515-49f4-4a76-85fc-1bbdf6edd941\", StoragePolicyID: \"86b24710-2136-4479-a0e8-f67368f63a17\", StorageClassName: \"wcp-vmfs-policy\", vCenter: \"lvn-dvm-10-161-92-251.dvm.lvn.broadcom.net\", Capacity: {i:{value:9159017472 scale:0} d:{Dec:<nil>} s:9159017472 Format:DecimalSI} in the namespace: \"vmware-system-csi\"","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:55.222147101Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:235","msg":"Successfully created CNSVolumeInfo CR for volumeID: \"bfb12515-49f4-4a76-85fc-1bbdf6edd941\" ,StoragePolicyID: \"86b24710-2136-4479-a0e8-f67368f63a17\",StorageClassName: \"wcp-vmfs-policy\", vCenter: \"lvn-dvm-10-161-92-251.dvm.lvn.broadcom.net\", Capacity: {i:{value:9159017472 scale:0} d:{Dec:<nil>} s:9159017472 Format:DecimalSI} mapping in the namespace: \"vmware-system-csi\". IsLinkedClone: false","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:55.30759068Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:869","msg":"Successfully decreased the reserved field by 9159017472 Mb for storagepolicyusage CR: \"wcp-vmfs-policy-pvc-usage\" in namespace: \"divyen-ns\"","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:55.307693536Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:873","msg":"Successfully increased the used field by 9159017472 Mb for storagepolicyusage CR: \"wcp-vmfs-policy-pvc-usage\" in namespace: \"divyen-ns\"","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:55.307716744Z","caller":"cnsregistervolume/util.go:413","msg":"Checking BackingType for PVC vm-56b2cblr07-1f0c5619.","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:55.307736069Z","caller":"cnsregistervolume/util.go:427","msg":"BackingType for PVC vm-56b2cblr07-1f0c5619 is up to date. Skip updating.","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
{"level":"info","time":"2026-03-04T23:12:55.349822725Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:909","msg":"Successfully registered the volume on namespace: divyen-ns","TraceId":"54160810-2fcd-4b58-b389-47c876048068"}
```

## Test-2

Registered PV/PVC using volume ID in the cnsregistervolume spec

```
# cat cnsregistervolume.yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: register-07cb49fa
  namespace: divyen-ns
spec:
  pvcName: my-pvc
  volumeID: 07cb49fa-d284-4d9b-93e8-c7cc79f1d700
  accessMode: ReadWriteOnce
  volumeMode: Filesystem


# kubectl get pvc my-pvc -n divyen-ns
NAME     STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS      VOLUMEATTRIBUTESCLASS   AGE
my-pvc   Bound    static-pv-07cb49fa-d284-4d9b-93e8-c7cc79f1d700   5Gi        RWO            wcp-vmfs-policy   <unset>                 2m2s
```


**Special notes for your reviewer**:

pre-checkins:
 - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1041/ :white_check_mark:
 - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/915/


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use PVC requested size for PV capacity when PVC has DataSourceRef
```
