### PR TITLE
Add CSI provisioner version update changes in K8s version 1.31 YAML as well

### DIFF
--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -310,7 +310,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v5.0.2_vmware.12
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.1.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add CSI provisioner version update changes in K8s version 1.31 YAML as well. Earlier we added these changes in K8s version 1.32, 1.33 and 1.34 YAMLs, but 1.34 version support is it in progress, so upgrade testing is still using 1.31 Version.
So, we need to add this fix in 1.31 YAML to resolve upgrade pipeline failures.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
This provisioner version is already working fine with 1.32, 1.33 and 1.34 K8s version specific YAMLs. 
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1244/
```
Ran 16 of 2324 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2308 Skipped | 0 Flaked
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Add CSI provisioner version update changes in K8s version 1.31 YAML as well
```
