### PR TITLE
skip CNS metadata push for FVS-backed file volumes

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -554,3 +554,32 @@ func IsCBTEnabledForNamespace(ctx context.Context, dynClient dynamic.Interface, 
 
 	return false, nil
 }
+
+// IsFVSVolumeHandle returns true if the supplied CSI volume handle was minted by
+// the vSAN FileVolumeService (FVS) workflow on the supervisor. FVS volume IDs are
+// formatted as "fv:<instance-namespace>:<filevolume-name>" (see FVSVolumeIDPrefix).
+//
+// This is the supervisor-side identification helper. The guest cluster cannot rely
+// on the volume handle (the supervisor-side volume id is opaque on the guest) and
+// must use IsFVSStorageClassName instead.
+func IsFVSVolumeHandle(volumeHandle string) bool {
+	return strings.HasPrefix(volumeHandle, FVSVolumeIDPrefix)
+}
+
+// IsFVSStorageClassName returns true if the supplied storage class name is one of
+// the vSAN file service storage classes that route provisioning through FVS on the
+// supervisor (StorageClassVsanFileServicePolicy or
+// StorageClassVsanFileServicePolicyLateBinding).
+//
+// This is the guest-cluster identification helper. The guest sees the supervisor
+// PVC name as the volume handle (no FVS prefix) so it must look at the storage
+// class to decide whether the volume is FVS-backed.
+func IsFVSStorageClassName(storageClassName string) bool {
+	switch storageClassName {
+	case StorageClassVsanFileServicePolicy,
+		StorageClassVsanFileServicePolicyLateBinding:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -686,3 +686,46 @@ func TestIsCBTEnabledForNamespace(t *testing.T) {
 		assert.True(t, ok)
 	})
 }
