### PR TITLE
Connect to VC through Volume Manager

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -28,9 +28,11 @@ import (
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	vim25types "github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vslm"
+	"google.golang.org/grpc/codes"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,6 +168,14 @@ type Manager interface {
 	SyncVolume(ctx context.Context, syncVolumeSpecs []cnstypes.CnsSyncVolumeSpec) (string, error)
 	// ReRegisterVolume re-registers a volume to CNS when CnsNotRegisteredFault is encountered
 	ReRegisterVolume(ctx context.Context, volumeID string) error
+	// QueryFCDAllocatedBlocks returns allocated block ranges using FCD VSLM QueryChangedDiskAreas (changeId "*").
+	QueryFCDAllocatedBlocks(ctx context.Context, volumeID, snapshotID string, startingOffset uint64,
+		maxResults uint32) ([]AllocatedArea, uint64, error)
+	// QueryFCDChangedBlocks returns changed block ranges using FCD VSLM QueryChangedDiskAreas with baseChangeID.
+	QueryFCDChangedBlocks(ctx context.Context, volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64,
+		maxResults uint32) ([]ChangedArea, uint64, error)
+	// GetFCDSnapshotChangeID returns the CBT change ID from an FCD snapshot (VSLM RetrieveSnapshotDetails).
+	GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error)
 }
 
 // CnsVolumeInfo hold information related to volume created by CNS.
@@ -4211,4 +4221,294 @@ func (m *defaultManager) unregisterVolume(ctx context.Context, volumeID string, 
 
 	log.Infof("volume %q unregistered successfully", volumeID)
 	return "", nil
+}
+
+// vslmNewClientFunc creates a VSLM client (overridable in unit tests).
+var vslmNewClientFunc = vslm.NewClient
+
+// AllocatedArea is a byte range reported as allocated on an FCD snapshot.
+type AllocatedArea struct {
+	Offset uint64
+	Length uint64
+}
+
+// ChangedArea is a byte range reported as changed between FCD snapshots.
+type ChangedArea struct {
+	Offset uint64
+	Length uint64
+}
+
+func runQueryChangedDiskAreasViaVslm(
+	ctx context.Context,
+	vim25Client *vim25.Client,
+	volumeID, snapshotID vim25types.ID,
+	startingOffset int64,
+	changeID string,
+) (*vim25types.DiskChangeInfo, error) {
+	if vim25Client == nil {
+		return nil, fmt.Errorf("vim25 client is nil")
+	}
+	vslmClient, err := vslmNewClientFunc(ctx, vim25Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VSLM client: %v", err)
+	}
+	globalObjectManager := vslm.NewGlobalObjectManager(vslmClient)
+	return globalObjectManager.QueryChangedDiskAreas(ctx, volumeID, snapshotID, startingOffset, changeID)
+}
+
+// defaultQueryChangedDiskAreasHook is the production VSLM path; tests may replace QueryChangedDiskAreasHook.
+func defaultQueryChangedDiskAreasHook(
+	ctx context.Context,
+	vcenter *cnsvsphere.VirtualCenter,
+	volumeID, snapshotID vim25types.ID,
+	startingOffset int64,
+	changeID string,
+) (*vim25types.DiskChangeInfo, error) {
+	if vcenter == nil || vcenter.Client == nil {
+		return nil, fmt.Errorf("vCenter is not connected")
+	}
+	return runQueryChangedDiskAreasViaVslm(ctx, vcenter.Client.Client, volumeID, snapshotID, startingOffset, changeID)
+}
+
+// QueryChangedDiskAreasHook calls VSLM QueryChangedDiskAreas; unit tests may replace it.
+var QueryChangedDiskAreasHook = defaultQueryChangedDiskAreasHook
+
+func runRetrieveSnapshotDetailsViaVslm(ctx context.Context, vim25Client *vim25.Client,
+	volumeID vim25types.ID, snapshotID vim25types.ID) (*vim25types.VStorageObjectSnapshotDetails, error) {
+	if vim25Client == nil {
+		return nil, fmt.Errorf("vim25 client is nil")
+	}
+	vslmClient, err := vslmNewClientFunc(ctx, vim25Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VSLM client: %v", err)
+	}
+	globalObjectManager := vslm.NewGlobalObjectManager(vslmClient)
+	return globalObjectManager.RetrieveSnapshotDetails(ctx, volumeID, snapshotID)
+}
+
+// defaultRetrieveSnapshotDetailsHook is the production VSLM path; tests may replace RetrieveSnapshotDetailsHook.
+func defaultRetrieveSnapshotDetailsHook(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+	volumeID vim25types.ID, snapshotID vim25types.ID) (*vim25types.VStorageObjectSnapshotDetails, error) {
+	if vcenter == nil || vcenter.Client == nil {
+		return nil, fmt.Errorf("vCenter is not connected")
+	}
+	return runRetrieveSnapshotDetailsViaVslm(ctx, vcenter.Client.Client, volumeID, snapshotID)
+}
+
+// RetrieveSnapshotDetailsHook calls VSLM RetrieveSnapshotDetails; unit tests may replace it.
+var RetrieveSnapshotDetailsHook = defaultRetrieveSnapshotDetailsHook
+
+// ConnectVslmHook sets up the VSLM client on the vCenter before any VSLM call.
+// Defined as a hook so unit tests can replace it without needing a live vCenter.
+var ConnectVslmHook = func(ctx context.Context, vc *cnsvsphere.VirtualCenter) error {
+	return vc.ConnectVslm(ctx)
+}
+
+func (m *defaultManager) connectVirtualCenter(ctx context.Context) (*cnsvsphere.VirtualCenter, error) {
+	log := logger.GetLogger(ctx)
+	err := validateManager(ctx, m)
+	if err != nil {
+		log.Errorf("failed to validate volume manager with err: %+v", err)
+		return nil, err
+	}
+	if err = ConnectVslmHook(ctx, m.virtualCenter); err != nil {
+		log.Errorf("ConnectVslm failed with err: %+v", err)
+		return nil, err
+	}
+	return m.virtualCenter, nil
+}
+
+// GetFCDSnapshotChangeID returns ChangedBlockTrackingId from FCD snapshot details (VSLM).
+func (m *defaultManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("GetFCDSnapshotChangeID: volume=%s snapshot=%s", volumeID, snapshotID)
+
+	vcenter, err := m.connectVirtualCenter(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get vCenter from volume manager: %v", err)
+	}
+
+	snapshotDetails, err := RetrieveSnapshotDetailsHook(ctx, vcenter,
+		vim25types.ID{Id: volumeID}, vim25types.ID{Id: snapshotID})
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve snapshot details via VSLM API: %v", err)
+	}
+
+	changeID := snapshotDetails.ChangedBlockTrackingId
+	if changeID == "" {
+		return "", fmt.Errorf("changeId is empty in snapshot %s (CBT may not be enabled)", snapshotID)
+	}
+
+	log.Debugf("Retrieved changeId %s for snapshot %s", changeID, snapshotID)
+	return changeID, nil
+}
+
+// QueryFCDAllocatedBlocks returns allocated block ranges using FCD VSLM QueryChangedDiskAreas with changeId "*".
+func (m *defaultManager) QueryFCDAllocatedBlocks(ctx context.Context, volumeID, snapshotID string,
+	startingOffset uint64, maxResults uint32) ([]AllocatedArea, uint64, error) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("QueryFCDAllocatedBlocks: volume=%s snapshot=%s offset=%d maxResults=%d",
+		volumeID, snapshotID, startingOffset, maxResults)
+
+	vcenter, err := m.connectVirtualCenter(ctx)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get vCenter from volume manager: %v", err)
+	}
+
+	vslmVolumeID := vim25types.ID{Id: volumeID}
+	vslmSnapshotID := vim25types.ID{Id: snapshotID}
+	const allocatedChangeID = "*"
+
+	log.Debugf("Calling QueryChangedDiskAreasHook with changeId='*' for all allocated blocks")
+	diskChangeInfo, err := QueryChangedDiskAreasHook(
+		ctx, vcenter, vslmVolumeID, vslmSnapshotID, int64(startingOffset), allocatedChangeID)
+	if err != nil {
+		return nil, 0, TranslateVslmError(ctx, err)
+	}
+
+	var allocatedAreas []AllocatedArea
+	nextOffset := startingOffset
+	for _, area := range diskChangeInfo.ChangedArea {
+		if uint32(len(allocatedAreas)) >= maxResults {
+			break
+		}
+		allocatedAreas = append(allocatedAreas, AllocatedArea{
+			Offset: uint64(area.Start),
+			Length: uint64(area.Length),
+		})
+		areaEnd := uint64(area.Start) + uint64(area.Length)
+		if areaEnd > nextOffset {
+			nextOffset = areaEnd
+		}
+	}
+	if uint32(len(allocatedAreas)) < maxResults {
+		nextOffset = 0
+	}
+	log.Debugf("QueryFCDAllocatedBlocks: returned %d allocated areas, next offset %d",
+		len(allocatedAreas), nextOffset)
+	return allocatedAreas, nextOffset, nil
+}
+
+// QueryFCDChangedBlocks returns changed block ranges using FCD VSLM QueryChangedDiskAreas with baseChangeID.
+func (m *defaultManager) QueryFCDChangedBlocks(ctx context.Context, volumeID, targetSnapshotID, baseChangeID string,
+	startingOffset uint64, maxResults uint32) ([]ChangedArea, uint64, error) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("QueryFCDChangedBlocks: volume=%s target=%s offset=%d maxResults=%d",
+		volumeID, targetSnapshotID, startingOffset, maxResults)
+
+	vcenter, err := m.connectVirtualCenter(ctx)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get vCenter from volume manager: %v", err)
+	}
+
+	vslmVolumeID := vim25types.ID{Id: volumeID}
+	vslmTargetSnapshotID := vim25types.ID{Id: targetSnapshotID}
+
+	log.Debugf("Calling QueryChangedDiskAreasHook with base changeId for delta")
+	diskChangeInfo, err := QueryChangedDiskAreasHook(
+		ctx, vcenter, vslmVolumeID, vslmTargetSnapshotID, int64(startingOffset), baseChangeID)
+	if err != nil {
+		return nil, 0, TranslateVslmError(ctx, err)
+	}
+
+	var changedAreas []ChangedArea
+	nextOffset := startingOffset
+	for _, area := range diskChangeInfo.ChangedArea {
+		if uint32(len(changedAreas)) >= maxResults {
+			break
+		}
+		changedAreas = append(changedAreas, ChangedArea{
+			Offset: uint64(area.Start),
+			Length: uint64(area.Length),
+		})
+		areaEnd := uint64(area.Start) + uint64(area.Length)
+		if areaEnd > nextOffset {
+			nextOffset = areaEnd
+		}
+	}
+	if uint32(len(changedAreas)) < maxResults {
+		nextOffset = 0
+	}
+	log.Debugf("QueryFCDChangedBlocks: returned %d changed areas, next offset %d",
+		len(changedAreas), nextOffset)
+	return changedAreas, nextOffset, nil
+}
+
+// TranslateVslmError maps VSLM and VADP error codes to standard CSI gRPC error codes.
+func TranslateVslmError(ctx context.Context, err error) error {
+	log := logger.GetLogger(ctx)
+	if err == nil {
+		return nil
+	}
+
+	errMsg := err.Error()
+
+	if soap.IsSoapFault(err) {
+		fault := soap.ToSoapFault(err).VimFault()
+
+		switch f := fault.(type) {
+		case *vim25types.FileFault:
+			msgID := ""
+			if len(f.FaultMessage) > 0 {
+				msgID = f.FaultMessage[0].Key
+			} else {
+				if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.noTrack") {
+					msgID = "vim.hostd.vmsvc.cbt.noTrack"
+				} else if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.noEpoch") {
+					msgID = "vim.hostd.vmsvc.cbt.noEpoch"
+				} else if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.cannotGetChanges") {
+					msgID = "vim.hostd.vmsvc.cbt.cannotGetChanges"
+				}
+			}
+
+			switch msgID {
+			case "vim.hostd.vmsvc.cbt.noTrack":
+				return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+					"CBT disabled or not enabled. The caller should perform a full backup instead: %v", err)
+			case "vim.hostd.vmsvc.cbt.noEpoch":
+				return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+					"Cannot get current epoch when changeId=*. The caller should perform a full backup instead: %v", err)
+			case "vim.hostd.vmsvc.cbt.cannotGetChanges":
+				if strings.Contains(strings.ToLower(errMsg), "corrupt") {
+					return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+						"ctk file corrupted. The caller should perform a full backup instead: %v", err)
+				}
+				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+					"changeID mismatch. The caller should correct the error and resubmit the call: %v", err)
+			default:
+				return logger.LogNewErrorCodef(log, codes.Internal,
+					"Internal errors such ctk disk open fails, FCD disk locked, disk missing, etc. "+
+						"CSI driver should retry the operation: %v", err)
+			}
+		case *vim25types.SystemError:
+			return logger.LogNewErrorCodef(log, codes.Internal,
+				"Internal system error. CSI driver should retry the operation: %v", err)
+		case *vim25types.InvalidArgument:
+			if f.InvalidProperty == "startOffset" || strings.Contains(errMsg, "startOffset") {
+				return logger.LogNewErrorCodef(log, codes.OutOfRange,
+					"start offset specified beyond volume size. The caller should specify a valid offset: %v", err)
+			}
+			if f.InvalidProperty == "snapshotId" || strings.Contains(errMsg, "snapshotId") {
+				return logger.LogNewErrorCodef(log, codes.NotFound,
+					"snapshot ID not found for FCD. The caller should re-check that these objects exist: %v", err)
+			}
+			if f.InvalidProperty == "changeId" || strings.Contains(errMsg, "changeId") {
+				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+					"invalid format for changeID. The caller should correct the error and resubmit the call: %v", err)
+			}
+			if f.InvalidProperty == "deviceKey" || strings.Contains(errMsg, "deviceKey") {
+				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+					"Device key doesn't exist, Disk has no backing, or Disk backing "+
+						"type doesn't support CBT. The caller should correct the "+
+						"error and resubmit the call: %v", err)
+			}
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"invalid argument %s: %v", f.InvalidProperty, err)
+		case *vim25types.NotFound:
+			return logger.LogNewErrorCodef(log, codes.NotFound,
+				"FCD not found in VC inventory. The caller should re-check that these objects exist: %v", err)
+		}
+	}
+
+	return logger.LogNewErrorCodef(log, codes.Internal, "failed with error: %v", err)
 }

