### PR TITLE
Replace gomonkey with injectable clients in admission and batch attachment tests to resolve local unit test failures on ARM64

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -63,6 +63,7 @@ var (
 	featureFileVolumesWithVmServiceEnabled bool
 	featureIsSharedDiskEnabled             bool
 	featureIsLinkedCloneSupportEnabled     bool
+
 )
 
 // watchConfigChange watches on the webhook configuration directory for changes

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -63,7 +63,6 @@ var (
 	featureFileVolumesWithVmServiceEnabled bool
 	featureIsSharedDiskEnabled             bool
 	featureIsLinkedCloneSupportEnabled     bool
-
 )
 
 // watchConfigChange watches on the webhook configuration directory for changes

--- a/pkg/syncer/admissionhandler/validatepvc.go
+++ b/pkg/syncer/admissionhandler/validatepvc.go
@@ -27,7 +27,7 @@ var (
 	// newK8sClient and newSnapshotterClient are package-level function variables
 	// that default to the real constructors. Tests can override them to inject
 	// fake clients without relying on architecture-specific monkey patching.
-	newK8sClient         func(ctx context.Context) (clientset.Interface, error)         = k8s.NewClient
+	newK8sClient         func(ctx context.Context) (clientset.Interface, error)            = k8s.NewClient
 	newSnapshotterClient func(ctx context.Context) (snapshotterClientSet.Interface, error) = k8s.NewSnapshotterClient
 )
 