+
+func TestIsFVSVolumeHandle(t *testing.T) {
+	tests := []struct {
+		name         string
+		volumeHandle string
+		want         bool
+	}{
+		{"empty handle", "", false},
+		{"legacy supervisor pvc name", "test-tkc-pvc-12345", false},
+		{"FCD volume id", "12345678-1234-1234-1234-123456789012", false},
+		{"legacy file: prefix", "file:abc-def", false},
+		{"FVS volume id", "fv:my-instance-ns:my-fv-name", true},
+		{"FVS prefix only", "fv:", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsFVSVolumeHandle(tt.volumeHandle); got != tt.want {
+				t.Fatalf("IsFVSVolumeHandle(%q) = %v, want %v", tt.volumeHandle, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsFVSStorageClassName(t *testing.T) {
+	tests := []struct {
+		name             string
+		storageClassName string
+		want             bool
+	}{
+		{"empty", "", false},
+		{"unrelated sc", "wcpglobal-storage-profile", false},
+		{"legacy file sc", "file-storage-class", false},
+		{"FVS immediate", StorageClassVsanFileServicePolicy, true},
+		{"FVS late binding", StorageClassVsanFileServicePolicyLateBinding, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsFVSStorageClassName(tt.storageClassName); got != tt.want {
+				t.Fatalf("IsFVSStorageClassName(%q) = %v, want %v", tt.storageClassName, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -133,6 +133,29 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 		return err
 	}
 
+	// Filter out PVs provisioned by the new vSAN FileVolumeService (FVS) on the supervisor.
+	// CNS is not the source of truth for these volumes and CNS QueryVolume will not return
+	// them, so we must skip pushing/creating/updating any volume metadata for them.
+	// See pkg/csi/service/wcp/fvs_filevolume.go for the provisioning workflow.
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload && IsVsanFileVolumeServiceEnabled {
+		filteredPVs := make([]*v1.PersistentVolume, 0, len(k8sPVs))
+		skipped := 0
+		for _, pv := range k8sPVs {
+			if isFVSPersistentVolume(pv) {
+				log.Debugf("FullSync for VC %s: skipping FVS-backed PV %q (volumeHandle=%q) for CNS metadata sync",
+					vc, pv.Name, pv.Spec.CSI.VolumeHandle)
+				skipped++
+				continue
+			}
+			filteredPVs = append(filteredPVs, pv)
+		}
+		if skipped > 0 {
+			log.Infof("FullSync for VC %s: filtered out %d FVS-backed PV(s) from CNS metadata reconciliation",
+				vc, skipped)
+		}
+		k8sPVs = filteredPVs
+	}
+
 	// k8sPVMap is useful for clean and quicker look up.
 	k8sPVMap := make(map[string]string)
 	// Instantiate volumeMigrationService when migration feature state is True.

--- a/pkg/syncer/fvs_skip_metadata_test.go
+++ b/pkg/syncer/fvs_skip_metadata_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+)
+
+// withFVSEnabled toggles IsVsanFileVolumeServiceEnabled for the duration of the test
+// (same variable is used on supervisor and guest; only one cluster flavor runs per process).
+func withFVSEnabled(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := IsVsanFileVolumeServiceEnabled
+	IsVsanFileVolumeServiceEnabled = enabled
+	t.Cleanup(func() { IsVsanFileVolumeServiceEnabled = prev })
+}
+
+func makeFVSPV(name, volumeID string) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: volumeID,
+				},
+			},
+		},
+	}
+}
+
+func makePVWithSC(name, scName, volumeHandle string) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PersistentVolumeSpec{
+			StorageClassName: scName,
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: volumeHandle,
+				},
+			},
+		},
+	}
+}
+
+func makePVCWithSC(name, namespace, scName string) *v1.PersistentVolumeClaim {
+	sc := scName
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1.PersistentVolumeClaimSpec{
+			StorageClassName: &sc,
+		},
+	}
+}
+
+func TestIsFVSPersistentVolume(t *testing.T) {
+	t.Run("nil pv", func(t *testing.T) {
+		assert.False(t, isFVSPersistentVolume(nil))
+	})
+	t.Run("nil CSI source", func(t *testing.T) {
+		pv := &v1.PersistentVolume{}
+		assert.False(t, isFVSPersistentVolume(pv))
+	})
+	t.Run("non FVS handle", func(t *testing.T) {
+		pv := makeFVSPV("pv-1", "block-1234")
+		assert.False(t, isFVSPersistentVolume(pv))
+	})
+	t.Run("FVS handle", func(t *testing.T) {
+		pv := makeFVSPV("pv-1", common.FVSVolumeIDPrefix+"tenant-ns:fv-foo")
+		assert.True(t, isFVSPersistentVolume(pv))
+	})
+}
+
+func TestIsFVSPersistentVolumeClaim(t *testing.T) {
+	t.Run("nil pvc", func(t *testing.T) {
+		assert.False(t, isFVSPersistentVolumeClaim(nil))
+	})
+	t.Run("nil storage class", func(t *testing.T) {
+		assert.False(t, isFVSPersistentVolumeClaim(&v1.PersistentVolumeClaim{}))
+	})
+	t.Run("non FVS storage class", func(t *testing.T) {
+		assert.False(t, isFVSPersistentVolumeClaim(makePVCWithSC("a", "ns", "vsan-default")))
+	})
+	t.Run("FVS storage class - immediate binding", func(t *testing.T) {
+		assert.True(t, isFVSPersistentVolumeClaim(
+			makePVCWithSC("a", "ns", common.StorageClassVsanFileServicePolicy)))
+	})
+	t.Run("FVS storage class - late binding", func(t *testing.T) {
+		assert.True(t, isFVSPersistentVolumeClaim(
+			makePVCWithSC("a", "ns", common.StorageClassVsanFileServicePolicyLateBinding)))
+	})
+}
+
+func TestShouldSkipFVSMetadataPushSupervisor(t *testing.T) {
+	fvsPV := makeFVSPV("pv-fvs", common.FVSVolumeIDPrefix+"ns:fv-1")
+	blockPV := makeFVSPV("pv-block", "block-1234")
+
+	t.Run("FSS disabled - never skip", func(t *testing.T) {
+		withFVSEnabled(t, false)
+		assert.False(t, shouldSkipFVSMetadataPushSupervisor(fvsPV))
+		assert.False(t, shouldSkipFVSMetadataPushSupervisor(blockPV))
+	})
+	t.Run("FSS enabled - skip only FVS PV", func(t *testing.T) {
+		withFVSEnabled(t, true)
+		assert.True(t, shouldSkipFVSMetadataPushSupervisor(fvsPV))
+		assert.False(t, shouldSkipFVSMetadataPushSupervisor(blockPV))
+	})
+	t.Run("nil PV under enabled FSS", func(t *testing.T) {
+		withFVSEnabled(t, true)
+		assert.False(t, shouldSkipFVSMetadataPushSupervisor(nil))
+	})
+}
+
+func TestShouldSkipFVSMetadataPushGuest(t *testing.T) {
+	fvsPVC := makePVCWithSC("pvc-fvs", "ns", common.StorageClassVsanFileServicePolicy)
+	fvsLBPVC := makePVCWithSC("pvc-fvs-lb", "ns", common.StorageClassVsanFileServicePolicyLateBinding)
+	blockPVC := makePVCWithSC("pvc-block", "ns", "vsan-default")
+
+	fvsPV := makePVWithSC("pv-fvs", common.StorageClassVsanFileServicePolicy, "supervisor-pvc-name")
+	blockPV := makePVWithSC("pv-block", "vsan-default", "block-handle")
+
+	t.Run("FSS disabled - never skip", func(t *testing.T) {
+		withFVSEnabled(t, false)
+		assert.False(t, shouldSkipFVSMetadataPushGuest(fvsPVC, fvsPV))
+		assert.False(t, shouldSkipFVSMetadataPushGuest(blockPVC, blockPV))
+	})
+	t.Run("FSS enabled - skip when PVC has FVS storage class", func(t *testing.T) {
+		withFVSEnabled(t, true)
+		assert.True(t, shouldSkipFVSMetadataPushGuest(fvsPVC, nil))
+		assert.True(t, shouldSkipFVSMetadataPushGuest(fvsLBPVC, nil))
+	})
+	t.Run("FSS enabled - skip when PV has FVS storage class and PVC is nil", func(t *testing.T) {
+		withFVSEnabled(t, true)
+		assert.True(t, shouldSkipFVSMetadataPushGuest(nil, fvsPV))
+	})
+	t.Run("FSS enabled - non FVS PVC/PV", func(t *testing.T) {
+		withFVSEnabled(t, true)
+		assert.False(t, shouldSkipFVSMetadataPushGuest(blockPVC, blockPV))
+		assert.False(t, shouldSkipFVSMetadataPushGuest(nil, blockPV))
+		assert.False(t, shouldSkipFVSMetadataPushGuest(blockPVC, nil))
+	})
+}
+
+// TestSupervisorFullSyncFiltersFVSPVs validates the in-line filter applied in
+// CsiFullSync that strips FVS-backed PVs before any CNS reconciliation runs.
+// The test uses the same filtering primitive used by the implementation
+// (isFVSPersistentVolume + IsVsanFileVolumeServiceEnabled) to assert behavior
+// without standing up the full VC/CNS/informer stack.
+func TestSupervisorFullSyncFiltersFVSPVs(t *testing.T) {
+	fvsPV1 := makeFVSPV("pv-fvs-1", common.FVSVolumeIDPrefix+"ns-a:fv-1")
+	fvsPV2 := makeFVSPV("pv-fvs-2", common.FVSVolumeIDPrefix+"ns-b:fv-2")
+	blockPV := makeFVSPV("pv-block", "block-1234")
+
+	pvs := []*v1.PersistentVolume{fvsPV1, blockPV, fvsPV2}
+
+	t.Run("FSS disabled - keep all PVs", func(t *testing.T) {
+		withFVSEnabled(t, false)
+		filtered := filterPVsForFullSync(pvs)
+		assert.Len(t, filtered, 3)
+	})
+	t.Run("FSS enabled - filter FVS PVs", func(t *testing.T) {
+		withFVSEnabled(t, true)
+		filtered := filterPVsForFullSync(pvs)
+		assert.Len(t, filtered, 1)
+		assert.Equal(t, "pv-block", filtered[0].Name)
+	})
+}
+
+// filterPVsForFullSync mirrors the CsiFullSync filter so the behavior can be
+// tested without invoking the full sync entrypoint (which requires a live
+// VC/CNS connection). Any future change to the filter in CsiFullSync should
+// keep this in lockstep.
+func filterPVsForFullSync(pvList []*v1.PersistentVolume) []*v1.PersistentVolume {
+	if !IsVsanFileVolumeServiceEnabled {
+		return pvList
+	}
+	out := make([]*v1.PersistentVolume, 0, len(pvList))
+	for _, pv := range pvList {
+		if isFVSPersistentVolume(pv) {
+			continue
+		}
+		out = append(out, pv)
+	}
+	return out
+}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -130,6 +130,15 @@ var (
 	// IsWorkloadDomainIsolationSupported is true when Workload_Domain_Isolation_Supported FSS is enabled.
 	IsWorkloadDomainIsolationSupported bool
 
+	// IsVsanFileVolumeServiceEnabled is the effective vSAN File Volume / FVS gate for this
+	// syncer process (exactly one cluster flavor applies):
+	//   - Supervisor (workload): set from common.VsanFileVolumeService (supports_vsan_fileservice).
+	//   - Guest: set to true only when both PVCSI internal FSS and supervisor capability
+	//     are enabled: IsPVCSIFSSEnabled(VsanFileVolumeServiceSupportFSS) &&
+	//     IsFSSEnabled(VsanFileVolumeServiceSupportFSS) (same keys as before).
+	// When true, metadata syncer / full-sync skip FVS-backed volume CNS / CnsVolumeMetadata paths.
+	IsVsanFileVolumeServiceEnabled bool
+
 	// PeriodicSyncIntervalInMin the time interval to run sync for
 	PeriodicSyncIntervalInMin time.Duration
 )