--- a/pkg/common/cns-lib/volume/manager_mock.go
+++ b/pkg/common/cns-lib/volume/manager_mock.go
@@ -217,3 +217,21 @@ func (m MockManager) ReRegisterVolume(ctx context.Context, volumeID string) erro
 
 	return nil
 }
+
+func (m MockManager) QueryFCDAllocatedBlocks(ctx context.Context,
+	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]AllocatedArea, uint64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m MockManager) QueryFCDChangedBlocks(ctx context.Context,
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
+	[]ChangedArea, uint64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m MockManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/pkg/common/cns-lib/volume/manager_test.go
+++ b/pkg/common/cns-lib/volume/manager_test.go
@@ -2,17 +2,33 @@ package volume
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
 	vim25types "github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
 const createVolumeTaskTimeout = 3 * time.Second
+
+// TestMain stubs out ConnectVslmHook so unit tests can use an empty
+// cnsvsphere.VirtualCenter without trying to dial a real vCenter.
+func TestMain(m *testing.M) {
+	ConnectVslmHook = func(ctx context.Context, vc *cnsvsphere.VirtualCenter) error { return nil }
+	os.Exit(m.Run())
+}
 
 func TestWaitForResultOrTimeoutFail(t *testing.T) {
 	// slow task times out and fails
@@ -529,4 +545,462 @@ func TestReRegistrationIdempotency(t *testing.T) {
 				"Test: %s - %s", tt.name, tt.description)
 		})
 	}
