### PR TITLE
Support per-namespace network providers for CnsFileAccessConfig

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -512,6 +512,9 @@ const (
 	// SupportsExposingStoragePolicyAttributes is the supervisor capability that gates exposing
 	// storage policy attributes to devops users.
 	SupportsExposingStoragePolicyAttributes = "supports_exposing_storage_policy_attributes"
+	// SupportsPerNamespaceNetworkProviders is a WCP capability indicating that network provider
+	// is resolved per namespace (NetworkSettings CR) rather than from the global wcp-network-config.
+	SupportsPerNamespaceNetworkProviders = "supports_per_namespace_network_providers"
 )
 
 var WCPFeatureStates = map[string]struct{}{
@@ -531,6 +534,7 @@ var WCPFeatureStates = map[string]struct{}{
 	VsanFileVolumeService:                   {},
 	CSI_Backup_API:                          {},
 	SupportsExposingStoragePolicyAttributes: {},
+	SupportsPerNamespaceNetworkProviders:    {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
@@ -548,6 +552,7 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 	VsanFileVolumeService:                   {},
 	CSI_Backup_API:                          {},
 	SupportsExposingStoragePolicyAttributes: {},
+	SupportsPerNamespaceNetworkProviders:    {},
 }
 
 // WCPFeatureAssociatedWithPVCSI contains FSS name used in PVCSI and associated WCP Capability name on a

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -768,6 +768,9 @@ func (r *ReconcileCnsFileAccessConfig) configureVolumeACLs(ctx context.Context,
 // getVMExternalIP helps to fetch the external facing IP for a given TKG VM.
 func (r *ReconcileCnsFileAccessConfig) getVMExternalIP(ctx context.Context,
 	vm *vmoperatortypes.VirtualMachine) (string, error) {
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupportsPerNamespaceNetworkProviders) {
+		return r.getVMExternalIPFromNetworkSettings(ctx, vm)
+	}
 	log := logger.GetLogger(ctx)
 	networkProvider, err := util.GetNetworkProvider(ctx)
 	if err != nil {
@@ -798,7 +801,21 @@ func (r *ReconcileCnsFileAccessConfig) getVMExternalIP(ctx context.Context,
 	}
 
 	tkgVMIP, err := util.GetTKGVMIP(ctx, r.vmOperatorClient,
-		r.dynamicClient, vm.Namespace, vm.Name, networkProvider)
+		r.dynamicClient, vm.Namespace, vm.Name, networkProvider, false)
+	if err != nil {
+		return "", logger.LogNewErrorf(log, "Failed to get external facing IP address for VM %q/%q. Err: %+v",
+			vm.Namespace, vm.Name, err)
+	}
+	log.Infof("Found tkg VMIP %q for VM %q in namespace %q", tkgVMIP, vm.Name, vm.Namespace)
+	return tkgVMIP, nil
+}
+
+// getVMExternalIPFromNetworkSettings resolves the VM IP when per-namespace NetworkSettings is used.
+func (r *ReconcileCnsFileAccessConfig) getVMExternalIPFromNetworkSettings(ctx context.Context,
+	vm *vmoperatortypes.VirtualMachine) (string, error) {
+	log := logger.GetLogger(ctx)
+	tkgVMIP, err := util.GetTKGVMIPFromNetworkSettings(ctx, r.vmOperatorClient, r.dynamicClient,
+		vm.Namespace, vm.Name)
 	if err != nil {
 		return "", logger.LogNewErrorf(log, "Failed to get external facing IP address for VM %q/%q. Err: %+v",
 			vm.Namespace, vm.Name, err)

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -24,8 +24,10 @@ import (
 	"strconv"
 	"strings"
 
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware/govmomi/object"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -62,6 +64,12 @@ var namespaceNetworkInfoGVR = schema.GroupVersionResource{
 	Resource: "namespacenetworkinfos",
 }
 
+var networkSettingsGVR = schema.GroupVersionResource{
+	Group:    "netoperator.vmware.com",
+	Version:  "v1alpha1",
+	Resource: "networksettings",
+}
+
 const (
 	snatIPAnnotation = "ncp/snat_ip"
 	// Namespace for system resources.
@@ -78,6 +86,10 @@ const (
 	VPCNetworkProvider = "NSX_VPC"
 	vpcDefaultSnatIp   = "defaultSNATIP"
 )
+
+// ErrNetworkSettingsUnavailable indicates no NetworkSettings object exists in the namespace or
+// provider is not set on the sole NetworkSettings object.
+var ErrNetworkSettingsUnavailable = errors.New("NetworkSettings CR is unavailable or provider is not set")
 
 // GetVolumeID gets the volume ID from the PV that is bound to PVC by pvcName.
 func GetVolumeID(ctx context.Context, client client.Client, pvcName string, namespace string) (string, error) {
@@ -105,11 +117,11 @@ func GetVolumeID(ctx context.Context, client client.Client, pvcName string, name
 	return pv.Spec.CSI.VolumeHandle, nil
 }
 
-// GetTKGVMIP finds the external facing IP address of a TKG VM object from a
-// given Supervisor Namespace based on the networking configuration (NSX-T or
-// VDS).
+// GetTKGVMIP finds the external facing IP address of a TKG VM in a Supervisor namespace for the given
+// networkProviderType (e.g. from GetNetworkProvider / wcp-network-config). allowVMIPFallback controls whether NSX-T/VPC
+// may fall back to the VM primary IP when SNAT is absent (true for per-namespace NetworkSettings workflow).
 func GetTKGVMIP(ctx context.Context, vmOperatorClient client.Client, dc dynamic.Interface,
-	vmNamespace, vmName string, network_provider_type string) (string, error) {
+	vmNamespace, vmName, networkProviderType string, allowVMIPFallback bool) (string, error) {
 	log := logger.GetLogger(ctx)
 	log.Infof("Determining external IP Address of VM: %s/%s", vmNamespace, vmName)
 	vmKey := apitypes.NamespacedName{
@@ -137,97 +149,204 @@ func GetTKGVMIP(ctx context.Context, vmOperatorClient client.Client, dc dynamic.
 	log.Debugf("VirtualMachine %s/%s is configured with networks %v", vmNamespace, vmName, networkNames)
 
 	var ip string
-	var exists bool
-	if network_provider_type == NSXTNetworkProvider {
-		for _, networkName := range networkNames {
-			virtualNetworkInstance, err := dc.Resource(virtualNetworkGVR).Namespace(vmNamespace).Get(ctx,
-				networkName, metav1.GetOptions{})
-			if err != nil {
-				return "", err
-			}
-			log.Debugf("Got VirtualNetwork instance %s/%s with annotations %v",
-				vmNamespace, virtualNetworkInstance.GetName(), virtualNetworkInstance.GetAnnotations())
-			ip, exists = virtualNetworkInstance.GetAnnotations()[snatIPAnnotation]
-			// Pick the network interface which has the snatIPAnnotation
-			if exists && ip != "" {
-				break
-			}
-		}
-		if ip == "" {
-			if !isFileVolumesWithVmServiceVmSupported {
-				return "", fmt.Errorf("failed to get SNAT IP annotation from VirtualMachine %s/%s",
-					vmNamespace, vmName)
-			}
-			if len(networkNames) != 0 {
-				// If networkNames for VirtualNetwork were found on the VM,
-				// then some error happened in getting the SNAT IP from VirtualNetwork CR.
-				return "", fmt.Errorf("failed to get SNAT IP annotation for VirtualMachine %s/%s "+
-					"from VirtualNetwrok",
-					vmNamespace, vmName)
-			}
-			// It is likely an NSX setup with VM service VMs.
-			// For TKG service VMs, virtual network CR will always be present.
-			ip, err = getSnatIpFromNamespaceNetworkInfo(ctx, dc, vmNamespace, vmName)
-			if err != nil {
-				log.Errorf("failed to get SNAT IP from NameSpaceNetworkInfo. Err %s", err)
-				return "", fmt.Errorf("failed to get SNAT IP from NameSpaceNetworkInfo %s/%s",
-					vmNamespace, vmName)
-			}
-			log.Infof("Obtained SNAT IP %s from NamespaceNetworkInfo for VirtualMachine %s/%s",
-				ip, vmNamespace, vmName)
-		}
-	} else if network_provider_type == VDSNetworkProvider {
-
-		if virtualMachineInstance.Status.Network == nil {
-			log.Errorf("virtualMachineInstance.Status.Network is nil for VM %s", vmName)
-			return "", fmt.Errorf("virtualMachineInstance.Status.Network is nil for VM %s", vmName)
-		}
-
-		ip = virtualMachineInstance.Status.Network.PrimaryIP4
-		if ip == "" {
-			ip = virtualMachineInstance.Status.Network.PrimaryIP6
-			if ip == "" {
-				return "", fmt.Errorf("vm.Status.Network.PrimaryIP6 & PrimaryIP4 is not populated for %s/%s",
-					vmNamespace, vmName)
-			}
-		}
-	} else {
-		vpcName := vmNamespace
-		networkInfoInstance, err := dc.Resource(networkInfoGVR).Namespace(vmNamespace).Get(ctx,
-			vpcName, metav1.GetOptions{})
+	switch networkProviderType {
+	case NSXTNetworkProvider:
+		ip, err = resolveNSXTExternalIP(ctx, dc, vmNamespace, vmName, networkNames, virtualMachineInstance,
+			isFileVolumesWithVmServiceVmSupported, allowVMIPFallback)
 		if err != nil {
 			return "", err
 		}
-		log.Debugf("Got NetworkInfo instance %s/%s", vmNamespace, networkInfoInstance.GetName())
-		vpcs, found, err := unstructured.NestedSlice(networkInfoInstance.Object, "vpcs")
-		if err != nil || !found || len(vpcs) == 0 {
-			return "", fmt.Errorf("failed to get vpcs from networkinfo %s/%s with error: %v",
-				vmNamespace, vmName, err)
+	case VDSNetworkProvider:
+		ip, err = vmPrimaryIPFromVirtualMachine(ctx, virtualMachineInstance, vmNamespace, vmName)
+		if err != nil {
+			return "", err
 		}
-
-		vpc, ok := vpcs[0].(map[string]interface{})
-		if !ok {
-			return "", fmt.Errorf("failed to assert vpc to map[string]interface{} %s/%s",
-				vmNamespace, vmName)
+	case VPCNetworkProvider:
+		ip, err = resolveVPCExternalIP(ctx, dc, vmNamespace, vmName, virtualMachineInstance, allowVMIPFallback)
+		if err != nil {
+			return "", err
 		}
-
-		for key, value := range vpc {
-			if key == vpcDefaultSnatIp {
-				ip, ok = value.(string)
-				if !ok {
-					return "", fmt.Errorf("failed to cast key %s value to string", key)
-				}
-				break
-			}
-
-		}
-		if ip == "" {
-			return "", fmt.Errorf("spec.vpc.defaultSNATIP is not populated for "+
-				"networkinfo %s/%s", vmNamespace, vmName)
-		}
+	default:
+		return "", fmt.Errorf("unknown network provider %q", networkProviderType)
 	}
 	log.Infof("Found external IP Address %s for VirtualMachine %s/%s", ip, vmNamespace, vmName)
 	return ip, nil
+}
+
+// GetTKGVMIPFromNetworkSettings finds the external facing IP for a TKG VM when per-namespace network
+// providers are enabled: provider is read from the sole NetworkSettings object in the namespace (provider).
+func GetTKGVMIPFromNetworkSettings(ctx context.Context, vmOperatorClient client.Client, dc dynamic.Interface,
+	vmNamespace, vmName string) (string, error) {
+	if dc == nil {
+		return "", fmt.Errorf("dynamic client is required when %s is enabled",
+			common.SupportsPerNamespaceNetworkProviders)
+	}
+	networkProviderType, err := getNetworkProviderFromNetworkSettings(ctx, dc, vmNamespace)
+	if err != nil {
+		return "", err
+	}
+	return GetTKGVMIP(ctx, vmOperatorClient, dc, vmNamespace, vmName, networkProviderType, true)
+}
+
+func getNetworkProviderFromNetworkSettings(ctx context.Context, dc dynamic.Interface,
+	namespace string) (string, error) {
+	list, err := dc.Resource(networkSettingsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+	switch len(list.Items) {
+	case 0:
+		return "", ErrNetworkSettingsUnavailable
+	case 1:
+		obj := &list.Items[0]
+		provider, _, _ := unstructured.NestedString(obj.Object, "provider")
+		if strings.TrimSpace(provider) == "" {
+			return "", fmt.Errorf("%w: provider is empty or missing on NetworkSettings %s/%s",
+				ErrNetworkSettingsUnavailable, namespace, obj.GetName())
+		}
+		switch provider {
+		case "vsphere-distributed":
+			return VDSNetworkProvider, nil
+		case "nsx-tier1":
+			return NSXTNetworkProvider, nil
+		case "vpc":
+			return VPCNetworkProvider, nil
+		default:
+			return "", fmt.Errorf("unknown NetworkSettings provider value %q", provider)
+		}
+	default:
+		return "", fmt.Errorf("expected exactly one NetworkSettings object in namespace %q, found %d",
+			namespace, len(list.Items))
+	}
+}
+
+func vmPrimaryIPFromVirtualMachine(ctx context.Context, vm *vmoperatortypes.VirtualMachine,
+	vmNamespace, vmName string) (string, error) {
+	log := logger.GetLogger(ctx)
+	if vm.Status.Network == nil {
+		log.Errorf("virtualMachineInstance.Status.Network is nil for VM %s", vmName)
+		return "", fmt.Errorf("virtualMachineInstance.Status.Network is nil for VM %s", vmName)
+	}
+	ip := vm.Status.Network.PrimaryIP4
+	if ip == "" {
+		ip = vm.Status.Network.PrimaryIP6
+		if ip == "" {
+			return "", fmt.Errorf("vm.Status.Network.PrimaryIP6 & PrimaryIP4 is not populated for %s/%s",
+				vmNamespace, vmName)
+		}
+	}
+	return ip, nil
+}
+
+func resolveNSXTExternalIP(ctx context.Context, dc dynamic.Interface, vmNamespace, vmName string,
+	networkNames []string, virtualMachineInstance *vmoperatortypes.VirtualMachine,
+	isFileVolumesWithVmServiceVmSupported, allowVMIPFallback bool) (string, error) {
+	log := logger.GetLogger(ctx)
+	if dc == nil {
+		return "", fmt.Errorf("dynamic client is nil")
+	}
+	var ip string
+	var exists bool
+	for _, networkName := range networkNames {
+		virtualNetworkInstance, err := dc.Resource(virtualNetworkGVR).Namespace(vmNamespace).Get(ctx,
+			networkName, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		log.Debugf("Got VirtualNetwork instance %s/%s with annotations %v",
+			vmNamespace, virtualNetworkInstance.GetName(), virtualNetworkInstance.GetAnnotations())
+		ip, exists = virtualNetworkInstance.GetAnnotations()[snatIPAnnotation]
+		if exists && ip != "" {
+			break
+		}
+	}
+	if ip != "" {
+		return ip, nil
+	}
+	if !isFileVolumesWithVmServiceVmSupported {
+		if allowVMIPFallback {
+			return vmPrimaryIPFromVirtualMachine(ctx, virtualMachineInstance, vmNamespace, vmName)
+		}
+		return "", fmt.Errorf("failed to get SNAT IP annotation from VirtualMachine %s/%s",
+			vmNamespace, vmName)
+	}
+	if len(networkNames) != 0 {
+		if allowVMIPFallback {
+			return vmPrimaryIPFromVirtualMachine(ctx, virtualMachineInstance, vmNamespace, vmName)
+		}
+		return "", fmt.Errorf("failed to get SNAT IP annotation for VirtualMachine %s/%s "+
+			"from VirtualNetwrok",
+			vmNamespace, vmName)
+	}
+	ip, err := getSnatIpFromNamespaceNetworkInfo(ctx, dc, vmNamespace, vmName)
+	if err != nil {
+		if allowVMIPFallback {
+			return vmPrimaryIPFromVirtualMachine(ctx, virtualMachineInstance, vmNamespace, vmName)
+		}
+		log.Errorf("failed to get SNAT IP from NameSpaceNetworkInfo. Err %s", err)
+		return "", fmt.Errorf("failed to get SNAT IP from NameSpaceNetworkInfo %s/%s",
+			vmNamespace, vmName)
+	}
+	log.Infof("Obtained SNAT IP %s from NamespaceNetworkInfo for VirtualMachine %s/%s",
+		ip, vmNamespace, vmName)
+	return ip, nil
+}
+
+func resolveVPCExternalIP(ctx context.Context, dc dynamic.Interface, vmNamespace, vmName string,
+	virtualMachineInstance *vmoperatortypes.VirtualMachine, allowVMIPFallback bool) (string, error) {
+	log := logger.GetLogger(ctx)
+	if dc == nil {
+		return "", fmt.Errorf("dynamic client is nil")
+	}
+	vpcName := vmNamespace
+	networkInfoInstance, err := dc.Resource(networkInfoGVR).Namespace(vmNamespace).Get(ctx,
+		vpcName, metav1.GetOptions{})
+	if err != nil {
+		if allowVMIPFallback && apierrors.IsNotFound(err) {
+			return vmPrimaryIPFromVirtualMachine(ctx, virtualMachineInstance, vmNamespace, vmName)
+		}
+		return "", err
+	}
+	log.Debugf("Got NetworkInfo instance %s/%s", vmNamespace, networkInfoInstance.GetName())
+	vpcs, found, err := unstructured.NestedSlice(networkInfoInstance.Object, "vpcs")
+	if err != nil || !found || len(vpcs) == 0 {
+		if allowVMIPFallback {
+			return vmPrimaryIPFromVirtualMachine(ctx, virtualMachineInstance, vmNamespace, vmName)
+		}
+		return "", fmt.Errorf("failed to get vpcs from networkinfo %s/%s with error: %v",
+			vmNamespace, vmName, err)
+	}
+
+	vpc, ok := vpcs[0].(map[string]interface{})
+	if !ok {
+		if allowVMIPFallback {
+			return vmPrimaryIPFromVirtualMachine(ctx, virtualMachineInstance, vmNamespace, vmName)
+		}
+		return "", fmt.Errorf("failed to assert vpc to map[string]interface{} %s/%s",
+			vmNamespace, vmName)
+	}
+
+	var ip string
+	for key, value := range vpc {
+		if key == vpcDefaultSnatIp {
+			ip, ok = value.(string)
+			if !ok {
+				if allowVMIPFallback {
+					return vmPrimaryIPFromVirtualMachine(ctx, virtualMachineInstance, vmNamespace, vmName)
+				}
+				return "", fmt.Errorf("failed to cast key %s value to string", key)
+			}
+			break
+		}
+	}
+	if ip != "" {
+		return ip, nil
+	}
+	if allowVMIPFallback {
+		return vmPrimaryIPFromVirtualMachine(ctx, virtualMachineInstance, vmNamespace, vmName)
+	}
+	return "", fmt.Errorf("spec.vpc.defaultSNATIP is not populated for "+
+		"networkinfo %s/%s", vmNamespace, vmName)
 }
 
 // getSnatIpFromNamespaceNetworkInfo finds VM's SNAT IP from the namespace's default NamespaceNetworkInfo CR.

--- a/pkg/syncer/cnsoperator/util/util_test.go
+++ b/pkg/syncer/cnsoperator/util/util_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -39,6 +40,17 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
+
+// newFakeDynamicClientForNetworkSettings returns a fake dynamic client that supports List/Get on
+// netoperator.vmware.com NetworkSettings (registers NetworkSettingsList for the fake tracker).
+func newFakeDynamicClientForNetworkSettings(objects ...runtime.Object) *fake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(networkSettingsGVR.GroupVersion())
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		networkSettingsGVR: "NetworkSettingsList",
+	}
+	return fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objects...)
+}
 
 func TestGetSnatIpFromNamespaceNetworkInfo(t *testing.T) {
 	ctx := context.Background()
@@ -423,6 +435,7 @@ func TestGetTKGVMIP_NetworkStatusNil(t *testing.T) {
 		vmNamespace,
 		vmName,
 		VDSNetworkProvider,
+		false,
 	)
 
 	if err == nil {
@@ -436,4 +449,167 @@ func TestGetTKGVMIP_NetworkStatusNil(t *testing.T) {
 	if !strings.Contains(err.Error(), "virtualMachineInstance.Status.Network is nil for VM") {
 		t.Fatalf("unexpected error message: %v", err)
 	}
+}
+
+func TestGetNetworkProviderFromNetworkSettings_ProviderMapping(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+
+	tests := []struct {
+		name     string
+		provider string
+		want     string
+		wantErr  bool
+	}{
+		{"vsphere-distributed", "vsphere-distributed", VDSNetworkProvider, false},
+		{"nsx-tier1", "nsx-tier1", NSXTNetworkProvider, false},
+		{"vpc", "vpc", VPCNetworkProvider, false},
+		{"unknown", "unknown-provider", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "netoperator.vmware.com/v1alpha1",
+					"kind":       "NetworkSettings",
+					"metadata":   map[string]interface{}{"name": "settings", "namespace": ns},
+					"provider":   tt.provider,
+				},
+			}
+			dc := newFakeDynamicClientForNetworkSettings()
+			_, err := dc.Resource(networkSettingsGVR).Namespace(ns).Create(ctx, cr, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("create NetworkSettings: %v", err)
+			}
+			got, err := getNetworkProviderFromNetworkSettings(ctx, dc, ns)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetTKGVMIP_NetworkSettingsUnavailable(t *testing.T) {
+	ctx := context.Background()
+	vmNamespace := "test-ns"
+	vmName := "test-vm"
+
+	vm := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: vmNamespace},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			ImageName: "test-image",
+			ClassName: "test-class",
+			Network:   &vmoperatortypes.VirtualMachineNetworkSpec{},
+		},
+		Status: vmoperatortypes.VirtualMachineStatus{
+			Network: &vmoperatortypes.VirtualMachineNetworkStatus{
+				PrimaryIP4: "192.0.2.1",
+			},
+		},
+	}
+	scheme := runtime.NewScheme()
+	err := vmoperatortypes.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	vmOpClient := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).WithObjects(vm).Build()
+	commonco.ContainerOrchestratorUtility, err = unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("orchestrator: %v", err)
+	}
+	dc := newFakeDynamicClientForNetworkSettings()
+
+	_, err = GetTKGVMIPFromNetworkSettings(ctx, vmOpClient, dc, vmNamespace, vmName)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNetworkSettingsUnavailable))
+}
+
+func TestGetNetworkProviderFromNetworkSettings_MultipleCRs(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	a := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "netoperator.vmware.com/v1alpha1",
+			"kind":       "NetworkSettings",
+			"metadata": map[string]interface{}{
+				"name": "a", "namespace": ns,
+			},
+			"provider": "vsphere-distributed",
+		},
+	}
+	b := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "netoperator.vmware.com/v1alpha1",
+			"kind":       "NetworkSettings",
+			"metadata": map[string]interface{}{
+				"name": "b", "namespace": ns,
+			},
+			"provider": "vsphere-distributed",
+		},
+	}
+	dc := newFakeDynamicClientForNetworkSettings()
+	_, err := dc.Resource(networkSettingsGVR).Namespace(ns).Create(ctx, a, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create a: %v", err)
+	}
+	_, err = dc.Resource(networkSettingsGVR).Namespace(ns).Create(ctx, b, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create b: %v", err)
+	}
+	_, err = getNetworkProviderFromNetworkSettings(ctx, dc, ns)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected exactly one NetworkSettings")
+}
+
+func TestGetTKGVMIP_PerNamespaceVDSUsesVMIP(t *testing.T) {
+	ctx := context.Background()
+	vmNamespace := "test-ns"
+	vmName := "test-vm"
+
+	vm := &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: vmNamespace},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			ImageName: "test-image",
+			ClassName: "test-class",
+			Network:   &vmoperatortypes.VirtualMachineNetworkSpec{},
+		},
+		Status: vmoperatortypes.VirtualMachineStatus{
+			Network: &vmoperatortypes.VirtualMachineNetworkStatus{
+				PrimaryIP4: "192.0.2.10",
+			},
+		},
+	}
+	scheme := runtime.NewScheme()
+	err := vmoperatortypes.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	vmOpClient := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).WithObjects(vm).Build()
+	commonco.ContainerOrchestratorUtility, err = unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("orchestrator: %v", err)
+	}
+	ns := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "netoperator.vmware.com/v1alpha1",
+			"kind":       "NetworkSettings",
+			"metadata": map[string]interface{}{
+				"name":      "arbitrary-network-settings-name",
+				"namespace": vmNamespace,
+			},
+			"provider": "vsphere-distributed",
+		},
+	}
+	dc := newFakeDynamicClientForNetworkSettings()
+	_, err = dc.Resource(networkSettingsGVR).Namespace(vmNamespace).Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create NetworkSettings: %v", err)
+	}
+
+	ip, err := GetTKGVMIPFromNetworkSettings(ctx, vmOpClient, dc, vmNamespace, vmName)
+	assert.NoError(t, err)
+	assert.Equal(t, "192.0.2.10", ip)
 }

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -379,6 +379,10 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,
 				common.SupportsExposingStoragePolicyAttributes, "", "")
 		}