@@ -360,7 +369,9 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
 				clusterFlavor, common.SharedDiskFss, "", "")
 		}
-		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VsanFileVolumeService) {
+		IsVsanFileVolumeServiceEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+			common.VsanFileVolumeService)
+		if !IsVsanFileVolumeServiceEnabled {
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,
 				common.VsanFileVolumeService, "", "")
 		}
@@ -393,6 +404,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			ctx, common.VsanFileVolumeServiceSupportFSS)
 		vsanFileServiceEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(
 			ctx, common.VsanFileVolumeServiceSupportFSS)
+		IsVsanFileVolumeServiceEnabled = vsanFilePVCSIFSS && vsanFileServiceEnabled
 		if vsanFilePVCSIFSS && !vsanFileServiceEnabled {
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
 				clusterFlavor, common.VsanFileVolumeService,
@@ -2631,9 +2643,19 @@ func pvcUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer
 	}
 
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		if shouldSkipFVSMetadataPushGuest(newPvc, pv) {
+			log.Infof("PVCUpdated: Skipping CnsVolumeMetadata push for FVS-backed PVC %q in namespace %q",
+				newPvc.Name, newPvc.Namespace)
+			return
+		}
 		// Invoke volume updated method for pvCSI.
 		pvcsiVolumeUpdated(ctx, newPvc, pv.Spec.CSI.VolumeHandle, metadataSyncer)
 	} else {
+		if shouldSkipFVSMetadataPushSupervisor(pv) {
+			log.Infof("PVCUpdated: Skipping CNS metadata push for FVS-backed PVC %q in namespace %q (volumeHandle=%q)",
+				newPvc.Name, newPvc.Namespace, pv.Spec.CSI.VolumeHandle)
+			return
+		}
 		csiPVCUpdated(ctx, newPvc, pv, metadataSyncer)
 	}
 }
