### PR TITLE
Revert csi provisioner to 4.0.1

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -381,7 +381,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Revert csi provisioner to 4.0.1 to allow topology aware provisioning.

**Testing done**:
```
21:14:51  Data Persistence [ef-wcp][csi-block-vanilla][cf-vanilla-block][pq-n1-vanilla-block][pq-n2-vanilla-block][ef-vks][csi-supervisor][csi-guest][csi-block-vanilla-parallelized][ef-vks-n1][ef-vks-n2] Should create and delete pod with the same volume source and data [p0, block, vanilla, wcp, tkg, core, vc70]
21:14:51  /home/worker/workspace/vsan-block/Results/400/vsphere-csi-driver/tests/e2e/data_persistence.go:121
21:14:51  
21:14:51    Timeline >>
21:14:51    STEP: Creating a kubernetes client @ 03/17/26 04:13:28.731
21:14:51    I0317 04:13:28.731976 664782 util.go:414] >>> kubeConfig: /home/worker/workspace/vsan-block/Results/400/gc-kubeconfig.yaml
21:14:51    STEP: Building a namespace api object, basename e2e-data-persistence @ 03/17/26 04:13:28.733
21:14:51    I0317 04:13:28.823645 664782 framework.go:275] Skipping waiting for service account
21:14:51    I0317 04:13:28.921918 664782 connection.go:72] Creating new VC session
21:14:51    STEP: Creating Storage Class and PVC @ 03/17/26 04:13:29.384
21:14:51    STEP: CNS_TEST: Running for vanilla k8s setup @ 03/17/26 04:13:29.384
21:14:51    STEP: Creating StorageClass  with scParameters: map[] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: false @ 03/17/26 04:13:29.384
21:14:51    STEP: Creating PVC using the Storage Class sc-zqn4f with disk size  and labels: map[] accessMode:  @ 03/17/26 04:13:29.501
21:14:51    I0317 04:13:29.571685 664782 util.go:910] PVC created: pvc-fs7fw in namespace: e2e-data-persistence-1768
21:14:51    STEP: Waiting for claim pvc-fs7fw to be in bound phase @ 03/17/26 04:13:29.571
21:14:51    I0317 04:13:29.571732 664782 pv.go:790] Waiting up to timeout=5m0s for PersistentVolumeClaims [pvc-fs7fw] to have phase Bound
21:14:51    I0317 04:13:29.582054 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:31.598262 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:33.614054 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:35.635436 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:37.650310 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:39.711669 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:47.920793 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:49.935988 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:51.949600 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:53.963233 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:55.977059 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:13:57.991348 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:14:00.025523 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:14:02.039163 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:14:04.055567 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:14:06.069609 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:14:08.081695 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:14:10.093932 664782 pv.go:806] PersistentVolumeClaim pvc-fs7fw found but phase is Pending instead of Bound.
21:14:51    I0317 04:14:12.382757 664782 pv.go:801] PersistentVolumeClaim pvc-fs7fw found and phase=Bound (42.810989381s)
21:14:51    STEP: Creating pod @ 03/17/26 04:14:12.481
21:14:51    I0317 04:14:12.669347  664782 warnings.go:107] "Warning: would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"write-pod\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"write-pod\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"write-pod\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"write-pod\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
21:14:51    STEP: Verify volume: 9724f74a-78b7-4d72-b5ca-3d370540eb3c is attached to the node: k8s-node-32-1773597161 @ 03/17/26 04:14:20.88
21:14:51    STEP: VM UUID is: 4229e38e-f86d-3644-27a7-f8ea910a3f03 for node: k8s-node-32-1773597161 @ 03/17/26 04:14:20.901
21:14:51    I0317 04:14:21.051568 664782 vsphere.go:283] vmRef: VirtualMachine:vm-49 for the VM uuid: 4229e38e-f86d-3644-27a7-f8ea910a3f03
21:14:51    I0317 04:14:21.107134 664782 util.go:721] Found FCDID "9724f74a-78b7-4d72-b5ca-3d370540eb3c" attached to VM "k8s-worker3"
21:14:51    I0317 04:14:21.107157 664782 vsphere.go:294] Found the disk "9724f74a-78b7-4d72-b5ca-3d370540eb3c" is attached to the VM with UUID: "4229e38e-f86d-3644-27a7-f8ea910a3f03"
21:14:51    STEP: Creating an empty file on the volume mounted on: pvc-tester-6kc9f @ 03/17/26 04:14:21.107
21:14:51    I0317 04:14:21.107289 664782 builder.go:130] Running '/usr/local/bin/kubectl --kubeconfig=/home/worker/workspace/vsan-block/Results/400/gc-kubeconfig.yaml --namespace=e2e-data-persistence-1768 exec pvc-tester-6kc9f -- /bin/sh -c touch /mnt/volume1/e2e-data-persistence-1768_file_A.txt'
21:14:51    I0317 04:14:21.511630 664782 builder.go:156] stderr: ""
21:14:51    I0317 04:14:21.511671 664782 builder.go:157] stdout: ""
21:14:51    STEP: Verify files exist on volume mounted on: pvc-tester-6kc9f @ 03/17/26 04:14:21.511
21:14:51    I0317 04:14:21.511825 664782 builder.go:130] Running '/usr/local/bin/kubectl --kubeconfig=/home/worker/workspace/vsan-block/Results/400/gc-kubeconfig.yaml --namespace=e2e-data-persistence-1768 exec --namespace=e2e-data-persistence-1768 pvc-tester-6kc9f -- /bin/ls /mnt/volume1/e2e-data-persistence-1768_file_A.txt'
21:14:51    I0317 04:14:21.804621 664782 builder.go:156] stderr: ""
21:14:51    I0317 04:14:21.804674 664782 builder.go:157] stdout: "/mnt/volume1/e2e-data-persistence-1768_file_A.txt\n"
21:14:51    STEP: Deleting the pod @ 03/17/26 04:14:21.804
21:14:51    I0317 04:14:21.804710 664782 delete.go:78] Deleting pod "pvc-tester-6kc9f" in namespace "e2e-data-persistence-1768"
21:14:51    I0317 04:14:21.847464 664782 delete.go:86] Wait up to 5m0s for pod "pvc-tester-6kc9f" to be fully deleted
21:14:51    STEP: Verify volume is detached from the node @ 03/17/26 04:14:23.872
21:14:51    STEP: VM UUID is: 4229e38e-f86d-3644-27a7-f8ea910a3f03 for node: k8s-node-32-1773597161 @ 03/17/26 04:14:23.883
21:14:51    I0317 04:14:24.077368 664782 vsphere.go:283] vmRef: VirtualMachine:vm-49 for the VM uuid: 4229e38e-f86d-3644-27a7-f8ea910a3f03
21:14:51    I0317 04:14:24.133343 664782 util.go:721] Found FCDID "9724f74a-78b7-4d72-b5ca-3d370540eb3c" attached to VM "k8s-worker3"
21:14:51    I0317 04:14:24.133374 664782 vsphere.go:294] Found the disk "9724f74a-78b7-4d72-b5ca-3d370540eb3c" is attached to the VM with UUID: "4229e38e-f86d-3644-27a7-f8ea910a3f03"
21:14:51    I0317 04:14:24.133394 664782 vsphere.go:329] Waiting for disk: "9724f74a-78b7-4d72-b5ca-3d370540eb3c" to be detached from the node :"k8s-node-32-1773597161"
21:14:51    STEP: VM UUID is: 4229e38e-f86d-3644-27a7-f8ea910a3f03 for node: k8s-node-32-1773597161 @ 03/17/26 04:14:25.885
21:14:51    I0317 04:14:26.085480 664782 vsphere.go:283] vmRef: VirtualMachine:vm-49 for the VM uuid: 4229e38e-f86d-3644-27a7-f8ea910a3f03
21:14:51    I0317 04:14:26.105845 664782 util.go:721] Found FCDID "9724f74a-78b7-4d72-b5ca-3d370540eb3c" attached to VM "k8s-worker3"
21:14:51    I0317 04:14:26.105910 664782 vsphere.go:294] Found the disk "9724f74a-78b7-4d72-b5ca-3d370540eb3c" is attached to the VM with UUID: "4229e38e-f86d-3644-27a7-f8ea910a3f03"
21:14:51    I0317 04:14:26.105927 664782 vsphere.go:329] Waiting for disk: "9724f74a-78b7-4d72-b5ca-3d370540eb3c" to be detached from the node :"k8s-node-32-1773597161"
21:14:51    STEP: VM UUID is: 4229e38e-f86d-3644-27a7-f8ea910a3f03 for node: k8s-node-32-1773597161 @ 03/17/26 04:14:27.889
21:14:51    I0317 04:14:28.045281 664782 vsphere.go:283] vmRef: VirtualMachine:vm-49 for the VM uuid: 4229e38e-f86d-3644-27a7-f8ea910a3f03
21:14:51    I0317 04:14:28.098739 664782 util.go:727] failed to find FCDID "9724f74a-78b7-4d72-b5ca-3d370540eb3c" attached to VM "k8s-worker3"
21:14:51    I0317 04:14:28.098789 664782 vsphere.go:326] Disk: 9724f74a-78b7-4d72-b5ca-3d370540eb3c successfully detached
21:14:51    STEP: Creating a new pod using the same volume @ 03/17/26 04:14:28.098
21:14:51    I0317 04:14:28.138269  664782 warnings.go:107] "Warning: would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"write-pod\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"write-pod\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"write-pod\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"write-pod\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
21:14:51    STEP: Verify volume: 9724f74a-78b7-4d72-b5ca-3d370540eb3c is attached to the node: k8s-node-32-1773597161 @ 03/17/26 04:14:38.248
21:14:51    STEP: VM UUID is: 4229e38e-f86d-3644-27a7-f8ea910a3f03 for node: k8s-node-32-1773597161 @ 03/17/26 04:14:38.259
21:14:51    I0317 04:14:38.459372 664782 vsphere.go:283] vmRef: VirtualMachine:vm-49 for the VM uuid: 4229e38e-f86d-3644-27a7-f8ea910a3f03
21:14:51    I0317 04:14:38.515244 664782 util.go:721] Found FCDID "9724f74a-78b7-4d72-b5ca-3d370540eb3c" attached to VM "k8s-worker3"
21:14:51    I0317 04:14:38.515283 664782 vsphere.go:294] Found the disk "9724f74a-78b7-4d72-b5ca-3d370540eb3c" is attached to the VM with UUID: "4229e38e-f86d-3644-27a7-f8ea910a3f03"
21:14:51    STEP: Creating a second empty file on the same volume mounted on: pvc-tester-c7skl @ 03/17/26 04:14:38.515
21:14:51    I0317 04:14:38.515410 664782 builder.go:130] Running '/usr/local/bin/kubectl --kubeconfig=/home/worker/workspace/vsan-block/Results/400/gc-kubeconfig.yaml --namespace=e2e-data-persistence-1768 exec pvc-tester-c7skl -- /bin/sh -c touch /mnt/volume1/e2e-data-persistence-1768_file_B.txt'
21:14:51    I0317 04:14:38.802494 664782 builder.go:156] stderr: ""
21:14:51    I0317 04:14:38.802532 664782 builder.go:157] stdout: ""
21:14:51    STEP: Verify files exist on volume mounted on: pvc-tester-c7skl @ 03/17/26 04:14:38.802
21:14:51    I0317 04:14:38.802629 664782 builder.go:130] Running '/usr/local/bin/kubectl --kubeconfig=/home/worker/workspace/vsan-block/Results/400/gc-kubeconfig.yaml --namespace=e2e-data-persistence-1768 exec --namespace=e2e-data-persistence-1768 pvc-tester-c7skl -- /bin/ls /mnt/volume1/e2e-data-persistence-1768_file_A.txt'
21:14:51    I0317 04:14:39.086279 664782 builder.go:156] stderr: ""
21:14:51    I0317 04:14:39.086321 664782 builder.go:157] stdout: "/mnt/volume1/e2e-data-persistence-1768_file_A.txt\n"
21:14:51    I0317 04:14:39.086441 664782 builder.go:130] Running '/usr/local/bin/kubectl --kubeconfig=/home/worker/workspace/vsan-block/Results/400/gc-kubeconfig.yaml --namespace=e2e-data-persistence-1768 exec --namespace=e2e-data-persistence-1768 pvc-tester-c7skl -- /bin/ls /mnt/volume1/e2e-data-persistence-1768_file_B.txt'
21:14:51    I0317 04:14:39.405834 664782 builder.go:156] stderr: ""
21:14:51    I0317 04:14:39.405878 664782 builder.go:157] stdout: "/mnt/volume1/e2e-data-persistence-1768_file_B.txt\n"
21:14:51    STEP: Deleting the pod @ 03/17/26 04:14:39.405
21:14:51    I0317 04:14:39.405913 664782 delete.go:78] Deleting pod "pvc-tester-c7skl" in namespace "e2e-data-persistence-1768"
21:14:51    I0317 04:14:39.462057 664782 delete.go:86] Wait up to 5m0s for pod "pvc-tester-c7skl" to be fully deleted
21:14:51    STEP: Verify volume is detached from the node @ 03/17/26 04:14:41.495
21:14:51    STEP: VM UUID is: 4229e38e-f86d-3644-27a7-f8ea910a3f03 for node: k8s-node-32-1773597161 @ 03/17/26 04:14:41.505
21:14:51    I0317 04:14:41.573546 664782 vsphere.go:283] vmRef: VirtualMachine:vm-49 for the VM uuid: 4229e38e-f86d-3644-27a7-f8ea910a3f03
21:14:51    I0317 04:14:41.587242 664782 util.go:721] Found FCDID "9724f74a-78b7-4d72-b5ca-3d370540eb3c" attached to VM "k8s-worker3"
21:14:51    I0317 04:14:41.587282 664782 vsphere.go:294] Found the disk "9724f74a-78b7-4d72-b5ca-3d370540eb3c" is attached to the VM with UUID: "4229e38e-f86d-3644-27a7-f8ea910a3f03"
21:14:51    I0317 04:14:41.587301 664782 vsphere.go:329] Waiting for disk: "9724f74a-78b7-4d72-b5ca-3d370540eb3c" to be detached from the node :"k8s-node-32-1773597161"
21:14:51    STEP: VM UUID is: 4229e38e-f86d-3644-27a7-f8ea910a3f03 for node: k8s-node-32-1773597161 @ 03/17/26 04:14:43.508
21:14:51    I0317 04:14:43.617368 664782 vsphere.go:283] vmRef: VirtualMachine:vm-49 for the VM uuid: 4229e38e-f86d-3644-27a7-f8ea910a3f03
21:14:51    I0317 04:14:43.672540 664782 util.go:721] Found FCDID "9724f74a-78b7-4d72-b5ca-3d370540eb3c" attached to VM "k8s-worker3"
21:14:51    I0317 04:14:43.672575 664782 vsphere.go:294] Found the disk "9724f74a-78b7-4d72-b5ca-3d370540eb3c" is attached to the VM with UUID: "4229e38e-f86d-3644-27a7-f8ea910a3f03"
21:14:51    I0317 04:14:43.672597 664782 vsphere.go:329] Waiting for disk: "9724f74a-78b7-4d72-b5ca-3d370540eb3c" to be detached from the node :"k8s-node-32-1773597161"
21:14:51    STEP: VM UUID is: 4229e38e-f86d-3644-27a7-f8ea910a3f03 for node: k8s-node-32-1773597161 @ 03/17/26 04:14:45.511
21:14:51    I0317 04:14:45.662364 664782 vsphere.go:283] vmRef: VirtualMachine:vm-49 for the VM uuid: 4229e38e-f86d-3644-27a7-f8ea910a3f03
21:14:51    I0317 04:14:45.678693 664782 util.go:721] Found FCDID "9724f74a-78b7-4d72-b5ca-3d370540eb3c" attached to VM "k8s-worker3"
21:14:51    I0317 04:14:45.678724 664782 vsphere.go:294] Found the disk "9724f74a-78b7-4d72-b5ca-3d370540eb3c" is attached to the VM with UUID: "4229e38e-f86d-3644-27a7-f8ea910a3f03"
21:14:51    I0317 04:14:45.678739 664782 vsphere.go:329] Waiting for disk: "9724f74a-78b7-4d72-b5ca-3d370540eb3c" to be detached from the node :"k8s-node-32-1773597161"
21:14:51    STEP: VM UUID is: 4229e38e-f86d-3644-27a7-f8ea910a3f03 for node: k8s-node-32-1773597161 @ 03/17/26 04:14:47.506
21:14:51    I0317 04:14:47.712333 664782 vsphere.go:283] vmRef: VirtualMachine:vm-49 for the VM uuid: 4229e38e-f86d-3644-27a7-f8ea910a3f03
21:14:51    I0317 04:14:47.725472 664782 util.go:727] failed to find FCDID "9724f74a-78b7-4d72-b5ca-3d370540eb3c" attached to VM "k8s-worker3"
21:14:51    I0317 04:14:47.725514 664782 vsphere.go:326] Disk: 9724f74a-78b7-4d72-b5ca-3d370540eb3c successfully detached
21:14:51    I0317 04:14:47.725533 664782 pv.go:205] Deleting PersistentVolumeClaim "pvc-fs7fw"
21:14:51    I0317 04:14:48.036656 664782 vsphere.go:481] waiting for Volume "9724f74a-78b7-4d72-b5ca-3d370540eb3c" to be deleted.
21:14:51    I0317 04:14:49.841918 664782 vsphere.go:478] volume "9724f74a-78b7-4d72-b5ca-3d370540eb3c" has successfully deleted
21:14:51    STEP: Destroying namespace "e2e-data-persistence-1768" for this suite. @ 03/17/26 04:14:49.898
21:14:51    << Timeline
21:14:51  ------------------------------
21:14:51  SSSSSSSSSSSSSSSSSSSSSSSSSSSS
21:14:51  ------------------------------
21:14:51  [ReportAfterSuite] PASSED [0.067 seconds]
21:14:51  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
21:14:51  autogenerated by Ginkgo
21:14:51  ------------------------------
21:14:51  
21:14:51  Ran 1 of 1264 Specs in 81.383 seconds
21:14:51  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 1263 Skipped
21:14:51  
21:14:51  Running Suite: CNS-CSI-Driver-End-to-End-MultiSvc-Tests - /home/worker/workspace/vsan-block/Results/400/vsphere-csi-driver/tests/e2e/multiSvc
21:14:51  =============================================================================================================================================
21:14:51  Random Seed: 1773720741
21:14:51  
21:14:51  Will run 0 of 531 specs
21:14:51  Running in parallel across 8 processes
21:14:51  SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
21:14:51  ------------------------------
21:14:51  [ReportAfterSuite] PASSED [0.031 seconds]
21:14:51  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
21:14:51  autogenerated by Ginkgo
21:14:51  ------------------------------
21:14:51  
21:14:51  Ran 0 of 531 Specs in 0.117 seconds
21:14:51  SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 531 Skipped
21:14:51  
21:14:51  Running Suite: CNS-CSI-Driver-End-to-End-Provisioning-Tests - /home/worker/workspace/vsan-block/Results/400/vsphere-csi-driver/tests/e2e/provisioning
21:14:51  =====================================================================================================================================================
21:14:51  Random Seed: 1773720741
21:14:51  
21:14:51  Will run 0 of 529 specs
21:14:51  Running in parallel across 8 processes
21:14:51  SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
21:14:51  ------------------------------
21:14:51  [ReportAfterSuite] PASSED [0.039 seconds]
21:14:51  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
21:14:51  autogenerated by Ginkgo
21:14:51  ------------------------------
21:14:51  
21:14:51  Ran 0 of 529 Specs in 0.112 seconds
21:14:51  SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 529 Skipped
21:14:51  
21:14:51  
21:14:51  Ginkgo ran 3 suites in 2m29.115792407s
21:14:51  Test Suite Passed
21:14:51  [38;5;228mYou're using deprecated Ginkgo functionality:[0m
21:14:51  [38;5;228m=============================================[0m
21:14:51    [38;5;11m--always-emit-ginkgo-writer is deprecated  - use -v instead, or one of Ginkgo's machine-readable report formats to get GinkgoWriter output for passing specs.[0m
21:14:51  
21:14:51  [38;5;243mTo silence deprecations that can be silenced set the following environment variable:[0m
21:14:51    [38;5;243mACK_GINKGO_DEPRECATIONS=2.27.3[0m
21:14:51  
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Revert csi provisioner to 4.0.1
```
