### PR TITLE
fix(topology): handle AvailabilityZone spec updates for multi-cluster zones

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -353,7 +353,9 @@ func startAvailabilityZoneInformer(ctx context.Context, cfg *restclient.Config) 
 		AddFunc: func(obj interface{}) {
 			azCRAdded(obj)
 		},
-		UpdateFunc: nil,
+		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+			azCRUpdated(oldObj, newObj)
+		},
 		DeleteFunc: func(obj interface{}) {
 			azCRDeleted(obj)
 		},
@@ -392,7 +394,42 @@ func azCRAdded(obj interface{}) {
 	addToAZClusterMap(ctx, azName, clusterComputeResourceMoIds)
 }
 
-// azCRUpdated handles deleting AZ name in the cache.
+// azCRUpdated syncs the azClusterMap when an AvailabilityZone CR is updated, for example
+// when a new cluster is added to the zone or a cluster is removed from the zone.
+func azCRUpdated(oldObj interface{}, newObj interface{}) {
+	ctx, log := logger.GetNewContextWithLogger()
+	azName, found, err := unstructured.NestedString(newObj.(*unstructured.Unstructured).Object, "metadata", "name")
+	if !found || err != nil {
+		log.Errorf("failed to get `name` from AvailabilityZone instance: %+v, Error: %+v", newObj, err)
+		return
+	}
+	newClusters, nFound, nErr := unstructured.NestedStringSlice(newObj.(*unstructured.Unstructured).Object,
+		"spec", "clusterComputeResourceMoIDs")
+	if len(newClusters) == 0 || !nFound || nErr != nil {
+		log.Errorf("failed to get `clusterComputeResourceMoIds` from AvailabilityZone instance: %+v, "+
+			"Error: %+v", newObj, nErr)
+		return
+	}
+	oldClusters, oFound, oErr := unstructured.NestedStringSlice(oldObj.(*unstructured.Unstructured).Object,
+		"spec", "clusterComputeResourceMoIDs")
+	oldOK := len(oldClusters) > 0 && oFound && oErr == nil
+	if oldOK && slices.Equal(oldClusters, newClusters) {
+		log.Debugf("azCRUpdated: no change in spec.clusterComputeResourceMoIDs for AvailabilityZone %q, ignoring",
+			azName)
+		return
+	}
+	if !oldOK {
+		log.Errorf("failed to get `clusterComputeResourceMoIds` from old AvailabilityZone instance: %+v, "+
+			"Error: %+v. Will still apply new spec to cache", oldObj, oErr)
+		log.Infof("azCRUpdated: refreshing AvailabilityZone %q cluster list in cache to %v", azName, newClusters)
+	} else {
+		log.Infof("azCRUpdated: AvailabilityZone %q cluster list changed from %v to %v, updating topology cache",
+			azName, oldClusters, newClusters)
+	}
+	addToAZClusterMap(ctx, azName, newClusters)
+}
+
+// azCRDeleted handles removing the AZ from the cache.
 func azCRDeleted(obj interface{}) {
 	ctx, log := logger.GetNewContextWithLogger()
 	// Retrieve name of CR instance.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology_wcp_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology_wcp_test.go
@@ -18,11 +18,16 @@ package k8sorchestrator
 
 import (
 	"context"
+	"runtime"
+	"slices"
+	"strings"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
@@ -446,5 +451,250 @@ func TestWCPControllerVolumeTopology_GetSharedDatastoresInTopology(t *testing.T)
 				}
 			}
 		})
