### PR TITLE
Use file volume prefix in volumeID to check whether volume type is block or file

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -853,25 +853,10 @@ func ListSnapshotsUtil(ctx context.Context, volManager cnsvolume.Manager, volume
 		return snapshots, "", nil
 	} else if volumeID != "" {
 		// Retrieve all snapshots for a volume-id
-		// Check if the volume-id specified is of Block type.
-		queryFilter := cnstypes.CnsQueryFilter{
-			VolumeIds: []cnstypes.CnsVolumeId{{Id: volumeID}},
-		}
-		querySelection := cnstypes.CnsQuerySelection{
-			Names: []string{string(cnstypes.QuerySelectionNameTypeVolumeType)},
-		}
-		// Validate that the volume-id is of block volume type.
-		queryResult, err := utils.QueryVolumeUtil(ctx, volManager, queryFilter, &querySelection)
-		if err != nil {
-			return nil, "", logger.LogNewErrorCodef(log, codes.Internal,
-				"queryVolumeUtil failed with err=%+v", err)
-		}
-
-		if len(queryResult.Volumes) == 0 {
-			return nil, "", logger.LogNewErrorCodef(log, codes.Internal,
-				"volumeID %q not found in QueryVolumeUtil", volumeID)
-		}
-		if queryResult.Volumes[0].VolumeType == FileVolumeType {
+		// Check if the volume-id is a file volume using prefix pattern.
+		// File volumes have "file:" prefix, avoiding expensive CNS QueryVolume call.
+		const FileVolumePrefix = "file:"
+		if strings.HasPrefix(volumeID, FileVolumePrefix) {
 			return nil, "", logger.LogNewErrorCodef(log, codes.Unimplemented,
 				"ListSnapshot for file volume: %q not supported", volumeID)
 		}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1835,30 +1835,10 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				"failed to get volume manager for volume Id: %q. Error: %v", req.VolumeId, err)
 		}
 		if !strings.Contains(req.VolumeId, ".vmdk") {
-			// Check if volume is block or file, skip detach for file volume.
-			queryFilter := cnstypes.CnsQueryFilter{
-				VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
-			}
-			querySelection := cnstypes.CnsQuerySelection{
-				Names: []string{
-					string(cnstypes.QuerySelectionNameTypeVolumeType),
-				},
-			}
-			// Select only the volume type.
-			queryResult, err := volumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
-			// TODO: QueryAllVolumeUtil need return faultType
-			//	and we should return the faultType.
-			// Currently, just return "csi.fault.Internal"
-			if err != nil {
-				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-					"queryVolume failed for volumeID: %q with err=%+v", req.VolumeId, err)
-			}
-
-			if len(queryResult.Volumes) == 0 {
-				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-					"volumeID %q not found in QueryVolume", req.VolumeId)
-			}
-			if queryResult.Volumes[0].VolumeType == common.FileVolumeType {
+			// Check if volume is file volume using volume ID prefix pattern.
+			// File volumes have "file:" prefix, so we can avoid expensive CNS QueryVolume call.
+			const FileVolumePrefix = "file:"
+			if strings.HasPrefix(req.VolumeId, FileVolumePrefix) {
 				volumeType = prometheus.PrometheusFileVolumeType
 				log.Infof("Skipping ControllerUnpublish for file volume %q", req.VolumeId)
 				return &csi.ControllerUnpublishVolumeResponse{}, "", nil

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -448,7 +448,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 			return reconcile.Result{RequeueAfter: timeout}, reconcile.TerminalError(err)
 		}
 
-		// Query volume for backing object details (still needed for access point configuration).
+		// Query volume for backing object details (needed for access point configuration).
 		log.Debugf("Querying volume: %s for CnsFileAccessConfig request with name: %q on namespace: %q",
 			volumeID, instance.Name, instance.Namespace)
 		querySelection := cnstypes.CnsQuerySelection{
@@ -470,13 +470,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 
-		// Double-check volume type from CNS (defensive programming)
-		if volume.VolumeType != string(cnstypes.CnsVolumeTypeFile) {
-			msg := fmt.Sprintf("CNS Volume: %s is not RWX volume (CNS reports type: %s)", volumeID, volume.VolumeType)
-			err = logger.LogNewError(log, msg)
-			setInstanceError(ctx, r, instance, msg)
-			return reconcile.Result{RequeueAfter: timeout}, reconcile.TerminalError(err)
-		}
+		// Volume type is guaranteed to be file volume due to prefix validation above
 		vSANFileBackingDetails := volume.BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails)
 		accessPoints := make(map[string]string)
 		for _, kv := range vSANFileBackingDetails.AccessPoints {

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -438,12 +438,21 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 
-		// Query volume.
+		// Early validation: Check if volume is file volume using volume ID prefix pattern.
+		// File volumes have "file:" prefix, allowing early rejection of non-file volumes.
+		const FileVolumePrefix = "file:"
+		if !strings.HasPrefix(volumeID, FileVolumePrefix) {
+			msg := fmt.Sprintf("CNS Volume: %s is not a file volume (missing file: prefix)", volumeID)
+			err = logger.LogNewError(log, msg)
+			setInstanceError(ctx, r, instance, msg)
+			return reconcile.Result{RequeueAfter: timeout}, reconcile.TerminalError(err)
+		}
+
+		// Query volume for backing object details (still needed for access point configuration).
 		log.Debugf("Querying volume: %s for CnsFileAccessConfig request with name: %q on namespace: %q",
 			volumeID, instance.Name, instance.Namespace)
 		querySelection := cnstypes.CnsQuerySelection{
 			Names: []string{
-				string(cnstypes.QuerySelectionNameTypeVolumeType),
 				string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
 			},
 		}
@@ -461,8 +470,9 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 
+		// Double-check volume type from CNS (defensive programming)
 		if volume.VolumeType != string(cnstypes.CnsVolumeTypeFile) {
-			msg := fmt.Sprintf("CNS Volume: %s is not RWX volume", volumeID)
+			msg := fmt.Sprintf("CNS Volume: %s is not RWX volume (CNS reports type: %s)", volumeID, volume.VolumeType)
 			err = logger.LogNewError(log, msg)
 			setInstanceError(ctx, r, instance, msg)
 			return reconcile.Result{RequeueAfter: timeout}, reconcile.TerminalError(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR optimizes file volume detection by replacing expensive CNS QueryVolume API calls with simple string prefix checks (strings.HasPrefix(volumeID, "file:")) to determine if a volume is a file volume. The optimization is applied in ControllerUnpublishVolume, ListSnapshots, and CnsFileAccessConfig controller, eliminating unnecessary network round-trips and reducing CNS load. This follows the existing pattern used elsewhere in the codebase and leverages the established "file:" prefix convention for RWX volumes. The changes maintain the same functionality while significantly improving performance and scalability when processing large numbers of volumes.

**Testing done**:
WCP e2e pipeline result attached in this comment : https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3949#issuecomment-4173248569


**File Volume tests**
```
GINKGO_FOCUS="Volume\\sProvision\\sAcross\\sNamespace|File\\sVolume\\sProvision\\swith\\sNon-VSAN\\sdatastore|File\\sVolume\\sOperation\\sstorm\\sTest|PVCs\\sclaiming\\sthe\\savailable\\sresource\\sin\\sparallel"
```
Results
```
09:53:09  Ran 6 of 1264 Specs in 2140.782 seconds
09:53:09  SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 1258 Skipped
09:53:09  PASS
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use file volume prefix in volumeID to check whether volume type is block or file
```