+}
+
+func createFCDSoapFault(fault vim25types.AnyType, msg string) error {
+	f := &soap.Fault{String: msg}
+	f.Detail.Fault = fault
+	return soap.WrapSoapFault(f)
+}
+
+func TestTranslateVslmError(t *testing.T) {
+	ctx := context.Background()
+	ctx = logger.NewContextWithLogger(ctx)
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode codes.Code
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			wantCode: codes.OK,
+		},
+		{
+			name: "SOAP FileFault with noTrack",
+			err: createFCDSoapFault(&vim25types.FileFault{
+				VimFault: vim25types.VimFault{
+					MethodFault: vim25types.MethodFault{
+						FaultMessage: []vim25types.LocalizableMessage{
+							{Key: "vim.hostd.vmsvc.cbt.noTrack"},
+						},
+					},
+				},
+			}, ""),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name: "SOAP FileFault with noEpoch",
+			err: createFCDSoapFault(&vim25types.FileFault{
+				VimFault: vim25types.VimFault{
+					MethodFault: vim25types.MethodFault{
+						FaultMessage: []vim25types.LocalizableMessage{
+							{Key: "vim.hostd.vmsvc.cbt.noEpoch"},
+						},
+					},
+				},
+			}, ""),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name: "SOAP FileFault with corrupt cannotGetChanges",
+			err: createFCDSoapFault(&vim25types.FileFault{
+				VimFault: vim25types.VimFault{
+					MethodFault: vim25types.MethodFault{
+						FaultMessage: []vim25types.LocalizableMessage{
+							{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges", Message: "file is corrupted"},
+						},
+					},
+				},
+			}, "file is corrupted"),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name: "SOAP FileFault with mismatched cannotGetChanges",
+			err: createFCDSoapFault(&vim25types.FileFault{
+				VimFault: vim25types.VimFault{
+					MethodFault: vim25types.MethodFault{
+						FaultMessage: []vim25types.LocalizableMessage{
+							{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges"},
+						},
+					},
+				},
+			}, ""),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:     "SOAP FileFault generic",
+			err:      createFCDSoapFault(&vim25types.FileFault{}, ""),
+			wantCode: codes.Internal,
+		},
+		{
+			name:     "SOAP SystemError",
+			err:      createFCDSoapFault(&vim25types.SystemError{}, ""),
+			wantCode: codes.Internal,
+		},
+		{
+			name: "SOAP InvalidArgument startOffset",
+			err: createFCDSoapFault(&vim25types.InvalidArgument{
+				InvalidProperty: "startOffset",
+			}, ""),
+			wantCode: codes.OutOfRange,
+		},
+		{
+			name: "SOAP InvalidArgument snapshotId",
+			err: createFCDSoapFault(&vim25types.InvalidArgument{
+				InvalidProperty: "snapshotId",
+			}, ""),
+			wantCode: codes.NotFound,
+		},
+		{
+			name: "SOAP InvalidArgument changeId",
+			err: createFCDSoapFault(&vim25types.InvalidArgument{
+				InvalidProperty: "changeId",
+			}, ""),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "SOAP InvalidArgument deviceKey",
+			err: createFCDSoapFault(&vim25types.InvalidArgument{
+				InvalidProperty: "deviceKey",
+			}, ""),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:     "SOAP NotFound",
+			err:      createFCDSoapFault(&vim25types.NotFound{}, ""),
+			wantCode: codes.NotFound,
+		},
+		{
+			name:     "plain error with CBT message substring",
+			err:      fmt.Errorf("some inner error: vim.hostd.vmsvc.cbt.noTrack"),
+			wantCode: codes.Internal,
+		},
+		{
+			name:     "plain error with vim.fault substring",
+			err:      fmt.Errorf("some inner error: vim.fault.NotFound occurred"),
+			wantCode: codes.Internal,
+		},
+		{
+			name:     "plain error generic",
+			err:      fmt.Errorf("random network timeout"),
+			wantCode: codes.Internal,
+		},
+		{
+			name: "SOAP FileFault noTrack via error message substring",
+			err: createFCDSoapFault(&vim25types.FileFault{
+				VimFault: vim25types.VimFault{MethodFault: vim25types.MethodFault{}},
+			}, "vim.hostd.vmsvc.cbt.noTrack"),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name: "SOAP FileFault noEpoch via error message substring",
+			err: createFCDSoapFault(&vim25types.FileFault{
+				VimFault: vim25types.VimFault{MethodFault: vim25types.MethodFault{}},
+			}, "vim.hostd.vmsvc.cbt.noEpoch"),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name: "SOAP FileFault cannotGetChanges via error message substring",
+			err: createFCDSoapFault(&vim25types.FileFault{
+				VimFault: vim25types.VimFault{MethodFault: vim25types.MethodFault{}},
+			}, "vim.hostd.vmsvc.cbt.cannotGetChanges"),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "SOAP InvalidArgument unknown property",
+			err: createFCDSoapFault(&vim25types.InvalidArgument{
+				InvalidProperty: "otherProperty",
+			}, ""),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:     "SOAP fault type not specially handled",
+			err:      createFCDSoapFault(&vim25types.AlreadyExists{}, "exists"),
+			wantCode: codes.Internal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := TranslateVslmError(ctx, tt.err)
+
+			if tt.err == nil {
+				if err != nil {
+					t.Errorf("Expected nil error, got: %v", err)
+				}
+				return
+			}
+
+			if status.Code(err) != tt.wantCode {
+				t.Errorf("TranslateVslmError() returned code %v, want %v. Error: %v", status.Code(err), tt.wantCode, err)
+			}
+		})
+	}
+}
+
+func TestConnectVirtualCenter(t *testing.T) {
+	ctx := context.Background()
+	ctx = logger.NewContextWithLogger(ctx)
+
+	mNil := &defaultManager{virtualCenter: nil}
+	_, err := mNil.connectVirtualCenter(ctx)
+	assert.Error(t, err)
+
+	mOK := &defaultManager{virtualCenter: &cnsvsphere.VirtualCenter{}}
+	vc, err := mOK.connectVirtualCenter(ctx)
+	assert.NoError(t, err)
+	assert.Same(t, mOK.virtualCenter, vc)
+}
+
+func TestGetFCDSnapshotChangeID(t *testing.T) {
+	ctx := context.Background()
+	ctx = logger.NewContextWithLogger(ctx)
+
+	orig := RetrieveSnapshotDetailsHook
+	defer func() { RetrieveSnapshotDetailsHook = orig }()
+
+	m := &defaultManager{virtualCenter: &cnsvsphere.VirtualCenter{}}
+
+	RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID vim25types.ID, snapshotID vim25types.ID) (*vim25types.VStorageObjectSnapshotDetails, error) {
+		assert.Equal(t, "vol-1", volumeID.Id)
+		assert.Equal(t, "snap-1", snapshotID.Id)
+		return &vim25types.VStorageObjectSnapshotDetails{ChangedBlockTrackingId: "cid-99"}, nil
+	}
+	id, err := m.GetFCDSnapshotChangeID(ctx, "vol-1", "snap-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "cid-99", id)
+
+	RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID vim25types.ID, snapshotID vim25types.ID) (*vim25types.VStorageObjectSnapshotDetails, error) {
+		return nil, fmt.Errorf("vslm failed")
+	}
+	_, err = m.GetFCDSnapshotChangeID(ctx, "v", "s")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve snapshot details")
+
+	RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID vim25types.ID, snapshotID vim25types.ID) (*vim25types.VStorageObjectSnapshotDetails, error) {
+		return &vim25types.VStorageObjectSnapshotDetails{ChangedBlockTrackingId: ""}, nil
+	}
+	_, err = m.GetFCDSnapshotChangeID(ctx, "v", "snap-empty")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "changeId is empty")
+
+	mBad := &defaultManager{virtualCenter: nil}
+	_, err = mBad.GetFCDSnapshotChangeID(ctx, "v", "s")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get vCenter from volume manager")
+}
+
+func TestQueryFCDAllocatedBlocks(t *testing.T) {
+	ctx := context.Background()
+	ctx = logger.NewContextWithLogger(ctx)
+
+	orig := QueryChangedDiskAreasHook
+	defer func() { QueryChangedDiskAreasHook = orig }()
+
+	m := &defaultManager{virtualCenter: &cnsvsphere.VirtualCenter{}}
+
+	QueryChangedDiskAreasHook = func(
+		ctx context.Context,
+		vcenter *cnsvsphere.VirtualCenter,
+		volumeID, snapshotID vim25types.ID,
+		startingOffset int64,
+		changeID string,
+	) (*vim25types.DiskChangeInfo, error) {
+		assert.Equal(t, "*", changeID)
+		return &vim25types.DiskChangeInfo{
+			ChangedArea: []vim25types.DiskChangeExtent{
+				{Start: 0, Length: 4096},
+				{Start: 8192, Length: 4096},
+			},
+		}, nil
+	}
+	areas, next, err := m.QueryFCDAllocatedBlocks(ctx, "vol", "snap", 0, 10)
+	assert.NoError(t, err)
+	assert.Len(t, areas, 2)
+	assert.Equal(t, uint64(0), next)
+
+	QueryChangedDiskAreasHook = func(
+		ctx context.Context,
+		vcenter *cnsvsphere.VirtualCenter,
+		volumeID, snapshotID vim25types.ID,
+		startingOffset int64,
+		changeID string,
+	) (*vim25types.DiskChangeInfo, error) {
+		return &vim25types.DiskChangeInfo{
+			ChangedArea: []vim25types.DiskChangeExtent{
+				{Start: 0, Length: 4096},
+				{Start: 4096, Length: 4096},
+			},
+		}, nil
+	}
+	areas, next, err = m.QueryFCDAllocatedBlocks(ctx, "vol", "snap", 0, 2)
+	assert.NoError(t, err)
+	assert.Len(t, areas, 2)
+	assert.Equal(t, uint64(8192), next)
+
+	QueryChangedDiskAreasHook = func(
+		ctx context.Context,
+		vcenter *cnsvsphere.VirtualCenter,
+		volumeID, snapshotID vim25types.ID,
+		startingOffset int64,
+		changeID string,
+	) (*vim25types.DiskChangeInfo, error) {
+		return &vim25types.DiskChangeInfo{
+			ChangedArea: []vim25types.DiskChangeExtent{
+				{Start: 0, Length: 4096},
+				{Start: 4096, Length: 4096},
+				{Start: 8192, Length: 4096},
+			},
+		}, nil
+	}
+	areas, next, err = m.QueryFCDAllocatedBlocks(ctx, "vol", "snap", 0, 2)
+	assert.NoError(t, err)
+	assert.Len(t, areas, 2)
+	assert.Equal(t, uint64(8192), next)
+
+	QueryChangedDiskAreasHook = func(
+		ctx context.Context,
+		vcenter *cnsvsphere.VirtualCenter,
+		volumeID, snapshotID vim25types.ID,
+		startingOffset int64,
+		changeID string,
+	) (*vim25types.DiskChangeInfo, error) {
+		return nil, fmt.Errorf("vslm down")
+	}
+	_, _, err = m.QueryFCDAllocatedBlocks(ctx, "v", "s", 0, 10)
+	assert.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+
+	mNil := &defaultManager{virtualCenter: nil}
+	_, _, err = mNil.QueryFCDAllocatedBlocks(ctx, "v", "s", 0, 10)
+	assert.Error(t, err)
+}
+
+func TestQueryFCDChangedBlocks(t *testing.T) {
+	ctx := context.Background()
+	ctx = logger.NewContextWithLogger(ctx)
+
+	orig := QueryChangedDiskAreasHook
+	defer func() { QueryChangedDiskAreasHook = orig }()
+
+	m := &defaultManager{virtualCenter: &cnsvsphere.VirtualCenter{}}
+
+	QueryChangedDiskAreasHook = func(
+		ctx context.Context,
+		vcenter *cnsvsphere.VirtualCenter,
+		volumeID, snapshotID vim25types.ID,
+		startingOffset int64,
+		changeID string,
+	) (*vim25types.DiskChangeInfo, error) {
+		assert.Equal(t, "base-cid", changeID)
+		return &vim25types.DiskChangeInfo{
+			ChangedArea: []vim25types.DiskChangeExtent{{Start: 100, Length: 200}},
+		}, nil
+	}
+	areas, next, err := m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "base-cid", 0, 5)
+	assert.NoError(t, err)
+	assert.Len(t, areas, 1)
+	assert.Equal(t, uint64(0), next)
+
+	QueryChangedDiskAreasHook = func(
+		ctx context.Context,
+		vcenter *cnsvsphere.VirtualCenter,
+		volumeID, snapshotID vim25types.ID,
+		startingOffset int64,
+		changeID string,
+	) (*vim25types.DiskChangeInfo, error) {
+		return &vim25types.DiskChangeInfo{
+			ChangedArea: []vim25types.DiskChangeExtent{
+				{Start: 0, Length: 512},
+				{Start: 512, Length: 512},
+			},
+		}, nil
+	}
+	areas, next, err = m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "cid", 0, 2)
+	assert.NoError(t, err)
+	assert.Len(t, areas, 2)
+	assert.Equal(t, uint64(1024), next)
+
+	QueryChangedDiskAreasHook = func(
+		ctx context.Context,
+		vcenter *cnsvsphere.VirtualCenter,
+		volumeID, snapshotID vim25types.ID,
+		startingOffset int64,
+		changeID string,
+	) (*vim25types.DiskChangeInfo, error) {
+		return nil, createFCDSoapFault(&vim25types.InvalidArgument{InvalidProperty: "snapshotId"}, "")
+	}
+	_, _, err = m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "cid", 0, 10)
+	assert.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+
+	mNil := &defaultManager{virtualCenter: nil}
+	_, _, err = mNil.QueryFCDChangedBlocks(ctx, "v", "t", "c", 0, 10)
+	assert.Error(t, err)
+
+	QueryChangedDiskAreasHook = func(
+		ctx context.Context,
+		vcenter *cnsvsphere.VirtualCenter,
+		volumeID, snapshotID vim25types.ID,
+		startingOffset int64,
+		changeID string,
+	) (*vim25types.DiskChangeInfo, error) {
+		return &vim25types.DiskChangeInfo{
+			ChangedArea: []vim25types.DiskChangeExtent{
+				{Start: 0, Length: 100},
+				{Start: 200, Length: 100},
+				{Start: 400, Length: 100},
+			},
+		}, nil
+	}
+	areas, next, err = m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "cid", 0, 2)
+	assert.NoError(t, err)
+	assert.Len(t, areas, 2)
+	assert.Equal(t, uint64(300), next)
+}
+
+func TestRunQueryChangedDiskAreasViaVslmNilClient(t *testing.T) {
+	ctx := context.Background()
+	_, err := runQueryChangedDiskAreasViaVslm(ctx, nil, vim25types.ID{Id: "v"}, vim25types.ID{Id: "s"}, 0, "*")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vim25 client is nil")
+}
+
+func TestRunRetrieveSnapshotDetailsViaVslmNilClient(t *testing.T) {
+	ctx := context.Background()
+	_, err := runRetrieveSnapshotDetailsViaVslm(ctx, nil, vim25types.ID{Id: "v"}, vim25types.ID{Id: "s"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vim25 client is nil")
+}
+
+func TestRunQueryChangedDiskAreasViaVslmNewClientError(t *testing.T) {
+	orig := vslmNewClientFunc
+	defer func() { vslmNewClientFunc = orig }()
+	vslmNewClientFunc = func(ctx context.Context, c *vim25.Client) (*vslm.Client, error) {
+		return nil, fmt.Errorf("injected vslm failure")
+	}
+	ctx := context.Background()
+	_, err := runQueryChangedDiskAreasViaVslm(ctx, &vim25.Client{}, vim25types.ID{Id: "v"}, vim25types.ID{Id: "s"}, 0, "*")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create VSLM client")
+}
+
+func TestRunRetrieveSnapshotDetailsViaVslmNewClientError(t *testing.T) {
+	orig := vslmNewClientFunc
+	defer func() { vslmNewClientFunc = orig }()
+	vslmNewClientFunc = func(ctx context.Context, c *vim25.Client) (*vslm.Client, error) {
+		return nil, fmt.Errorf("injected vslm failure")
+	}
+	ctx := context.Background()
+	_, err := runRetrieveSnapshotDetailsViaVslm(ctx, &vim25.Client{}, vim25types.ID{Id: "v"}, vim25types.ID{Id: "s"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create VSLM client")
+}
+
+func TestDefaultVslmHooksDisconnectedVC(t *testing.T) {
+	ctx := context.Background()
+	_, err := defaultQueryChangedDiskAreasHook(ctx, nil, vim25types.ID{}, vim25types.ID{}, 0, "*")
+	assert.Error(t, err)
+	_, err = defaultQueryChangedDiskAreasHook(ctx, &cnsvsphere.VirtualCenter{}, vim25types.ID{}, vim25types.ID{}, 0, "*")
+	assert.Error(t, err)
+
+	_, err = defaultRetrieveSnapshotDetailsHook(ctx, nil, vim25types.ID{}, vim25types.ID{})
+	assert.Error(t, err)
+	_, err = defaultRetrieveSnapshotDetailsHook(ctx, &cnsvsphere.VirtualCenter{}, vim25types.ID{}, vim25types.ID{})
+	assert.Error(t, err)
 }

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -174,6 +174,18 @@ func (m *MockVolumeManager) ExpandVolume(ctx context.Context, volumeID string, s
 func (m *MockVolumeManager) ResetManager(ctx context.Context, vcenter *vsphere.VirtualCenter) error {
 	return nil
 }
+func (m *MockVolumeManager) QueryFCDAllocatedBlocks(ctx context.Context,
+	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]cnsvolume.AllocatedArea, uint64, error) {
+	return nil, 0, nil
+}
+func (m *MockVolumeManager) QueryFCDChangedBlocks(ctx context.Context,
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
+	[]cnsvolume.ChangedArea, uint64, error) {
+	return nil, 0, nil
+}
+func (m *MockVolumeManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
+	return "", nil
+}
 func (m *MockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
 	return nil
 }

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -83,6 +83,18 @@ func (m *mockVolumeManager) ExpandVolume(ctx context.Context, volumeID string, s
 func (m *mockVolumeManager) ResetManager(ctx context.Context, vcenter *vsphere.VirtualCenter) error {
 	return nil
 }
+func (m *mockVolumeManager) QueryFCDAllocatedBlocks(ctx context.Context,
+	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]cnsvolume.AllocatedArea, uint64, error) {
+	return nil, 0, nil
+}
+func (m *mockVolumeManager) QueryFCDChangedBlocks(ctx context.Context,
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
+	[]cnsvolume.ChangedArea, uint64, error) {
+	return nil, 0, nil
+}
+func (m *mockVolumeManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
+	return "", nil
+}
 func (m *mockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
 	return nil
 }

--- a/pkg/csi/service/wcp/controller_cbt.go
+++ b/pkg/csi/service/wcp/controller_cbt.go
@@ -19,18 +19,13 @@ package wcp
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	cnstypes "github.com/vmware/govmomi/cns/types"
-	"github.com/vmware/govmomi/vim25/soap"
-	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/govmomi/vslm"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
-	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -43,29 +38,24 @@ const (
 	defaultMaxResults = 10000
 )
 
+// vslmErrorToCSICode returns the gRPC status code from err if it is already a
+// gRPC status error (e.g. one produced by cnsvolume.TranslateVslmError, which
+// already classifies VSLM faults as FailedPrecondition / OutOfRange /
+// InvalidArgument / NotFound / Internal). Errors without a status default to
+// codes.Internal. This lets callers wrap with a contextual message without
+// clobbering the original code.
+func vslmErrorToCSICode(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+	if c := status.Code(err); c != codes.Unknown {
+		return c
+	}
+	return codes.Internal
+}
+
 // GetMetadataAllocated returns the allocated blocks for a snapshot using FCD VSLM APIs.
 // This implementation uses pure Go through govmomi's VSLM package (no CGO/VDDK required).
-
-// For unit testing purposes
-var queryChangedDiskAreasFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-	volumeID types.ID, snapshotID types.ID, startingOffset int64, changeId string) (*types.DiskChangeInfo, error) {
-	vslmClient, err := vslm.NewClient(ctx, vcenter.Client.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create VSLM client: %v", err)
-	}
-	globalObjectManager := vslm.NewGlobalObjectManager(vslmClient)
-	return globalObjectManager.QueryChangedDiskAreas(ctx, volumeID, snapshotID, startingOffset, changeId)
-}
-
-var retrieveSnapshotDetailsFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-	volumeID types.ID, snapshotID types.ID) (*types.VStorageObjectSnapshotDetails, error) {
-	vslmClient, err := vslm.NewClient(ctx, vcenter.Client.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create VSLM client: %v", err)
-	}
-	globalObjectManager := vslm.NewGlobalObjectManager(vslmClient)
-	return globalObjectManager.RetrieveSnapshotDetails(ctx, volumeID, snapshotID)
-}
 
 func (c *controller) GetMetadataAllocated(req *csi.GetMetadataAllocatedRequest,
 	server csi.SnapshotMetadata_GetMetadataAllocatedServer) error {
@@ -147,11 +137,10 @@ func (c *controller) GetMetadataAllocated(req *csi.GetMetadataAllocatedRequest,
 		}
 		volumeCapacityBytes := blockBacking.CapacityInMb * common.MbInBytes
 
-		// Query allocated blocks using FCD APIs
-		allocatedAreas, nextOffset, err := c.queryAllocatedBlocksFromFCD(
+		allocatedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDAllocatedBlocks(
 			ctx, volumeID, cnsSnapshotID, uint64(startingOffset), uint32(maxResults))
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return nil, logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
 				"failed to query allocated blocks: %v", err)
 		}
 
@@ -288,11 +277,11 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 		}
 		volumeCapacityBytes := blockBacking.CapacityInMb * common.MbInBytes
 
-		// Query changed blocks using FCD APIs. baseChangeID is the change-id from the caller.
-		changedAreas, nextOffset, err := c.queryChangedAreasFromFCD(
-			ctx, volumeID, baseChangeID, targetCnsSnapshotID, uint64(startingOffset), uint32(maxResults))
+		// Query changed blocks via volume manager (FCD/VSLM). baseChangeID is supplied by the caller.
+		changedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDChangedBlocks(
+			ctx, volumeID, targetCnsSnapshotID, baseChangeID, uint64(startingOffset), uint32(maxResults))
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return nil, logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
 				"failed to query changed blocks: %v", err)
 		}
 
