### PR TITLE
Batch Attach race condition fix

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -30,6 +30,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoperatorv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -250,6 +251,12 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 		err = vmoperatortypes.AddToScheme(scheme)
 		if err != nil {
 			log.Errorf("failed to add to scheme with err: %+v", err)
+			return nil, err
+		}
+		log.Info("adding scheme for vm-operator version v1alpha5")
+		err = vmoperatorv1alpha5.AddToScheme(scheme)
+		if err != nil {
+			log.Errorf("failed to add to scheme for v1alpha5 with err: %+v", err)
 			return nil, err
 		}
 	case cnsoperatorv1alpha1.GroupName:

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -292,7 +292,7 @@ func (r *Reconciler) Reconcile(ctx context.Context,
 	} else {
 		// If VM was found on vCenter, find the volumes to be attached and detached.
 		volumesToAttach, volumesToDetach, err = getVolumesToAttachAndDetach(batchAttachCtx, instance, vm, r.client, k8sClient,
-			r.cnsOperatorClient)
+			r.cnsOperatorClient, r.vmOperatorClient)
 		if err != nil {
 			log.Errorf("failed to find volumes to detach for instance %s. Err: %s",
 				request.NamespacedName.String(), err)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -41,7 +42,6 @@ import (
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
@@ -146,16 +146,65 @@ func removeFinalizerFromCRDInstance(ctx context.Context,
 	return k8s.PatchFinalizers(ctx, c, instance, finalizersOnInstance)
 }
 
+// getVirtualMachine retrieves a VirtualMachine by name and namespace using v1alpha5 API
+func getVirtualMachine(ctx context.Context, vmOperatorClient client.Client,
+	vmName string, namespace string) (*vmoperatortypes.VirtualMachine, error) {
+	vm := &vmoperatortypes.VirtualMachine{}
+	err := vmOperatorClient.Get(ctx, client.ObjectKey{
+		Name:      vmName,
+		Namespace: namespace,
+	}, vm)
+	return vm, err
+}
+
+// validatePVCDetachSafety performs a critical safety check to verify that the PVC is NOT referenced
+// in the VirtualMachine spec that corresponds to this batch attach CR (VM with the same name as the CR).
+// If it is still referenced, it logs a warning and returns false to indicate the PVC should not be detached.
+// Callers must load the VirtualMachine (e.g. with getVirtualMachine) before calling this; vm must be non-nil.
+// Returns (shouldDetach bool, error) where shouldDetach=false means skip this PVC from detachment.
+func validatePVCDetachSafety(ctx context.Context, vm *vmoperatortypes.VirtualMachine,
+	instance *v1alpha1.CnsNodeVMBatchAttachment, pvcName, pvcNs, attachedFcdId string) (bool, error) {
+	log := logger.GetLogger(ctx)
+
+	// Check if this PVC is referenced in the VM's spec
+	for _, vmVol := range vm.Spec.Volumes {
+		if vmVol.PersistentVolumeClaim != nil &&
+			vmVol.PersistentVolumeClaim.ClaimName == pvcName {
+			log.Infof("Skipping detach for PVC %s/%s with FCD %s from VM %s because it is still "+
+				"referenced in VirtualMachine %s spec. This indicates the PVC is actively used by the VM.",
+				pvcNs, pvcName, attachedFcdId, instance.Spec.InstanceUUID, instance.Name)
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 // getVolumesToDetachFromInstance finds out which are the volumes to detach by finding out which are
 // the volumes present in attachedFCDs but not in spec of the instance.
+// It validates with the namesake VirtualMachine API object when that object exists; if the VM is
+// not found, VM spec safety checks are skipped and detach candidates are still computed.
 func getVolumesToDetachFromInstance(ctx context.Context,
 	instance *v1alpha1.CnsNodeVMBatchAttachment,
+	vmOperatorClient client.Client,
 	attachedFCDs map[string]FCDBackingDetails,
 	volumeIdsInSpec map[string]FCDBackingDetails) (pvcsToDetach map[string]string, err error) {
 	log := logger.GetLogger(ctx)
 
 	// Map contains PVCs which need to be detached.
 	pvcsToDetach = make(map[string]string)
+
+	vm, vmGetErr := getVirtualMachine(ctx, vmOperatorClient, instance.Name, instance.Namespace)
+	if vmGetErr != nil {
+		if apierrors.IsNotFound(vmGetErr) {
+			log.Infof("VirtualMachine %s/%s not found; skipping VM spec safety check and continuing detach list computation",
+				instance.Namespace, instance.Name)
+			vm = nil
+		} else {
+			return pvcsToDetach, fmt.Errorf("failed to get VirtualMachine %s in namespace %s: %s",
+				instance.Name, instance.Namespace, vmGetErr.Error())
+		}
+	}
 
 	/// Add those volumes to to pvcsToDetach
 	// which are present in attachedFCDs list but not in
@@ -176,10 +225,13 @@ func getVolumesToDetachFromInstance(ctx context.Context,
 		}
 
 		addPVCToDetachList := false
+		performSafetyCheck := false
 
 		if volumeInSpec, ok := volumeIdsInSpec[attachedFcdId]; !ok {
 			// If PVC is not present in CR spec but is attached to the VM, then add it to PVCs to detach list.
 			addPVCToDetachList = true
+			// ensure PVC does not exist on VM spec.
+			performSafetyCheck = true
 		} else if volumeInSpec.ControllerKey != attachedFcdIdBacking.ControllerKey ||
 			volumeInSpec.UnitNumber != attachedFcdIdBacking.UnitNumber ||
 			volumeInSpec.SharingMode != attachedFcdIdBacking.SharingMode ||
@@ -210,6 +262,18 @@ func getVolumesToDetachFromInstance(ctx context.Context,
 				controllerutil.ContainsFinalizer(pvcObj, cnsoperatortypes.CNSPvcFinalizer) {
 				log.Debugf("PVC %s does not have usedby-vm annotation. PVC not attached via CnsNodeVMBatchAttachment.", pvcName)
 				continue
+			}
+
+			if performSafetyCheck && vm != nil {
+				// Ensure the PVC is not still referenced in VM spec before detaching.
+				shouldDetach, err := validatePVCDetachSafety(ctx, vm, instance, pvcName, pvcNs, attachedFcdId)
+				if err != nil {
+					return pvcsToDetach, err
+				}
+				if !shouldDetach {
+					log.Infof("Skipping PVC %s from detach list due to safety check", pvcName)
+					continue
+				}
 			}
 			pvcsToDetach[pvcName] = attachedFcdId
 		}
@@ -385,6 +449,7 @@ func getVolumesToDetachForVmFromVC(ctx context.Context,
 	client client.Client,
 	k8sClient kubernetes.Interface,
 	cnsOperatorClient client.Client,
+	vmOperatorClient client.Client,
 	attachedFCDs map[string]FCDBackingDetails,
 	volumeIdsInSpec map[string]FCDBackingDetails,
 	volumeNamesInSpec map[string]string) (map[string]string, error) {
@@ -392,7 +457,7 @@ func getVolumesToDetachForVmFromVC(ctx context.Context,
 
 	// Find out the volumes to detach by taking a diff between
 	// the instance spec and the FCDs currently attached to the VM on vCenter.
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	if err != nil {
 		log.Errorf("failed to find volumes to attach and volumes to detach from instance spec. Err: %s", err)
 		return pvcsToDetach, err
@@ -689,7 +754,7 @@ func getVmObject(ctx context.Context, client client.Client, configInfo config.Co
 
 func getVolumesToAttachAndDetach(ctx context.Context, instance *v1alpha1.CnsNodeVMBatchAttachment,
 	vm *cnsvsphere.VirtualMachine, client client.Client, k8sClient kubernetes.Interface,
-	cnsOperatorClient client.Client) (map[string]string,
+	cnsOperatorClient client.Client, vmOperatorClient client.Client) (map[string]string,
 	map[string]string, error) {
 	log := logger.GetLogger(ctx)
 
@@ -720,7 +785,7 @@ func getVolumesToAttachAndDetach(ctx context.Context, instance *v1alpha1.CnsNode
 	}
 
 	// Find the volumes to detach from the vCenter.
-	pvcsToDetach, err = getVolumesToDetach(ctx, client, k8sClient, cnsOperatorClient, instance, vm,
+	pvcsToDetach, err = getVolumesToDetach(ctx, client, k8sClient, cnsOperatorClient, vmOperatorClient, instance, vm,
 		attachedFcdList, volumeIdsInSpec, volumeNamesInSpec)
 	if err != nil {
 		log.Errorf("failed to find volumes to detach from the vCenter for instance %s", instance.Name)
@@ -743,6 +808,7 @@ func getVolumesToAttachAndDetach(ctx context.Context, instance *v1alpha1.CnsNode
 func getVolumesToDetach(ctx context.Context, client client.Client,
 	k8sClient kubernetes.Interface,
 	cnsOperatorClient client.Client,
+	vmOperatorClient client.Client,
 	instance *v1alpha1.CnsNodeVMBatchAttachment,
 	vm *cnsvsphere.VirtualMachine, attachedFcdList map[string]FCDBackingDetails,
 	volumeIdsInSpec map[string]FCDBackingDetails, volumeNamesInSpec map[string]string) (map[string]string, error) {
@@ -750,7 +816,7 @@ func getVolumesToDetach(ctx context.Context, client client.Client,
 
 	// Find volumes to be detached from the VM by takinga diff with FCDs attached to VM on vCenter.
 	volumesToDetach, err := getVolumesToDetachForVmFromVC(ctx, instance, client, k8sClient,
-		cnsOperatorClient, attachedFcdList, volumeIdsInSpec, volumeNamesInSpec)
+		cnsOperatorClient, vmOperatorClient, attachedFcdList, volumeIdsInSpec, volumeNamesInSpec)
 	if err != nil {
 		log.Errorf("failed to find volumes to attach and detach. Err: %s", err)
 		return map[string]string{}, err
@@ -1154,7 +1220,8 @@ func updateInstanceVolumeStatus(
 func isVmInSameNamespace(ctx context.Context, vmOperatorClient client.Client,
 	instanceUUID string, namespace string) (bool, error) {
 	log := logger.GetLogger(ctx)
-	vmList, err := utils.ListVirtualMachines(ctx, vmOperatorClient, namespace)
+	vmList := &vmoperatortypes.VirtualMachineList{}
+	err := vmOperatorClient.List(ctx, vmList, client.InNamespace(namespace))
 	if err != nil {
 		msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
 		log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -58,7 +58,7 @@ import (
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 
 	"github.com/agiledragon/gomonkey/v2"
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	"k8s.io/apimachinery/pkg/runtime"
 	v1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1"
 )
@@ -834,7 +834,19 @@ func schemeForCnsBatchAttachTests() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = v1.AddToScheme(s)
 	_ = cnsopapis.AddToScheme(s)
+	_ = vmoperatortypes.AddToScheme(s)
 	return s
+}
+
+// vmForBatchAttachDetachTests is a minimal VirtualMachine matching setupTestCnsNodeVMBatchAttachment
+// name/namespace so getVolumesToDetachFromInstance can load the VM API object (required for detach safety).
+func vmForBatchAttachDetachTests() *vmoperatortypes.VirtualMachine {
+	return &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testCnsNodeVMBatchAttachmentName,
+			Namespace: testNamespace,
+		},
+	}
 }
 
 func TestRemovePvcProtectionFinalizersForTrackedPVCs_AllSucceed(t *testing.T) {
@@ -1044,6 +1056,9 @@ func TestGetVolumesToDetachFromInstanceWhenAVolumeIsRemoved(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-1": {ControllerKey: 1000, UnitNumber: 1,
@@ -1056,7 +1071,7 @@ func TestGetVolumesToDetachFromInstanceWhenAVolumeIsRemoved(t *testing.T) {
 			SharingMode: "None", DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-1"}, pvcsToDetach)
 }
@@ -1066,6 +1081,9 @@ func TestGetVolumesToDetachFromInstanceWhenNothingHasChanged(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1001,
@@ -1076,7 +1094,7 @@ func TestGetVolumesToDetachFromInstanceWhenNothingHasChanged(t *testing.T) {
 			UnitNumber: 2, SharingMode: "None", DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{}, pvcsToDetach)
 }
@@ -1086,6 +1104,9 @@ func TestGetVolumesToDetachFromInstanceWhenControllerKeyIsChanged(t *testing.T) 
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1000,
@@ -1096,7 +1117,7 @@ func TestGetVolumesToDetachFromInstanceWhenControllerKeyIsChanged(t *testing.T) 
 			UnitNumber: 2, SharingMode: "None", DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-2"}, pvcsToDetach)
 }
@@ -1106,6 +1127,9 @@ func TestGetVolumesToDetachFromInstanceWhenUnitNumberIsChanged(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1000,
@@ -1116,7 +1140,7 @@ func TestGetVolumesToDetachFromInstanceWhenUnitNumberIsChanged(t *testing.T) {
 			UnitNumber: 4, SharingMode: "None", DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-2"}, pvcsToDetach)
 }
@@ -1126,6 +1150,9 @@ func TestGetVolumesToDetachFromInstanceWhenSharingIsChanged(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1000,
@@ -1137,7 +1164,7 @@ func TestGetVolumesToDetachFromInstanceWhenSharingIsChanged(t *testing.T) {
 			DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-2"}, pvcsToDetach)
 }
@@ -1147,6 +1174,9 @@ func TestGetVolumesToDetachFromInstanceWhenDiskModeIsChanged(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1000,
@@ -1158,7 +1188,7 @@ func TestGetVolumesToDetachFromInstanceWhenDiskModeIsChanged(t *testing.T) {
 			DiskMode: "independent_persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-2"}, pvcsToDetach)
 }
@@ -1168,6 +1198,9 @@ func TestGetVolumesToDetachFromInstanceWhenUsedByAndPvcFinalizerIsMissing(t *tes
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"no-finalizer-no-usedby-1": {ControllerKey: 1000,
@@ -1179,7 +1212,7 @@ func TestGetVolumesToDetachFromInstanceWhenUsedByAndPvcFinalizerIsMissing(t *tes
 			DiskMode: "independent_persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"no-finalizer-no-usedby-1": "no-finalizer-no-usedby-1"}, pvcsToDetach)
 }
@@ -1189,6 +1222,9 @@ func TestGetVolumesToDetachFromInstanceWhenOnlyPvcFinalizerIsMissing(t *testing.
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"no-finalizer": {ControllerKey: 1000,
@@ -1200,7 +1236,7 @@ func TestGetVolumesToDetachFromInstanceWhenOnlyPvcFinalizerIsMissing(t *testing.
 			DiskMode: "independent_persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"no-finalizer-1": "no-finalizer"}, pvcsToDetach)
 }
@@ -1210,6 +1246,9 @@ func TestGetVolumesToDetachFromInstanceWhenOnlyUsedByIsMissingFinalizerIsPresent
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"12345": {ControllerKey: 1000,
@@ -1221,9 +1260,29 @@ func TestGetVolumesToDetachFromInstanceWhenOnlyUsedByIsMissingFinalizerIsPresent
 			DiskMode: "independent_persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{}, pvcsToDetach)
+}
+
+func TestGetVolumesToDetachFromInstance_VirtualMachineNotFound(t *testing.T) {
+	ctx := context.Background()
+	instance := setupTestCnsNodeVMBatchAttachment()
+
+	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).Build()
+
+	attachedFCDs := map[string]FCDBackingDetails{
+		"with-used-by-annotation-1": {ControllerKey: 1000, UnitNumber: 1,
+			SharingMode: "None", DiskMode: "persistent"},
+	}
+	volumeIdsInSpec := map[string]FCDBackingDetails{}
+
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
+	assert.NoError(t, err)
+	// No VM in API: safety check is skipped; volume not in spec -> PVC is eligible to detach.
+	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-1"}, pvcsToDetach)
 }
 
 func TestGetVolumesToAttach(t *testing.T) {
@@ -2241,5 +2300,119 @@ func TestIsVmInSameNamespace_NotFound(t *testing.T) {
 
 	if found {
 		t.Fatalf("expected VM not to be found, got true")
+	}
+}
+
+func TestValidatePVCDetachSafety(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		vmHasPVC      bool
+		pvcName       string
+		pvcNamespace  string
+		attachedFcdId string
+		instanceName  string
+		instanceNS    string
+		instanceUUID  string
+		expectDetach  bool
+	}{
+		{
+			name:          "VM exists but PVC not referenced - safe to detach",
+			vmHasPVC:      false,
+			pvcName:       "test-pvc",
+			pvcNamespace:  "default",
+			attachedFcdId: "fcd-123",
+			instanceName:  "test-vm",
+			instanceNS:    "default",
+			instanceUUID:  "vm-uuid-123",
+			expectDetach:  true,
+		},
+		{
+			name:          "VM exists and PVC is referenced - should not detach",
+			vmHasPVC:      true,
+			pvcName:       "test-pvc",
+			pvcNamespace:  "default",
+			attachedFcdId: "fcd-123",
+			instanceName:  "test-vm",
+			instanceNS:    "default",
+			instanceUUID:  "vm-uuid-123",
+			expectDetach:  false,
+		},
+		{
+			name:          "VM exists with multiple volumes but target PVC not referenced - safe to detach",
+			vmHasPVC:      false,
+			pvcName:       "target-pvc",
+			pvcNamespace:  "default",
+			attachedFcdId: "fcd-456",
+			instanceName:  "test-vm",
+			instanceNS:    "default",
+			instanceUUID:  "vm-uuid-123",
+			expectDetach:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &v1alpha1.CnsNodeVMBatchAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.instanceName,
+					Namespace: tt.instanceNS,
+				},
+				Spec: v1alpha1.CnsNodeVMBatchAttachmentSpec{
+					InstanceUUID: tt.instanceUUID,
+				},
+			}
+
+			vm := &vmoperatortypes.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.instanceName,
+					Namespace: tt.instanceNS,
+				},
+			}
+
+			if tt.vmHasPVC {
+				vm.Spec.Volumes = []vmoperatortypes.VirtualMachineVolume{
+					{
+						Name: "other-volume",
+						VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "other-pvc",
+								},
+							},
+						},
+					},
+					{
+						Name: "target-volume",
+						VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+									ClaimName: tt.pvcName,
+								},
+							},
+						},
+					},
+				}
+			} else {
+				vm.Spec.Volumes = []vmoperatortypes.VirtualMachineVolume{
+					{
+						Name: "other-volume",
+						VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "different-pvc",
+								},
+							},
+						},
+					},
+				}
+			}
+
+			shouldDetach, err := validatePVCDetachSafety(
+				ctx, vm, instance, tt.pvcName, tt.pvcNamespace, tt.attachedFcdId)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectDetach, shouldDetach, "shouldDetach flag should match expectation")
+		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

During VM import, there is a race condition where there may be a delay from VM operator in adding a volume to batch attach spec.

In the meantime, CSI might incorrectly interpret that as a detach request (since volume is not there in batchattach spec but is attached to the VM on VM inventory).

In order to fix this, before adding a volume to detach list, it is important that CSI also validates that the volume is not being referenced in the VM spec. If it is being referenced, then skip adding that volume to detach list.

If VM object is not found, then fail the reconciliation.

As discussed on private chat, we should ignore safety check if PVC VM object is not found k8s cluster.

**Testing done**:
IN PROGESS:
WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1307/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1050/

1. Successfully attached a PVC to a VM.
2. Sucessfully detached a PVC from a VM.
3. Removed PVC from batchattach spec while it was still there in VM spec. Observed that detach was deined:

```
{"level":"info","time":"2026-04-29T17:09:21.219126053Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:171","msg":"Skipping detach for PVC test/pvc-2 with FCD 2474f3b8-e404-4710-aeb5-575a78f5fa5a from VM Instance UUID 15294371-1935-4a95-96cb-56e2862bf2e2 because it is still referenced in VirtualMachine testvm-1 spec. This indicates the PVC is actively used by the VM.","TraceId":"bff7b482-a75d-4527-afb2-678f14515b25"}
```
