### PR TITLE
Fix StatefulSet cleanup 

### DIFF
--- a/tests/e2e/labelupdates.go
+++ b/tests/e2e/labelupdates.go
@@ -699,8 +699,11 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 			Spec.StorageClassName = &storageClassName
 		CreateStatefulSet(namespace, statefulset, client)
 		defer func() {
-			ginkgo.By(fmt.Sprintf("Deleting all statefulsets in namespace: %v", namespace))
-			fss.DeleteAllStatefulSets(ctx, client, namespace)
+			ginkgo.By(fmt.Sprintf("Deleting StatefulSet %s and its associated PVCs in namespace: %v", statefulset.Name, namespace))
+			err := deleteStatefulSetAndClaimPVCs(ctx, client, statefulset)
+			if err != nil {
+				framework.Logf("Warning: failed to delete StatefulSet and PVCs: %v", err)
+			}
 		}()
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready

--- a/tests/e2e/sts_utils.go
+++ b/tests/e2e/sts_utils.go
@@ -18,12 +18,24 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
 
 	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+)
+
+const (
+	// Timeout constants for StatefulSet operations
+	STATEFULSET_TIMEOUT = 15 * time.Minute
+	PVC_DELETION_POLL   = 2 * time.Second
 )
 
 // CreateStatefulSet creates a StatefulSet from the manifest at manifestPath in the given namespace.