@@ -334,188 +323,9 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 	return server.Send(resp)
 }
 
-// AllocatedArea represents an allocated area on disk
-type AllocatedArea struct {
-	Offset uint64
-	Length uint64
-}
-
-// ChangedArea represents a changed area between two snapshots
-type ChangedArea struct {
-	Offset uint64
-	Length uint64
-}
-
-// queryAllocatedBlocksFromFCD queries allocated blocks using FCD VSLM APIs.
-// It uses QueryChangedDiskAreas with changeId="*" to get all allocated blocks.
-func (c *controller) queryAllocatedBlocksFromFCD(ctx context.Context, volumeID, snapshotID string,
-	startingOffset uint64, maxResults uint32) ([]AllocatedArea, uint64, error) {
-
-	log := logger.GetLogger(ctx)
-	log.Debugf("queryAllocatedBlocksFromFCD: volume=%s snapshot=%s offset=%d maxResults=%d",
-		volumeID, snapshotID, startingOffset, maxResults)
-
-	// Get vCenter connection
-	vcenter, err := common.GetVCenter(ctx, c.manager)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get vCenter instance: %v", err)
-	}
-
-	// Convert IDs to VSLM format
-	vslmVolumeID := types.ID{Id: volumeID}
-	vslmSnapshotID := types.ID{Id: snapshotID}
-
-	// Use "*" as changeId to get all allocated blocks
-	changeId := "*"
-
-	// Query changed disk areas (all allocated blocks when changeId="*")
-	log.Debugf("Calling VSLM QueryChangedDiskAreas with changeId='*' for all allocated blocks")
-	diskChangeInfo, err := queryChangedDiskAreasFunc(
-		ctx,
-		vcenter,
-		vslmVolumeID,
-		vslmSnapshotID,
-		int64(startingOffset),
-		changeId,
-	)
-	if err != nil {
-		return nil, 0, translateVslmError(log, err)
-	}
-
-	// Convert to our result format
-	var allocatedAreas []AllocatedArea
-	nextOffset := startingOffset
-
-	for _, area := range diskChangeInfo.ChangedArea {
-		if uint32(len(allocatedAreas)) >= maxResults {
-			break
-		}
-
-		allocatedArea := AllocatedArea{
-			Offset: uint64(area.Start),
-			Length: uint64(area.Length),
-		}
-		allocatedAreas = append(allocatedAreas, allocatedArea)
-
-		// Track the end of this area
-		areaEnd := uint64(area.Start) + uint64(area.Length)
-		if areaEnd > nextOffset {
-			nextOffset = areaEnd
-		}
-	}
-
-	// If we got fewer results than requested, we're done (set nextOffset to 0)
-	if uint32(len(allocatedAreas)) < maxResults {
-		nextOffset = 0
-	}
-
-	log.Debugf("queryAllocatedBlocksFromFCD: returned %d allocated areas, next offset %d",
-		len(allocatedAreas), nextOffset)
-
-	return allocatedAreas, nextOffset, nil
-}
-
-// queryChangedAreasFromFCD queries changed blocks using FCD VSLM APIs.
-// baseChangeID is the vSphere CBT change-id supplied by the caller (via the CSI
-// GetMetadataDelta request's base_snapshot_id field). It is forwarded verbatim to
-// VSLM.QueryChangedDiskAreas; the base snapshot itself does not have to exist anymore.
-func (c *controller) queryChangedAreasFromFCD(ctx context.Context, volumeID, baseChangeID,
-	targetSnapshotID string, startingOffset uint64, maxResults uint32) ([]ChangedArea, uint64, error) {
-
-	log := logger.GetLogger(ctx)
-	log.Debugf("queryChangedAreasFromFCD: volume=%s target=%s offset=%d maxResults=%d (base change-id supplied)",
-		volumeID, targetSnapshotID, startingOffset, maxResults)
-
-	// Get vCenter connection
-	vcenter, err := common.GetVCenter(ctx, c.manager)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get vCenter instance: %v", err)
-	}
-
-	// Convert IDs to VSLM format
-	vslmVolumeID := types.ID{Id: volumeID}
-	vslmTargetSnapshotID := types.ID{Id: targetSnapshotID}
-
-	// Query changed disk areas
-	log.Debugf("Calling VSLM QueryChangedDiskAreas with caller-supplied baseChangeID for delta")
-	diskChangeInfo, err := queryChangedDiskAreasFunc(
-		ctx,
-		vcenter,
-		vslmVolumeID,
-		vslmTargetSnapshotID,
-		int64(startingOffset),
-		baseChangeID,
-	)
-	if err != nil {
-		return nil, 0, translateVslmError(log, err)
-	}
-
-	// Convert to our result format
-	var changedAreas []ChangedArea
-	nextOffset := startingOffset
-
-	for _, area := range diskChangeInfo.ChangedArea {
-		if uint32(len(changedAreas)) >= maxResults {
-			break
-		}
-
-		changedArea := ChangedArea{
-			Offset: uint64(area.Start),
-			Length: uint64(area.Length),
-		}
-		changedAreas = append(changedAreas, changedArea)
-
-		// Track the end of this area
-		areaEnd := uint64(area.Start) + uint64(area.Length)
-		if areaEnd > nextOffset {
-			nextOffset = areaEnd
-		}
-	}
-
-	// If we got fewer results than requested, we're done (set nextOffset to 0)
-	if uint32(len(changedAreas)) < maxResults {
-		nextOffset = 0
-	}
-
-	log.Debugf("queryChangedAreasFromFCD: returned %d changed areas, next offset %d",
-		len(changedAreas), nextOffset)
-
-	return changedAreas, nextOffset, nil
-}
-
-// getSnapshotChangeIdFromFCD retrieves the changeId from a snapshot using FCD VSLM APIs.
+// getSnapshotChangeIdFromFCD retrieves the changeId from a snapshot using FCD VSLM APIs via the volume manager.
 func (c *controller) getSnapshotChangeIdFromFCD(ctx context.Context, volumeID, snapshotID string) (string, error) {
-	log := logger.GetLogger(ctx)
-
-	// Get vCenter connection
-	vcenter, err := common.GetVCenter(ctx, c.manager)
-	if err != nil {
-		return "", fmt.Errorf("failed to get vCenter instance: %v", err)
-	}
-
-	vslmVolumeID := types.ID{Id: volumeID}
-	vslmSnapshotID := types.ID{Id: snapshotID}
-
-	// Retrieve snapshot details
-	log.Debugf("Retrieving snapshot details for snapshot %s", snapshotID)
-	snapshotDetails, err := retrieveSnapshotDetailsFunc(
-		ctx,
-		vcenter,
-		vslmVolumeID,
-		vslmSnapshotID,
-	)
-	if err != nil {
-		return "", fmt.Errorf("failed to retrieve snapshot details via VSLM API: %v", err)
-	}
-
-	// Extract changeId from snapshot
-	changeId := snapshotDetails.ChangedBlockTrackingId
-	if changeId == "" {
-		return "", fmt.Errorf("changeId is empty in snapshot %s (CBT may not be enabled)", snapshotID)
-	}
-
-	log.Debugf("Retrieved changeId %s for snapshot %s", changeId, snapshotID)
-	return changeId, nil
+	return c.manager.VolumeManager.GetFCDSnapshotChangeID(ctx, volumeID, snapshotID)
 }
 
 // validateGetMetadataAllocatedRequest validates the GetMetadataAllocated request
