### PR TITLE
add wcp capability check and pvcsi fss for new vsan file volume service

### DIFF
--- a/manifests/guestcluster/1.34/pvcsi.yaml
+++ b/manifests/guestcluster/1.34/pvcsi.yaml
@@ -743,6 +743,7 @@ data:
   "workload-domain-isolation": "true"
   "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "true"
+  "vsan-file-volume-service-support": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.35/pvcsi.yaml
+++ b/manifests/guestcluster/1.35/pvcsi.yaml
@@ -744,6 +744,7 @@ data:
   "workload-domain-isolation": "true"
   "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "true"
+  "vsan-file-volume-service-support": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.36/pvcsi.yaml
+++ b/manifests/guestcluster/1.36/pvcsi.yaml
@@ -744,6 +744,7 @@ data:
   "workload-domain-isolation": "true"
   "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "true"
+  "vsan-file-volume-service-support": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -476,6 +476,10 @@ const (
 	LinkedCloneSupport = "supports_FCD_linked_clone"
 	// LinkedCloneSupportFSS is an FSS for LinkedClone support in pvcsi
 	LinkedCloneSupportFSS = "linked-clone-support"
+	// VsanFileVolumeService is the WCP capability for provisioning file volumes using the vSAN file service architecture.
+	VsanFileVolumeService = "supports_vsan_fileservice"
+	// VsanFileVolumeServiceSupportFSS is the PVCSI FSS paired with VsanFileVolumeService on the supervisor.
+	VsanFileVolumeServiceSupportFSS = "vsan-file-volume-service-support"
 	// WCPVMServiceVMSnapshots is a supervisor capability indicating
 	// if supports_VM_service_VM_snapshots FSS is enabled
 	WCPVMServiceVMSnapshots = "supports_VM_service_VM_snapshots"
@@ -498,6 +502,7 @@ var WCPFeatureStates = map[string]struct{}{
 	FCDTransactionSupport:          {},
 	MultipleClustersPerVsphereZone: {},
 	FileVolumesWithVmService:       {},
+	VsanFileVolumeService:          {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
@@ -512,6 +517,7 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 	BYOKEncryption:                 {},
 	SharedDiskFss:                  {},
 	FileVolumesWithVmService:       {},
+	VsanFileVolumeService:          {},
 }
 
 // WCPFeatureAssociatedWithPVCSI contains FSS name used in PVCSI and associated WCP Capability name on a
@@ -519,6 +525,7 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 // on supervisor cluster. If PVCSI feature is enabled, then we need to check if associated Capability is enabled
 // or not on the supervisor cluster to decide if effective value of this FSS is enabled or disabled.
 var WCPFeatureStateAssociatedWithPVCSI = map[string]string{
-	WorkloadDomainIsolationFSS: WorkloadDomainIsolation,
-	LinkedCloneSupportFSS:      LinkedCloneSupport,
+	WorkloadDomainIsolationFSS:      WorkloadDomainIsolation,
+	LinkedCloneSupportFSS:           LinkedCloneSupport,
+	VsanFileVolumeServiceSupportFSS: VsanFileVolumeService,
 }

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -194,6 +194,10 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
 			common.SharedDiskFss, "", "")
 	}
+	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VsanFileVolumeService) {
+		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
+			common.VsanFileVolumeService, "", "")
+	}
 	if idempotencyHandlingEnabled {
 		log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
 		operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx,

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -164,6 +164,14 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 			common.LinkedCloneSupport, config.GC.Port, config.GC.Endpoint)
 	}
+	vsanFileVolumeServicePVCSIFSS := commonco.ContainerOrchestratorUtility.IsPVCSIFSSEnabled(
+		ctx, common.VsanFileVolumeServiceSupportFSS)
+	vsanFileServiceEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(
+		ctx, common.VsanFileVolumeServiceSupportFSS)
+	if vsanFileVolumeServicePVCSIFSS && !vsanFileServiceEnabled {
+		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
+			common.VsanFileVolumeService, config.GC.Port, config.GC.Endpoint)
+	}
 	if isWorkloadDomainIsolationSupported {
 		err := commonco.ContainerOrchestratorUtility.StartZonesInformer(ctx, c.restClientConfig, c.supervisorNamespace)
 		if err != nil {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -359,6 +359,10 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
 				clusterFlavor, common.SharedDiskFss, "", "")
 		}
+		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VsanFileVolumeService) {
+			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,
+				common.VsanFileVolumeService, "", "")
+		}
 	}
 
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
@@ -382,6 +386,15 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		if linkedClonePVCSIFSS && !linkedCloneCapability {
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
 				clusterFlavor, common.LinkedCloneSupport,
+				metadataSyncer.configInfo.Cfg.GC.Port, metadataSyncer.configInfo.Cfg.GC.Endpoint)
+		}
+		vsanFilePVCSIFSS := commonco.ContainerOrchestratorUtility.IsPVCSIFSSEnabled(
+			ctx, common.VsanFileVolumeServiceSupportFSS)
+		vsanFileServiceEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(
+			ctx, common.VsanFileVolumeServiceSupportFSS)
+		if vsanFilePVCSIFSS && !vsanFileServiceEnabled {
+			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
+				clusterFlavor, common.VsanFileVolumeService,
 				metadataSyncer.configInfo.Cfg.GC.Port, metadataSyncer.configInfo.Cfg.GC.Endpoint)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
add wcp capability check and pvcsi fss for new vsan file volume service

- supports_vsan_fileservice is the new supervisor capability for new vSAN file volume service
- "vsan-file-volume-service-support" is the PVCSI
- Register in WCP FSS maps and PVCSI↔capability association
- Start late-enablement watchers in supervisor controller, guest controller, and syncer

**Testing done**:
precheckin
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1183/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/987/


**Special notes for your reviewer**:

verified logs to confirm capability is read correctly from supervisor

```
{"level":"info","time":"2026-04-10T18:40:45.234989952Z","caller":"k8sorchestrator/k8sorchestrator.go:635","msg":"New supervisor feature states values stored successfully: map[block-volume-snapshot:true cnsmgr-suspend-create-volume:true csi-sv-feature-states-replication:true file-volume:true high-pv-node-density:false improved-csi-idempotency:true list-volumes:true online-volume-extend:true storage-quota-m2:true sv-pvc-snapshot-protection-finalizer:true tkgs-ha:true trigger-csi-fullsync:false volume-extend:true volume-health:true workload-domain-isolation:true]","TraceId":"d74844e5-f76e-45f6-a620-9507efd2733c"}
{"level":"info","time":"2026-04-10T18:40:45.247197687Z","caller":"k8sorchestrator/k8sorchestrator.go:732","msg":"configMapAdded: Supervisor feature state values from \"csi-feature-states\" stored successfully: map[block-volume-snapshot:true cnsmgr-suspend-create-volume:true csi-sv-feature-states-replication:true file-volume:true high-pv-node-density:false improved-csi-idempotency:true list-volumes:true online-volume-extend:true storage-quota-m2:true sv-pvc-snapshot-protection-finalizer:true tkgs-ha:true trigger-csi-fullsync:false volume-extend:true volume-health:true workload-domain-isolation:true]","TraceId":"c68fd472-f9f7-4b72-b3ac-277ad529ac19"}
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add wcp capability check and pvcsi fss for new vsan file volume service
```
