### PR TITLE
Add CSI CBT support in WCP

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -599,6 +599,7 @@ data:
   "storage-quota-m2": "true"
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
+  "csi-changed-block-tracking": "false"
   "high-pv-node-density": "false" # When enabled, increases the MAX_VOLUMES_PER_NODE from 59 to 255 for guest cluster nodes
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -599,6 +599,7 @@ data:
   "storage-quota-m2": "true"
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
+  "csi-changed-block-tracking": "false"
   "high-pv-node-density": "false" # When enabled, increases the MAX_VOLUMES_PER_NODE from 59 to 255 for guest cluster nodes
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -599,6 +599,7 @@ data:
   "storage-quota-m2": "true"
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
+  "csi-changed-block-tracking": "false"
   "high-pv-node-density": "false" # When enabled, increases the MAX_VOLUMES_PER_NODE from 59 to 255 for guest cluster nodes
 kind: ConfigMap
 metadata:

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -483,6 +483,12 @@ func (c *FakeK8SOrchestrator) AnnotateVolumeSnapshot(ctx context.Context, volume
 	return true, nil
 }
 
+// GetVolumeSnapshotChangeIDBySnapshotID retrieves the change-id annotation from the VolumeSnapshot
+func (c *FakeK8SOrchestrator) GetVolumeSnapshotChangeIDBySnapshotID(ctx context.Context,
+	snapshotID string) (string, error) {
+	return "mock-change-id", nil
+}
+
 // GetConfigMap checks if ConfigMap with given name exists in the given namespace.
 // If it exists, this function returns ConfigMap data, otherwise returns error.
 func (c *FakeK8SOrchestrator) GetConfigMap(ctx context.Context, name string,

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -83,6 +83,9 @@ type COCommonInterface interface {
 	// AnnotateVolumeSnapshot annotates the volumesnapshot CR in k8s cluster with the snapshot-id and fcd-id
 	AnnotateVolumeSnapshot(ctx context.Context, volumeSnapshotName string,
 		volumeSnapshotNamespace string, annotations map[string]string) (bool, error)
+	// GetVolumeSnapshotChangeIDBySnapshotID retrieves the change-id annotation
+	// from the VolumeSnapshot corresponding to the given snapshotID
+	GetVolumeSnapshotChangeIDBySnapshotID(ctx context.Context, snapshotID string) (string, error)
 	// GetConfigMap checks if ConfigMap with given name exists in the given namespace.
 	// If it exists, this function returns ConfigMap data, otherwise returns error.
 	GetConfigMap(ctx context.Context, name string, namespace string) (map[string]string, error)

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/util/retry"
 
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
@@ -2044,6 +2045,56 @@ func (c *K8sOrchestrator) GetAllVolumes() []string {
 func (c *K8sOrchestrator) AnnotateVolumeSnapshot(ctx context.Context, volumeSnapshotName string,
 	volumeSnapshotNamespace string, annotations map[string]string) (bool, error) {
 	return c.updateVolumeSnapshotAnnotations(ctx, volumeSnapshotName, volumeSnapshotNamespace, annotations)
+}
+
+// GetVolumeSnapshotChangeIDBySnapshotID retrieves the csi.vsphere.volume/change-id annotation
+// from the VolumeSnapshot corresponding to the given snapshotID (SnapshotHandle)
+func (c *K8sOrchestrator) GetVolumeSnapshotChangeIDBySnapshotID(ctx context.Context,
+	snapshotID string) (string, error) {
+	log := logger.GetLogger(ctx)
+	if c.snapshotterClient == nil {
+		return "", fmt.Errorf("snapshotterClient is not initialized")
+	}
+
+	// 1. List VolumeSnapshotContent to find the one matching the snapshotID
+	vscList, err := c.snapshotterClient.SnapshotV1().VolumeSnapshotContents().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list VolumeSnapshotContents: %v", err)
+	}
+
+	var targetVSC *snapshotv1.VolumeSnapshotContent
+	for _, vsc := range vscList.Items {
+		if vsc.Status != nil && vsc.Status.SnapshotHandle != nil && *vsc.Status.SnapshotHandle == snapshotID {
+			targetVSC = &vsc
+			break
+		}
+	}
+
+	if targetVSC == nil {
+		return "", fmt.Errorf("VolumeSnapshotContent not found for SnapshotHandle: %s", snapshotID)
+	}
+
+	if targetVSC.Spec.VolumeSnapshotRef.Name == "" || targetVSC.Spec.VolumeSnapshotRef.Namespace == "" {
+		return "", fmt.Errorf("VolumeSnapshotRef is missing in VolumeSnapshotContent %s", targetVSC.Name)
+	}
+
+	// 2. Get the corresponding VolumeSnapshot
+	vs, err := c.snapshotterClient.SnapshotV1().VolumeSnapshots(targetVSC.Spec.VolumeSnapshotRef.Namespace).Get(
+		ctx, targetVSC.Spec.VolumeSnapshotRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get VolumeSnapshot %s/%s: %v",
+			targetVSC.Spec.VolumeSnapshotRef.Namespace, targetVSC.Spec.VolumeSnapshotRef.Name, err)
+	}
+
+	// 3. Extract the annotation
+	changeID, ok := vs.Annotations["csi.vsphere.volume/change-id"]
+	if !ok {
+		return "", fmt.Errorf("annotation csi.vsphere.volume/change-id not found on VolumeSnapshot %s/%s",
+			targetVSC.Spec.VolumeSnapshotRef.Namespace, targetVSC.Spec.VolumeSnapshotRef.Name)
+	}
+
+	log.Debugf("Successfully retrieved change-id %s for SnapshotHandle %s", changeID, snapshotID)
+	return changeID, nil
 }
 
 // GetConfigMap checks if ConfigMap with given name exists in the given namespace.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_cbt_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_cbt_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sorchestrator
+
+import (
+	"context"
+	"testing"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	fakesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetVolumeSnapshotChangeIDBySnapshotID(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		snapshotID    string
+		vsc           *snapshotv1.VolumeSnapshotContent
+		vs            *snapshotv1.VolumeSnapshot
+		nilClient     bool
+		expectedID    string
+		expectedError string
+	}{
+		{
+			name:       "success",
+			snapshotID: "test-snapshot-handle",
+			vsc: &snapshotv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vsc",
+				},
+				Spec: snapshotv1.VolumeSnapshotContentSpec{
+					VolumeSnapshotRef: corev1.ObjectReference{
+						Name:      "test-vs",
+						Namespace: "default",
+					},
+				},
+				Status: &snapshotv1.VolumeSnapshotContentStatus{
+					SnapshotHandle: func() *string { s := "test-snapshot-handle"; return &s }(),
+				},
+			},
+			vs: &snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vs",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"csi.vsphere.volume/change-id": "test-change-id/1",
+					},
+				},
+			},
+			expectedID:    "test-change-id/1",
+			expectedError: "",
+		},
+		{
+			name:          "snapshotterClient is nil",
+			snapshotID:    "test-snapshot-handle",
+			vsc:           nil,
+			vs:            nil,
+			nilClient:     true,
+			expectedID:    "",
+			expectedError: "snapshotterClient is not initialized",
+		},
+		{
+			name:       "vsc empty ref name",
+			snapshotID: "test-snapshot-handle",
+			vsc: &snapshotv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vsc",
+				},
+				Spec: snapshotv1.VolumeSnapshotContentSpec{
+					VolumeSnapshotRef: corev1.ObjectReference{
+						Namespace: "default",
+					},
+				},
+				Status: &snapshotv1.VolumeSnapshotContentStatus{
+					SnapshotHandle: func() *string { s := "test-snapshot-handle"; return &s }(),
+				},
+			},
+			vs:            nil,
+			expectedID:    "",
+			expectedError: "VolumeSnapshotRef is missing in VolumeSnapshotContent test-vsc",
+		},
+		{
+			name:       "vs get error",
+			snapshotID: "test-snapshot-handle",
+			vsc: &snapshotv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vsc",
+				},
+				Spec: snapshotv1.VolumeSnapshotContentSpec{
+					VolumeSnapshotRef: corev1.ObjectReference{
+						Name:      "test-vs",
+						Namespace: "default",
+					},
+				},
+				Status: &snapshotv1.VolumeSnapshotContentStatus{
+					SnapshotHandle: func() *string { s := "test-snapshot-handle"; return &s }(),
+				},
+			},
+			vs:            nil, // vs doesn't exist, will cause Get() to fail
+			expectedID:    "",
+			expectedError: "failed to get VolumeSnapshot default/test-vs",
+		},
+		{
+			name:       "vsc not found",
+			snapshotID: "non-existent-handle",
+			vsc: &snapshotv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vsc",
+				},
+				Spec: snapshotv1.VolumeSnapshotContentSpec{
+					VolumeSnapshotRef: corev1.ObjectReference{
+						Name:      "test-vs",
+						Namespace: "default",
+					},
+				},
+				Status: &snapshotv1.VolumeSnapshotContentStatus{
+					SnapshotHandle: func() *string { s := "test-snapshot-handle"; return &s }(),
+				},
+			},
+			vs:            nil,
+			expectedID:    "",
+			expectedError: "VolumeSnapshotContent not found for SnapshotHandle",
+		},
+		{
+			name:       "annotation missing",
+			snapshotID: "test-snapshot-handle",
+			vsc: &snapshotv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vsc",
+				},
+				Spec: snapshotv1.VolumeSnapshotContentSpec{
+					VolumeSnapshotRef: corev1.ObjectReference{
+						Name:      "test-vs",
+						Namespace: "default",
+					},
+				},
+				Status: &snapshotv1.VolumeSnapshotContentStatus{
+					SnapshotHandle: func() *string { s := "test-snapshot-handle"; return &s }(),
+				},
+			},
+			vs: &snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vs",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"other-annotation": "value",
+					},
+				},
+			},
+			expectedID:    "",
+			expectedError: "annotation csi.vsphere.volume/change-id not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fakesnapshot.NewSimpleClientset()
+			if tt.vsc != nil {
+				_, err := fakeClient.SnapshotV1().VolumeSnapshotContents().Create(ctx, tt.vsc, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			if tt.vs != nil {
+				_, err := fakeClient.SnapshotV1().VolumeSnapshots(tt.vs.Namespace).Create(ctx, tt.vs, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			k8sOrch := &K8sOrchestrator{
+				snapshotterClient: fakeClient,
+			}
+			if tt.nilClient {
+				k8sOrch.snapshotterClient = nil
+			}
+
+			changeID, err := k8sOrch.GetVolumeSnapshotChangeIDBySnapshotID(ctx, tt.snapshotID)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedID, changeID)
+			}
+		})
+	}
+}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -422,6 +422,10 @@ const (
 	// BlockVolumeSnapshot is the feature to support CSI Snapshots for block
 	// volume on vSphere CSI driver.
 	BlockVolumeSnapshot = "block-volume-snapshot"
+	// CBT is the feature to support Changed Block Tracking (CBT) for efficient
+	// backup and restore operations using CSI SnapshotMetadata service.
+	// This enables GetMetadataAllocated and GetMetadataDelta RPCs.
+	CBT = "csi-changed-block-tracking"
 	// CSIWindowsSupport is the feature to support csi block volumes for windows
 	// node.
 	CSIWindowsSupport = "csi-windows-support"

--- a/pkg/csi/service/driver.go
+++ b/pkg/csi/service/driver.go
@@ -69,6 +69,7 @@ type vsphereCSIDriver struct {
 	volumeLocks *node.VolumeLocks
 	csi.UnimplementedNodeServer
 	csi.UnimplementedIdentityServer
+	csi.UnimplementedSnapshotMetadataServer
 }
 
 // If k8s node died unexpectedly in an earlier run, the unix socket is left
@@ -212,7 +213,17 @@ func (driver *vsphereCSIDriver) Run(ctx context.Context, endpoint string) {
 		os.Exit(1)
 	}
 
+	// Determine if SnapshotMetadata service should be registered
+	// The service is only registered in controller mode when CBT feature is enabled
+	var snapshotMetadataServer csi.SnapshotMetadataServer
+	if driver.mode == "controller" && commonco.ContainerOrchestratorUtility != nil &&
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CBT) {
+		// Pass the controller server which implements the SnapshotMetadata RPCs
+		snapshotMetadataServer = controllerServer.(csi.SnapshotMetadataServer)
+		log.Info("SnapshotMetadata service will be registered (CBT support enabled)")
+	}
+
 	//Start the nonblocking GRPC
 	grpc := NewNonBlockingGRPCServer()
