### PR TITLE
Upgrade Go to 1.25.9 to fix CVE-2026-32280 (release-3.7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/vsphere-csi-driver/v3
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -49,7 +49,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=<docker-registry>/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.25.7
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.25.9
 
 ARCH=amd64
 OSVERSION=1809

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.25.7
+ARG GOLANG_IMAGE=golang:1.25.9
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.25.7
+ARG GOLANG_IMAGE=golang:1.25.9
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.25.7
+ARG GOLANG_IMAGE=golang:1.25.9
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.25.7
+ARG GOLANG_IMAGE=golang:1.25.9
 ARG OSVERSION
 ARG ARCH=amd64
 


### PR DESCRIPTION
Ports the intent of upstream PR #3974 to the release-3.7 branch. The upstream change bumped Go to 1.26.2 on master; release-3.7 stays on the 1.25.x line, where the same fix landed in Go 1.25.9.

CVE-2026-32280 is a high severity (CVSS 7.5) denial of service vulnerability in Go's crypto/x509 package: during chain building, the amount of work done is not correctly limited when a large number of intermediate certificates are passed in VerifyOptions.Intermediates, which can lead to excessive CPU consumption. This affects both direct users of crypto/x509 and users of crypto/tls.

Files updated:
- go.mod: go directive 1.25.0 -> 1.25.9
- images/driver/Dockerfile: golang 1.25.7 -> 1.25.9
- images/syncer/Dockerfile: golang 1.25.7 -> 1.25.9
- images/windows/driver/Dockerfile: golang 1.25.7 -> 1.25.9
- images/ci/Dockerfile: golang 1.25.7 -> 1.25.9
- hack/release.sh: golang 1.25.7 -> 1.25.9

Reference: https://nvd.nist.gov/vuln/detail/CVE-2026-32280
Upstream PR: kubernetes-sigs/vsphere-csi-driver#3974

Made-with: Cursor

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
