### PR TITLE
Upgrade Go to 1.26.2 on release-3.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/vsphere-csi-driver/v3
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0

--- a/hack/check-golangci-lint.sh
+++ b/hack/check-golangci-lint.sh
@@ -53,8 +53,8 @@ shift $((OPTIND-1))
 
 export GOOS=linux
 if [ ! "${DO_DOCKER-}" ]; then
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v2.7.2
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v2.11.2
   "$(go env GOPATH)"/bin/golangci-lint run -v --timeout=1200s
 else
-  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v2.7.2 golangci-lint run -v --timeout=1200s
+  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v2.11.2 golangci-lint run -v --timeout=1200s
 fi

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -49,7 +49,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=<docker-registry>/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.25.5
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.26.2
 
 ARCH=amd64
 OSVERSION=1809

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.25.5
+ARG GOLANG_IMAGE=golang:1.26.2
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/ci/e2e/Dockerfile
+++ b/images/ci/e2e/Dockerfile
@@ -18,7 +18,7 @@
 # docker tag <image-name:version> <repo>/<image-name:version>
 # docker push <repo>/<image-name:version>
 
-FROM --platform=linux/amd64 golang:1.19
+FROM --platform=linux/amd64 golang:1.26.2
 
 RUN apt-get update && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.25.5
+ARG GOLANG_IMAGE=golang:1.26.2
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.25.5
+ARG GOLANG_IMAGE=golang:1.26.2
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.25.5
+ARG GOLANG_IMAGE=golang:1.26.2
 ARG OSVERSION
 ARG ARCH=amd64
 


### PR DESCRIPTION
Align go.mod and all container build references with Go 1.26.2, including the CI e2e image (previously golang:1.19).

Made-with: Cursor