-	grpc.Start(endpoint, driver, controllerServer, driver)
+	grpc.Start(endpoint, driver, controllerServer, driver, snapshotMetadataServer)
 }

--- a/pkg/csi/service/identity.go
+++ b/pkg/csi/service/identity.go
@@ -20,6 +20,8 @@ import (
 	"context"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 )
 
@@ -50,23 +52,39 @@ func (driver *vsphereCSIDriver) GetPluginCapabilities(
 	req *csi.GetPluginCapabilitiesRequest) (
 	*csi.GetPluginCapabilitiesResponse, error) {
 
-	rep := &csi.GetPluginCapabilitiesResponse{
-		Capabilities: []*csi.PluginCapability{
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
-					},
+	caps := []*csi.PluginCapability{
+		{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
 				},
 			},
 		},
+		{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+				},
+			},
+		},
+	}
+
+	// Advertise SnapshotMetadata service for CBT support if CBT feature is enabled
+	// The SnapshotMetadata service provides GetMetadataAllocated and GetMetadataDelta RPCs
+	// for efficient backup and restore operations (CSI spec v1.10.0+)
+	if commonco.ContainerOrchestratorUtility != nil &&
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CBT) {
+		caps = append(caps, &csi.PluginCapability{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_SNAPSHOT_METADATA_SERVICE,
+				},
+			},
+		})
+	}
+
+	rep := &csi.GetPluginCapabilitiesResponse{
+		Capabilities: caps,
 	}
 	return rep, nil
 }

--- a/pkg/csi/service/server.go
+++ b/pkg/csi/service/server.go
@@ -36,7 +36,8 @@ var (
 // NonBlockingGRPCServer defines non-blocking GRPC server interfaces.
 type NonBlockingGRPCServer interface {
 	// Start services at the endpoint.
-	Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer)
+	Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer,
+		sms csi.SnapshotMetadataServer)
 
 	// Stop stops the gRPC server. It immediately closes all open connections
 	// and listeners. It cancels all active RPCs on the server side and the
@@ -61,9 +62,9 @@ type nonBlockingGRPCServer struct {
 }
 
 func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer,
