### PR TITLE
Update CSI provisioner sidecar version for supervisor K8s version 1.34+

### DIFF
--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -310,7 +310,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.12
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.1.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update CSI provisioner sidecar version for supervisor K8s version 1.34+

6.1.0 external provisioner version has requirement of minimum K8s version as 1.34 (https://github.com/kubernetes-csi/external-provisioner/releases/tag/v6.1.0), hence updated 1.34 specific YAML only in supervisor.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Unit tests and build is working fine with these changes.
FVT team verified these changes and didn't find any issue in regression cycle.

**Special notes for your reviewer**:

**Release note**:
```release-note
Update CSI provisioner sidecar version for supervisor K8s version 1.34+
```