@@ -556,84 +366,4 @@ func validateGetMetadataDeltaRequest(ctx context.Context, req *csi.GetMetadataDe
 
 	log.Debugf("GetMetadataDelta request validation passed")
 	return nil
-}
-
-// translateVslmError maps VSLM and VADP error codes to standard CSI gRPC error codes
-func translateVslmError(log *zap.SugaredLogger, err error) error {
-	if err == nil {
-		return nil
-	}
-
-	errMsg := err.Error()
-
-	// Check if it's a SOAP fault from vCenter
-	if soap.IsSoapFault(err) {
-		fault := soap.ToSoapFault(err).VimFault()
-
-		switch f := fault.(type) {
-		case *types.FileFault:
-			msgID := ""
-			if len(f.FaultMessage) > 0 {
-				msgID = f.FaultMessage[0].Key
-			} else {
-				if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.noTrack") {
-					msgID = "vim.hostd.vmsvc.cbt.noTrack"
-				} else if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.noEpoch") {
-					msgID = "vim.hostd.vmsvc.cbt.noEpoch"
-				} else if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.cannotGetChanges") {
-					msgID = "vim.hostd.vmsvc.cbt.cannotGetChanges"
-				}
-			}
-
-			switch msgID {
-			case "vim.hostd.vmsvc.cbt.noTrack":
-				return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
-					"CBT disabled or not enabled. The caller should perform a full backup instead: %v", err)
-			case "vim.hostd.vmsvc.cbt.noEpoch":
-				return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
-					"Cannot get current epoch when changeId=*. The caller should perform a full backup instead: %v", err)
-			case "vim.hostd.vmsvc.cbt.cannotGetChanges":
-				if strings.Contains(strings.ToLower(errMsg), "corrupt") {
-					return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
-						"ctk file corrupted. The caller should perform a full backup instead: %v", err)
-				}
-				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
-					"changeID mismatch. The caller should correct the error and resubmit the call: %v", err)
-			default:
-				return logger.LogNewErrorCodef(log, codes.Internal,
-					"Internal errors such ctk disk open fails, FCD disk locked, disk missing, etc. "+
-						"CSI driver should retry the operation: %v", err)
-			}
-		case *types.SystemError:
-			return logger.LogNewErrorCodef(log, codes.Internal,
-				"Internal system error. CSI driver should retry the operation: %v", err)
-		case *types.InvalidArgument:
-			if f.InvalidProperty == "startOffset" || strings.Contains(errMsg, "startOffset") {
-				return logger.LogNewErrorCodef(log, codes.OutOfRange,
-					"start offset specified beyond volume size. The caller should specify a valid offset: %v", err)
-			}
-			if f.InvalidProperty == "snapshotId" || strings.Contains(errMsg, "snapshotId") {
-				return logger.LogNewErrorCodef(log, codes.NotFound,
-					"snapshot ID not found for FCD. The caller should re-check that these objects exist: %v", err)
-			}
-			if f.InvalidProperty == "changeId" || strings.Contains(errMsg, "changeId") {
-				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
-					"invalid format for changeID. The caller should correct the error and resubmit the call: %v", err)
-			}
-			if f.InvalidProperty == "deviceKey" || strings.Contains(errMsg, "deviceKey") {
-				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
-					"Device key doesn't exist, Disk has no backing, or Disk backing "+
-						"type doesn't support CBT. The caller should correct the "+
-						"error and resubmit the call: %v", err)
-			}
-			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
-				"invalid argument %s: %v", f.InvalidProperty, err)
-		case *types.NotFound:
-			return logger.LogNewErrorCodef(log, codes.NotFound,
-				"FCD not found in VC inventory. The caller should re-check that these objects exist: %v", err)
-		}
-	}
-
-	// Default fallback
-	return logger.LogNewErrorCodef(log, codes.Internal, "failed with error: %v", err)
 }

