### PR TITLE
Ensure that CNS PVC protection finalizer is removed from all PVCs before batchattach instance is deleted.

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -306,27 +306,7 @@ func (r *Reconciler) Reconcile(ctx context.Context,
 	if instance.DeletionTimestamp != nil && vm == nil {
 		log.Infof("Instance %s is being deleted and VM object is also deleted from VC", request.NamespacedName.String())
 
-		pvcsInSpecAndStatus := getPvcsFromSpecAndStatus(ctx, instance)
-
-		// For every PVC mentioned in instance.Spec and in instance.Status, remove finalizer from it.
-		// It is important to remove the finalizer from PVCs in instance.Status also as it is possible
-		// that someone removes the PVC from spec after triggering deletion of VM.
-		for pvcName, volumeName := range pvcsInSpecAndStatus {
-			err := removePvcFinalizer(ctx, r.client, k8sClient, r.cnsOperatorClient,
-				pvcName, instance.Namespace,
-				instance.Spec.InstanceUUID)
-			if err != nil {
-				updateInstanceVolumeStatus(ctx, instance, volumeName, pvcName, "", "", err,
-					v1alpha1.ConditionDetached, v1alpha1.ReasonDetachFailed)
-				log.Errorf("failed to remove finalizer from PVC %s. Err: %s", pvcName, err)
-				return r.completeReconciliationWithError(batchAttachCtx, instance, request.NamespacedName, timeout, err)
-			} else {
-				updateInstanceVolumeStatus(ctx, instance, volumeName, pvcName, "", "", err,
-					v1alpha1.ConditionDetached, "")
-			}
-		}
-
-		patchErr := removeFinalizerFromCRDInstance(batchAttachCtx, instance, r.client)
+		patchErr := removeFinalizerFromCRDInstance(batchAttachCtx, instance, r.client, k8sClient, r.cnsOperatorClient)
 		if patchErr != nil {
 			log.Errorf("failed to update CnsNodeVMBatchAttachment %s. Err: %s", instance.Name, patchErr)
 			return r.completeReconciliationWithError(batchAttachCtx, instance, request.NamespacedName, timeout, patchErr)
@@ -399,7 +379,7 @@ func (r *Reconciler) reconcileInstanceWithDeletionTimestamp(ctx context.Context,
 	}
 
 	// CR is being deleted and all volumes were detached successfully.
-	return removeFinalizerFromCRDInstance(ctx, instance, r.client)
+	return removeFinalizerFromCRDInstance(ctx, instance, r.client, k8sClient, r.cnsOperatorClient)
 }
 
 // reconcileInstanceWithoutDeletionTimestamp calls CNS batch attach for all volumes in instance spec

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -88,12 +88,48 @@ func trimMessage(err error) error {
 	return err
 }
 
+// removePvcProtectionFinalizersForTrackedPVCs walks every PVC named in the batch attachment
+// spec and status (see getPvcsFromSpecAndStatus). For each, it calls removePvcFinalizer, which
+// handles missing PVCs (NotFound) and whether cns.vmware.com/pvc-protection is present.
+// Volume status is updated to detached on success or detach-failed on error.
+func removePvcProtectionFinalizersForTrackedPVCs(ctx context.Context,
+	instance *v1alpha1.CnsNodeVMBatchAttachment,
+	c client.Client,
+	k8sClient kubernetes.Interface,
+	cnsOperatorClient client.Client) error {
+	log := logger.GetLogger(ctx)
+
+	for pvcName, volumeName := range getPvcsFromSpecAndStatus(ctx, instance) {
+		err := removePvcFinalizer(ctx, c, k8sClient, cnsOperatorClient,
+			pvcName, instance.Namespace, instance.Spec.InstanceUUID)
+		if err != nil {
+			updateInstanceVolumeStatus(ctx, instance, volumeName, pvcName, "", "", err,
+				v1alpha1.ConditionDetached, v1alpha1.ReasonDetachFailed)
+			log.Errorf("failed to remove protection finalizer from PVC %s before removing batch attachment finalizer: %v",
+				pvcName, err)
+			return err
+		}
+		updateInstanceVolumeStatus(ctx, instance, volumeName, pvcName, "", "", nil,
+			v1alpha1.ConditionDetached, "")
+	}
+	return nil
+}
+
 // removeFinalizerFromCRDInstance will remove the CNS Finalizer, cns.vmware.com,
-// from a given nodevmbatchattachment instance.
+// from a given nodevmbatchattachment instance only after attempting to clear
+// cns.vmware.com/pvc-protection from every PVC listed in spec and status.
 func removeFinalizerFromCRDInstance(ctx context.Context,
 	instance *v1alpha1.CnsNodeVMBatchAttachment,
-	c client.Client) error {
+	c client.Client,
+	k8sClient kubernetes.Interface,
+	cnsOperatorClient client.Client) error {
 	log := logger.GetLogger(ctx)
+
+	// First ensure that none of the PVCs have CNS PVC protection finalizer.
+	if err := removePvcProtectionFinalizersForTrackedPVCs(ctx, instance, c, k8sClient, cnsOperatorClient); err != nil {
+		return err
+	}
+
 	finalizersOnInstance := instance.Finalizers
 	for i, finalizer := range instance.Finalizers {
 		if finalizer == cnsoperatortypes.CNSFinalizer {

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
 
@@ -818,6 +819,111 @@ func TestUpdatePvcStatusEntryName_SkipsNonTargetPVC(t *testing.T) {
 	if got != want {
 		t.Fatalf("expected volume name %q (unchanged), got %q", want, got)
 	}
+}
+
+func findVolumeDetachedCondition(vol v1alpha1.VolumeStatus) *metav1.Condition {
+	for i := range vol.PersistentVolumeClaim.Conditions {
+		if vol.PersistentVolumeClaim.Conditions[i].Type == v1alpha1.ConditionDetached {
+			return &vol.PersistentVolumeClaim.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func schemeForCnsBatchAttachTests() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = v1.AddToScheme(s)
+	_ = cnsopapis.AddToScheme(s)
+	return s
+}
+
+func TestRemovePvcProtectionFinalizersForTrackedPVCs_AllSucceed(t *testing.T) {
+	ctx := context.Background()
+	base := setupTestCnsNodeVMBatchAttachment()
+	instance := base.DeepCopy()
+
+	s := schemeForCnsBatchAttachTests()
+	crClient := fake.NewClientBuilder().WithScheme(s).WithObjects(instance).WithStatusSubresource(instance).Build()
+	clientset := k8sFake.NewClientset()
+	cnsOperatorClient := fake.NewClientBuilder().WithScheme(s).Build()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(removePvcFinalizer, func(ctx context.Context, patchClient crclient.Client,
+		k8sClient kubernetes.Interface, cnsOpClient crclient.Client,
+		pvcName, namespace, vmInstanceUUID string) error {
+		assert.Equal(t, testNamespace, namespace)
+		assert.Equal(t, base.Spec.InstanceUUID, vmInstanceUUID)
+		assert.Contains(t, []string{"pvc-1", "pvc-2"}, pvcName)
+		return nil
+	})
+
+	err := removePvcProtectionFinalizersForTrackedPVCs(ctx, instance, crClient, clientset, cnsOperatorClient)
+	assert.NoError(t, err)
+
+	for _, vol := range instance.Status.VolumeStatus {
+		cond := findVolumeDetachedCondition(vol)
+		assert.NotNil(t, cond, "volume %q should have %s condition", vol.Name, v1alpha1.ConditionDetached)
+		assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	}
+}
+
+func TestRemovePvcProtectionFinalizersForTrackedPVCs_RemoveFinalizerErrorUpdatesStatus(t *testing.T) {
+	ctx := context.Background()
+	base := setupTestCnsNodeVMBatchAttachment()
+	base.Spec.Volumes = base.Spec.Volumes[:1]
+	base.Status.VolumeStatus = base.Status.VolumeStatus[:1]
+	instance := base.DeepCopy()
+
+	s := schemeForCnsBatchAttachTests()
+	crClient := fake.NewClientBuilder().WithScheme(s).WithObjects(instance).WithStatusSubresource(instance).Build()
+	clientset := k8sFake.NewClientset()
+	cnsOperatorClient := fake.NewClientBuilder().WithScheme(s).Build()
+
+	wantErr := errors.New("mock removePvcFinalizer failure")
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(removePvcFinalizer, func(ctx context.Context, patchClient crclient.Client,
+		k8sClient kubernetes.Interface, cnsOpClient crclient.Client,
+		pvcName, namespace, vmInstanceUUID string) error {
+		return wantErr
+	})
+
+	err := removePvcProtectionFinalizersForTrackedPVCs(ctx, instance, crClient, clientset, cnsOperatorClient)
+	assert.ErrorIs(t, err, wantErr)
+
+	require.Len(t, instance.Status.VolumeStatus, 1)
+	cond := findVolumeDetachedCondition(instance.Status.VolumeStatus[0])
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, v1alpha1.ReasonDetachFailed, cond.Reason)
+}
+
+func TestRemovePvcProtectionFinalizersForTrackedPVCs_NoTrackedPVCs(t *testing.T) {
+	ctx := context.Background()
+	base := setupTestCnsNodeVMBatchAttachment()
+	base.Spec.Volumes = nil
+	base.Status.VolumeStatus = nil
+	instance := base.DeepCopy()
+
+	s := schemeForCnsBatchAttachTests()
+	crClient := fake.NewClientBuilder().WithScheme(s).WithObjects(instance).Build()
+	clientset := k8sFake.NewClientset()
+	cnsOperatorClient := fake.NewClientBuilder().WithScheme(s).Build()
+
+	called := false
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(removePvcFinalizer, func(ctx context.Context, patchClient crclient.Client,
+		k8sClient kubernetes.Interface, cnsOpClient crclient.Client,
+		pvcName, namespace, vmInstanceUUID string) error {
+		called = true
+		return nil
+	})
+
+	err := removePvcProtectionFinalizersForTrackedPVCs(ctx, instance, crClient, clientset, cnsOperatorClient)
+	assert.NoError(t, err)
+	assert.False(t, called, "removePvcFinalizer should not run when there are no tracked PVCs")
 }
 
 func TestRemovePvcFinalizer_WhenPVCIsAlreadyDeleted(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There is a possibility where used-by annotation could be removed from a PVC but not the CNS protection finalizer and the batchattach instance CRD gets deleted.
This will leave PVCs in Terminating state forever when they're deleted.

To fix this, we need to ensure that before removing finalizer from batch attach instance, finalizer has been removed from all PVCs.

Scenario where this can happen:
After successful detach, used-by annotation from the PVC was removed: https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go#L916

But PVC's finalizer removal failed for some reason: https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go#L972


Since PVC was successfully detached, in the next reconciliation, volumeToDetach is an empty list: https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go#L670


So detach call returns success without actually doing any detach (because there are no volumes to detach): https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go#L395

Next, finalizer from the batch attach instance itself is removed as detach was successful: https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go#L402C9-L402C39

The PVC remained in Terminating state and the finalizer was never removed from it.

**Testing done**:

Test 1 — Detach volume
Create RWO PVC + VirtualMachine with a volume (vol-data) pointing at that PVC.
Wait for PVC Bound and confirm CNS finalizer / used-by annotation on the PVC.
Remove the data volume from spec.volumes.

Result: Pass — cns.vmware.com/pvc-protection was removed after detach. kubernetes.io/pvc-protection may remain until the PVC is deleted (expected).

Test 2 — Delete VirtualMachine

Re-attach the same PVC (data volume back in spec.volumes).
Confirm cns.vmware.com/pvc-protection is present again.
Delete the VM.

Result: Pass — cns.vmware.com/pvc-protection removed from the PVC; CnsNodeVMBatchAttachment for that VM removed. The PVC can remain until deleted explicitly.

Test 3 — Delete workload namespace

Create a new PVC + VirtualMachine in test with the volume attached.
Confirm cns.vmware.com/pvc-protection and the batch attach CR.
kubectl delete namespace test --wait=true.

Result: Pass — Namespace test deleted (~37s in this run); 

kubectl get namespace test → NotFound. 

PVCs and other namespaced objects were removed with the namespace; no PVC stuck Terminating in this run.

WCP pre-checkin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1179/
VKS pre-checkin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/984/