-	cs csi.ControllerServer, ns csi.NodeServer) {
+	cs csi.ControllerServer, ns csi.NodeServer, sms csi.SnapshotMetadataServer) {
 	log := logger.GetLoggerWithNoContext()
-	if err := s.serve(endpoint, ids, cs, ns); err != nil {
+	if err := s.serve(endpoint, ids, cs, ns, sms); err != nil {
 		log.Errorf("failed to start grpc server. Err: %v", err)
 	}
 }
@@ -89,7 +90,7 @@ func (s *nonBlockingGRPCServer) Stop() {
 }
 
 func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer,
-	cs csi.ControllerServer, ns csi.NodeServer) error {
+	cs csi.ControllerServer, ns csi.NodeServer, sms csi.SnapshotMetadataServer) error {
 	log := logger.GetLoggerWithNoContext()
 
 	const (
@@ -138,6 +139,14 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer,
 		}
 		csi.RegisterControllerServer(s.server, cs)
 		log.Info("controller service registered")
+
+		// Register SnapshotMetadata service for controller mode if provided
+		// This service provides GetMetadataAllocated and GetMetadataDelta RPCs
+		// for efficient backup and restore operations (CBT support)
+		if sms != nil {
+			csi.RegisterSnapshotMetadataServer(s.server, sms)
+			log.Info("snapshot metadata service registered")
+		}
 	} else if strings.EqualFold(mode, "node") {
 		if ns == nil {
 			return logger.LogNewError(log, "node service required when running in node mode")

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -144,6 +144,7 @@ type controller struct {
 	authMgrs    map[string]*common.AuthManager
 	topologyMgr commoncotypes.ControllerTopologyService
 	csi.UnimplementedControllerServer
+	csi.UnimplementedSnapshotMetadataServer
 	topologyCalc TopologyCalculatorInterface
 }
 

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -119,6 +119,7 @@ type controller struct {
 	snapshotLockMgr *snapshotLockManager
 	k8sClient       kubernetes.Interface
 	csi.UnimplementedControllerServer
+	csi.UnimplementedSnapshotMetadataServer
 }
 
 // New creates a CNS controller.
@@ -2632,10 +2633,21 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 			cnsSnapshotInfo.SnapshotLatestOperationCompleteTime, createSnapshotResponse)
 
 		volumeSnapshotName := req.Parameters[common.VolumeSnapshotNameKey]
-		log.Infof("Attempting to annotate volumesnapshot %s/%s with annotation %s:%s",
-			volumeSnapshotNamespace, volumeSnapshotName, common.VolumeSnapshotInfoKey, snapshotID)
+		annotations := map[string]string{common.VolumeSnapshotInfoKey: snapshotID}
+
+		// TODO: This code will be updated when we can retrieve change-id from CNS
+		// Retrieve change-id from FCD and add it to the annotations
+		changeId, err := c.getSnapshotChangeIdFromFCD(ctx, volumeID, cnsSnapshotInfo.SnapshotID)
+		if err != nil {
+			log.Warnf("Failed to retrieve changeId for snapshot %s: %v", snapshotID, err)
+		} else {
+			annotations["csi.vsphere.volume/change-id"] = changeId
+		}
+
+		log.Infof("Attempting to annotate volumesnapshot %s/%s with annotations %v",
+			volumeSnapshotNamespace, volumeSnapshotName, annotations)
 		annotated, err := commonco.ContainerOrchestratorUtility.AnnotateVolumeSnapshot(ctx, volumeSnapshotName,
-			volumeSnapshotNamespace, map[string]string{common.VolumeSnapshotInfoKey: snapshotID})
+			volumeSnapshotNamespace, annotations)
 		if err != nil || !annotated {
 			log.Warnf("The snapshot: %s was created successfully, but failed to annotate volumesnapshot %s/%s"+
 				"with annotation %s:%s. Error: %v", snapshotID, volumeSnapshotNamespace,

--- a/pkg/csi/service/wcp/controller_cbt.go
+++ b/pkg/csi/service/wcp/controller_cbt.go
@@ -1,0 +1,638 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+const (
+	// defaultMaxResults defines the default maximum number of blocks to return in a single gRPC stream
+	// if the CSI caller (e.g. external-snapshot-metadata) passes 0 (no limit).
+	defaultMaxResults = 10000
+)
+
+// GetMetadataAllocated returns the allocated blocks for a snapshot using FCD VSLM APIs.
+// This implementation uses pure Go through govmomi's VSLM package (no CGO/VDDK required).
+
+// For unit testing purposes
+var queryChangedDiskAreasFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+	volumeID types.ID, snapshotID types.ID, startingOffset int64, changeId string) (*types.DiskChangeInfo, error) {
+	vslmClient, err := vslm.NewClient(ctx, vcenter.Client.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VSLM client: %v", err)
+	}
+	globalObjectManager := vslm.NewGlobalObjectManager(vslmClient)
+	return globalObjectManager.QueryChangedDiskAreas(ctx, volumeID, snapshotID, startingOffset, changeId)
+}
+
+var retrieveSnapshotDetailsFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+	volumeID types.ID, snapshotID types.ID) (*types.VStorageObjectSnapshotDetails, error) {
+	vslmClient, err := vslm.NewClient(ctx, vcenter.Client.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VSLM client: %v", err)
+	}
+	globalObjectManager := vslm.NewGlobalObjectManager(vslmClient)
+	return globalObjectManager.RetrieveSnapshotDetails(ctx, volumeID, snapshotID)
+}
+
+func (c *controller) GetMetadataAllocated(req *csi.GetMetadataAllocatedRequest,
+	server csi.SnapshotMetadata_GetMetadataAllocatedServer) error {
+
+	ctx := server.Context()
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+	log.Infof("GetMetadataAllocated: called with args %+v", req)
+
+	// Check if CBT feature is enabled
+	isCBTEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CBT)
+	if !isCBTEnabled {
+		return logger.LogNewErrorCode(log, codes.Unimplemented, "GetMetadataAllocated")
+	}
+
+	start := time.Now()
+	volumeType := prometheus.PrometheusBlockVolumeType
+
+	getMetadataAllocatedInternal := func() (*csi.GetMetadataAllocatedResponse, error) {
+		// Validate request
+		if err := validateGetMetadataAllocatedRequest(ctx, req); err != nil {
+			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"validation for GetMetadataAllocated Request: %+v has failed. Error: %v", req, err)
+		}
+
+		snapshotID := req.GetSnapshotId()
+		startingOffset := req.GetStartingOffset()
+		maxResults := req.GetMaxResults()
+		if maxResults == 0 {
+			// CSI spec: If zero, the Plugin MUST choose a reasonable maximum number of results.
+			maxResults = defaultMaxResults
+		}
+
+		// Parse snapshot ID to get volume ID and snapshot handle
+		// CSI snapshot ID format: "volumeID+snapshotID"
+		volumeID, cnsSnapshotID, err := common.ParseCSISnapshotID(snapshotID)
+		if err != nil {
+			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"failed to parse snapshot ID %s: %v", snapshotID, err)
+		}
+
+		log.Infof("GetMetadataAllocated: querying allocated blocks for volume %s, snapshot %s, offset %d, max %d",
+			volumeID, cnsSnapshotID, startingOffset, maxResults)
+
+		// Query volume details to get volume information
+		volumeIds := []cnstypes.CnsVolumeId{{Id: volumeID}}
+		cnsQueryFilter := cnstypes.CnsQueryFilter{
+			VolumeIds: volumeIds,
+		}
+
+		queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, cnsQueryFilter)
+		if err != nil {
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to query volume %s: %v", volumeID, err)
+		}
+
+		if len(queryResult.Volumes) == 0 {
+			return nil, logger.LogNewErrorCodef(log, codes.NotFound,
+				"volume %s not found", volumeID)
+		}
+
+		// Verify volume type
+		cnsVolumeType := queryResult.Volumes[0].VolumeType
+		if cnsVolumeType != common.BlockVolumeType {
+			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"GetMetadataAllocated is only supported for block volumes, got volume type: %s",
+				cnsVolumeType)
+		}
+
+		blockBacking, ok := queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+		if !ok {
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"volume %s does not have block backing details", volumeID)
+		}
+		volumeCapacityBytes := blockBacking.CapacityInMb * common.MbInBytes
+
+		// Query allocated blocks using FCD APIs
+		allocatedAreas, nextOffset, err := c.queryAllocatedBlocksFromFCD(
+			ctx, volumeID, cnsSnapshotID, uint64(startingOffset), uint32(maxResults))
+		if err != nil {
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to query allocated blocks: %v", err)
+		}
+
+		// Convert to CSI response format
+		var blockMetadata []*csi.BlockMetadata
+		for _, area := range allocatedAreas {
+			blockMetadata = append(blockMetadata, &csi.BlockMetadata{
+				ByteOffset: int64(area.Offset),
+				SizeBytes:  int64(area.Length),
+			})
+		}
+
+		response := &csi.GetMetadataAllocatedResponse{
+			BlockMetadata:       blockMetadata,
+			VolumeCapacityBytes: int64(volumeCapacityBytes),
+			BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+		}
+
+		// Note: CSI spec doesn't have StartingOffset in response for pagination.
+		// Clients should track nextOffset from the number of results returned.
+		// If fewer results than maxResults are returned, pagination is complete.
+
+		log.Infof("GetMetadataAllocated succeeded for snapshot %s, returned %d allocated blocks, next offset %d",
+			snapshotID, len(blockMetadata), nextOffset)
+
+		return response, nil
+	}
+
+	resp, err := getMetadataAllocatedInternal()
+	if err != nil {
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataAllocated",
+			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
+		return err
+	} else {
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataAllocated",
+			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
+	}
+	return server.Send(resp)
+}
+
+// GetMetadataDelta returns the changed blocks between two snapshots using FCD VSLM APIs.
+// This implementation uses pure Go through govmomi's VSLM package (no CGO/VDDK required).
+func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
+	server csi.SnapshotMetadata_GetMetadataDeltaServer) error {
+
+	ctx := server.Context()
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+	log.Infof("GetMetadataDelta: called with args %+v", req)
+
+	// Check if CBT feature is enabled
+	isCBTEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CBT)
+	if !isCBTEnabled {
+		return logger.LogNewErrorCode(log, codes.Unimplemented, "GetMetadataDelta")
+	}
+
+	start := time.Now()
+	volumeType := prometheus.PrometheusBlockVolumeType
+
+	getMetadataDeltaInternal := func() (*csi.GetMetadataDeltaResponse, error) {
+		// Validate request
+		if err := validateGetMetadataDeltaRequest(ctx, req); err != nil {
+			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"validation for GetMetadataDelta Request: %+v has failed. Error: %v", req, err)
+		}
+
+		baseSnapshotID := req.GetBaseSnapshotId()
+		targetSnapshotID := req.GetTargetSnapshotId()
+		startingOffset := req.GetStartingOffset()
+		maxResults := req.GetMaxResults()
+		if maxResults == 0 {
+			// CSI spec: If zero, the Plugin MUST choose a reasonable maximum number of results.
+			maxResults = defaultMaxResults
+		}
+
+		// Parse snapshot IDs
+		baseVolumeID, baseCnsSnapshotID, err := common.ParseCSISnapshotID(baseSnapshotID)
+		if err != nil {
+			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"failed to parse base snapshot ID %s: %v", baseSnapshotID, err)
+		}
+
+		targetVolumeID, targetCnsSnapshotID, err := common.ParseCSISnapshotID(targetSnapshotID)
+		if err != nil {
+			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"failed to parse target snapshot ID %s: %v", targetSnapshotID, err)
+		}
+
+		// Verify both snapshots are from the same volume
+		if baseVolumeID != targetVolumeID {
+			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"base snapshot and target snapshot must be from the same volume, got %s and %s",
+				baseVolumeID, targetVolumeID)
+		}
+
+		volumeID := baseVolumeID
+
+		log.Infof("GetMetadataDelta: querying changed blocks for volume %s, "+
+			"base snapshot %s, target snapshot %s, offset %d, max %d",
+			volumeID, baseCnsSnapshotID, targetCnsSnapshotID, startingOffset, maxResults)
+
+		// Query volume details
+		volumeIds := []cnstypes.CnsVolumeId{{Id: volumeID}}
+		cnsQueryFilter := cnstypes.CnsQueryFilter{
+			VolumeIds: volumeIds,
+		}
+
+		queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, cnsQueryFilter)
+		if err != nil {
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to query volume %s: %v", volumeID, err)
+		}
+
+		if len(queryResult.Volumes) == 0 {
+			return nil, logger.LogNewErrorCodef(log, codes.NotFound,
+				"volume %s not found", volumeID)
+		}
+
+		// Verify volume type
+		cnsVolumeType := queryResult.Volumes[0].VolumeType
+		if cnsVolumeType != common.BlockVolumeType {
+			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"GetMetadataDelta is only supported for block volumes, got volume type: %s",
+				cnsVolumeType)
+		}
+
+		blockBacking, ok := queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+		if !ok {
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"volume %s does not have block backing details", volumeID)
+		}
+		volumeCapacityBytes := blockBacking.CapacityInMb * common.MbInBytes
+
+		// Query changed blocks using FCD APIs
+		changedAreas, nextOffset, err := c.queryChangedAreasFromFCD(
+			ctx, volumeID, baseSnapshotID, targetCnsSnapshotID, uint64(startingOffset), uint32(maxResults))
+		if err != nil {
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to query changed blocks: %v", err)
+		}
+
+		// Convert to CSI response format
+		var blockMetadata []*csi.BlockMetadata
+		for _, area := range changedAreas {
+			blockMetadata = append(blockMetadata, &csi.BlockMetadata{
+				ByteOffset: int64(area.Offset),
+				SizeBytes:  int64(area.Length),
+			})
+		}
+
+		response := &csi.GetMetadataDeltaResponse{
+			BlockMetadata:       blockMetadata,
+			VolumeCapacityBytes: int64(volumeCapacityBytes),
+			BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+		}
+
+		// Note: CSI spec doesn't have StartingOffset in response for pagination.
+		// Clients should track nextOffset from the number of results returned.
+		// If fewer results than maxResults are returned, pagination is complete.
+
+		log.Infof("GetMetadataDelta succeeded for base snapshot %s, target snapshot %s, "+
+			"returned %d changed blocks, next offset %d",
+			baseSnapshotID, targetSnapshotID, len(blockMetadata), nextOffset)
+
+		return response, nil
+	}
+
+	resp, err := getMetadataDeltaInternal()
+	if err != nil {
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataDelta",
+			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
+		return err
+	} else {
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataDelta",
+			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
+	}
+	return server.Send(resp)
+}
+
+// AllocatedArea represents an allocated area on disk
+type AllocatedArea struct {
+	Offset uint64
+	Length uint64
+}
+
+// ChangedArea represents a changed area between two snapshots
+type ChangedArea struct {
+	Offset uint64
+	Length uint64
+}
+
+// queryAllocatedBlocksFromFCD queries allocated blocks using FCD VSLM APIs.
+// It uses QueryChangedDiskAreas with changeId="*" to get all allocated blocks.
+func (c *controller) queryAllocatedBlocksFromFCD(ctx context.Context, volumeID, snapshotID string,
+	startingOffset uint64, maxResults uint32) ([]AllocatedArea, uint64, error) {
+
+	log := logger.GetLogger(ctx)
+	log.Debugf("queryAllocatedBlocksFromFCD: volume=%s snapshot=%s offset=%d maxResults=%d",
+		volumeID, snapshotID, startingOffset, maxResults)
+
+	// Get vCenter connection
+	vcenter, err := common.GetVCenter(ctx, c.manager)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get vCenter instance: %v", err)
+	}
+
+	// Convert IDs to VSLM format
+	vslmVolumeID := types.ID{Id: volumeID}
+	vslmSnapshotID := types.ID{Id: snapshotID}
+
+	// Use "*" as changeId to get all allocated blocks
+	changeId := "*"
+
+	// Query changed disk areas (all allocated blocks when changeId="*")
+	log.Debugf("Calling VSLM QueryChangedDiskAreas with changeId='*' for all allocated blocks")
+	diskChangeInfo, err := queryChangedDiskAreasFunc(
+		ctx,
+		vcenter,
+		vslmVolumeID,
+		vslmSnapshotID,
+		int64(startingOffset),
+		changeId,
+	)
+	if err != nil {
+		return nil, 0, translateVslmError(log, err)
+	}
+
+	// Convert to our result format
+	var allocatedAreas []AllocatedArea
+	nextOffset := startingOffset
+
+	for _, area := range diskChangeInfo.ChangedArea {
+		if uint32(len(allocatedAreas)) >= maxResults {
+			break
+		}
+
+		allocatedArea := AllocatedArea{
+			Offset: uint64(area.Start),
+			Length: uint64(area.Length),
+		}
+		allocatedAreas = append(allocatedAreas, allocatedArea)
+
+		// Track the end of this area
+		areaEnd := uint64(area.Start) + uint64(area.Length)
+		if areaEnd > nextOffset {
+			nextOffset = areaEnd
+		}
+	}
+
+	// If we got fewer results than requested, we're done (set nextOffset to 0)
+	if uint32(len(allocatedAreas)) < maxResults {
+		nextOffset = 0
+	}
+
+	log.Debugf("queryAllocatedBlocksFromFCD: returned %d allocated areas, next offset %d",
+		len(allocatedAreas), nextOffset)
+
+	return allocatedAreas, nextOffset, nil
+}
+
+// queryChangedAreasFromFCD queries changed blocks using FCD VSLM APIs.
+// It uses QueryChangedDiskAreas with a specific changeId to get blocks changed since the base snapshot.
+func (c *controller) queryChangedAreasFromFCD(ctx context.Context, volumeID, fullBaseSnapshotID,
+	targetSnapshotID string, startingOffset uint64, maxResults uint32) ([]ChangedArea, uint64, error) {
+
+	log := logger.GetLogger(ctx)
+	log.Debugf("queryChangedAreasFromFCD: volume=%s base=%s target=%s offset=%d maxResults=%d",
+		volumeID, fullBaseSnapshotID, targetSnapshotID, startingOffset, maxResults)
+
+	// Get vCenter connection
+	vcenter, err := common.GetVCenter(ctx, c.manager)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get vCenter instance: %v", err)
+	}
+
+	// Step 1: Get the changeId from the base snapshot
+	baseChangeId, err := commonco.ContainerOrchestratorUtility.GetVolumeSnapshotChangeIDBySnapshotID(
+		ctx, fullBaseSnapshotID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get base snapshot changeId from annotation: %v", err)
+	}
+
+	log.Debugf("Retrieved base snapshot changeId from annotation: %s", baseChangeId)
+
+	// Convert IDs to VSLM format
+	vslmVolumeID := types.ID{Id: volumeID}
+	vslmTargetSnapshotID := types.ID{Id: targetSnapshotID}
+
+	// Query changed disk areas
+	log.Debugf("Calling VSLM QueryChangedDiskAreas with base changeId for delta")
+	diskChangeInfo, err := queryChangedDiskAreasFunc(
+		ctx,
+		vcenter,
+		vslmVolumeID,
+		vslmTargetSnapshotID,
+		int64(startingOffset),
+		baseChangeId,
+	)
+	if err != nil {
+		return nil, 0, translateVslmError(log, err)
+	}
+
+	// Convert to our result format
+	var changedAreas []ChangedArea
+	nextOffset := startingOffset
+
+	for _, area := range diskChangeInfo.ChangedArea {
+		if uint32(len(changedAreas)) >= maxResults {
+			break
+		}
+
+		changedArea := ChangedArea{
+			Offset: uint64(area.Start),
+			Length: uint64(area.Length),
+		}
+		changedAreas = append(changedAreas, changedArea)
+
+		// Track the end of this area
+		areaEnd := uint64(area.Start) + uint64(area.Length)
+		if areaEnd > nextOffset {
+			nextOffset = areaEnd
+		}
+	}
+
+	// If we got fewer results than requested, we're done (set nextOffset to 0)
+	if uint32(len(changedAreas)) < maxResults {
+		nextOffset = 0
+	}
+
+	log.Debugf("queryChangedAreasFromFCD: returned %d changed areas, next offset %d",
+		len(changedAreas), nextOffset)
+
+	return changedAreas, nextOffset, nil
+}
+
+// getSnapshotChangeIdFromFCD retrieves the changeId from a snapshot using FCD VSLM APIs.
+func (c *controller) getSnapshotChangeIdFromFCD(ctx context.Context, volumeID, snapshotID string) (string, error) {
+	log := logger.GetLogger(ctx)
+
+	// Get vCenter connection
+	vcenter, err := common.GetVCenter(ctx, c.manager)
+	if err != nil {
+		return "", fmt.Errorf("failed to get vCenter instance: %v", err)
+	}
+
+	vslmVolumeID := types.ID{Id: volumeID}
+	vslmSnapshotID := types.ID{Id: snapshotID}
+
+	// Retrieve snapshot details
+	log.Debugf("Retrieving snapshot details for snapshot %s", snapshotID)
+	snapshotDetails, err := retrieveSnapshotDetailsFunc(
+		ctx,
+		vcenter,
+		vslmVolumeID,
+		vslmSnapshotID,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve snapshot details via VSLM API: %v", err)
+	}
+
+	// Extract changeId from snapshot
+	changeId := snapshotDetails.ChangedBlockTrackingId
+	if changeId == "" {
+		return "", fmt.Errorf("changeId is empty in snapshot %s (CBT may not be enabled)", snapshotID)
+	}
+
+	log.Debugf("Retrieved changeId %s for snapshot %s", changeId, snapshotID)
+	return changeId, nil
+}
+
+// validateGetMetadataAllocatedRequest validates the GetMetadataAllocated request
+func validateGetMetadataAllocatedRequest(ctx context.Context, req *csi.GetMetadataAllocatedRequest) error {
+	log := logger.GetLogger(ctx)
+
+	if req == nil {
+		return fmt.Errorf("GetMetadataAllocated request is nil")
+	}
+
+	if req.SnapshotId == "" {
+		return fmt.Errorf("snapshot ID is required")
+	}
+
+	log.Debugf("GetMetadataAllocated request validation passed")
+	return nil
+}
+
+// validateGetMetadataDeltaRequest validates the GetMetadataDelta request
+func validateGetMetadataDeltaRequest(ctx context.Context, req *csi.GetMetadataDeltaRequest) error {
+	log := logger.GetLogger(ctx)
+
+	if req == nil {
+		return fmt.Errorf("GetMetadataDelta request is nil")
+	}
+
+	if req.BaseSnapshotId == "" {
+		return fmt.Errorf("base snapshot ID is required")
+	}
+
+	if req.TargetSnapshotId == "" {
+		return fmt.Errorf("target snapshot ID is required")
+	}
+
+	if req.BaseSnapshotId == req.TargetSnapshotId {
+		return fmt.Errorf("base snapshot and target snapshot must be different")
+	}
+
+	log.Debugf("GetMetadataDelta request validation passed")
+	return nil
+}
+
+// translateVslmError maps VSLM and VADP error codes to standard CSI gRPC error codes
+func translateVslmError(log *zap.SugaredLogger, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	errMsg := err.Error()
+
+	// Check if it's a SOAP fault from vCenter
+	if soap.IsSoapFault(err) {
+		fault := soap.ToSoapFault(err).VimFault()
+
+		switch f := fault.(type) {
+		case *types.FileFault:
+			msgID := ""
+			if len(f.FaultMessage) > 0 {
+				msgID = f.FaultMessage[0].Key
+			} else {
+				if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.noTrack") {
+					msgID = "vim.hostd.vmsvc.cbt.noTrack"
+				} else if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.noEpoch") {
+					msgID = "vim.hostd.vmsvc.cbt.noEpoch"
+				} else if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.cannotGetChanges") {
+					msgID = "vim.hostd.vmsvc.cbt.cannotGetChanges"
+				}
+			}
+
+			switch msgID {
+			case "vim.hostd.vmsvc.cbt.noTrack":
+				return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+					"CBT disabled or not enabled. The caller should perform a full backup instead: %v", err)
+			case "vim.hostd.vmsvc.cbt.noEpoch":
+				return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+					"Cannot get current epoch when changeId=*. The caller should perform a full backup instead: %v", err)
+			case "vim.hostd.vmsvc.cbt.cannotGetChanges":
+				if strings.Contains(strings.ToLower(errMsg), "corrupt") {
+					return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+						"ctk file corrupted. The caller should perform a full backup instead: %v", err)
+				}
+				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+					"changeID mismatch. The caller should correct the error and resubmit the call: %v", err)
+			default:
+				return logger.LogNewErrorCodef(log, codes.Internal,
+					"Internal errors such ctk disk open fails, FCD disk locked, disk missing, etc. "+
+						"CSI driver should retry the operation: %v", err)
+			}
+		case *types.SystemError:
+			return logger.LogNewErrorCodef(log, codes.Internal,
+				"Internal system error. CSI driver should retry the operation: %v", err)
+		case *types.InvalidArgument:
+			if f.InvalidProperty == "startOffset" || strings.Contains(errMsg, "startOffset") {
+				return logger.LogNewErrorCodef(log, codes.OutOfRange,
+					"start offset specified beyond volume size. The caller should specify a valid offset: %v", err)
+			}
+			if f.InvalidProperty == "snapshotId" || strings.Contains(errMsg, "snapshotId") {
+				return logger.LogNewErrorCodef(log, codes.NotFound,
+					"snapshot ID not found for FCD. The caller should re-check that these objects exist: %v", err)
+			}
+			if f.InvalidProperty == "changeId" || strings.Contains(errMsg, "changeId") {
+				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+					"invalid format for changeID. The caller should correct the error and resubmit the call: %v", err)
+			}
+			if f.InvalidProperty == "deviceKey" || strings.Contains(errMsg, "deviceKey") {
+				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+					"Device key doesn't exist, Disk has no backing, or Disk backing "+
+						"type doesn't support CBT. The caller should correct the "+
+						"error and resubmit the call: %v", err)
+			}
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"invalid argument %s: %v", f.InvalidProperty, err)
+		case *types.NotFound:
+			return logger.LogNewErrorCodef(log, codes.NotFound,
+				"FCD not found in VC inventory. The caller should re-check that these objects exist: %v", err)
+		}
+	}
+
+	// Default fallback
+	return logger.LogNewErrorCodef(log, codes.Internal, "failed with error: %v", err)
+}