@@ -35,4 +47,115 @@ func CreateStatefulSet(ns string, ss *apps.StatefulSet, c clientset.Interface) {
 	_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	fss.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
+}
+
+// deleteStatefulSetAndClaimPVCs deletes a specific StatefulSet and its associated PVCs only.
+// This prevents issues where fss.DeleteAllStatefulSets deletes unrelated PVCs in the same namespace.
+func deleteStatefulSetAndClaimPVCs(ctx context.Context, c clientset.Interface, ss *apps.StatefulSet) error {
+	namespace := ss.Namespace
+	statefulsetName := ss.Name
+
+	framework.Logf("Deleting StatefulSet %s/%s and its associated PVCs", namespace, statefulsetName)
+
+	// Scale down to 0 replicas first
+	framework.Logf("Scaling down StatefulSet %s/%s to 0 replicas", namespace, statefulsetName)
+	_, err := fss.Scale(ctx, c, ss, 0)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to scale down StatefulSet %s/%s: %v", namespace, statefulsetName, err)
+	}
+
+	// Wait for StatefulSet to be scaled down
+	fss.WaitForStatusReplicas(ctx, c, ss, 0)
+
+	// Delete the StatefulSet
+	framework.Logf("Deleting StatefulSet %s/%s", namespace, statefulsetName)
+	err = c.AppsV1().StatefulSets(namespace).Delete(ctx, statefulsetName, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete StatefulSet %s/%s: %v", namespace, statefulsetName, err)
+	}
+
+	// Get and delete PVCs that match the StatefulSet naming convention
+	framework.Logf("Identifying PVCs associated with StatefulSet %s/%s", namespace, statefulsetName)
+	pvcList, err := c.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list PVCs in namespace %s: %v", namespace, err)
+	}
+
+	var statefulSetPVCs []string
+	for _, pvc := range pvcList.Items {
+		if isStatefulSetPVC(pvc.Name, statefulsetName, ss.Spec.VolumeClaimTemplates) {
+			statefulSetPVCs = append(statefulSetPVCs, pvc.Name)
+		}
+	}
+
+	framework.Logf("Found %d PVCs associated with StatefulSet %s/%s: %v", len(statefulSetPVCs), namespace, statefulsetName, statefulSetPVCs)
+
+	// Delete the identified PVCs
+	for _, pvcName := range statefulSetPVCs {
+		framework.Logf("Deleting PVC %s/%s", namespace, pvcName)
+		err = c.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvcName, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			framework.Logf("Warning: failed to delete PVC %s/%s: %v", namespace, pvcName, err)
+		}
+	}
+
+	// Wait for all associated PVCs and PVs to be deleted
+	framework.Logf("Waiting for PVCs associated with StatefulSet %s/%s to be deleted", namespace, statefulsetName)
+	err = wait.PollUntilContextTimeout(ctx, PVC_DELETION_POLL, STATEFULSET_TIMEOUT, false, func(ctx context.Context) (bool, error) {
+		remainingPVCs := 0
+		for _, pvcName := range statefulSetPVCs {
+			_, err := c.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+			if err == nil {
+				remainingPVCs++
+			} else if !errors.IsNotFound(err) {
+				return false, fmt.Errorf("error checking PVC %s/%s: %v", namespace, pvcName, err)
+			}
+		}
+
+		if remainingPVCs > 0 {
+			framework.Logf("Still waiting for %d PVCs of StatefulSet %s/%s to disappear", remainingPVCs, namespace, statefulsetName)
+			return false, nil
+		}
+
+		framework.Logf("All PVCs associated with StatefulSet %s/%s have been deleted", namespace, statefulsetName)
+		return true, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("timeout waiting for PVCs of StatefulSet %s/%s to be deleted: %v", namespace, statefulsetName, err)
+	}
+
+	return nil
+}
+
+// isStatefulSetPVC checks if a PVC name matches the StatefulSet volumeClaimTemplate naming convention.
+// StatefulSet PVCs follow the pattern: <claimName>-<statefulsetName>-<ordinal>
+// Example: www-web-0, www-web-1, etc.
+func isStatefulSetPVC(pvcName, statefulsetName string, volumeClaimTemplates []v1.PersistentVolumeClaim) bool {
+	for _, template := range volumeClaimTemplates {
+		claimName := template.Name
+		// StatefulSet PVC naming convention: <claimName>-<statefulsetName>-<ordinal>
+		prefix := fmt.Sprintf("%s-%s-", claimName, statefulsetName)
+		if strings.HasPrefix(pvcName, prefix) {
+			// Check if the suffix after the prefix is a valid ordinal (numeric)
+			suffix := strings.TrimPrefix(pvcName, prefix)
+			if len(suffix) > 0 && isNumeric(suffix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isNumeric checks if a string contains only numeric characters
+func isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, char := range s {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Fix StatefulSet cleanup in label-updates test to prevent unintended PV deletion

The "Verify label updates on PVC and PV attached to a stateful set" test was failing due to unintended deletion of statically created PVs. The issue was that fss.DeleteAllStatefulSets() was deleting ALL StatefulSets in the namespace, including unrelated PVCs from other workloads that might still be actively mounted.

Changes made:
1. Added deleteStatefulSetAndClaimPVCs() helper function in sts_utils.go
   - Deletes only the specific StatefulSet under test
   - Identifies and deletes PVCs strictly associated with that StatefulSet
   - Uses StatefulSet naming convention: <claimName>-<statefulsetName>-<ordinal>
   - Avoids deleting any PVCs that do not conform to this pattern

2. Updated labelupdates.go to use the new scoped helper instead of fss.DeleteAllStatefulSets() in the label-updates test cleanup logic

This ensures cleanup is scoped correctly and does not impact unrelated PVCs in the supervisor namespace, preventing test failures due to deletion of volumes that are still in use by other pods.

Testing Done: Done

https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1204/console

Log snippet where its identifying pvc associated with a statefulset adn deleting the same:

12:55:25    I0415 07:25:18.809391 61178 sts_utils.go:71] Deleting StatefulSet e2e-test-namespace/web
12:55:25    I0415 07:25:18.815444 61178 sts_utils.go:78] Identifying PVCs associated with StatefulSet e2e-test-namespace/web
12:55:25    I0415 07:25:18.826538 61178 sts_utils.go:91] Found 5 PVCs associated with StatefulSet e2e-test-namespace/web: [www-web-0 www-web-1 www-web-2 www-web-3 www-web-4]
12:55:25    I0415 07:25:18.826595 61178 sts_utils.go:95] Deleting PVC e2e-test-namespace/www-web-0
12:55:25    I0415 07:25:18.851882 61178 sts_utils.go:95] Deleting PVC e2e-test-namespace/www-web-1
12:55:25    I0415 07:25:18.952080 61178 sts_utils.go:95] Deleting PVC e2e-test-namespace/www-web-2
12:55:25    I0415 07:25:19.056054 61178 sts_utils.go:95] Deleting PVC e2e-test-namespace/www-web-3
12:55:25    I0415 07:25:19.156170 61178 sts_utils.go:95] Deleting PVC e2e-test-namespace/www-web-4
12:55:25    I0415 07:25:19.252140 61178 sts_utils.go:103] Waiting for PVCs associated with StatefulSet e2e-test-namespace/web to be deleted
12:55:25    I0415 07:25:21.272881 61178 sts_utils.go:120] All PVCs associated with StatefulSet e2e-test-namespace/web have been deleted
12:55:25    STEP: Destroying namespace "e2e-volume-label-updates-2898" for this suite. @ 04/15/26 07:25:21.302