--- a/pkg/csi/service/wcp/controller_cbt_test.go
+++ b/pkg/csi/service/wcp/controller_cbt_test.go
@@ -275,7 +275,7 @@ func TestGetMetadataAllocated_InvalidSnapshotID(t *testing.T) {
 
 // TestAllocatedAreaConversion tests the conversion from VSLM response to CSI format
 func TestAllocatedAreaConversion(t *testing.T) {
-	areas := []AllocatedArea{
+	areas := []cnsvolume.AllocatedArea{
 		{Offset: 0, Length: 4096},
 		{Offset: 8192, Length: 4096},
 		{Offset: 16384, Length: 8192},
@@ -305,7 +305,7 @@ func TestAllocatedAreaConversion(t *testing.T) {
 
 // TestChangedAreaConversion tests the conversion from VSLM response to CSI format
 func TestChangedAreaConversion(t *testing.T) {
-	areas := []ChangedArea{
+	areas := []cnsvolume.ChangedArea{
 		{Offset: 4096, Length: 4096},
 		{Offset: 12288, Length: 4096},
 	}
@@ -331,14 +331,14 @@ func TestChangedAreaConversion(t *testing.T) {
 func TestPaginationLogic(t *testing.T) {
 	tests := []struct {
 		name           string
-		areas          []AllocatedArea
+		areas          []cnsvolume.AllocatedArea
 		maxResults     uint32
 		startingOffset uint64
 		wantNextOffset uint64
 	}{
 		{
 			name: "fewer results than max",
-			areas: []AllocatedArea{
+			areas: []cnsvolume.AllocatedArea{
 				{Offset: 0, Length: 4096},
 				{Offset: 8192, Length: 4096},
 			},
@@ -348,7 +348,7 @@ func TestPaginationLogic(t *testing.T) {
 		},
 		{
 			name: "exactly max results",
-			areas: []AllocatedArea{
+			areas: []cnsvolume.AllocatedArea{
 				{Offset: 0, Length: 4096},
 				{Offset: 4096, Length: 4096},
 			},
@@ -358,7 +358,7 @@ func TestPaginationLogic(t *testing.T) {
 		},
 		{
 			name: "more results than max",
-			areas: []AllocatedArea{
+			areas: []cnsvolume.AllocatedArea{
 				{Offset: 0, Length: 4096},
 				{Offset: 4096, Length: 4096},
 				{Offset: 8192, Length: 4096},
@@ -469,12 +469,11 @@ func TestGetMetadataAllocated_Success(t *testing.T) {
 	}
 	volID := respCreate.Volume.VolumeId
 
-	// Mock the VSLM call
-	origQueryChangedDiskAreasFunc := queryChangedDiskAreasFunc
-	defer func() { queryChangedDiskAreasFunc = origQueryChangedDiskAreasFunc }()
+	origHook := cnsvolume.QueryChangedDiskAreasHook
+	defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
 
-	queryChangedDiskAreasFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeId string) (*types.DiskChangeInfo, error) {
+	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
 		return &types.DiskChangeInfo{
 			ChangedArea: []types.DiskChangeExtent{
 				{Start: 0, Length: 4096},
@@ -527,12 +526,11 @@ func TestGetMetadataDelta_Success(t *testing.T) {
 	}
 	volID := respCreate.Volume.VolumeId
 
-	// Mock the VSLM call
-	origQueryChangedDiskAreasFunc := queryChangedDiskAreasFunc
-	defer func() { queryChangedDiskAreasFunc = origQueryChangedDiskAreasFunc }()
+	origHook := cnsvolume.QueryChangedDiskAreasHook
+	defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
 
-	queryChangedDiskAreasFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeId string) (*types.DiskChangeInfo, error) {
+	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
 		return &types.DiskChangeInfo{
 			ChangedArea: []types.DiskChangeExtent{
 				{Start: 8192, Length: 4096},
@@ -555,15 +553,190 @@ func TestGetMetadataDelta_Success(t *testing.T) {
 	}
 }
 
+// makeFCDSoapFault builds a govmomi SOAP fault wrapping the given vim fault
+// payload. Mirrors the helper used in the cnsvolume package tests.
+func makeFCDSoapFault(fault types.AnyType, msg string) error {
+	f := &soap.Fault{String: msg}
+	f.Detail.Fault = fault
+	return soap.WrapSoapFault(f)
+}
+
+// TestVslmErrorToCSICode locks in the unit-level mapping used by the wcp
+// controller when wrapping VSLM errors: it must surface any explicit gRPC
+// status code from the inner error (e.g. FailedPrecondition / OutOfRange /
+// NotFound) and only fall back to Internal for plain errors.
+func TestVslmErrorToCSICode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{name: "nil", err: nil, want: codes.OK},
+		{name: "FailedPrecondition status", err: status.Error(codes.FailedPrecondition, "x"), want: codes.FailedPrecondition},
+		{name: "OutOfRange status", err: status.Error(codes.OutOfRange, "x"), want: codes.OutOfRange},
+		{name: "InvalidArgument status", err: status.Error(codes.InvalidArgument, "x"), want: codes.InvalidArgument},
+		{name: "NotFound status", err: status.Error(codes.NotFound, "x"), want: codes.NotFound},
+		{name: "Internal status", err: status.Error(codes.Internal, "x"), want: codes.Internal},
+		{name: "plain error", err: fmt.Errorf("oops"), want: codes.Internal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := vslmErrorToCSICode(tt.err); got != tt.want {
+				t.Errorf("vslmErrorToCSICode(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// runVSLMErrorPropagationCase asserts that the wcp controller propagates the
+// gRPC status code produced by cnsvolume.TranslateVslmError end-to-end (instead
+// of overwriting it with codes.Internal).
+//
+// Each case: stub QueryChangedDiskAreasHook to return a SOAP fault, then drive
+// either GetMetadataAllocated or GetMetadataDelta and assert status.Code(err).
+func runVSLMErrorPropagationCase(t *testing.T, name string, vimFault types.AnyType,
+	faultMsg string, isDelta bool, wantCode codes.Code) {
+	t.Run(name, func(t *testing.T) {
+		ct := getControllerTest(t)
+		fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+		_ = fakeOrchestrator.EnableFSS(ctx, common.CSI_Backup_API)
+
+		origVolumeManager := ct.controller.manager.VolumeManager
+		ct.controller.manager.VolumeManager = &mockVolumeManager{Manager: origVolumeManager}
+		defer func() { ct.controller.manager.VolumeManager = origVolumeManager }()
+
+		reqCreate := &csi.CreateVolumeRequest{
+			Name: fmt.Sprintf("%s-%s", testVolumeName, name),
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: 1 * common.GbInBytes,
+			},
+			VolumeCapabilities: []*csi.VolumeCapability{
+				{
+					AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			},
+		}
+		respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+		if err != nil {
+			t.Fatalf("Failed to create volume: %v", err)
+		}
+		volID := respCreate.Volume.VolumeId
+
+		origHook := cnsvolume.QueryChangedDiskAreasHook
+		defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
+		cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+			volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
+			return nil, makeFCDSoapFault(vimFault, faultMsg)
+		}
+
+		if isDelta {
+			req := &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/123",
+				TargetSnapshotId: volID + "+snapshot-456",
+				MaxResults:       1,
+			}
+			err = ct.controller.GetMetadataDelta(req, &mockDeltaServer{ctx: ctx})
+		} else {
+			req := &csi.GetMetadataAllocatedRequest{
+				SnapshotId: volID + "+snapshot-456",
+				MaxResults: 1,
+			}
+			err = ct.controller.GetMetadataAllocated(req, &mockAllocatedServer{ctx: ctx})
+		}
+
+		if err == nil {
+			t.Fatalf("Expected error %v, got nil", wantCode)
+		}
+		if got := status.Code(err); got != wantCode {
+			t.Errorf("Expected status code %v, got %v (err=%v)", wantCode, got, err)
+		}
+	})
+}
+
+// TestGetMetadataAllocated_PreservesVSLMErrorCode verifies that for
+// GetMetadataAllocated the controller surfaces the gRPC code chosen by
+// cnsvolume.TranslateVslmError instead of clobbering it with codes.Internal.
+func TestGetMetadataAllocated_PreservesVSLMErrorCode(t *testing.T) {
+	// noTrack -> CBT not enabled -> FailedPrecondition.
+	runVSLMErrorPropagationCase(t, "FailedPrecondition_noTrack",
+		&types.FileFault{
+			VimFault: types.VimFault{
+				MethodFault: types.MethodFault{
+					FaultMessage: []types.LocalizableMessage{{Key: "vim.hostd.vmsvc.cbt.noTrack"}},
+				},
+			},
+		}, "", false, codes.FailedPrecondition)
+
+	// startOffset out of range -> OutOfRange.
+	runVSLMErrorPropagationCase(t, "OutOfRange_startOffset",
+		&types.InvalidArgument{InvalidProperty: "startOffset"}, "",
+		false, codes.OutOfRange)
+
+	// snapshotId not found -> NotFound.
+	runVSLMErrorPropagationCase(t, "NotFound_snapshotId",
+		&types.InvalidArgument{InvalidProperty: "snapshotId"}, "",
+		false, codes.NotFound)
+
+	// changeId malformed -> InvalidArgument.
+	runVSLMErrorPropagationCase(t, "InvalidArgument_changeId",
+		&types.InvalidArgument{InvalidProperty: "changeId"}, "",
+		false, codes.InvalidArgument)
+
+	// Generic VSLM SystemError -> Internal (already-wrapped case still works).
+	runVSLMErrorPropagationCase(t, "Internal_systemError",
+		&types.SystemError{}, "", false, codes.Internal)
+}
+
+// TestGetMetadataDelta_PreservesVSLMErrorCode is the same end-to-end
+// propagation check as above, but driven through GetMetadataDelta (which uses
+// QueryFCDChangedBlocks under the hood).
+func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
+	runVSLMErrorPropagationCase(t, "FailedPrecondition_noEpoch",
+		&types.FileFault{
+			VimFault: types.VimFault{
+				MethodFault: types.MethodFault{
+					FaultMessage: []types.LocalizableMessage{{Key: "vim.hostd.vmsvc.cbt.noEpoch"}},
+				},
+			},
+		}, "", true, codes.FailedPrecondition)
+
+	runVSLMErrorPropagationCase(t, "FailedPrecondition_corruptCTK",
+		&types.FileFault{
+			VimFault: types.VimFault{
+				MethodFault: types.MethodFault{
+					FaultMessage: []types.LocalizableMessage{
+						{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges", Message: "file is corrupted"},
+					},
+				},
+			},
+		}, "file is corrupted", true, codes.FailedPrecondition)
+
+	runVSLMErrorPropagationCase(t, "InvalidArgument_changeIDMismatch",
+		&types.FileFault{
+			VimFault: types.VimFault{
+				MethodFault: types.MethodFault{
+					FaultMessage: []types.LocalizableMessage{
+						{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges"},
+					},
+				},
+			},
+		}, "", true, codes.InvalidArgument)
+
+	runVSLMErrorPropagationCase(t, "NotFound_FCD",
+		&types.NotFound{}, "", true, codes.NotFound)
+}
+
 // TestGetSnapshotChangeIdFromFCD tests the function that retrieves change ID
 func TestGetSnapshotChangeIdFromFCD(t *testing.T) {
 	ct := getControllerTest(t)
 
-	// Mock the VSLM call
-	origRetrieveSnapshotDetailsFunc := retrieveSnapshotDetailsFunc
-	defer func() { retrieveSnapshotDetailsFunc = origRetrieveSnapshotDetailsFunc }()
+	origHook := cnsvolume.RetrieveSnapshotDetailsHook
+	defer func() { cnsvolume.RetrieveSnapshotDetailsHook = origHook }()
 
-	retrieveSnapshotDetailsFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+	cnsvolume.RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
 		volumeID types.ID, snapshotID types.ID) (*types.VStorageObjectSnapshotDetails, error) {
 		return &types.VStorageObjectSnapshotDetails{
 			ChangedBlockTrackingId: "mock-change-id-from-fcd",
@@ -578,8 +751,7 @@ func TestGetSnapshotChangeIdFromFCD(t *testing.T) {
 		t.Errorf("Expected mock-change-id-from-fcd, got: %s", changeId)
 	}
 
-	// Test empty change ID
-	retrieveSnapshotDetailsFunc = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+	cnsvolume.RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
 		volumeID types.ID, snapshotID types.ID) (*types.VStorageObjectSnapshotDetails, error) {
 		return &types.VStorageObjectSnapshotDetails{
 			ChangedBlockTrackingId: "", // empty
@@ -589,157 +761,5 @@ func TestGetSnapshotChangeIdFromFCD(t *testing.T) {
 	_, err = ct.controller.getSnapshotChangeIdFromFCD(ctx, testVolumeName, "snapshot-123")
 	if err == nil {
 		t.Errorf("Expected error for empty change ID, got nil")
-	}
-}
-
-func createSoapFault(fault types.AnyType, msg string) error {
-	f := &soap.Fault{String: msg}
-	f.Detail.Fault = fault
-	return soap.WrapSoapFault(f)
-}
-
-// TestTranslateVslmError tests the error mapping logic for VSLM API errors
-func TestTranslateVslmError(t *testing.T) {
-	ctx := context.Background()
-	ctx = logger.NewContextWithLogger(ctx)
-	log := logger.GetLogger(ctx)
-
-	tests := []struct {
-		name     string
-		err      error
-		wantCode codes.Code
-	}{
-		{
-			name:     "nil error",
-			err:      nil,
-			wantCode: codes.OK,
-		},
-		{
-			name: "SOAP FileFault with noTrack",
-			err: createSoapFault(&types.FileFault{
-				VimFault: types.VimFault{
-					MethodFault: types.MethodFault{
-						FaultMessage: []types.LocalizableMessage{
-							{Key: "vim.hostd.vmsvc.cbt.noTrack"},
-						},
-					},
-				},
-			}, ""),
-			wantCode: codes.FailedPrecondition,
-		},
-		{
-			name: "SOAP FileFault with noEpoch",
-			err: createSoapFault(&types.FileFault{
-				VimFault: types.VimFault{
-					MethodFault: types.MethodFault{
-						FaultMessage: []types.LocalizableMessage{
-							{Key: "vim.hostd.vmsvc.cbt.noEpoch"},
-						},
-					},
-				},
-			}, ""),
-			wantCode: codes.FailedPrecondition,
-		},
-		{
-			name: "SOAP FileFault with corrupt cannotGetChanges",
-			err: createSoapFault(&types.FileFault{
-				VimFault: types.VimFault{
-					MethodFault: types.MethodFault{
-						FaultMessage: []types.LocalizableMessage{
-							{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges", Message: "file is corrupted"},
-						},
-					},
-				},
-			}, "file is corrupted"),
-			wantCode: codes.FailedPrecondition,
-		},
-		{
-			name: "SOAP FileFault with mismatched cannotGetChanges",
-			err: createSoapFault(&types.FileFault{
-				VimFault: types.VimFault{
-					MethodFault: types.MethodFault{
-						FaultMessage: []types.LocalizableMessage{
-							{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges"},
-						},
-					},
-				},
-			}, ""),
-			wantCode: codes.InvalidArgument,
-		},
-		{
-			name:     "SOAP FileFault generic",
-			err:      createSoapFault(&types.FileFault{}, ""),
-			wantCode: codes.Internal,
-		},
-		{
-			name:     "SOAP SystemError",
-			err:      createSoapFault(&types.SystemError{}, ""),
-			wantCode: codes.Internal,
-		},
-		{
-			name: "SOAP InvalidArgument startOffset",
-			err: createSoapFault(&types.InvalidArgument{
-				InvalidProperty: "startOffset",
-			}, ""),
-			wantCode: codes.OutOfRange,
-		},
-		{
-			name: "SOAP InvalidArgument snapshotId",
-			err: createSoapFault(&types.InvalidArgument{
-				InvalidProperty: "snapshotId",
-			}, ""),
-			wantCode: codes.NotFound,
-		},
-		{
-			name: "SOAP InvalidArgument changeId",
-			err: createSoapFault(&types.InvalidArgument{
-				InvalidProperty: "changeId",
-			}, ""),
-			wantCode: codes.InvalidArgument,
-		},
-		{
-			name: "SOAP InvalidArgument deviceKey",
-			err: createSoapFault(&types.InvalidArgument{
-				InvalidProperty: "deviceKey",
-			}, ""),
-			wantCode: codes.InvalidArgument,
-		},
-		{
-			name:     "SOAP NotFound",
-			err:      createSoapFault(&types.NotFound{}, ""),
-			wantCode: codes.NotFound,
-		},
-		{
-			name:     "plain error with CBT message substring",
-			err:      fmt.Errorf("some inner error: vim.hostd.vmsvc.cbt.noTrack"),
-			wantCode: codes.Internal,
-		},
-		{
-			name:     "plain error with vim.fault substring",
-			err:      fmt.Errorf("some inner error: vim.fault.NotFound occurred"),
-			wantCode: codes.Internal,
-		},
-		{
-			name:     "plain error generic",
-			err:      fmt.Errorf("random network timeout"),
-			wantCode: codes.Internal,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := translateVslmError(log, tt.err)
-
-			if tt.err == nil {
-				if err != nil {
-					t.Errorf("Expected nil error, got: %v", err)
-				}
-				return
-			}
-
-			if status.Code(err) != tt.wantCode {
-				t.Errorf("translateVslmError() returned code %v, want %v. Error: %v", status.Code(err), tt.wantCode, err)
-			}
-		})
 	}
 }

--- a/pkg/csi/service/wcp/fvs_filevolume_test.go
+++ b/pkg/csi/service/wcp/fvs_filevolume_test.go
@@ -42,6 +42,8 @@ import (
 
 	fvsapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume"
 	fvv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume/v1alpha1"
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
@@ -55,6 +57,9 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	commonco.ContainerOrchestratorUtility = co
+	// Stub out ConnectVslmHook so wcp unit tests don't try to dial the
+	// govmomi simulator's /vslm/sdk endpoint (the simulator returns 404).
+	cnsvolume.ConnectVslmHook = func(ctx context.Context, vc *cnsvsphere.VirtualCenter) error { return nil }
 	m.Run()
 }
 

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -139,6 +139,24 @@ func (m *mockVolumeManager) ResetManager(ctx context.Context, vcenter *cnsvspher
 	panic("implement me")
 }
 
+func (m *mockVolumeManager) QueryFCDAllocatedBlocks(ctx context.Context,
+	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]cnsvolume.AllocatedArea, uint64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) QueryFCDChangedBlocks(ctx context.Context,
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
+	[]cnsvolume.ChangedArea, uint64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockVolumeManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
 	//TODO implement me
 	panic("implement me")

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -851,6 +851,22 @@ func (m *mockVolumeManagerForFullSync) ResetManager(ctx context.Context, vcenter
 	return nil
 }
 
+func (m *mockVolumeManagerForFullSync) QueryFCDAllocatedBlocks(ctx context.Context,
+	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]volumes.AllocatedArea, uint64, error) {
+	return nil, 0, nil
+}
+
+func (m *mockVolumeManagerForFullSync) QueryFCDChangedBlocks(ctx context.Context,
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
+	[]volumes.ChangedArea, uint64, error) {
+	return nil, 0, nil
+}
+
+func (m *mockVolumeManagerForFullSync) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (
+	string, error) {
+	return "", nil
+}
+
 func (m *mockVolumeManagerForFullSync) ConfigureVolumeACLs(
 	ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec,
 ) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds code to connect to VC through Volume Manager for the newly added CSI CBT functions.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1384/ (13 tests passed; 1 failed test is not related to this PR)
```
17:23:00    [FAIL] Volume Expansion Test [It] [ef-wcp] [csi-supervisor] Offline and Online volume resize on statically created volume [p0, block, wcp, vc70]
17:23:00    /home/worker/workspace/wcp-instapp-e2e-pre-checkin/Results/1384/vsphere-csi-driver/tests/e2e/vsphere_volume_expansion.go:1416
17:23:00  
17:23:00  Ran 14 of 1264 Specs in 2259.075 seconds
17:23:00  FAIL! -- 13 Passed | 1 Failed | 0 Pending | 1250 Skipped
```
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1095/ (passed)

Manual testing results are included [here](https://gist.github.com/xing-yang/285eaf2a32478698d9872044323c0e3e#file-csi-cbt-wcp_volume-manager-md).

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
