### PR TITLE
WIP: Fix volume provision issue with latest provisoner sidecar 

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -352,17 +352,23 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		}
 
 		// Get supervisorStorageClass and accessMode
-		var supervisorStorageClass string
-		for param := range req.Parameters {
+		var (
+			supervisorStorageClass string
+			storageTopologyType    string
+		)
+		for param, val := range req.Parameters {
 			paramName := strings.ToLower(param)
 			if paramName == common.AttributeSupervisorStorageClass {
-				supervisorStorageClass = req.Parameters[param]
+				supervisorStorageClass = val
 			}
 			if paramName == common.AttributePvcName {
-				pvcName = req.Parameters[param]
+				pvcName = val
 			}
 			if paramName == common.AttributePvcNamespace {
-				pvcNamespace = req.Parameters[param]
+				pvcNamespace = val
+			}
+			if paramName == common.AttributeStorageTopologyType {
+				storageTopologyType = strings.ToLower(val)
 			}
 		}
 
@@ -402,6 +408,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				labels[key] = c.tanzukubernetesClusterUID
 				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 					req.AccessibilityRequirements != nil &&
+					storageTopologyType != "" &&
 					!isLinkedCloneRequest && // the cns-csi mutation webhook in supervisor will automatically set it.
 					(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 						!isFileVolumeRequest) {

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -413,17 +413,23 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		}
 
 		// Get supervisorStorageClass and accessMode
-		var supervisorStorageClass string
-		for param := range req.Parameters {
+		var (
+			supervisorStorageClass string
+			storageTopologyType    string
+		)
+		for param, val := range req.Parameters {
 			paramName := strings.ToLower(param)
 			if paramName == common.AttributeSupervisorStorageClass {
-				supervisorStorageClass = req.Parameters[param]
+				supervisorStorageClass = val
 			}
 			if paramName == common.AttributePvcName {
-				pvcName = req.Parameters[param]
+				pvcName = val
 			}
 			if paramName == common.AttributePvcNamespace {
-				pvcNamespace = req.Parameters[param]
+				pvcNamespace = val
+			}
+			if paramName == common.AttributeStorageTopologyType {
+				storageTopologyType = strings.ToLower(val)
 			}
 		}
 
@@ -463,6 +469,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				labels[key] = c.tanzukubernetesClusterUID
 				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 					req.AccessibilityRequirements != nil &&
+					storageTopologyType != "" &&
 					!isLinkedCloneRequest && // the cns-csi mutation webhook in supervisor will automatically set it.
 					(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 						!isFileVolumeRequest) {
@@ -587,7 +594,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		// Calculate node affinity terms for topology aware provisioning.
 		var accessibleTopologies []map[string]string
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
-			req.AccessibilityRequirements != nil &&
+			req.AccessibilityRequirements != nil && storageTopologyType != "" &&
 			(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 				!isFileVolumeRequest) {
 			// Retrieve the latest version of the PVC


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix volume provision issue with latest provisoner sidecar 

With the upgrade of csi-provisioner from v4.0.1 to v6.x, the Topology feature gate default changed from false to true [#1167](https://github.com/kubernetes-csi/external-provisioner/pull/1167). This causes the provisioner to populate AccessibilityRequirements in CreateVolumeRequest for all StorageClasses, not just zonal ones.

In the guest cluster controller, the existing code checks only for TKGs-HA FSS and non-nil AccessibilityRequirements before generating the volume topology requirement annotation on Supervisor PVCs.
With the new provisioner, this annotation is now generated even for non-zonal StorageClasses, which triggers the Supervisor-side validation error: StorageTopologyType is unset while topology label is present, causing PVCs to remain in Pending state.

This fix adds a storageTopologyType != "" check so the topology annotation is only generated when the StorageClass explicitly sets StorageTopologyType, so that topology annotation will be added correctly and only when user used zonal storage policies with csi-provisioner v6.x.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
e2e pipeline
manual testing
**VC 9.x topology enabled setup:**
```
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml 
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k get deploy -n vmware-system-csi
NAME                     READY   UP-TO-DATE   AVAILABLE   AGE
vsphere-csi-controller   1/1     1            1           6d18h
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k get deploy -n vmware-system-csi -o yaml | grep image:
          image: localhost:5000/tkg/packages/core/vsphere-pv-csi@sha256:a6081bdfcd9649f46673a6de5ddbec93f706f32f7a2bff195292ded130543b5c
          image: cns-docker-dev-local.packages.vcfd.broadcom.net/nbarge/driver:04May2026
          image: cns-docker-dev-local.packages.vcfd.broadcom.net/nbarge/syncer:04May2026
          image: localhost:5000/tkg/packages/core/vsphere-pv-csi@sha256:a257a1c850e48e6e78488411d71d28104078449077da6c27450aaa06ca87cd8e
          image: cns-docker-dev-local.packages.vcfd.broadcom.net/nbarge/csi-provisioner:v6.1.1_vmware.1
          image: localhost:5000/tkg/packages/core/vsphere-pv-csi@sha256:f59dc0f9141097d95b3be8ab29e5238a3e7d31873fad09836b820042f9de228f
          image: localhost:5000/tkg/packages/core/vsphere-pv-csi@sha256:3b8dcdf84ee44058d3fc01ef009de6e68d8f5f9e6c98e9f575924584272b041a
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# 
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k get sc  gc-storage-profile -o yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2026-04-27T20:02:56Z"
  labels:
    isSyncedFromSupervisor: "yes"
  name: gc-storage-profile
  resourceVersion: "402"
  uid: ff9be7a1-d344-41dc-bd64-34ea4f8b8785
parameters:
  svStorageClass: gc-storage-profile
provisioner: csi.vsphere.vmware.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k get sc  test-zonal-topology -o yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2026-04-28T09:33:00Z"
  labels:
    isSyncedFromSupervisor: "yes"
  name: test-zonal-topology
  resourceVersion: "149200"
  uid: 8b472a24-b585-4671-a6f1-85aeb001dca3
parameters:
  StorageTopologyType: Zonal
  svStorageClass: test-zonal-topology
provisioner: csi.vsphere.vmware.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# cat pvc-zonal-sc.yaml 
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: example-raw-block-pvc-zonal
spec:
  volumeMode: Block
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: test-zonal-topology
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# cat pvc-non-zonal-sc.yaml 
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: example-raw-block-pvc-non-zonal
spec:
  volumeMode: Block
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: gc-storage-profile
  root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# ls
gc-cluster.yaml                                              original.yaml    pvc-az2-sc.yaml  pvc-non-zonal-sc.yaml  velero-vsphere
lvmdump-422d641087a5ff5be7c0cf26a0688493-20260427204432.tgz  pvc-az1-sc.yaml  pvc-az3-sc.yaml  pvc-zonal-sc.yaml      vsphere-cloud-provider.conf
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k apply -f pvc-zonal-sc.yaml 
persistentvolumeclaim/example-raw-block-pvc-zonal created
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k apply -f pvc-non-zonal-sc.yaml 
persistentvolumeclaim/example-raw-block-pvc-non-zonal created
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k apply -f pvc-az1-sc.yaml 
persistentvolumeclaim/example-raw-block-pvc-az1 created
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k apply -f pvc-az2-sc.yaml 
persistentvolumeclaim/example-raw-block-pvc-az2 created
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k apply -f pvc-az3-sc.yaml 
persistentvolumeclaim/example-raw-block-pvc-az3 created
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k get pvc -A
NAMESPACE   NAME                              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS          VOLUMEATTRIBUTESCLASS   AGE
default     example-raw-block-pvc-az1         Bound    pvc-2ed16dce-98af-4f19-8f78-e6965c612e88   5Gi        RWO            az1-policy            <unset>                 20s
default     example-raw-block-pvc-az2         Bound    pvc-c9b1efbe-a543-42c5-a408-6b924bafae85   5Gi        RWO            az2-policy            <unset>                 14s
default     example-raw-block-pvc-az3         Bound    pvc-0382beff-a545-445b-a220-a75e9bc8de5c   5Gi        RWO            az3-policy            <unset>                 9s
default     example-raw-block-pvc-non-zonal   Bound    pvc-00807bd8-7eab-4aad-b7a7-65de778b69f1   5Gi        RWO            gc-storage-profile    <unset>                 28s
default     example-raw-block-pvc-zonal       Bound    pvc-aa9a4947-894c-4e3e-82a9-9de905c11598   5Gi        RWO            test-zonal-topology   <unset>                 34s
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k get pvc -n test-gc-e2e-demo-ns 
NAME                                                                        STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS          VOLUMEATTRIBUTESCLASS   AGE
24809731-9282-435c-8fa7-b897193096bd-00807bd8-7eab-4aad-b7a7-65de778b69f1   Bound    pvc-89d49503-02f1-4052-b28a-1f10a28a281d         5Gi        RWO            gc-storage-profile    <unset>                 14m
24809731-9282-435c-8fa7-b897193096bd-0382beff-a545-445b-a220-a75e9bc8de5c   Bound    pvc-975507c3-22a0-4abc-95ec-ac8bf4718627         5Gi        RWO            az3-policy            <unset>                 13m
24809731-9282-435c-8fa7-b897193096bd-2ed16dce-98af-4f19-8f78-e6965c612e88   Bound    pvc-6ae2a83b-e61c-45ad-9efe-a9cfa22a1b12         5Gi        RWO            az1-policy            <unset>                 13m
24809731-9282-435c-8fa7-b897193096bd-aa9a4947-894c-4e3e-82a9-9de905c11598   Bound    pvc-5a09066f-7306-4981-ac8f-c1494e773b86         5Gi        RWO            test-zonal-topology   <unset>                 14m
24809731-9282-435c-8fa7-b897193096bd-c9b1efbe-a543-42c5-a408-6b924bafae85   Bound    pvc-fac3d740-3de9-43eb-91e1-d144ab61fff9         5Gi        RWO            az2-policy            <unset>                 13m
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# export KUBECONFIG=
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# cat > pod-non-zonal.yaml
apiVersion: v1
kind: Pod
metadata:
  name: example-raw-block-pod-non-zonal
spec:
  containers:
    - name: test-container
      image: wcp-docker-local.packages.vcfd.broadcom.net/busybox/busybox:1.35
      command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
      volumeDevices:
        - devicePath: /dev/xvda
          name: data
  restartPolicy: Never
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: example-raw-block-pvc-non-zonal
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# cat > pod-zonal.yaml
apiVersion: v1
kind: Pod
metadata:
  name: example-raw-block-pod-zonal
spec:
  containers:
    - name: test-container
      image: wcp-docker-local.packages.vcfd.broadcom.net/busybox/busybox:1.35
      command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
      volumeDevices:
        - devicePath: /dev/xvda
          name: data
  restartPolicy: Never
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: example-raw-block-pvc-zonal
root@422d641087a5ff5be7c0cf26a0688493 [ ~ ]# k get pod 
NAME                              READY   STATUS    RESTARTS   AGE
example-raw-block-pod-az1         1/1     Running   0          30s
example-raw-block-pod-az2         1/1     Running   0          26s
example-raw-block-pod-az3         1/1     Running   0          22s
example-raw-block-pod-non-zonal   1/1     Running   0          38s
example-raw-block-pod-zonal       1/1     Running   0          54s
```
[testing_topology-enabled-setup.log](https://github.com/user-attachments/files/27366908/testing_topology-enabled-setup.log)
[topology-csi-controller-supervisor.log](https://github.com/user-attachments/files/27366912/topology-csi-controller-supervisor.log)
[topology-syncer-supervisor.log](https://github.com/user-attachments/files/27366916/topology-syncer-supervisor.log)
[topology-csi-controller-gc.log](https://github.com/user-attachments/files/27366911/topology-csi-controller-gc.log)
[topology-provisioner-gc.log](https://github.com/user-attachments/files/27366913/topology-provisioner-gc.log)
[topology-syncer-gc.log](https://github.com/user-attachments/files/27366914/topology-syncer-gc.log)




**VC 9.x Non-topology**
```
root@421552680131e299fb520ef8c960f688 [ ~ ]# k get sc worker-storagepolicy  -o yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2026-05-04T12:22:20Z"
  labels:
    isSyncedFromSupervisor: "yes"
  name: worker-storagepolicy
  resourceVersion: "447"
  uid: 5c7264d3-35f4-444b-9a18-c292dcd44826
parameters:
  svStorageClass: worker-storagepolicy
provisioner: csi.vsphere.vmware.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
root@421552680131e299fb520ef8c960f688 [ ~ ]# k get sc wcpglobalstorageprofile  -o yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2026-05-04T12:22:20Z"
  labels:
    isSyncedFromSupervisor: "yes"
  name: wcpglobalstorageprofile
  resourceVersion: "444"
  uid: 21a1dbad-25d7-490d-ab6a-62e53481f3d1
parameters:
  svStorageClass: wcpglobalstorageprofile
provisioner: csi.vsphere.vmware.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
root@421552680131e299fb520ef8c960f688 [ ~ ]# k apply -f pvc.yaml 
persistentvolumeclaim/example-raw-block-pvc created
root@421552680131e299fb520ef8c960f688 [ ~ ]# k apply -f pvc2.yaml 
persistentvolumeclaim/example-raw-block-pvc-wp created
root@421552680131e299fb520ef8c960f688 [ ~ ]# k get pvc 
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS              VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc      Bound    pvc-3f3a7b8f-2712-4e0a-8b67-4909e7da1e22   5Gi        RWO            wcpglobalstorageprofile   <unset>                 6s
example-raw-block-pvc-wp   Bound    pvc-1d2af999-7d12-4630-ab87-07e8d1ad90bc   5Gi        RWO            worker-storagepolicy      <unset>                 3s
root@421552680131e299fb520ef8c960f688 [ ~ ]# cat > pod1.yaml
apiVersion: v1
kind: Pod
metadata:
  name: example-raw-block-pod-non-zonal
spec:
  containers:
    - name: test-container
      image: wcp-docker-local.packages.vcfd.broadcom.net/busybox/busybox:1.35
      command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
      volumeDevices:
        - devicePath: /dev/xvda
          name: data
  restartPolicy: Never
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: example-raw-block-pvc
root@421552680131e299fb520ef8c960f688 [ ~ ]# kubectl label ns default pod-security.kubernetes.io/enforce=privileged
namespace/default labeled
root@421552680131e299fb520ef8c960f688 [ ~ ]# k apply -f pod1.yaml 
pod/example-raw-block-pod created
root@421552680131e299fb520ef8c960f688 [ ~ ]# k apply -f pod2.yaml 
pod/example-raw-block-pod-wp created
root@421552680131e299fb520ef8c960f688 [ ~ ]# k get pod  
NAME                       READY   STATUS    RESTARTS   AGE
example-raw-block-pod      1/1     Running   0          17s
example-raw-block-pod-wp   1/1     Running   0          13s
```

[non_toplogy_csi-controller_gc.log](https://github.com/user-attachments/files/27374027/non_toplogy_csi-controller_gc.log)
[non_toplogy_csi-controller_supervisor.log](https://github.com/user-attachments/files/27374028/non_toplogy_csi-controller_supervisor.log)
[non_toplogy_csi-provisioner_gc.log](https://github.com/user-attachments/files/27374030/non_toplogy_csi-provisioner_gc.log)
[non_toplogy_syncer_gc.log](https://github.com/user-attachments/files/27374032/non_toplogy_syncer_gc.log)
[non_toplogy_syncer_supervisor.log](https://github.com/user-attachments/files/27374033/non_toplogy_syncer_supervisor.log)
[testing-non-toplogy.log](https://github.com/user-attachments/files/27374034/testing-non-toplogy.log)



**VC 8 non topology**
```
root@421743c94af763042ea1e86aa795dc27 [ ~ ]# k get sc
NAME                                  PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
wcpglobalstorageprofile               csi.vsphere.vmware.com   Delete          Immediate              true                   4h26m
wcpglobalstorageprofile-latebinding   csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   4h26m
worker-storagepolicy                  csi.vsphere.vmware.com   Delete          Immediate              true                   4h26m
worker-storagepolicy-latebinding      csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   4h26m
root@421743c94af763042ea1e86aa795dc27 [ ~ ]# k apply -f pvc1.yaml 
persistentvolumeclaim/example-raw-block-pvc-ws created
root@421743c94af763042ea1e86aa795dc27 [ ~ ]# k apply -f pvc2.yaml 
persistentvolumeclaim/example-raw-block-pvc-wg created
root@421743c94af763042ea1e86aa795dc27 [ ~ ]# k get pvc 
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS              VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc-wg   Bound    pvc-ffeefcd2-048a-4c7e-b4df-5a85cfa1df50   5Gi        RWO            wcpglobalstorageprofile   <unset>                 3m1s
example-raw-block-pvc-ws   Bound    pvc-c8fdd731-9a05-494e-a3b8-6ce057b5143d   5Gi        RWO            worker-storagepolicy      <unset>                 3m6s
root@421743c94af763042ea1e86aa795dc27 [ ~ ]# k apply -f pod1.yaml 
pod/example-raw-block-pod-ws created
root@421743c94af763042ea1e86aa795dc27 [ ~ ]# k apply -f pod2.yaml 
pod/example-raw-block-pod-wg created
root@421743c94af763042ea1e86aa795dc27 [ ~ ]# k get pod 
NAME                       READY   STATUS    RESTARTS   AGE
example-raw-block-pod-wg   1/1     Running   0          15s
example-raw-block-pod-ws   1/1     Running   0          18s
```

[non_toplogy_csi-controller_vc8_gc.log](https://github.com/user-attachments/files/27406101/non_toplogy_csi-controller_vc8_gc.log)
[non_toplogy_csi-controller_vc8_supervisor.log](https://github.com/user-attachments/files/27406104/non_toplogy_csi-controller_vc8_supervisor.log)
[non_toplogy_csi-provisioner_vc8_gc.log](https://github.com/user-attachments/files/27406105/non_toplogy_csi-provisioner_vc8_gc.log)
[non_toplogy_syncer_vc8_gc.log](https://github.com/user-attachments/files/27406106/non_toplogy_syncer_vc8_gc.log)
[non_toplogy_syncer_vc8_supervisor.log](https://github.com/user-attachments/files/27406107/non_toplogy_syncer_vc8_supervisor.log)
[testing_vc_8_non-topology.log](https://github.com/user-attachments/files/27406108/testing_vc_8_non-topology.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix volume provision issue with latest provisoner sidecar 
```