+		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupportsPerNamespaceNetworkProviders) {
+			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,
+				common.SupportsPerNamespaceNetworkProviders, "", "")
+		}
 	}
 
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolve network provider and external VM IP from the namespace's NetworkSettings CR when WCP capability supports_per_namespace_network_providers is enabled; otherwise keep reading wcp-network-config via GetNetworkProvider.

- List NetworkSettings in the namespace and require exactly one object; map status.provider (vsphere-distributed / nsx-tier1 / vpc) to existing VDS / NSX-T / VPC IP logic.
- When per-namespace mode is on, use SNAT when present else fall back to VM primary IP (NSX-T and VPC); legacy behavior unchanged when the capability is off.
- Register the capability in WCP feature maps and SupportsLateEnablement; start HandleLateEnablementOfCapability from metadatasyncer so the syncer restarts when the capability is enabled later.
- Add/adjust unit tests (fake dynamic client with NetworkSettingsList).



**Testing done**:
Pre-checkin: 
- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1464/

2 test failed but not related to this change

```
16:55:40  Summarizing 2 Failures:
16:55:40    [FAIL] Basic Static Provisioning [It] [ef-wcp][ef-f-stretched-svc][csi-supervisor] [stretched-svc] Verify static provisioning workflow on SVC import FCD [p0, block, wcp, vc70]
16:55:40    /home/worker/workspace/wcp-instapp-e2e-pre-checkin/Results/1464/vsphere-csi-driver/tests/e2e/csi_static_provisioning_basic.go:901
16:55:40    [FAIL] Volume Snapshot Basic Test [It] [cf-wcp] [cf-vanilla-block][pq-n1-vanilla-block][pq-n2-vanilla-block][block-vanilla-snapshot][tkg-snapshot][supervisor-snapshot][ef-vks-snapshot] Verify snapshot dynamic provisioning workflow [p0, block, tkg, vanilla, wcp, snapshot, stable, vc90]
16:55:40    /home/worker/workspace/wcp-instapp-e2e-pre-checkin/Results/1464/vsphere-csi-driver/tests/e2e/csi_snapshot_basic.go:296
16:55:40  
16:55:40  Ran 12 of 1275 Specs in 3417.044 seconds
16:55:40  FAIL! -- 10 Passed | 2 Failed | 3 Flaked | 0 Pending | 1263 Skipped
```
VKS pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1132/

```
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2351 Skipped | 0 Flaked
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support per-namespace network providers for CnsFileAccessConfig
```