--- a/pkg/csi/service/wcp/controller_cbt_test.go
+++ b/pkg/csi/service/wcp/controller_cbt_test.go
@@ -1,0 +1,764 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+type mockAllocatedServer struct {
+	grpc.ServerStream
+	ctx context.Context
+	t   *testing.T
+}
+
+func (m *mockAllocatedServer) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockAllocatedServer) Send(resp *csi.GetMetadataAllocatedResponse) error {
+	if m.t != nil && resp.BlockMetadataType != csi.BlockMetadataType_VARIABLE_LENGTH {
+		m.t.Errorf("Expected BlockMetadataType to be %v, got %v",
+			csi.BlockMetadataType_VARIABLE_LENGTH, resp.BlockMetadataType)
+	}
+	return nil
+}
+
+type mockDeltaServer struct {
+	grpc.ServerStream
+	ctx context.Context
+	t   *testing.T
+}
+
+func (m *mockDeltaServer) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockDeltaServer) Send(resp *csi.GetMetadataDeltaResponse) error {
+	if m.t != nil && resp.BlockMetadataType != csi.BlockMetadataType_VARIABLE_LENGTH {
+		m.t.Errorf("Expected BlockMetadataType to be %v, got %v",
+			csi.BlockMetadataType_VARIABLE_LENGTH, resp.BlockMetadataType)
+	}
+	return nil
+}
+
+type mockVolumeManager struct {
+	cnsvolume.Manager
+}
+
+func (m *mockVolumeManager) QueryVolume(ctx context.Context,
+	queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+	res, err := m.Manager.QueryVolume(ctx, queryFilter)
+	if err == nil && res != nil && len(res.Volumes) > 0 {
+		for i := range res.Volumes {
+			res.Volumes[i].BackingObjectDetails = &cnstypes.CnsBlockBackingDetails{
+				CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
+			}
+		}
+	}
+	return res, err
+}
+
+// TestValidateGetMetadataAllocatedRequest tests the validation function
+func TestValidateGetMetadataAllocatedRequest(t *testing.T) {
+	ctx := context.Background()
+	ctx = logger.NewContextWithLogger(ctx)
+
+	tests := []struct {
+		name    string
+		req     *csi.GetMetadataAllocatedRequest
+		wantErr bool
+	}{
+		{
+			name:    "nil request",
+			req:     nil,
+			wantErr: true,
+		},
+		{
+			name: "empty snapshot ID",
+			req: &csi.GetMetadataAllocatedRequest{
+				SnapshotId: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid request",
+			req: &csi.GetMetadataAllocatedRequest{
+				SnapshotId:     "volume-123+snapshot-456",
+				StartingOffset: 0,
+				MaxResults:     1000,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGetMetadataAllocatedRequest(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateGetMetadataAllocatedRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateGetMetadataDeltaRequest tests the validation function
+func TestValidateGetMetadataDeltaRequest(t *testing.T) {
+	ctx := context.Background()
+	ctx = logger.NewContextWithLogger(ctx)
+
+	tests := []struct {
+		name    string
+		req     *csi.GetMetadataDeltaRequest
+		wantErr bool
+	}{
+		{
+			name:    "nil request",
+			req:     nil,
+			wantErr: true,
+		},
+		{
+			name: "empty base snapshot ID",
+			req: &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   "",
+				TargetSnapshotId: "volume-123+snapshot-456",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty target snapshot ID",
+			req: &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   "volume-123+snapshot-123",
+				TargetSnapshotId: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "same base and target snapshot",
+			req: &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   "volume-123+snapshot-456",
+				TargetSnapshotId: "volume-123+snapshot-456",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid request",
+			req: &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   "volume-123+snapshot-123",
+				TargetSnapshotId: "volume-123+snapshot-456",
+				StartingOffset:   0,
+				MaxResults:       1000,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGetMetadataDeltaRequest(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateGetMetadataDeltaRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestGetMetadataAllocated_FSSDisabled tests that the API returns Unimplemented when FSS is disabled
+func TestGetMetadataAllocated_FSSDisabled(t *testing.T) {
+	ct := getControllerTest(t)
+
+	// Since we use the fake orchestrator, we need to ensure CBT feature state returns false.
+	// Actually, by default in unittestcommon it returns false if not set.
+
+	req := &csi.GetMetadataAllocatedRequest{
+		SnapshotId: "volume-123+snapshot-456",
+	}
+
+	err := ct.controller.GetMetadataAllocated(req, &mockAllocatedServer{ctx: ctx})
+	if status.Code(err) != codes.Unimplemented {
+		t.Errorf("Expected Unimplemented error when CBT FSS is disabled, got: %v", err)
+	}
+}
+
+// TestGetMetadataDelta_FSSDisabled tests that the API returns Unimplemented when FSS is disabled
+func TestGetMetadataDelta_FSSDisabled(t *testing.T) {
+	ct := getControllerTest(t)
+
+	req := &csi.GetMetadataDeltaRequest{
+		BaseSnapshotId:   "volume-123+snapshot-123",
+		TargetSnapshotId: "volume-123+snapshot-456",
+	}
+
+	err := ct.controller.GetMetadataDelta(req, &mockDeltaServer{ctx: ctx})
+	if status.Code(err) != codes.Unimplemented {
+		t.Errorf("Expected Unimplemented error when CBT FSS is disabled, got: %v", err)
+	}
+}
+
+// TestGetMetadataAllocated_VolumeNotFound tests that the API returns NotFound when volume is not found
+func TestGetMetadataAllocated_VolumeNotFound(t *testing.T) {
+	ct := getControllerTest(t)
+	fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+	_ = fakeOrchestrator.EnableFSS(ctx, common.CBT)
+
+	req := &csi.GetMetadataAllocatedRequest{
+		SnapshotId: "nonexistent-volume+snapshot-456",
+	}
+
+	err := ct.controller.GetMetadataAllocated(req, &mockAllocatedServer{ctx: ctx})
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("Expected NotFound error when volume does not exist, got: %v", err)
+	}
+}
+
+// TestGetMetadataDelta_VolumeNotFound tests that the API returns NotFound when volume is not found
+func TestGetMetadataDelta_VolumeNotFound(t *testing.T) {
+	ct := getControllerTest(t)
+	fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+	_ = fakeOrchestrator.EnableFSS(ctx, common.CBT)
+
+	req := &csi.GetMetadataDeltaRequest{
+		BaseSnapshotId:   "nonexistent-volume+snapshot-123",
+		TargetSnapshotId: "nonexistent-volume+snapshot-456",
+	}
+
+	err := ct.controller.GetMetadataDelta(req, &mockDeltaServer{ctx: ctx})
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("Expected NotFound error when volume does not exist, got: %v", err)
+	}
+}
+
+// TestGetMetadataAllocated_InvalidSnapshotID tests error handling for invalid snapshot IDs
+func TestGetMetadataAllocated_InvalidSnapshotID(t *testing.T) {
+	ctx := context.Background()
+	ctx = logger.NewContextWithLogger(ctx)
+
+	req := &csi.GetMetadataAllocatedRequest{
+		SnapshotId: "invalid-snapshot-id-format",
+	}
+
+	err := validateGetMetadataAllocatedRequest(ctx, req)
+	if err != nil {
+		// Expected to pass validation, but will fail when parsing
+		t.Logf("Validation passed, parsing would fail: %v", err)
+	}
+}
+
+// TestGetMetadataDelta_DifferentVolumes tests that the API returns InvalidArgument when the base and
+// target snapshot IDs refer to different CNS volumes (volume ID mismatch after parsing).
+func TestGetMetadataDelta_DifferentVolumes(t *testing.T) {
+	ct := getControllerTest(t)
+	fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+	_ = fakeOrchestrator.EnableFSS(ctx, common.CBT)
+
+	req := &csi.GetMetadataDeltaRequest{
+		BaseSnapshotId:   "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa+11111111-1111-1111-1111-111111111111",
+		TargetSnapshotId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb+22222222-2222-2222-2222-222222222222",
+	}
+
+	err := ct.controller.GetMetadataDelta(req, &mockDeltaServer{ctx: ctx})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("Expected InvalidArgument when base and target snapshots are on different volumes, got: %v", err)
+	}
+}
+
+// Mock structures for testing (would be expanded in full test suite)
+
+// TestAllocatedAreaConversion tests the conversion from VSLM response to CSI format
+func TestAllocatedAreaConversion(t *testing.T) {
+	areas := []AllocatedArea{
+		{Offset: 0, Length: 4096},
+		{Offset: 8192, Length: 4096},
+		{Offset: 16384, Length: 8192},
+	}
+
+	var blockMetadata []*csi.BlockMetadata
+	for _, area := range areas {
+		blockMetadata = append(blockMetadata, &csi.BlockMetadata{
+			ByteOffset: int64(area.Offset),
+			SizeBytes:  int64(area.Length),
+		})
+	}
+
+	if len(blockMetadata) != 3 {
+		t.Errorf("Expected 3 block metadata entries, got %d", len(blockMetadata))
+	}
+
+	if blockMetadata[0].ByteOffset != 0 || blockMetadata[0].SizeBytes != 4096 {
+		t.Errorf("First block metadata incorrect: offset=%d size=%d",
+			blockMetadata[0].ByteOffset, blockMetadata[0].SizeBytes)
+	}
+
+	if blockMetadata[2].SizeBytes != 8192 {
+		t.Errorf("Third block metadata size incorrect: %d", blockMetadata[2].SizeBytes)
+	}
+}
+
+// TestChangedAreaConversion tests the conversion from VSLM response to CSI format
+func TestChangedAreaConversion(t *testing.T) {
+	areas := []ChangedArea{
+		{Offset: 4096, Length: 4096},
+		{Offset: 12288, Length: 4096},
+	}
+
+	var blockMetadata []*csi.BlockMetadata
+	for _, area := range areas {
+		blockMetadata = append(blockMetadata, &csi.BlockMetadata{
+			ByteOffset: int64(area.Offset),
+			SizeBytes:  int64(area.Length),
+		})
+	}
+
+	if len(blockMetadata) != 2 {
+		t.Errorf("Expected 2 block metadata entries, got %d", len(blockMetadata))
+	}
+
+	if blockMetadata[0].ByteOffset != 4096 {
+		t.Errorf("First changed block offset incorrect: %d", blockMetadata[0].ByteOffset)
+	}
+}
+
+// TestPaginationLogic tests the nextOffset calculation
+func TestPaginationLogic(t *testing.T) {
+	tests := []struct {
+		name           string
+		areas          []AllocatedArea
+		maxResults     uint32
+		startingOffset uint64
+		wantNextOffset uint64
+	}{
+		{
+			name: "fewer results than max",
+			areas: []AllocatedArea{
+				{Offset: 0, Length: 4096},
+				{Offset: 8192, Length: 4096},
+			},
+			maxResults:     10,
+			startingOffset: 0,
+			wantNextOffset: 0, // Signals completion
+		},
+		{
+			name: "exactly max results",
+			areas: []AllocatedArea{
+				{Offset: 0, Length: 4096},
+				{Offset: 4096, Length: 4096},
+			},
+			maxResults:     2,
+			startingOffset: 0,
+			wantNextOffset: 8192, // End of last area
+		},
+		{
+			name: "more results than max",
+			areas: []AllocatedArea{
+				{Offset: 0, Length: 4096},
+				{Offset: 4096, Length: 4096},
+				{Offset: 8192, Length: 4096},
+			},
+			maxResults:     2,
+			startingOffset: 0,
+			wantNextOffset: 8192, // After taking first 2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate pagination logic
+			nextOffset := tt.startingOffset
+			resultCount := 0
+
+			for _, area := range tt.areas {
+				if uint32(resultCount) >= tt.maxResults {
+					break
+				}
+				resultCount++
+				areaEnd := area.Offset + area.Length
+				if areaEnd > nextOffset {
+					nextOffset = areaEnd
+				}
+			}
+
+			if uint32(resultCount) < tt.maxResults {
+				nextOffset = 0
+			}
+
+			if nextOffset != tt.wantNextOffset {
+				t.Errorf("nextOffset = %d, want %d", nextOffset, tt.wantNextOffset)
+			}
+		})
+	}
+}
+
+// TestErrorCodes tests that proper gRPC error codes are returned
+func TestErrorCodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		errCheck func(error) bool
+		wantCode codes.Code
+	}{
+		{
+			name:     "InvalidArgument",
+			errCheck: func(err error) bool { return status.Code(err) == codes.InvalidArgument },
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:     "NotFound",
+			errCheck: func(err error) bool { return status.Code(err) == codes.NotFound },
+			wantCode: codes.NotFound,
+		},
+		{
+			name:     "Internal",
+			errCheck: func(err error) bool { return status.Code(err) == codes.Internal },
+			wantCode: codes.Internal,
+		},
+		{
+			name:     "Unimplemented",
+			errCheck: func(err error) bool { return status.Code(err) == codes.Unimplemented },
+			wantCode: codes.Unimplemented,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := status.Error(tt.wantCode, "test error")
+			if !tt.errCheck(err) {
+				t.Errorf("Error code check failed for %s", tt.name)
+			}
+		})
+	}
+}
+
+// TestGetMetadataAllocated_Success tests the success path
+func TestGetMetadataAllocated_Success(t *testing.T) {
+	ct := getControllerTest(t)
+	fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+	_ = fakeOrchestrator.EnableFSS(ctx, common.CBT)
+
+	origVolumeManager := ct.controller.manager.VolumeManager
+	ct.controller.manager.VolumeManager = &mockVolumeManager{Manager: origVolumeManager}
+	defer func() { ct.controller.manager.VolumeManager = origVolumeManager }()
+
+	// Create a volume first to avoid NotFound error
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-allocated",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatalf("Failed to create volume: %v", err)
+	}
+	volID := respCreate.Volume.VolumeId
+
+	// Mock the VSLM call
+	origQueryChangedDiskAreasFunc := queryChangedDiskAreasFunc
+	defer func() { queryChangedDiskAreasFunc = origQueryChangedDiskAreasFunc }()
+
+	queryChangedDiskAreasFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeId string) (*types.DiskChangeInfo, error) {
+		return &types.DiskChangeInfo{
+			ChangedArea: []types.DiskChangeExtent{
+				{Start: 0, Length: 4096},
+				{Start: 4096, Length: 8192},
+			},
+		}, nil
+	}
+
+	req := &csi.GetMetadataAllocatedRequest{
+		SnapshotId: volID + "+snapshot-456",
+		MaxResults: 2,
+	}
+
+	err = ct.controller.GetMetadataAllocated(req, &mockAllocatedServer{ctx: ctx, t: t})
+	if err != nil {
+		t.Errorf("Expected success, got error: %v", err)
+	}
+}
+
+// TestGetMetadataDelta_Success tests the success path
+func TestGetMetadataDelta_Success(t *testing.T) {
+	ct := getControllerTest(t)
+	fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+	_ = fakeOrchestrator.EnableFSS(ctx, common.CBT)
+
+	origVolumeManager := ct.controller.manager.VolumeManager
+	ct.controller.manager.VolumeManager = &mockVolumeManager{Manager: origVolumeManager}
+	defer func() { ct.controller.manager.VolumeManager = origVolumeManager }()
+
+	// Create a volume first to avoid NotFound error
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-delta",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatalf("Failed to create volume: %v", err)
+	}
+	volID := respCreate.Volume.VolumeId
+
+	// Mock the VSLM call
+	origQueryChangedDiskAreasFunc := queryChangedDiskAreasFunc
+	defer func() { queryChangedDiskAreasFunc = origQueryChangedDiskAreasFunc }()
+
+	queryChangedDiskAreasFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeId string) (*types.DiskChangeInfo, error) {
+		return &types.DiskChangeInfo{
+			ChangedArea: []types.DiskChangeExtent{
+				{Start: 8192, Length: 4096},
+			},
+		}, nil
+	}
+
+	req := &csi.GetMetadataDeltaRequest{
+		BaseSnapshotId:   volID + "+snapshot-123",
+		TargetSnapshotId: volID + "+snapshot-456",
+		MaxResults:       1,
+	}
+
+	err = ct.controller.GetMetadataDelta(req, &mockDeltaServer{ctx: ctx, t: t})
+	if err != nil {
+		t.Errorf("Expected success, got error: %v", err)
+	}
+}
+
+// TestGetSnapshotChangeIdFromFCD tests the function that retrieves change ID
+func TestGetSnapshotChangeIdFromFCD(t *testing.T) {
+	ct := getControllerTest(t)
+
+	// Mock the VSLM call
+	origRetrieveSnapshotDetailsFunc := retrieveSnapshotDetailsFunc
+	defer func() { retrieveSnapshotDetailsFunc = origRetrieveSnapshotDetailsFunc }()
+
+	retrieveSnapshotDetailsFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID types.ID, snapshotID types.ID) (*types.VStorageObjectSnapshotDetails, error) {
+		return &types.VStorageObjectSnapshotDetails{
+			ChangedBlockTrackingId: "mock-change-id-from-fcd",
+		}, nil
+	}
+
+	changeId, err := ct.controller.getSnapshotChangeIdFromFCD(ctx, testVolumeName, "snapshot-123")
+	if err != nil {
+		t.Errorf("Expected success, got error: %v", err)
+	}
+	if changeId != "mock-change-id-from-fcd" {
+		t.Errorf("Expected mock-change-id-from-fcd, got: %s", changeId)
+	}
+
+	// Test empty change ID
+	retrieveSnapshotDetailsFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID types.ID, snapshotID types.ID) (*types.VStorageObjectSnapshotDetails, error) {
+		return &types.VStorageObjectSnapshotDetails{
+			ChangedBlockTrackingId: "", // empty
+		}, nil
+	}
+
+	_, err = ct.controller.getSnapshotChangeIdFromFCD(ctx, testVolumeName, "snapshot-123")
+	if err == nil {
+		t.Errorf("Expected error for empty change ID, got nil")
+	}
+}
+
+func createSoapFault(fault types.AnyType, msg string) error {
+	f := &soap.Fault{String: msg}
+	f.Detail.Fault = fault
+	return soap.WrapSoapFault(f)
+}
+
+// TestTranslateVslmError tests the error mapping logic for VSLM API errors
+func TestTranslateVslmError(t *testing.T) {
+	ctx := context.Background()
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode codes.Code
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			wantCode: codes.OK,
+		},
+		{
+			name: "SOAP FileFault with noTrack",
+			err: createSoapFault(&types.FileFault{
+				VimFault: types.VimFault{
+					MethodFault: types.MethodFault{
+						FaultMessage: []types.LocalizableMessage{
+							{Key: "vim.hostd.vmsvc.cbt.noTrack"},
+						},
+					},
+				},
+			}, ""),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name: "SOAP FileFault with noEpoch",
+			err: createSoapFault(&types.FileFault{
+				VimFault: types.VimFault{
+					MethodFault: types.MethodFault{
+						FaultMessage: []types.LocalizableMessage{
+							{Key: "vim.hostd.vmsvc.cbt.noEpoch"},
+						},
+					},
+				},
+			}, ""),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name: "SOAP FileFault with corrupt cannotGetChanges",
+			err: createSoapFault(&types.FileFault{
+				VimFault: types.VimFault{
+					MethodFault: types.MethodFault{
+						FaultMessage: []types.LocalizableMessage{
+							{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges", Message: "file is corrupted"},
+						},
+					},
+				},
+			}, "file is corrupted"),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name: "SOAP FileFault with mismatched cannotGetChanges",
+			err: createSoapFault(&types.FileFault{
+				VimFault: types.VimFault{
+					MethodFault: types.MethodFault{
+						FaultMessage: []types.LocalizableMessage{
+							{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges"},
+						},
+					},
+				},
+			}, ""),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:     "SOAP FileFault generic",
+			err:      createSoapFault(&types.FileFault{}, ""),
+			wantCode: codes.Internal,
+		},
+		{
+			name:     "SOAP SystemError",
+			err:      createSoapFault(&types.SystemError{}, ""),
+			wantCode: codes.Internal,
+		},
+		{
+			name: "SOAP InvalidArgument startOffset",
+			err: createSoapFault(&types.InvalidArgument{
+				InvalidProperty: "startOffset",
+			}, ""),
+			wantCode: codes.OutOfRange,
+		},
+		{
+			name: "SOAP InvalidArgument snapshotId",
+			err: createSoapFault(&types.InvalidArgument{
+				InvalidProperty: "snapshotId",
+			}, ""),
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "SOAP InvalidArgument changeId",
+			err: createSoapFault(&types.InvalidArgument{
+				InvalidProperty: "changeId",
+			}, ""),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "SOAP InvalidArgument deviceKey",
+			err: createSoapFault(&types.InvalidArgument{
+				InvalidProperty: "deviceKey",
+			}, ""),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:     "SOAP NotFound",
+			err:      createSoapFault(&types.NotFound{}, ""),
+			wantCode: codes.NotFound,
+		},
+		{
+			name:     "plain error with CBT message substring",
+			err:      fmt.Errorf("some inner error: vim.hostd.vmsvc.cbt.noTrack"),
+			wantCode: codes.Internal,
+		},
+		{
+			name:     "plain error with vim.fault substring",
+			err:      fmt.Errorf("some inner error: vim.fault.NotFound occurred"),
+			wantCode: codes.Internal,
+		},
+		{
+			name:     "plain error generic",
+			err:      fmt.Errorf("random network timeout"),
+			wantCode: codes.Internal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := translateVslmError(log, tt.err)
+
+			if tt.err == nil {
+				if err != nil {
+					t.Errorf("Expected nil error, got: %v", err)
+				}
+				return
+			}
+
+			if status.Code(err) != tt.wantCode {
+				t.Errorf("translateVslmError() returned code %v, want %v. Error: %v", status.Code(err), tt.wantCode, err)
+			}
+		})
+	}
+}

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -89,6 +89,7 @@ type controller struct {
 	tanzukubernetesClusterName  string
 	guestClusterDist            string
 	csi.UnimplementedControllerServer
+	csi.UnimplementedSnapshotMetadataServer
 }
 
 // New creates a CNS controller

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -165,6 +165,12 @@ func (m *MockCOCommonInterface) AnnotateVolumeSnapshot(ctx context.Context, volu
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockCOCommonInterface) GetVolumeSnapshotChangeIDBySnapshotID(ctx context.Context,
+	snapshotID string) (string, error) {
+	args := m.Called(ctx, snapshotID)
+	return args.String(0), args.Error(1)
+}
+
 func (m *MockCOCommonInterface) GetConfigMap(ctx context.Context, name, namespace string) (map[string]string, error) {
 	args := m.Called(ctx, name, namespace)
 	if args.Get(0) == nil {

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -342,6 +342,10 @@ func (m *mockCOCommon) AnnotateVolumeSnapshot(ctx context.Context, volumeSnapsho
 	panic("implement me")
 }
 
+func (m *mockCOCommon) GetVolumeSnapshotChangeIDBySnapshotID(ctx context.Context, snapshotID string) (string, error) {
+	return "mock-change-id", nil
+}
+
 func (m *mockCOCommon) GetConfigMap(ctx context.Context, name string, namespace string) (map[string]string, error) {
 	//TODO implement me
 	panic("implement me")

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -647,6 +647,11 @@ func (m *mockCOCommonForFullSync) AnnotateVolumeSnapshot(ctx context.Context, vo
 	return false, nil
 }
 
+func (m *mockCOCommonForFullSync) GetVolumeSnapshotChangeIDBySnapshotID(ctx context.Context,
+	snapshotID string) (string, error) {
+	return "mock-change-id", nil
+}
+
 func (m *mockCOCommonForFullSync) GetConfigMap(
 	ctx context.Context, name string, namespace string,
 ) (map[string]string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for CSI CBT in WCP. It implements a new SNAPSHOT METADATA SERVICE and two CSI RPCs:
- GetMetadataAllocated
- GetMetadataDelta

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1192/ (Passed)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/992/ (Passed)

**Manual testing:**

**CSI Controller Pods (with the `snapshot-metadata-service` sidecar):**
```bash
$ kubectl get pods -n vmware-system-csi -l app=vsphere-csi-controller
NAME                                      READY   STATUS    RESTARTS        AGE
vsphere-csi-controller-599646df65-qfsx6   8/8     Running   1 (3h53m ago)   3h53m

$ # List all containers inside the controller pod to confirm the sidecar is running
$ kubectl get pod vsphere-csi-controller-599646df65-qfsx6 -n vmware-system-csi -o jsonpath='{range .spec.containers[*]}{"  - "}{.name}{" ("}{.image}{")\n"}{end}'
  - csi-provisioner (localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.12)
  - csi-attacher (localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1)
  - csi-provisioner (localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.12)
  - csi-attacher (localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1)
  - csi-resizer (localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.12.0_vmware.1)
  - vsphere-csi-controller (cns-docker-dev-local.packages.vcfd.broadcom.net/xyang/csi_driver:v0410-0212)
  - liveness-probe (localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1)
  - vsphere-syncer (cns-docker-dev-local.packages.vcfd.broadcom.net/xyang/csi_syncer:v0410-0210)
  - csi-snapshotter (localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1)
  - snapshot-metadata-service (registry.k8s.io/sig-storage/csi-snapshot-metadata:v1.0.0)
```

**Snapshot Metadata Lister Pod:**
This is the upstream tool that is used to test snapshot metadata functions.

```bash
$ kubectl get pods cbt-lister-host-pod-6 -n vmware-system-csi
NAME                    READY   STATUS    RESTARTS   AGE
cbt-lister-host-pod-6   1/1     Running   0          3h52m
```

**PVC**
Create a PVC.
```
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         VOLUMEATTRIBUTESCLASS   AGE
cbt-test-pvc   Bound    pvc-a80d87e6-af12-404d-985a-33c6a9db3a3b   1Gi        RWO            gc-storage-profile   <unset>                 38h
```

**Test Pod YAML (`cbt-test-pod`):**
Create a Pod using the PVC.
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: cbt-test-pod
  namespace: test-gc-e2e-demo-ns
  uid: 73ab3aec-3e1f-493c-a679-c13e501fedbd
  annotations:
    vmware-system-ephemeral-disk-uuid: 6000C29b-858f-f728-4215-b401eb4c5a30
    vmware-system-vm-moid: vm-204:b2e86cff-82a6-4b04-8163-2f083a58efc7
    vmware-system-vm-uuid: 5017a0e7-5c33-96d2-bf31-b9a441fdcb70
spec:
  containers:
  - command:
  containers:
  - command:
    - /bin/sh
    - -c
    - tail -f /dev/null
    image: busybox:1.37.0
    imagePullPolicy: IfNotPresent
    name: test-container
    volumeMounts:
    - mountPath: /data
      name: data
  nodeName: lvn-dvm-10-161-158-204.dvm.lvn.broadcom.net
  volumes:
  - name: data
    persistentVolumeClaim:
      claimName: cbt-test-pvc
status:
  phase: Running
  podIP: 166.168.19.177
```

**VolumeSnapshots:**
Create VolumeSnapshot cbt-test-snap-5; wrote some data; create VolumeSnapshot cbt-test-snap-6.
```bash
$ kubectl get volumesnapshot cbt-test-snap-5 cbt-test-snap-6 -n test-gc-e2e-demo-ns
NAME              READYTOUSE   SOURCEPVC      SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
cbt-test-snap-5   true         cbt-test-pvc                           1Gi           volumesnapshotclass-delete   snapcontent-00ad7310-5e26-4323-a869-31d011d6de4b   18h            18h
cbt-test-snap-6   true         cbt-test-pvc                           1Gi           volumesnapshotclass-delete   snapcontent-04bb2aeb-3c47-4ebe-bc31-02cf948feb66   18h            18h
```

**Annotation Verification**
`change-id` was added as an annotation to the VolumeSnapshot after it was created:

```yaml
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  annotations:
    csi.vsphere.volume/change-id: 52 44 d7 68 6e a2 8a de-c3 6b 5f 04 8c 85 ba ef/1
    csi.vsphere.volume/snapshot: a80d87e6-af12-404d-985a-33c6a9db3a3b+f13f0b4f-d8d1-4b12-a4f5-a114a71c202c
...
  name: cbt-test-snap-5
```

**GetMetadataAllocated**
The Snapshot Metadata Lister Pod uses the CSI function GetMetadataAllocated to get the metadata of allocated blocks of the snapshot cbt-test-snap-5.

```bash
kubectl exec cbt-lister-host-pod-6 -n vmware-system-csi -- /output/lister -n test-gc-e2e-demo-ns -s cbt-test-snap-5 -kubeconfig /output/kubeconfig -service-account test-backup-client -service-account-namespace test-gc-e2e-demo-ns
```

```text
Record#   VolCapBytes  BlockMetadataType   ByteOffset     SizeBytes
------- -------------- ----------------- -------------- --------------
      1     1073741824   VARIABLE_LENGTH              0       17432576
      1     1073741824   VARIABLE_LENGTH      134217728          65536
      1     1073741824   VARIABLE_LENGTH      136314880          65536
      1     1073741824   VARIABLE_LENGTH      138412032        2097152
      1     1073741824   VARIABLE_LENGTH      142606336        8388608
      1     1073741824   VARIABLE_LENGTH      268435456       92274688
      1     1073741824   VARIABLE_LENGTH      364904448       37814272
      1     1073741824   VARIABLE_LENGTH      406847488      111149056
      1     1073741824   VARIABLE_LENGTH      536870912       33554432
      1     1073741824   VARIABLE_LENGTH      671088640          65536
      1     1073741824   VARIABLE_LENGTH      939524096          65536
      1     1073741824   VARIABLE_LENGTH     1073676288          65536
```

**GetMetadataDelta**
The Snapshot Metadata Lister Pod uses the CSI function GetMetadataDelta to get the metadata of changed blocks between snapshots cbt-test-snap-5 and cbt-test-snap-6.

```bash
kubectl exec cbt-lister-host-pod-6 -n vmware-system-csi -- /output/lister -n test-gc-e2e-demo-ns -p cbt-test-snap-5 -s cbt-test-snap-6 -kubeconfig /output/kubeconfig -service-account test-backup-client -service-account-namespace test-gc-e2e-demo-ns
```

```text
Record#   VolCapBytes  BlockMetadataType   ByteOffset     SizeBytes
------- -------------- ----------------- -------------- --------------
      1     1073741824   VARIABLE_LENGTH              0          65536
      1     1073741824   VARIABLE_LENGTH         524288         131072
      1     1073741824   VARIABLE_LENGTH       17367040          65536
      1     1073741824   VARIABLE_LENGTH      486539264       31457280
      1     1073741824   VARIABLE_LENGTH      536936448         131072
```

**Special notes for your reviewer**:
A followup PR will be submitted to add the capability check and to connect through the volume manager.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds support for CSI Changed Block Tracking functionality in Supervisor.
```
