### PR TITLE
Add the ability to obtain the topology of attached hosts to the datastore

### DIFF
--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -309,6 +309,18 @@ func fetchHosts(ctx context.Context, entity mo.Reference, vCenter *cnsvsphere.Vi
 			hosts = append(hosts,
 				&cnsvsphere.HostSystem{HostSystem: object.NewHostSystem(vCenter.Client.Client, host.Reference())})
 		}
+	case "Datastore":
+		ds := object.NewDatastore(vCenter.Client.Client, entity.Reference())
+		hostList, err := ds.AttachedHosts(ctx)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log,
+				"failed to retrieve attached host from Datastore %+v. Error: %+v",
+				entity.Reference(), err)
+		}
+		for _, host := range hostList {
+			hosts = append(hosts,
+				&cnsvsphere.HostSystem{HostSystem: object.NewHostSystem(vCenter.Client.Client, host.Reference())})
+		}
 	case "HostSystem":
 		host := cnsvsphere.HostSystem{HostSystem: object.NewHostSystem(vCenter.Client.Client, entity.Reference())}
 		hosts = append(hosts, &host)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a controller crashloop that occurs when vSphere topology tags (region/zone) are assigned to datastore objects. The topology host resolution code did not handle `Datastore` managed object types, causing a panic/nil pointer dereference during full sync or volume provisioning.

**Which issue(s) this PR fixes**

Fixes #3919

**How was this tested?**

- Manual testing on a vSphere environment with region/zone tags on datastores
- Verified controller no longer crashes and correctly skips datastore objects during host resolution

**Release note**:

```release-note
Fixed a bug where the vSphere CSI controller would crashloop when topology tags (region/zone) were assigned to datastore objects in vCenter.
```