--- a/pkg/syncer/admissionhandler/validatepvc.go
+++ b/pkg/syncer/admissionhandler/validatepvc.go
@@ -13,12 +13,22 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+)
+
+var (
+	// newK8sClient and newSnapshotterClient are package-level function variables
+	// that default to the real constructors. Tests can override them to inject
+	// fake clients without relying on architecture-specific monkey patching.
+	newK8sClient         func(ctx context.Context) (clientset.Interface, error)         = k8s.NewClient
+	newSnapshotterClient func(ctx context.Context) (snapshotterClientSet.Interface, error) = k8s.NewSnapshotterClient
 )
 
 const (
@@ -213,7 +223,7 @@ func getPVReclaimPolicyForPVC(ctx context.Context, pvc corev1.PersistentVolumeCl
 		return result, logger.LogNewErrorf(log, "No PV is bound to the PVC %s/%s", pvc.Namespace, pvc.Name)
 	}
 
-	kubeClient, err := k8s.NewClient(ctx)
+	kubeClient, err := newK8sClient(ctx)
 	if err != nil {
 		return result, logger.LogNewErrorf(log, "failed to get kube client with error: %v. "+
 			"Stopping getting reclaim policy for PVC, %s/%s", err, pvc.Namespace, pvc.Name)
@@ -233,7 +243,7 @@ func getSnapshotsForPVC(ctx context.Context, ns string, name string) ([]snapshot
 
 	var result []snapshotv1.VolumeSnapshot
 
-	snapshotterClient, err := k8s.NewSnapshotterClient(ctx)
+	snapshotterClient, err := newSnapshotterClient(ctx)
 	if err != nil {
 		log.Errorf("failed to get snapshotterClient with error: %v. "+
 			"Stopping getting snapshots for PVC, %s/%s", err, ns, name)
@@ -366,7 +376,7 @@ func validateGuestPVCOperation(ctx context.Context, req *admissionv1.AdmissionRe
 		}
 	}
 
-	k8sClient, err := k8s.NewClient(ctx)
+	k8sClient, err := newK8sClient(ctx)
 	if err != nil {
 		return &admissionv1.AdmissionResponse{
 			Allowed: false,
@@ -377,7 +387,7 @@ func validateGuestPVCOperation(ctx context.Context, req *admissionv1.AdmissionRe
 		}
 	}
 
-	snapClient, err := k8s.NewSnapshotterClient(ctx)
+	snapClient, err := newSnapshotterClient(ctx)
 	if err != nil {
 		return &admissionv1.AdmissionResponse{
 			Allowed: false,

--- a/pkg/syncer/admissionhandler/validatepvc_test.go
+++ b/pkg/syncer/admissionhandler/validatepvc_test.go
@@ -8,7 +8,6 @@ import (
 
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/agiledragon/gomonkey/v2"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	snapshotclientfake "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
@@ -21,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
 var (
@@ -603,18 +601,18 @@ func TestValidatePVC(t *testing.T) {
 			snapshotClient := snapshotclientfake.NewSimpleClientset(test.snapshotObjs...)
 			kubeClient := fake.NewClientset(test.kubeObjs...)
 
-			var patches *gomonkey.Patches
-			patches = gomonkey.ApplyFunc(
-				k8s.NewSnapshotterClient, func(ctx context.Context) (snapshotterClientSet.Interface, error) {
-					return snapshotClient, nil
-				})
-			defer patches.Reset()
-
-			patches = gomonkey.ApplyFunc(
-				k8s.NewClient, func(ctx context.Context) (clientset.Interface, error) {
-					return kubeClient, nil
-				})
-			defer patches.Reset()
+			origK8sClient := newK8sClient
+			origSnapshotterClient := newSnapshotterClient
+			defer func() {
+				newK8sClient = origK8sClient
+				newSnapshotterClient = origSnapshotterClient
+			}()
+			newK8sClient = func(ctx context.Context) (clientset.Interface, error) {
+				return kubeClient, nil
+			}
+			newSnapshotterClient = func(ctx context.Context) (snapshotterClientSet.Interface, error) {
+				return snapshotClient, nil
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -1099,18 +1097,18 @@ func TestValidateGuestPVCOperation_LinkedClone_StorageClass(t *testing.T) {
 			kubeClient := fake.NewClientset(test.kubeObjs...)
 			snapshotClient := snapshotclientfake.NewSimpleClientset(test.snapshotObjs...)
 
-			// Patch k8s client functions
-			patches := gomonkey.ApplyFunc(
-				k8s.NewClient, func(ctx context.Context) (clientset.Interface, error) {
-					return kubeClient, nil
-				})
-			defer patches.Reset()
-
-			patches = gomonkey.ApplyFunc(
-				k8s.NewSnapshotterClient, func(ctx context.Context) (snapshotterClientSet.Interface, error) {
-					return snapshotClient, nil
-				})
-			defer patches.Reset()
+			origK8sClient := newK8sClient
+			origSnapshotterClient := newSnapshotterClient
+			defer func() {
+				newK8sClient = origK8sClient
+				newSnapshotterClient = origSnapshotterClient
+			}()
+			newK8sClient = func(ctx context.Context) (clientset.Interface, error) {
+				return kubeClient, nil
+			}
+			newSnapshotterClient = func(ctx context.Context) (snapshotterClientSet.Interface, error) {
+				return snapshotClient, nil
+			}
 
 			// Marshal the PVC to raw JSON
 			pvcBytes, err := json.Marshal(test.pvc)

--- a/pkg/syncer/admissionhandler/validatesnapshotoperation.go
+++ b/pkg/syncer/admissionhandler/validatesnapshotoperation.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 
 	snap "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 )
@@ -91,7 +90,7 @@ func validateSnapshotOperationGuestRequest(ctx context.Context, req *admissionv1
 		// If no volume snapshot class mentioned i.e. default volume snapshot class to be used, then
 		// following checks are skipped. Currently vSphere driver snapshot class is not marked default.
 		if *vs.Spec.VolumeSnapshotClassName != "" {
-			snapshotterClient, err := k8s.NewSnapshotterClient(ctx)
+			snapshotterClient, err := newSnapshotterClient(ctx)
 			if err != nil {
 				reason := fmt.Sprintf("failed to get snapshotterClient with error: %v. for class %s",
 					err, *vs.Spec.VolumeSnapshotClassName)
@@ -153,7 +152,7 @@ func validateSnapshotOperationSupervisorRequest(ctx context.Context,
 // checkIfLinkedClonesExist checks if there are any LinkedClone volumes created out of the
 // VolumeSnapshot
 func checkIfLinkedClonesExist(ctx context.Context, vs snap.VolumeSnapshot) admission.Response {
-	k8sClient, err := k8s.NewClient(ctx)
+	k8sClient, err := newK8sClient(ctx)
 	if err != nil {
 		return admission.Denied("failed to get k8s client. Error: " + err.Error())
 	}
@@ -187,7 +186,7 @@ func checkIfLinkedClonesExist(ctx context.Context, vs snap.VolumeSnapshot) admis
 // 2. Namespace is not found (already deleted)
 func isNamespaceBeingDeleted(ctx context.Context, namespaceName string) bool {
 	log := logger.GetLogger(ctx)
-	k8sClient, err := k8s.NewClient(ctx)
+	k8sClient, err := newK8sClient(ctx)
 	if err != nil {
 		log.Errorf("Failed to get kubernetes client while checking namespace deletion status: %v", err)
 		return false

--- a/pkg/syncer/admissionhandler/validatesnapshotoperation_test.go
+++ b/pkg/syncer/admissionhandler/validatesnapshotoperation_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agiledragon/gomonkey/v2"
 	snap "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	snapshotclientfake "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
@@ -31,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
 var admissionReview_snapshotclass = v1.AdmissionReview{
@@ -113,11 +111,11 @@ func TestValidateVolumeSnapshotInGuestWithFSSDisabled(t *testing.T) {
 		},
 	}
 	snapshotClient := snapshotclientfake.NewSimpleClientset(snapshotClassObj...)
-	patches := gomonkey.ApplyFunc(
-		k8s.NewSnapshotterClient, func(ctx context.Context) (snapshotterClientSet.Interface, error) {
-			return snapshotClient, nil
-		})
-	defer patches.Reset()
+	origSnapshotterClient := newSnapshotterClient
+	defer func() { newSnapshotterClient = origSnapshotterClient }()
+	newSnapshotterClient = func(ctx context.Context) (snapshotterClientSet.Interface, error) {
+		return snapshotClient, nil
+	}
 
 	// Validate vSphere VolumeSnapshot creation with CSI snapshot FSS disabled
 	admissionReview_snapshot.Request.Object = runtime.RawExtension{
@@ -145,11 +143,9 @@ func TestValidateVolumeSnapshotInGuestWithFSSDisabled(t *testing.T) {
 		},
 	}
 	snapshotClient = snapshotclientfake.NewSimpleClientset(snapshotClassObj...)
-	patches_nonvSphere := gomonkey.ApplyFunc(
-		k8s.NewSnapshotterClient, func(ctx context.Context) (snapshotterClientSet.Interface, error) {
-			return snapshotClient, nil
-		})
-	defer patches_nonvSphere.Reset()
+	newSnapshotterClient = func(ctx context.Context) (snapshotterClientSet.Interface, error) {
+		return snapshotClient, nil
+	}
 
 	// Validate non-vSphere VolumeSnapshot creation with CSI snapshot FSS disabled
 	admissionReview_snapshot.Request.Object = runtime.RawExtension{
@@ -256,12 +252,11 @@ func TestValidateSnapshotOperationSupervisorRequestWithNamespaceDeletion(t *test
 			// Create fake k8s client with the test namespace
 			k8sClient := fake.NewClientset(tt.namespace)
 
-			// Patch the k8s.NewClient function to return our fake client
-			patches := gomonkey.ApplyFunc(
-				k8s.NewClient, func(ctx context.Context) (kubernetes.Interface, error) {
-					return k8sClient, nil
-				})
-			defer patches.Reset()
+			origK8sClient := newK8sClient
+			defer func() { newK8sClient = origK8sClient }()
+			newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
+				return k8sClient, nil
+			}
 
 			// Create admission request for VolumeSnapshot deletion
 			volumeSnapshotJSON := `{
@@ -354,12 +349,11 @@ func TestIsNamespaceBeingDeleted(t *testing.T) {
 				k8sClient = fake.NewClientset()
 			}
 
-			// Patch the k8s.NewClient function to return our fake client
-			patches := gomonkey.ApplyFunc(
-				k8s.NewClient, func(ctx context.Context) (kubernetes.Interface, error) {
-					return k8sClient, nil
-				})
-			defer patches.Reset()
+			origK8sClient := newK8sClient
+			defer func() { newK8sClient = origK8sClient }()
+			newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
+				return k8sClient, nil
+			}
 
 			// Call the function under test
 			result := isNamespaceBeingDeleted(ctx, tt.namespaceName)
@@ -468,12 +462,11 @@ func TestValidateSnapshotOperationGuestRequestWithNamespaceDeletion(t *testing.T
 			// Create fake k8s client with the test namespace
 			k8sClient := fake.NewClientset(tt.namespace)
 
-			// Patch the k8s.NewClient function to return our fake client
-			patches := gomonkey.ApplyFunc(
-				k8s.NewClient, func(ctx context.Context) (kubernetes.Interface, error) {
-					return k8sClient, nil
-				})
-			defer patches.Reset()
+			origK8sClient := newK8sClient
+			defer func() { newK8sClient = origK8sClient }()
+			newK8sClient = func(ctx context.Context) (kubernetes.Interface, error) {
+				return k8sClient, nil
+			}
 
 			// Create admission request for VolumeSnapshot deletion
 			volumeSnapshotJSON := `{

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -54,6 +54,10 @@ import (
 var (
 	GetVMFromVcenter = cnsoperatorutil.GetVMFromVcenter
 	attachedVmPrefix = "cns.vmware.com/usedby-vm-"
+
+	// removePvcFinalizerFn is a package-level function variable so tests can
+	// inject a fake implementation without architecture-specific monkey patching.
+	removePvcFinalizerFn = removePvcFinalizer
 )
 
 const (
@@ -100,7 +104,7 @@ func removePvcProtectionFinalizersForTrackedPVCs(ctx context.Context,
 	log := logger.GetLogger(ctx)
 
 	for pvcName, volumeName := range getPvcsFromSpecAndStatus(ctx, instance) {
-		err := removePvcFinalizer(ctx, c, k8sClient, cnsOperatorClient,
+		err := removePvcFinalizerFn(ctx, c, k8sClient, cnsOperatorClient,
 			pvcName, instance.Namespace, instance.Spec.InstanceUUID)
 		if err != nil {
 			updateInstanceVolumeStatus(ctx, instance, volumeName, pvcName, "", "", err,

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -847,16 +847,16 @@ func TestRemovePvcProtectionFinalizersForTrackedPVCs_AllSucceed(t *testing.T) {
 	clientset := k8sFake.NewClientset()
 	cnsOperatorClient := fake.NewClientBuilder().WithScheme(s).Build()
 
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(removePvcFinalizer, func(ctx context.Context, patchClient crclient.Client,
+	origRemovePvcFinalizerFn := removePvcFinalizerFn
+	defer func() { removePvcFinalizerFn = origRemovePvcFinalizerFn }()
+	removePvcFinalizerFn = func(ctx context.Context, patchClient crclient.Client,
 		k8sClient kubernetes.Interface, cnsOpClient crclient.Client,
 		pvcName, namespace, vmInstanceUUID string) error {
 		assert.Equal(t, testNamespace, namespace)
 		assert.Equal(t, base.Spec.InstanceUUID, vmInstanceUUID)
 		assert.Contains(t, []string{"pvc-1", "pvc-2"}, pvcName)
 		return nil
-	})
+	}
 
 	err := removePvcProtectionFinalizersForTrackedPVCs(ctx, instance, crClient, clientset, cnsOperatorClient)
 	assert.NoError(t, err)
@@ -881,13 +881,13 @@ func TestRemovePvcProtectionFinalizersForTrackedPVCs_RemoveFinalizerErrorUpdates
 	cnsOperatorClient := fake.NewClientBuilder().WithScheme(s).Build()
 
 	wantErr := errors.New("mock removePvcFinalizer failure")
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(removePvcFinalizer, func(ctx context.Context, patchClient crclient.Client,
+	origRemovePvcFinalizerFn := removePvcFinalizerFn
+	defer func() { removePvcFinalizerFn = origRemovePvcFinalizerFn }()
+	removePvcFinalizerFn = func(ctx context.Context, patchClient crclient.Client,
 		k8sClient kubernetes.Interface, cnsOpClient crclient.Client,
 		pvcName, namespace, vmInstanceUUID string) error {
 		return wantErr
-	})
+	}
 
 	err := removePvcProtectionFinalizersForTrackedPVCs(ctx, instance, crClient, clientset, cnsOperatorClient)
 	assert.ErrorIs(t, err, wantErr)


### PR DESCRIPTION
**What this PR does / why we need it**:

Summary
Replace gomonkey-based function patching with package-level function variables that default to the real implementations. Unit tests override these variables to inject fake Kubernetes / snapshot clients (or custom stubs), then restore them in defer. This avoids architecture-specific and fragile runtime patching while keeping the same test coverage.

Motivation
* gomonkey relies on unsafe/low-level patching and can be sensitive to Go version, inlining, and OS/arch.
* Explicit dependency injection at package boundaries is easier to reason about and keeps tests portable.


**Which issue this PR fixes**
Fixes: vsphere-csi-driver unit test is failing on ARM64. [PR3687208](https://bugzilla-vcf.lvn.broadcom.net//show_bug.cgi?id=3687208)

**Testing done**:
WCP precheckin - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3980#issuecomment-4284635652

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Replace gomonkey with injectable clients in admission and batch attachment tests to resolve local unit test failures on ARM64.
```