@@ -2684,9 +2706,19 @@ func pvcDeleted(obj interface{}, metadataSyncer *metadataSyncInformer) {
 		}
 	}
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		if shouldSkipFVSMetadataPushGuest(pvc, pv) {
+			log.Infof("PVCDeleted: Skipping CnsVolumeMetadata delete for FVS-backed PVC %q in namespace %q",
+				pvc.Name, pvc.Namespace)
+			return
+		}
 		// Invoke volume deleted method for pvCSI.
 		pvcsiVolumeDeleted(ctx, string(pvc.GetUID()), metadataSyncer, pv)
 	} else {
+		if shouldSkipFVSMetadataPushSupervisor(pv) {
+			log.Infof("PVCDeleted: Skipping CNS metadata delete for FVS-backed PVC %q in namespace %q (volumeHandle=%q)",
+				pvc.Name, pvc.Namespace, pv.Spec.CSI.VolumeHandle)
+			return
+		}
 		csiPVCDeleted(ctx, pvc, pv, metadataSyncer)
 	}
 }
@@ -2807,9 +2839,19 @@ func pvUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer)
 		return
 	}
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		if shouldSkipFVSMetadataPushGuest(nil, newPv) {
+			log.Infof("PVUpdated: Skipping CnsVolumeMetadata push for FVS-backed PV %q (storageClass=%q)",
+				newPv.Name, newPv.Spec.StorageClassName)
+			return
+		}
 		// Invoke volume updated method for pvCSI.
 		pvcsiVolumeUpdated(ctx, newPv, newPv.Spec.CSI.VolumeHandle, metadataSyncer)
 	} else {
+		if shouldSkipFVSMetadataPushSupervisor(newPv) {
+			log.Infof("PVUpdated: Skipping CNS metadata push for FVS-backed PV %q (volumeHandle=%q)",
+				newPv.Name, newPv.Spec.CSI.VolumeHandle)
+			return
+		}
 		csiPVUpdated(ctx, newPv, oldPv, metadataSyncer)
 	}
 }
