### PR TITLE
Add storage policy update feature related fields in CnsVolumeInfo CRD

### DIFF
--- a/pkg/internalapis/cnsvolumeinfo/config/cns.vmware.com_cnsvolumeinfoes.yaml
+++ b/pkg/internalapis/cnsvolumeinfo/config/cns.vmware.com_cnsvolumeinfoes.yaml
@@ -49,8 +49,15 @@ spec:
                 storagePolicyID:
                   description: StoragePolicyID is the ID of the storage policy associated with the volume
                   type: string
+                k8sCompliantName:
+                  description: K8sCompliantName is the K8s-compliant name derived from storage policy name
+                    to ensure unique identification across multiple vCenters.
+                  type: string
                 storageClassName:
                   description: StorageClassName is the name of the storage class associated with the volume
+                  type: string
+                volumeAttributeClassName:
+                  description: VolumeAttributeClassName is the name of the K8s volume attributes class.
                   type: string
                 capacity:
                   anyOf:
@@ -85,6 +92,56 @@ spec:
               required:
                 - vCenterServer
                 - volumeID
+              type: object
+            status:
+              description: CNSVolumeInfoStatus defines the observed state of CNSVolumeInfo
+              properties:
+                migrationConditions:
+                  description: MigrationConditions describe the current conditions of
+                    the migration. Known condition types are "InProgress", "Infeasible",
+                    "Error", "Complete".
+                  items:
+                    description: metav1.Condition represents an observation of an
+                      object's state. Some examples are available at
+                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Z0-9][-A-Z0-9_.]*)?[A-Z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
               type: object
           required:
             - spec

--- a/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
+++ b/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
@@ -41,8 +41,15 @@ type CNSVolumeInfoSpec struct {
 	// ID of the storage policy
 	StoragePolicyID string `json:"storagePolicyID,omitempty"`
 
+	// K8sCompliantName is the K8s-compliant name derived from storage policy name to ensure
+	// unique identification across multiple vCenters.
+	K8sCompliantName string `json:"k8sCompliantName,omitempty"`
+
 	// Name of the storage class
 	StorageClassName string `json:"storageClassName,omitempty"`
+
+	// VolumeAttributeClassName is the name of the K8s volume attributes class.
+	VolumeAttributeClassName string `json:"volumeAttributeClassName,omitempty"`
 
 	// Capacity stores the current capacity of the PersistentVolume this volume represents.
 	Capacity *resource.Quantity `json:"capacity,omitempty"`
@@ -64,6 +71,24 @@ type CNSVolumeInfoSpec struct {
 	IsLinkedClone bool `json:"isLinkedClone"`
 }
 
+// CNSVolumeInfoStatus defines the observed state of CNSVolumeInfo
+type CNSVolumeInfoStatus struct {
+	// MigrationConditions describe the current conditions of the migration.
+	//
+	// Known condition types are:
+	//
+	// "InProgress"
+	// "Infeasible"
+	// "Error"
+	// "Complete"
+	//
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=8
+	MigrationConditions []metav1.Condition `json:"migrationConditions,omitempty"`
+}
+
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
@@ -72,7 +97,8 @@ type CNSVolumeInfo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec CNSVolumeInfoSpec `json:"spec"`
+	Spec   CNSVolumeInfoSpec   `json:"spec"`
+	Status CNSVolumeInfoStatus `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -82,4 +108,16 @@ type CNSVolumeInfoList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []CNSVolumeInfo `json:"items"`
+}
+
+// GetConditions returns the list of conditions for the CNSVolumeInfo object.
+// Implements the conditions.Getter interface.
+func (in *CNSVolumeInfo) GetConditions() []metav1.Condition {
+	return in.Status.MigrationConditions
+}
+
+// SetConditions sets the list of conditions for the CNSVolumeInfo object.
+// Implements the conditions.Setter interface.
+func (in *CNSVolumeInfo) SetConditions(conditions []metav1.Condition) {
+	in.Status.MigrationConditions = conditions
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add storage policy update feature related fields in CnsVolumeInfo CRD

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
pre-checkin pipelines
wcp: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1182/
```
Ran 16 of 2324 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2308 Skipped | 0 Flaked
<br>VC ob-25348001 <br>ESX null <br>VC IP 172.21.1.69
```

vks: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/994/

**Special notes for your reviewer**:

**Release note**:
```release-note
Add storage policy update feature related fields in CnsVolumeInfo CRD
```