+	}
+}
+
+// makeTestAvailabilityZoneUnstructured builds a minimal AvailabilityZone-shaped object for informer handler tests.
+func makeTestAvailabilityZoneUnstructured(t *testing.T, name string, clusterMoIDs []string) *unstructured.Unstructured {
+	t.Helper()
+	u := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	if err := unstructured.SetNestedField(u.Object, name, "metadata", "name"); err != nil {
+		t.Fatalf("SetNestedField metadata.name: %v", err)
+	}
+	err := unstructured.SetNestedStringSlice(
+		u.Object, clusterMoIDs, "spec", "clusterComputeResourceMoIDs")
+	if err != nil {
+		t.Fatalf("SetNestedStringSlice spec.clusterComputeResourceMoIDs: %v", err)
+	}
+	return u
+}
+
+// TestAzCRUpdated_MultipleClustersPerZone tests MCZ: when a new cluster is added to an existing
+// AvailabilityZone (in-place CR update), azClustersMap must include the new cluster so datastore
+// intersection and register-volume topology can see datastores from that cluster.
+func TestAzCRUpdated_MultipleClustersPerZone(t *testing.T) {
+	origPodVM := isPodVMOnStretchedSupervisorEnabled
+	origAz := azClusterMap
+	origAzs := azClustersMap
+	defer func() {
+		isPodVMOnStretchedSupervisorEnabled = origPodVM
+		azClusterMap = origAz
+		azClustersMap = origAzs
+	}()
+
+	isPodVMOnStretchedSupervisorEnabled = true
+	azClusterMap = make(map[string]string)
+	zoneName := "wcp-vpc-compute-cluster-domain"
+	azClustersMap = map[string][]string{
+		zoneName: {"domain-c58"},
+	}
+
+	oldObj := makeTestAvailabilityZoneUnstructured(t, zoneName, []string{"domain-c58"})
+	newObj := makeTestAvailabilityZoneUnstructured(t, zoneName, []string{"domain-c58", "domain-c51"})
+
+	azCRUpdated(oldObj, newObj)
+
+	got := azClustersMap[zoneName]
+	want := []string{"domain-c58", "domain-c51"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("azClustersMap[%q] = %v, want %v", zoneName, got, want)
+	}
+}
+
+// TestAzCRUpdated_SingleClusterModeFirstElement tests non-MCZ path: cache stores the first cluster MOID only;
+// updates must refresh when that first entry changes.
+func TestAzCRUpdated_SingleClusterModeFirstElement(t *testing.T) {
+	origPodVM := isPodVMOnStretchedSupervisorEnabled
+	origAz := azClusterMap
+	origAzs := azClustersMap
+	defer func() {
+		isPodVMOnStretchedSupervisorEnabled = origPodVM
+		azClusterMap = origAz
+		azClustersMap = origAzs
+	}()
+
+	isPodVMOnStretchedSupervisorEnabled = false
+	azClustersMap = make(map[string][]string)
+	zoneName := "zone-a"
+	azClusterMap = map[string]string{zoneName: "domain-old"}
+
+	oldObj := makeTestAvailabilityZoneUnstructured(t, zoneName, []string{"domain-old"})
+	newObj := makeTestAvailabilityZoneUnstructured(t, zoneName, []string{"domain-new", "domain-old"})
+
+	azCRUpdated(oldObj, newObj)
+
+	if got := azClusterMap[zoneName]; got != "domain-new" {
+		t.Fatalf("azClusterMap[%q] = %q, want domain-new (first spec.clusterComputeResourceMoID)", zoneName, got)
+	}
+}
+
+// TestAzCRUpdated_NoChangeSkipsCacheWrite verifies identical old/new spec does not require a spec change
+// (equivalent cluster lists are a no-op for the update path).
+func TestAzCRUpdated_NoChangeSkipsCacheWrite(t *testing.T) {
+	origPodVM := isPodVMOnStretchedSupervisorEnabled
+	origAz := azClusterMap
+	origAzs := azClustersMap
+	defer func() {
+		isPodVMOnStretchedSupervisorEnabled = origPodVM
+		azClusterMap = origAz
+		azClustersMap = origAzs
+	}()
+
+	isPodVMOnStretchedSupervisorEnabled = true
+	azClusterMap = make(map[string]string)
+	zoneName := "zone-unchanged"
+	origSlice := []string{"domain-c1", "domain-c2"}
+	azClustersMap = map[string][]string{zoneName: origSlice}
+
+	u := makeTestAvailabilityZoneUnstructured(t, zoneName, origSlice)
+	azCRUpdated(u, u)
+
+	if got := azClustersMap[zoneName]; !slices.Equal(got, origSlice) {
+		t.Fatalf("azClustersMap[%q] = %v, want unchanged %v", zoneName, got, origSlice)
+	}
+}
+
+// TestGetTopologyInfoFromNodes_CnsRegisterVolumeSucceedsWhenClusterAddedToZone covers MCZ: a static volume on a
+// datastore that exists only after a new vSphere cluster is added to the zone cannot be resolved until
+// azCRUpdated applies the in-place AvailabilityZone spec change; then GetTopologyInfoFromNodes returns the zone.
+func TestGetTopologyInfoFromNodes_CnsRegisterVolumeSucceedsWhenClusterAddedToZone(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Skipping test on ARM64 due to gomonkey function patching limitations")
+	}
+	ctx := context.Background()
+	origPodVM := isPodVMOnStretchedSupervisorEnabled
+	origAz := azClusterMap
+	origAzs := azClustersMap
+	defer func() {
+		isPodVMOnStretchedSupervisorEnabled = origPodVM
+		azClusterMap = origAz
+		azClustersMap = origAzs
+	}()
+
+	zoneName := "wcp-vpc-compute-cluster-zone"
+	// Datastore only visible once domain-c51 is in the zone's cluster list (e.g. volume on new cluster's vSAN).
+	newClusterOnlyDatastoreURL := "ds:///vmfs/volumes/vsan-new-c51-only/"
+
+	patches := gomonkey.ApplyFunc(getSharedDatastoresInClusters, func(
+		_ context.Context, clusterMorefs []string, _ *cnsvsphere.VirtualCenter,
+	) ([]*cnsvsphere.DatastoreInfo, error) {
+		existingURL := "ds:///vmfs/volumes/vsan-c58-shared/"
+		out := []*cnsvsphere.DatastoreInfo{createDatastoreInfo("ds-c58", existingURL)}
+		for _, m := range clusterMorefs {
+			if m == "domain-c51" {
+				out = append(out, createDatastoreInfo("ds-c51", newClusterOnlyDatastoreURL))
+				break
+			}
+		}
+		return out, nil
+	})
+	defer patches.Reset()
+
+	isPodVMOnStretchedSupervisorEnabled = true
+	azClusterMap = make(map[string]string)
+	// Stale cache: only the original cluster (second cluster not yet applied by informer).
+	azClustersMap = map[string][]string{zoneName: {"domain-c58"}}
+
+	wcpTopo := &wcpControllerVolumeTopology{}
+	params := commoncotypes.WCPRetrieveTopologyInfoParams{
+		DatastoreURL:           newClusterOnlyDatastoreURL,
+		StorageTopologyType:    "zonal",
+		TopologyRequirement:    nil,
+		Vc:                     nil,
+		TopoSegToDatastoresMap: nil,
+	}
+
+	_, err := wcpTopo.GetTopologyInfoFromNodes(ctx, params)
+	if err == nil {
+		t.Fatal("GetTopologyInfoFromNodes with stale cache: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "could not find the topology of the volume provisioned on datastore") {
+		t.Fatalf("expected topology-not-found with stale cache, got: %v", err)
+	}
+
+	oldCR := makeTestAvailabilityZoneUnstructured(t, zoneName, []string{"domain-c58"})
+	newCR := makeTestAvailabilityZoneUnstructured(t, zoneName, []string{"domain-c58", "domain-c51"})
+	azCRUpdated(oldCR, newCR)
+
+	segments, err := wcpTopo.GetTopologyInfoFromNodes(ctx, params)
+	if err != nil {
+		t.Fatalf("GetTopologyInfoFromNodes after cluster add: unexpected error: %v", err)
+	}
+	if len(segments) != 1 {
+		t.Fatalf("len(segments) = %d, want 1: %+v", len(segments), segments)
+	}
+	if got := segments[0][v1.LabelTopologyZone]; got != zoneName {
+		t.Fatalf("zone = %q, want %q", got, zoneName)
+	}
+}
+
+// TestGetTopologyInfoFromNodes_CnsRegisterVolumeFailsWhenClusterRemovedFromZone mirrors the CnsRegisterVolume
+// control path: GetTopologyInfoFromNodes with zonal + nil topology requirement, using azClustersMap. When
+// a vSphere cluster is removed from the AvailabilityZone (cache updated by azCRUpdated) but the volume
+// still sits on a datastore that was only part of the removed cluster, registration must not succeed with
+// a made-up zone—the same "could not find the topology" error the controller returns.
+func TestGetTopologyInfoFromNodes_CnsRegisterVolumeFailsWhenClusterRemovedFromZone(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Skipping test on ARM64 due to gomonkey function patching limitations")
+	}
+	ctx := context.Background()
+	origPodVM := isPodVMOnStretchedSupervisorEnabled
+	origAz := azClusterMap
+	origAzs := azClustersMap
+	defer func() {
+		isPodVMOnStretchedSupervisorEnabled = origPodVM
+		azClusterMap = origAz
+		azClustersMap = origAzs
+	}()
+
+	zoneName := "wcp-vpc-compute-cluster-zone"
+	// URL only present when the removed vSphere cluster is still in the zone's cluster list.
+	removedClusterOnlyDatastoreURL := "ds:///vmfs/volumes/vsan-removed-c51-only/"
+
+	patches := gomonkey.ApplyFunc(getSharedDatastoresInClusters, func(
+		_ context.Context, clusterMorefs []string, _ *cnsvsphere.VirtualCenter,
+	) ([]*cnsvsphere.DatastoreInfo, error) {
+		remainingURL := "ds:///vmfs/volumes/vsan-c58-shared/"
+		out := []*cnsvsphere.DatastoreInfo{createDatastoreInfo("ds-remaining", remainingURL)}
+		for _, m := range clusterMorefs {
+			if m == "domain-c51" {
+				out = append(out, createDatastoreInfo("ds-on-removed", removedClusterOnlyDatastoreURL))
+				break
+			}
+		}
+		return out, nil
+	})
+	defer patches.Reset()
+
+	isPodVMOnStretchedSupervisorEnabled = true
+	azClusterMap = make(map[string]string)
+	azClustersMap = map[string][]string{zoneName: {"domain-c58", "domain-c51"}}
+
+	wcpTopo := &wcpControllerVolumeTopology{}
+	params := commoncotypes.WCPRetrieveTopologyInfoParams{
+		DatastoreURL:           removedClusterOnlyDatastoreURL,
+		StorageTopologyType:    "zonal",
+		TopologyRequirement:    nil,
+		Vc:                     nil,
+		TopoSegToDatastoresMap: nil,
+	}
+
+	_, err := wcpTopo.GetTopologyInfoFromNodes(ctx, params)
+	if err != nil {
+		t.Fatalf("GetTopologyInfoFromNodes (both clusters in zone) unexpected error: %v", err)
+	}
+
+	// In-place CR update: domain-c51 removed from spec.clusterComputeResourceMoIDs; cache matches production.
+	oldCR := makeTestAvailabilityZoneUnstructured(t, zoneName, []string{"domain-c58", "domain-c51"})
+	newCR := makeTestAvailabilityZoneUnstructured(t, zoneName, []string{"domain-c58"})
+	azCRUpdated(oldCR, newCR)
+
+	_, err = wcpTopo.GetTopologyInfoFromNodes(ctx, params)
+	if err == nil {
+		t.Fatalf("GetTopologyInfoFromNodes after cluster removal: want error " +
+			"(CnsRegisterVolume would succeed incorrectly), got nil")
+	}
+	if !strings.Contains(err.Error(), "could not find the topology of the volume provisioned on datastore") {
+		t.Fatalf("expected static-provision / CnsRegisterVolume style topology error, got: %v", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add UpdateFunc on the AvailabilityZone informer so in-place changes to `spec.clusterComputeResourceMoIDs` (add or remove a vSphere cluster) update azClustersMap.

CnsRegisterVolume calls GetTopologyInfoFromNodes from the datastore URL to set PV affinity; that path depends on the zone→cluster map. A stale map after a new cluster was added to a zone (MCZ) caused static registration to fail with "could not find the topology of the volume provisioned on datastore" until CSI restarted. UPDATE handling on AvailabilityZone keeps the map in sync.

Add unit tests for azCRUpdated and GetTopologyInfoFromNodes.

**Testing done**:

1. Create legacy VM on the cluster scope datastore on the vSphere Cluster not added to zone yet.
2. Added vSphere cluster to zone
3. added cluster to zone. 

Verified logs, informer cache is updated when new cluster is added to zone

```
{"level":"info","time":"2026-04-24T18:58:18.467207116Z","caller":"k8sorchestrator/topology.go:426","msg":"azCRUpdated: AvailabilityZone \"zone3\" cluster list changed from [domain-c223] to [domain-c223 domain-c225], updating topology cache","TraceId":"91612ccf-a726-4675-ac7b-0072f45ffe15"}
{"level":"info","time":"2026-04-24T18:58:18.467441302Z","caller":"k8sorchestrator/topology.go:452","msg":"Added clusters [domain-c223 domain-c225] to \"zone3\" zone in azClustersMap","TraceId":"91612ccf-a726-4675-ac7b-0072f45ffe15"}
```

4. created new namespace and confirmed newly added cluster is selected as active cluster for namespace.

```
]# kubectl get zone -n testnewns -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.namespace.clusterMoIDs}{"\n"}{end}'
zone3	["domain-c225"]

```

5. Imported vm and verified volume registration is happening.

```
root@422fef82ccc05d83e1d3e69bc4ba394c [ ~ ]# kubectl get pvc -n testnewns
NAME                      STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
test-import-vm-beb5b7d5   Bound    static-pv-ce863ede-cbf8-4346-8920-f9241210f75a   16Gi       RWO            esa2-policy    <unset>                 117s
root@422fef82ccc05d83e1d3e69bc4ba394c [ ~ ]# kubectl get vm -n testnewns
NAME             POWER-STATE   AGE
test-import-vm   PoweredOn    2m14s
```



**Special notes for your reviewer**:

Pre-checkin
- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1308/
- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1052/

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
handle AvailabilityZone spec updates for multi-cluster zones
```