@@ -2848,9 +2890,19 @@ func pvDeleted(obj interface{}, metadataSyncer *metadataSyncInformer) {
 		}
 	}
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		if shouldSkipFVSMetadataPushGuest(nil, pv) {
+			log.Infof("PVDeleted: Skipping CnsVolumeMetadata delete for FVS-backed PV %q (storageClass=%q)",
+				pv.Name, pv.Spec.StorageClassName)
+			return
+		}
 		// Invoke volume deleted method for pvCSI.
 		pvcsiVolumeDeleted(ctx, string(pv.GetUID()), metadataSyncer, pv)
 	} else {
+		if shouldSkipFVSMetadataPushSupervisor(pv) {
+			log.Infof("PVDeleted: Skipping CNS metadata delete for FVS-backed PV %q (volumeHandle=%q)",
+				pv.Name, pv.Spec.CSI.VolumeHandle)
+			return
+		}
 		csiPVDeleted(ctx, pv, metadataSyncer)
 	}
 }
@@ -3586,6 +3638,13 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 		if volume.PersistentVolumeClaim != nil {
 			valid, pv, pvc := IsValidVolume(ctx, volume, pod, metadataSyncer)
 			if valid {
+				// Skip FVS-backed file volumes: CNS does not own these volumes so we should not
+				// push pod metadata updates for them.
+				if shouldSkipFVSMetadataPushSupervisor(pv) {
+					log.Infof("PodUpdated: skipping pod metadata push for FVS-backed PVC %q in namespace %q "+
+						"on pod %q (volumeHandle=%q)", pvc.Name, pvc.Namespace, pod.Name, pv.Spec.CSI.VolumeHandle)
+					continue
+				}
 				if !deleteFlag {
 					// We need to update metadata for pods having corresponding PVC
 					// as an entity reference.

--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -238,6 +238,16 @@ func createCnsVolumeMetadataList(ctx context.Context, metadataSyncer *metadataSy
 
 	// Create cnsvolumemetadata objects for PV and PVC entity types.
 	for _, pv := range pvList {
+		// Skip PVs that are backed by the new vSAN FileVolumeService on the supervisor.
+		// For these PVs, the supervisor does not push CnsVolumeMetadata to CNS, so there
+		// is no need to reconcile guest CnsVolumeMetadata for them either. Detection is
+		// based on the storage class name; the guest cannot rely on the supervisor's
+		// FVS volume-id prefix because the volume handle is opaque on this side.
+		if IsVsanFileVolumeServiceEnabled && common.IsFVSStorageClassName(pv.Spec.StorageClassName) {
+			log.Debugf("FullSync: skipping FVS-backed PV %q (storageClass=%q) for CnsVolumeMetadata sync",
+				pv.Name, pv.Spec.StorageClassName)
+			continue
+		}
 		var volumeNames []string
 		volumeNames = append(volumeNames, pv.Spec.CSI.VolumeHandle)
 

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -162,6 +162,12 @@ func pvcsiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSy
 		if volume.PersistentVolumeClaim != nil {
 			valid, pv, pvc := IsValidVolume(ctx, volume, pod, metadataSyncer)
 			if valid {
+				// Skip FVS-backed file volumes: CnsVolumeMetadata is not pushed for them.
+				if shouldSkipFVSMetadataPushGuest(pvc, pv) {
+					log.Infof("pvCSI PODUpdatedDeleted: skipping pod entityReference for FVS-backed PVC %q "+
+						"in namespace %q on pod %q", pvc.Name, pvc.Namespace, pod.Name)
+					continue
+				}
 				entityReferences = append(entityReferences,
 					cnsvolumemetadatav1alpha1.GetCnsOperatorEntityReference(pvc.Name, pvc.Namespace,
 						cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePVC,

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -301,6 +301,64 @@ func isValidvSphereVolume(ctx context.Context, pv *v1.PersistentVolume) bool {
 	return false
 }
 
+// isFVSPersistentVolume returns true when the supplied PV was provisioned by the new
+// vSAN FileVolumeService on the supervisor. Detection relies on the FVS volume-id
+// prefix carried in pv.Spec.CSI.VolumeHandle which is set by the supervisor controller
+// when routing through the FileVolume CR workflow. The volume-handle check is delegated
+// to the shared helper common.IsFVSVolumeHandle so the guest-cluster
+// ControllerPublish/Unpublish path and this metadata syncer agree on the predicate.
+//
+// This is the supervisor-side identification helper. Guest clusters cannot rely on the
+// volume handle (which is opaque to them) and use common.IsFVSStorageClassName instead.
+func isFVSPersistentVolume(pv *v1.PersistentVolume) bool {
+	if pv == nil || pv.Spec.CSI == nil {
+		return false
+	}
+	return common.IsFVSVolumeHandle(pv.Spec.CSI.VolumeHandle)
+}
+
+// isFVSPersistentVolumeClaim returns true if the PVC's storage class is one of the
+// FVS storage classes. Used by the guest cluster metadata syncer where only the
+// PVC/PV objects are available (no access to supervisor volume IDs). Storage-class
+// matching is delegated to the shared helper common.IsFVSStorageClassName.
+func isFVSPersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) bool {
+	if pvc == nil || pvc.Spec.StorageClassName == nil {
+		return false
+	}
+	return common.IsFVSStorageClassName(*pvc.Spec.StorageClassName)
+}
+
+// shouldSkipFVSMetadataPush decides whether the metadata syncer / full-sync should
+// skip pushing volume metadata for the supplied PV in the supervisor cluster.
+// Returns true only when the VsanFileVolumeService capability is enabled AND the
+// PV carries the FVS volume-id prefix. Volumes provisioned via the legacy CNS path
+// continue to receive metadata updates as before.
+func shouldSkipFVSMetadataPushSupervisor(pv *v1.PersistentVolume) bool {
+	if !IsVsanFileVolumeServiceEnabled {
+		return false
+	}
+	return isFVSPersistentVolume(pv)
+}
+
+// shouldSkipFVSMetadataPushGuest decides whether the guest-cluster metadata syncer /
+// full-sync should skip pushing CnsVolumeMetadata for a PVC/PV pair. Returns true
+// only when the guest FVS gate IsVsanFileVolumeServiceEnabled is true (PVCSI FSS plus
+// supervisor capability, set at init) AND the PVC's storage class matches an FVS
+// storage class. The PV is checked as a fallback when the PVC reference is nil but
+// the PV carries the storage class name.
+func shouldSkipFVSMetadataPushGuest(pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) bool {
+	if !IsVsanFileVolumeServiceEnabled {
+		return false
+	}
+	if isFVSPersistentVolumeClaim(pvc) {
+		return true
+	}
+	if pv != nil && common.IsFVSStorageClassName(pv.Spec.StorageClassName) {
+		return true
+	}
+	return false
+}
+
 // IsFileVolume returns true for PVs that have accessMode as RWX or ROM
 // and volumeMode as FileSystem.
 func IsFileVolume(pv *v1.PersistentVolume) bool {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Volumes provisioned via the new vSAN FileVolumeService (FVS) on the supervisor do not go through the CNS API, so CNS does not own them and QueryVolume on the supervisor will not list them. Pushing PV/PVC/Pod metadata for these volumes through UpdateVolumeMetadata or via guest CnsVolumeMetadata CRs is unnecessary and produces errors.

This change makes the metadata syncer (event-driven path) and the periodic full-sync skip these volumes on both the supervisor and the guest cluster:

- Supervisor identifies FVS PVs by the FVS volume-id prefix "fv:" set on pv.Spec.CSI.VolumeHandle by the FileVolume CR provisioning path.
- Guest cluster identifies FVS PVCs/PVs by storage class name (vsan-file-service-policy and vsan-file-service-policy-latebinding) since the supervisor's FVS volume-id is opaque on this side.

The skip is gated by capability checks:
- Supervisor: common.VsanFileVolumeService capability.
- Guest: PVCSI internal FSS common.VsanFileVolumeServiceSupportFSS AND the corresponding supervisor capability.

Skip points:
- pvcUpdated/pvcDeleted/pvUpdated/pvDeleted dispatch in metadatasyncer.
- Per-volume loop in csiUpdatePod and pvcsiUpdatePod (mixed pods only filter the FVS volume).
- CsiFullSync filters FVS PVs out of k8sPVs before reconciliation, so they are excluded from cnsCreationMap and update-spec generation.
- PvcsiFullSync skips FVS PVs in createCnsVolumeMetadataList; pod metadata follows because pvcToVolumeName is keyed only on synced PVCs.

Unit tests cover the helper predicates, capability gating, and the full-sync filter behavior.


**Testing done**:
WCP pre-checkin: 
- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1364/ - Pass

VKS pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1079/ - Pass

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
 skip CNS metadata push for FVS-backed file volumes
```
