### PR TITLE
Add support for K8s 1.35 for supervisor

### DIFF
--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -1,0 +1,904 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: vmware-system-csi
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "resourcequotas", "namespaces", "services", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnscsisvfeaturestates"]
+    verbs: ["create", "get", "list", "update", "watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfilevolumeclients"]
+    verbs: ["get", "list", "update", "create", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsregistervolumes", "cnsregistervolumes/status", "cnsunregistervolumes", "cnsunregistervolumes/status"]
+    verbs: ["get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["triggercsifullsyncs"]
+    verbs: ["create", "get", "update", "watch", "list"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagepools"]
+    verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["vmware.com"]
+    resources: ["virtualnetworks"]
+    verbs: ["get"]
+  - apiGroups: ["netoperator.vmware.com"]
+    resources: ["networkinterfaces"]
+    verbs: ["get"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumeoperationrequests"]
+    verbs: ["create", "get", "list", "update", "delete", "watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagepolicyusages"]
+    verbs: ["create", "get", "list", "patch", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagepolicyusages/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagequotaperiodicsyncs"]
+    verbs: ["create", "get", "list", "patch", "delete" ,"watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagequotaperiodicsyncs/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagepolicyquotas"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagepolicyreservations"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["list"]
+  - apiGroups: ["topology.tanzu.vmware.com"]
+    resources: ["availabilityzones", "zones"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshots" ]
+    verbs: [ "get", "list", "patch", "update", "watch" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotclasses" ]
+    verbs: [ "watch", "get", "list" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents/status" ]
+    verbs: [ "update", "patch" ]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumeinfoes"]
+    verbs: ["create", "get", "list", "watch", "delete", "patch"]
+  - apiGroups: ["crd.nsx.vmware.com"]
+    resources: ["networkinfos"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["crd.nsx.vmware.com"]
+    resources: ["vpcnetworkconfigurations"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["fvs.vcf.broadcom.com"]
+    resources: ["filevolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+  - apiGroups: ["fvs.vcf.broadcom.com"]
+    resources: ["filevolumeservices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["encryption.vmware.com"]
+    resources: ["encryptionclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cluster.x-k8s.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["nsx.vmware.com"]
+    resources: ["namespacenetworkinfos"]
+    verbs: ["get", "list"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachinesnapshots"]
+    verbs: ["get", "list", "patch", "update", "watch"]
+  - apiGroups: ["iaas.vmware.com"]
+    resources: ["capabilities"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cnsdp.vmware.com"]
+    resources: ["cbtconfigs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cbt.storage.k8s.io"]
+    resources: ["snapshotmetadataservices"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificates/status"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: vmware-system-csi
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csiRole
+  namespace: vmware-system-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wcp-privileged-psp
+subjects:
+  # For the vmware-system-csi nodes.
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:vmware-system-csi
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-admin-csi-role
+rules:
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsregistervolumes", "cnsunregistervolumes"]
+    verbs: ["get", "list", "create", "delete", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wcp:administrators:cluster-edit-csirole
+subjects:
+  - kind: Group
+    name: sso:Administrators@<sso_domain>
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: vsphere-admin-csi-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cnsfileaccessconfigs-view-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["cns.vmware.com"]
+  resources: ["cnsfileaccessconfigs"]
+  verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cnsfileaccessconfigs-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["cns.vmware.com"]
+  resources: ["cnsfileaccessconfigs"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: vmware-system-csi
+  name: vsphere-csi-secret-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vsphere-csi-provisioner-secret-binding
+  namespace: vmware-system-csi
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: vmware-system-csi
+roleRef:
+  kind: Role
+  name: vsphere-csi-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: vmware-system-csi
+  name: vsphere-csi-configmap-writer
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vsphere-csi-controller-configmap-writer
+  namespace: vmware-system-csi
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: vmware-system-csi
+roleRef:
+  kind: Role
+  name: vsphere-csi-configmap-writer
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+        role: vsphere-csi
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - vsphere-csi-controller
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccount: vsphere-csi-controller
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ''
+      tolerations:
+        - operator: "Exists"
+          key: "node-role.kubernetes.io/control-plane"
+          effect: "NoSchedule"
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      containers:
+        - name: csi-provisioner
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.1.0_vmware.1
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--feature-gates=Topology=true"
+            - "--strict-topology"
+            - "--leader-election"
+            - "--enable-hostlocal-placement=true"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
+            - "--use-service-for-placement-engine=false"
+            - "--tkgs-ha=true"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
+            - "--enable-vdpp-on-stretched-supervisor=true"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_PORT
+              value: "29000"
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAME # service name to be used by csi-provisioner to connect to placement engine
+              value: vmware-system-psp-operator-k8s-cloud-operator-service
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
+              value: vmware-system-appplatform-operator-system
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-attacher
+          image: localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1
+          args:
+            - "--reconcile-sync=5m"
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
+            - "--worker-threads=100"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-resizer
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v2.1.0_vmware.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=4
+            - --timeout=300s
+            - --handle-volume-inuse-error=false  # Set this to true if used in vSphere 7.0U1
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-csi-controller
+          image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--enable-profile-server=true"
+          ports:
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 180
+            failureThreshold: 3
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: CLUSTER_FLAVOR
+              value: "WORKLOAD"
+            - name: X_CSI_MODE
+              value: "controller"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: POD_LISTENER_SERVICE_PORT
+              value: "29000"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "200"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "200"
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
+          volumeMounts:
+            - mountPath: /etc/vmware/wcp
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
+        - name: liveness-probe
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
+          args:
+            - "--csi-address=/csi/csi.sock"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-syncer
+          image: localhost:5000/vmware/syncer:<syncer_ver>
+          args:
+            - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
+            - "--storagequota-sync-interval=10m"
+            - "--webhook-client-cert-verification"
+            - "--enable-profile-server=true"
+          env:
+            - name: CLUSTER_FLAVOR
+              value: "WORKLOAD"
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VOLUME_HEALTH_INTERVAL_MINUTES
+              value: "5"
+            - name: WORKER_THREADS_NODEVM_ATTACH
+              value: "20"
+            - name: WORKER_THREADS_NODEVM_BATCH_ATTACH
+              value: "20"
+            - name: POD_POLL_INTERVAL_SECONDS
+              value: "2"
+            - name: POD_LISTENER_SERVICE_PORT
+              value: "29000"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "200"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "200"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 5Gi
+          volumeMounts:
+            - mountPath: /etc/vmware/wcp
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
+            - mountPath: /etc/vmware/wcp/webhook-certs/client-ca
+              name: client-ca
+              readOnly: true
+        - name: csi-snapshotter
+          image: localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+            - "--extra-create-metadata"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - name: vsphere-config-volume
+          secret:
+            secretName: vsphere-config-secret
+        - name: socket-dir
+          emptyDir: {}
+        - name: host-vmca
+          hostPath:
+            path: /etc/vmware/wcp/tls/
+            type: Directory
+        - name: client-ca
+          configMap:
+            name: kube-root-ca.crt
+            defaultMode: 420
+            items:
+            - key: "ca.crt"
+              path: "ca.crt"
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.vsphere.vmware.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+---
+apiVersion: v1
+data:
+  "volume-extend": "true"
+  "volume-health": "true"
+  "online-volume-extend": "true"
+  "file-volume": "true"
+  "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "true"
+  "improved-csi-idempotency": "true"
+  "block-volume-snapshot": "true"
+  "tkgs-ha": "true"
+  "list-volumes": "true"
+  "cnsmgr-suspend-create-volume": "true"
+  "storage-quota-m2": "true"
+  "workload-domain-isolation": "false"
+  "sv-pvc-snapshot-protection-finalizer": "true"
+  "high-pv-node-density": "false" # When enabled, increases the MAX_VOLUMES_PER_NODE from 59 to 255 for guest cluster nodes
+kind: ConfigMap
+metadata:
+  name: csi-feature-states
+  namespace: vmware-system-csi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vmware-system-csi-webhook-service
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-webhook
+spec:
+  ports:
+    - port: 443
+      targetPort: 9883
+  selector:
+    app: vsphere-csi-webhook
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-webhook
+  name: vmware-system-csi-serving-cert
+  namespace: vmware-system-csi
+spec:
+  dnsNames:
+    - vmware-system-csi-webhook-service.vmware-system-csi.svc
+    - vmware-system-csi-webhook-service.vmware-system-csi.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-selfsigned-issuer
+  secretName: vmware-system-csi-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: vsphere-csi-webhook
+  name: vmware-system-csi-selfsigned-issuer
+  namespace: vmware-system-csi
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: vmware-system-csi-validating-webhook-configuration
+  labels:
+    app: vsphere-csi-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: vmware-system-csi/vmware-system-csi-serving-cert
+webhooks:
+  - name: validation.csi.vsphere.vmware.com
+    clientConfig:
+      service:
+        name: vmware-system-csi-webhook-service
+        namespace: vmware-system-csi
+        path: "/validate"
+    rules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
+        resources:   ["persistentvolumeclaims"]
+        scope: "Namespaced"
+      - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "DELETE"]
+        resources:   ["volumesnapshots"]
+        scope:       "Namespaced"
+      - apiGroups:   ["cns.vmware.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "DELETE"]
+        resources:   ["cnsfileaccessconfigs"]
+        scope:       "Namespaced"
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: vmware-system-csi-mutating-webhook-configuration
+  labels:
+    app: vsphere-csi-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: vmware-system-csi/vmware-system-csi-serving-cert
+webhooks:
+  - name: mutation.csi.vsphere.vmware.com
+    clientConfig:
+      service:
+        name: vmware-system-csi-webhook-service
+        namespace: vmware-system-csi
+        path: "/mutate"
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["persistentvolumeclaims"]
+        scope: "Namespaced"
+      - apiGroups:   ["cns.vmware.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE"]
+        resources:   ["cnsfileaccessconfigs"]
+        scope: "Namespaced"
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["encryption.vmware.com"]
+    resources: ["encryptionclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfileaccessconfigs"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-webhook
+    namespace: vmware-system-csi
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-webhook-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-role
+  namespace: vmware-system-csi
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-role-binding
+  namespace: vmware-system-csi
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-webhook
+    namespace: vmware-system-csi
+roleRef:
+  kind: Role
+  name: vsphere-csi-webhook-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-webhook
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: vsphere-csi-webhook
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-webhook
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - vsphere-csi-webhook
+              topologyKey: kubernetes.io/hostname
+      hostNetwork: true
+      serviceAccount: vsphere-csi-webhook
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      terminationGracePeriodSeconds: 10
+      securityContext:
+        fsGroup: 65533
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - effect: NoExecute
+          key: node.alpha.kubernetes.io/notReady
+          operator: Exists
+        - effect: NoExecute
+          key: node.alpha.kubernetes.io/unreachable
+          operator: Exists
+      containers:
+        - name: vsphere-webhook
+          image: localhost:5000/vmware/syncer:<syncer_ver>
+          args:
+            - "--operation-mode=WEBHOOK_SERVER"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 9883
+              name: webhook-server
+              protocol: TCP
+          env:
+            - name: CNSCSI_WEBHOOK_SERVICE_CONTAINER_PORT
+              value: "9883"
+            - name: CLUSTER_FLAVOR
+              value: "WORKLOAD"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "50"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65533
+          volumeMounts:
+            - mountPath: /etc/vmware/wcp/webhook-certs
+              name: webhook-certs
+              readOnly: true
+      volumes:
+        - name: webhook-certs
+          secret:
+            defaultMode: 0440
+            secretName: vmware-system-csi-webhook-service-cert

--- a/manifests/supervisorcluster/1.35/kustomization.yaml
+++ b/manifests/supervisorcluster/1.35/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cns-csi.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add YAMLs for K8s 1.35 support.
WCP team is not yet ready with builds. E2E testing will be done once they provide the builds for the same.

Since no one is accessing these files, it is safe to merge them.

**Testing done**:

WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1357/
VKS prcheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1057/