### PR TITLE
Upgrade Go to 1.26.2 to fix CVE-2026-32280

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/vsphere-csi-driver/v3
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0

--- a/hack/cover-images.sh
+++ b/hack/cover-images.sh
@@ -55,7 +55,7 @@ usage: ${0} [FLAGS]
   minimal Docker images. This approach is much faster than multi-stage Docker builds.
 
   Prerequisites:
-    - Go 1.26 or later
+    - Go 1.26.2 or later
     - Docker (running)
     - Git
     - Network access to download Go dependencies

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -49,7 +49,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=<docker-registry>/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.26.1
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.26.2
 
 ARCH=amd64
 OSVERSION=1809

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.26.1
+ARG GOLANG_IMAGE=golang:1.26.2
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.26.1
+ARG GOLANG_IMAGE=golang:1.26.2
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.26.1
+ARG GOLANG_IMAGE=golang:1.26.2
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.26.1
+ARG GOLANG_IMAGE=golang:1.26.2
 ARG OSVERSION
 ARG ARCH=amd64
 


### PR DESCRIPTION
This commit upgrades Go from 1.26.1 to 1.26.2 to address CVE-2026-32280, a high severity (CVSS 7.5) denial of service vulnerability in Go's crypto/x509 package.

The vulnerability affects certificate chain building when many intermediate certificates are passed in VerifyOptions.Intermediates, which can lead to excessive CPU consumption and denial of service.

Files updated:
- go.mod: Go version directive
- images/driver/Dockerfile: CSI driver container
- images/syncer/Dockerfile: Syncer container
- images/windows/driver/Dockerfile: Windows driver container
- images/ci/Dockerfile: CI image
- hack/release.sh: Release script

Reference: https://nvd.nist.gov/vuln/detail/CVE-2026-32280
Made-with: Cursor
Testing Done:Yes
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1257/

