### PR TITLE
Add CSI provisioner version update changes in Supervisor K8s 1.32 and 1.33 YAMLs

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -310,7 +310,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.12
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.1.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -310,7 +310,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.12
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.1.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
**What this PR does / why we need it**:
CSI provisioner version update changes were merged to Supervisor K8s version 1.34 YAML through https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3922.
Adding same changes to K8s YAMLs 1.32 and 1.33 as well.
Earlier we made changes only to 1.34 YAML, as 6.x provisioner versions has recommended minimum K8s version as 1.34. But we verified that it is working on earlier versions as well. Otherwise we won't be able to update provisioner version unless we start supporting K8s version 1.36 on supervisor.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
FVT tested new provisioner image on K8s version 1.33, no regression observed.

**Special notes for your reviewer**:

**Release note**:
```release-note
Add CSI provisioner version update changes in Supervisor K8s 1.32 and 1.33 YAMLs
```
