### PR TITLE
wcpguest: skip CnsFileAccessConfig for FVS-backed file volumes on controller publish/unpublish

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -29,6 +29,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiMeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -582,4 +583,15 @@ func IsFVSStorageClassName(storageClassName string) bool {
 	default:
 		return false
 	}
+}
+
+// IsFVSPersistentVolumeClaim returns true when the PVC's storage class is one
+// of the vSAN file service storage classes used for the new FileVolumeService
+// workflow (see IsFVSStorageClassName). Applies to guest or supervisor PVC
+// objects wherever the FVS storage class names are set.
+func IsFVSPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) bool {
+	if pvc == nil || pvc.Spec.StorageClassName == nil {
+		return false
+	}
+	return IsFVSStorageClassName(*pvc.Spec.StorageClassName)
 }

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/dynamic"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -725,6 +727,34 @@ func TestIsFVSStorageClassName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsFVSStorageClassName(tt.storageClassName); got != tt.want {
 				t.Fatalf("IsFVSStorageClassName(%q) = %v, want %v", tt.storageClassName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsFVSPersistentVolumeClaim(t *testing.T) {
+	scFVS := StorageClassVsanFileServicePolicy
+	scLegacy := "legacy-file-sc"
+	tests := []struct {
+		name string
+		pvc  *corev1.PersistentVolumeClaim
+		want bool
+	}{
+		{"nil pvc", nil, false},
+		{"nil storage class", &corev1.PersistentVolumeClaim{}, false},
+		{"legacy sc", &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "p"},
+			Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &scLegacy},
+		}, false},
+		{"FVS immediate", &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "p"},
+			Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &scFVS},
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsFVSPersistentVolumeClaim(tt.pvc); got != tt.want {
+				t.Fatalf("IsFVSPersistentVolumeClaim() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -173,6 +173,7 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorGuest,
 			common.VsanFileVolumeService, config.GC.Port, config.GC.Endpoint)
 	}
+	IsVsanFileVolumeServiceEnabled = vsanFileVolumeServicePVCSIFSS && vsanFileServiceEnabled
 	if isWorkloadDomainIsolationSupported {
 		err := commonco.ContainerOrchestratorUtility.StartZonesInformer(ctx, c.restClientConfig, c.supervisorNamespace)
 		if err != nil {
@@ -909,6 +910,27 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 func controllerPublishForFileVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest, c *controller) (
 	*csi.ControllerPublishVolumeResponse, string, error) {
 	log := logger.GetLogger(ctx)
+	if IsVsanFileVolumeServiceEnabled {
+		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+			ctx, req.VolumeId, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				msg := fmt.Sprintf("supervisor PVC %q not found in namespace %q", req.VolumeId, c.supervisorNamespace)
+				log.Error(msg)
+				return nil, csifault.CSINotFoundFault, status.Error(codes.NotFound, msg)
+			}
+			msg := fmt.Sprintf("failed to retrieve supervisor PVC %q in namespace %q. Error: %+v",
+				req.VolumeId, c.supervisorNamespace, err)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+		}
+		// FVS-backed supervisor volumes skip CnsFileAccessConfig: the NFS export is reachable
+		// across the VPC without per-VM ACLs. The legacy guest file path would create that CR
+		// for attach ACLs, which is unnecessary and incorrect for File Volume Service volumes.
+		if common.IsFVSPersistentVolumeClaim(svPVC) {
+			return ControllerPublishForFileVolumeServiceVolume(ctx, req, svPVC)
+		}
+	}
 	// Build the CnsFileAccessConfig instance name and namespace
 	cnsFileAccessConfigInstance := &cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
 	cnsFileAccessConfigInstanceName := req.NodeId + "-" + req.VolumeId
@@ -1251,6 +1273,27 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 func controllerUnpublishForFileVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest, c *controller) (
 	*csi.ControllerUnpublishVolumeResponse, string, error) {
 	log := logger.GetLogger(ctx)
+
+	if IsVsanFileVolumeServiceEnabled {
+		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+			ctx, req.VolumeId, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				msg := fmt.Sprintf("supervisor PVC %q not found in namespace %q", req.VolumeId, c.supervisorNamespace)
+				log.Error(msg)
+				return nil, csifault.CSINotFoundFault, status.Error(codes.NotFound, msg)
+			}
+			msg := fmt.Sprintf("failed to retrieve supervisor PVC %q in namespace %q. Error: %+v",
+				req.VolumeId, c.supervisorNamespace, err)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+		}
+		// Same rationale as FVS publish: no CnsFileAccessConfig was created, so do not run the
+		// legacy unpublish path that deletes it; return success after the FVS-specific handling.
+		if common.IsFVSPersistentVolumeClaim(svPVC) {
+			return ControllerUnpublishForFileVolumeServiceVolume(ctx, req)
+		}
+	}
 	// Adding watch on the CnsFileAccessConfig instance to register for updates
 	cnsFileAccessConfigWatcher, err := k8s.NewCnsFileAccessConfigWatcher(ctx, c.restClientConfig, c.supervisorNamespace)
 	if err != nil {

--- a/pkg/csi/service/wcpguest/fvs_publish.go
+++ b/pkg/csi/service/wcpguest/fvs_publish.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// File-volume ControllerPublish/Unpublish handling for the new vSAN
+// FileVolumeService (FVS) workflow on the supervisor.
+//
+// Background:
+// With the legacy CNS file-volume architecture, before a guest pod can mount a
+// file volume the supervisor must add the guest VM's IP to the file share ACL.
+// CSI in the guest cluster drives that flow with a CnsFileAccessConfig CR (see
+// controllerPublishForFileVolume / controllerUnpublishForFileVolume); the
+// reconciler resolves the VM IP and updates the share ACL.
+//
+// The new vSAN FileVolumeService architecture provisions file volumes through
+// FileVolume CRs on the supervisor and exposes them on a sticky raw IP that is
+// reachable to every VM in the same VPC. No per-VM ACL is required, so the
+// guest must not create / delete a CnsFileAccessConfig CR for these volumes.
+// The export endpoint and path are returned to CSI on the supervisor PVC's
+// "csi.vsphere.exportpath.nfs41" annotation (common.Nfsv4ExportPathAnnotationKey)
+// at CreateVolume time.
+//
+// Identification: the controller must gate on IsVsanFileVolumeServiceEnabled and
+// common.IsFVSPersistentVolumeClaim(supervisor PVC) before calling these helpers.
+//
+// Gating: IsVsanFileVolumeServiceEnabled is set in controller.Init when both the
+// PVCSI internal FSS common.VsanFileVolumeServiceSupportFSS and the supervisor
+// capability common.VsanFileVolumeService are enabled. If the FSS is on but the
+// capability is not yet on, HandleLateEnablementOfCapability triggers a
+// controller restart when the capability flips, so the flag does not need to be
+// refreshed on each RPC.
+
+package wcpguest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+
+	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// IsVsanFileVolumeServiceEnabled is the package-level gate for the new vSAN
+// FileVolumeService publish/unpublish workflow on the guest cluster. It is
+// true only when BOTH the PVCSI internal FSS
+// common.VsanFileVolumeServiceSupportFSS AND the corresponding supervisor
+// capability common.VsanFileVolumeService are enabled. Initialized in
+// controller.Init.
+var IsVsanFileVolumeServiceEnabled bool
+
+// ControllerPublishForFileVolumeServiceVolume handles a ControllerPublishVolume for a
+// file volume that has been provisioned by the new vSAN FileVolumeService.
+// There is no per-VM ACL to manage, so we simply read the NFSv4.1 export path
+// from the supervisor PVC's csi.vsphere.exportpath.nfs41 annotation and
+// return it to the node. CnsFileAccessConfig is intentionally not created.
+//
+// The caller must have verified FVS (e.g. common.IsFVSPersistentVolumeClaim on
+// the supervisor PVC) before invoking this function.
+func ControllerPublishForFileVolumeServiceVolume(ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest, svPVC *v1.PersistentVolumeClaim) (
+	*csi.ControllerPublishVolumeResponse, string, error) {
+	log := logger.GetLogger(ctx)
+
+	exportPath := svPVC.Annotations[common.Nfsv4ExportPathAnnotationKey]
+	if exportPath == "" {
+		// Export-path annotation has not been written by the supervisor yet.
+		// Surface as a retryable error so the external-attacher will retry.
+		msg := fmt.Sprintf("FVS supervisor PVC %q in namespace %q is missing required %q annotation; "+
+			"the supervisor has not yet populated the NFSv4.1 export path",
+			svPVC.Name, svPVC.Namespace, common.Nfsv4ExportPathAnnotationKey)
+		log.Error(msg)
+		return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+	}
+
+	publishInfo := map[string]string{
+		common.AttributeDiskType: common.DiskTypeFileVolume,
+		common.Nfsv4AccessPoint:  exportPath,
+	}
+	log.Infof("ControllerPublishVolume: FVS file volume %q published to node %q with access point %q; "+
+		"skipping CnsFileAccessConfig",
+		req.VolumeId, req.NodeId, exportPath)
+	return &csi.ControllerPublishVolumeResponse{PublishContext: publishInfo}, "", nil
+}
+
+// ControllerUnpublishForFileVolumeServiceVolume handles a ControllerUnpublishVolume for
+// an FVS-provisioned file volume. There is no per-VM ACL to revoke, so we
+// short-circuit with a success response without touching CnsFileAccessConfig.
+// The caller must have verified FVS (e.g. common.IsFVSPersistentVolumeClaim on
+// the supervisor PVC) before invoking this function.
+func ControllerUnpublishForFileVolumeServiceVolume(ctx context.Context,
+	req *csi.ControllerUnpublishVolumeRequest) (
+	*csi.ControllerUnpublishVolumeResponse, string, error) {
+	log := logger.GetLogger(ctx)
+	log.Infof("ControllerUnpublishVolume: FVS file volume %q on node %q; "+
+		"no CnsFileAccessConfig to delete, returning success",
+		req.VolumeId, req.NodeId)
+	return &csi.ControllerUnpublishVolumeResponse{}, "", nil
+}

--- a/pkg/csi/service/wcpguest/fvs_publish_test.go
+++ b/pkg/csi/service/wcpguest/fvs_publish_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wcpguest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+)
+
+const (
+	fvsTestNamespace      = "test-namespace-fvs"
+	fvsTestSupervisorPVC  = "tkc-uid-fvs-pvc-12345"
+	fvsTestNodeID         = "guest-vm-node-1"
+	fvsTestNfsv41Endpoint = "10.20.30.40:/nfs/v4/share-1"
+)
+
+func newPVC(name, sc, exportPath string) *v1.PersistentVolumeClaim {
+	scCopy := sc
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: fvsTestNamespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			StorageClassName: &scCopy,
+		},
+	}
+	if exportPath != "" {
+		pvc.Annotations = map[string]string{
+			common.Nfsv4ExportPathAnnotationKey: exportPath,
+		}
+	}
+	return pvc
+}
+
+func setVsanFileVolumeServiceEnabledForTest(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := IsVsanFileVolumeServiceEnabled
+	IsVsanFileVolumeServiceEnabled = enabled
+	t.Cleanup(func() { IsVsanFileVolumeServiceEnabled = prev })
+}
+
+// --- controllerPublishForFileVolume / controllerUnpublishForFileVolume -----
+
+func TestControllerPublishForFileVolume_GateOn_FVSSupervisorPVC(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	pvc := newPVC(fvsTestSupervisorPVC, common.StorageClassVsanFileServicePolicy, fvsTestNfsv41Endpoint)
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(pvc),
+		supervisorNamespace: fvsTestNamespace,
+	}
+	req := &csi.ControllerPublishVolumeRequest{VolumeId: fvsTestSupervisorPVC, NodeId: fvsTestNodeID}
+
+	resp, faultType, err := controllerPublishForFileVolume(context.Background(), req, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v fault=%q", err, faultType)
+	}
+	if resp == nil || resp.PublishContext[common.Nfsv4AccessPoint] != fvsTestNfsv41Endpoint {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if resp.PublishContext[common.AttributeDiskType] != common.DiskTypeFileVolume {
+		t.Fatalf("unexpected disk type: %q", resp.PublishContext[common.AttributeDiskType])
+	}
+}
+
+func TestControllerPublishForFileVolume_GateOn_SupervisorPVCNotFound(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(),
+		supervisorNamespace: fvsTestNamespace,
+	}
+	req := &csi.ControllerPublishVolumeRequest{VolumeId: "missing-supervisor-pvc", NodeId: fvsTestNodeID}
+
+	_, faultType, err := controllerPublishForFileVolume(context.Background(), req, c)
+	if err == nil {
+		t.Fatal("expected error when supervisor PVC is missing")
+	}
+	if faultType != csifault.CSINotFoundFault {
+		t.Fatalf("faultType=%q want %q", faultType, csifault.CSINotFoundFault)
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.NotFound {
+		t.Fatalf("expected gRPC NotFound, got ok=%v code=%v err=%v", ok, st.Code(), err)
+	}
+}
+
+func TestControllerPublishForFileVolume_GateOn_FVSSC_MissingExportAnnotation(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	pvc := newPVC(fvsTestSupervisorPVC, common.StorageClassVsanFileServicePolicy, "")
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(pvc),
+		supervisorNamespace: fvsTestNamespace,
+	}
+	req := &csi.ControllerPublishVolumeRequest{VolumeId: fvsTestSupervisorPVC, NodeId: fvsTestNodeID}
+
+	_, faultType, err := controllerPublishForFileVolume(context.Background(), req, c)
+	if err == nil {
+		t.Fatal("expected error when export-path annotation is missing")
+	}
+	if faultType != csifault.CSIInternalFault {
+		t.Fatalf("faultType=%q want %q", faultType, csifault.CSIInternalFault)
+	}
+}
+
+func TestControllerUnpublishForFileVolume_GateOn_FVSSupervisorPVC(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	pvc := newPVC(fvsTestSupervisorPVC, common.StorageClassVsanFileServicePolicy, fvsTestNfsv41Endpoint)
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(pvc),
+		supervisorNamespace: fvsTestNamespace,
+	}
+	req := &csi.ControllerUnpublishVolumeRequest{VolumeId: fvsTestSupervisorPVC, NodeId: fvsTestNodeID}
+
+	resp, faultType, err := controllerUnpublishForFileVolume(context.Background(), req, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v fault=%q", err, faultType)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+}
+
+func TestControllerUnpublishForFileVolume_GateOn_LateBindingFVS(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	pvc := newPVC(fvsTestSupervisorPVC, common.StorageClassVsanFileServicePolicyLateBinding, fvsTestNfsv41Endpoint)
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(pvc),
+		supervisorNamespace: fvsTestNamespace,
+	}
+	req := &csi.ControllerUnpublishVolumeRequest{VolumeId: fvsTestSupervisorPVC, NodeId: fvsTestNodeID}
+
+	resp, _, err := controllerUnpublishForFileVolume(context.Background(), req, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+}
+
+func TestControllerUnpublishForFileVolume_GateOn_SupervisorPVCNotFound(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(),
+		supervisorNamespace: fvsTestNamespace,
+	}
+	req := &csi.ControllerUnpublishVolumeRequest{VolumeId: "missing-supervisor-pvc", NodeId: fvsTestNodeID}
+
+	_, faultType, err := controllerUnpublishForFileVolume(context.Background(), req, c)
+	if err == nil {
+		t.Fatal("expected error when supervisor PVC is missing")
+	}
+	if faultType != csifault.CSINotFoundFault {
+		t.Fatalf("faultType=%q want %q", faultType, csifault.CSINotFoundFault)
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.NotFound {
+		t.Fatalf("expected gRPC NotFound, got ok=%v code=%v err=%v", ok, st.Code(), err)
+	}
+}
+
+func TestControllerPublishForFileVolume_GateOn_LateBindingFVS(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	pvc := newPVC(fvsTestSupervisorPVC, common.StorageClassVsanFileServicePolicyLateBinding, fvsTestNfsv41Endpoint)
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(pvc),
+		supervisorNamespace: fvsTestNamespace,
+	}
+	req := &csi.ControllerPublishVolumeRequest{VolumeId: fvsTestSupervisorPVC, NodeId: fvsTestNodeID}
+
+	resp, _, err := controllerPublishForFileVolume(context.Background(), req, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil || resp.PublishContext[common.Nfsv4AccessPoint] != fvsTestNfsv41Endpoint {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+// --- ControllerPublishForFileVolumeServiceVolume --------------------------------------
+
+func TestControllerPublishForFileVolumeServiceVolume_Success(t *testing.T) {
+	pvc := newPVC(fvsTestSupervisorPVC, common.StorageClassVsanFileServicePolicy, fvsTestNfsv41Endpoint)
+	req := &csi.ControllerPublishVolumeRequest{VolumeId: fvsTestSupervisorPVC, NodeId: fvsTestNodeID}
+
+	resp, faultType, err := ControllerPublishForFileVolumeServiceVolume(context.Background(), req, pvc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v (fault=%q)", err, faultType)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil response")
+	}
+	if got := resp.PublishContext[common.AttributeDiskType]; got != common.DiskTypeFileVolume {
+		t.Fatalf("unexpected DiskType: %q", got)
+	}
+	if got := resp.PublishContext[common.Nfsv4AccessPoint]; got != fvsTestNfsv41Endpoint {
+		t.Fatalf("unexpected Nfsv4AccessPoint: %q (want %q)", got, fvsTestNfsv41Endpoint)
+	}
+}
+
+func TestControllerPublishForFileVolumeServiceVolume_LateBindingSC(t *testing.T) {
+	pvc := newPVC(fvsTestSupervisorPVC, common.StorageClassVsanFileServicePolicyLateBinding, fvsTestNfsv41Endpoint)
+	req := &csi.ControllerPublishVolumeRequest{VolumeId: fvsTestSupervisorPVC, NodeId: fvsTestNodeID}
+
+	resp, _, err := ControllerPublishForFileVolumeServiceVolume(context.Background(), req, pvc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil || resp.PublishContext[common.Nfsv4AccessPoint] != fvsTestNfsv41Endpoint {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestControllerPublishForFileVolumeServiceVolume_MissingExportAnnotation(t *testing.T) {
+	pvc := newPVC(fvsTestSupervisorPVC, common.StorageClassVsanFileServicePolicy, "")
+	req := &csi.ControllerPublishVolumeRequest{VolumeId: fvsTestSupervisorPVC, NodeId: fvsTestNodeID}
+
+	resp, _, err := ControllerPublishForFileVolumeServiceVolume(context.Background(), req, pvc)
+	if err == nil {
+		t.Fatalf("expected error when FVS PVC is missing export-path annotation")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on error")
+	}
+}
+
+// --- ControllerUnpublishForFileVolumeServiceVolume ------------------------------------
+
+func TestControllerUnpublishForFileVolumeServiceVolume_Success(t *testing.T) {
+	req := &csi.ControllerUnpublishVolumeRequest{VolumeId: fvsTestSupervisorPVC, NodeId: fvsTestNodeID}
+
+	resp, _, err := ControllerUnpublishForFileVolumeServiceVolume(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil response")
+	}
+}

--- a/pkg/syncer/fvs_skip_metadata_test.go
+++ b/pkg/syncer/fvs_skip_metadata_test.go
@@ -92,20 +92,20 @@ func TestIsFVSPersistentVolume(t *testing.T) {
 
 func TestIsFVSPersistentVolumeClaim(t *testing.T) {
 	t.Run("nil pvc", func(t *testing.T) {
-		assert.False(t, isFVSPersistentVolumeClaim(nil))
+		assert.False(t, common.IsFVSPersistentVolumeClaim(nil))
 	})
 	t.Run("nil storage class", func(t *testing.T) {
-		assert.False(t, isFVSPersistentVolumeClaim(&v1.PersistentVolumeClaim{}))
+		assert.False(t, common.IsFVSPersistentVolumeClaim(&v1.PersistentVolumeClaim{}))
 	})
 	t.Run("non FVS storage class", func(t *testing.T) {
-		assert.False(t, isFVSPersistentVolumeClaim(makePVCWithSC("a", "ns", "vsan-default")))
+		assert.False(t, common.IsFVSPersistentVolumeClaim(makePVCWithSC("a", "ns", "vsan-default")))
 	})
 	t.Run("FVS storage class - immediate binding", func(t *testing.T) {
-		assert.True(t, isFVSPersistentVolumeClaim(
+		assert.True(t, common.IsFVSPersistentVolumeClaim(
 			makePVCWithSC("a", "ns", common.StorageClassVsanFileServicePolicy)))
 	})
 	t.Run("FVS storage class - late binding", func(t *testing.T) {
-		assert.True(t, isFVSPersistentVolumeClaim(
+		assert.True(t, common.IsFVSPersistentVolumeClaim(
 			makePVCWithSC("a", "ns", common.StorageClassVsanFileServicePolicyLateBinding)))
 	})
 }

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -317,17 +317,6 @@ func isFVSPersistentVolume(pv *v1.PersistentVolume) bool {
 	return common.IsFVSVolumeHandle(pv.Spec.CSI.VolumeHandle)
 }
 
-// isFVSPersistentVolumeClaim returns true if the PVC's storage class is one of the
-// FVS storage classes. Used by the guest cluster metadata syncer where only the
-// PVC/PV objects are available (no access to supervisor volume IDs). Storage-class
-// matching is delegated to the shared helper common.IsFVSStorageClassName.
-func isFVSPersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) bool {
-	if pvc == nil || pvc.Spec.StorageClassName == nil {
-		return false
-	}
-	return common.IsFVSStorageClassName(*pvc.Spec.StorageClassName)
-}
-
 // shouldSkipFVSMetadataPush decides whether the metadata syncer / full-sync should
 // skip pushing volume metadata for the supplied PV in the supervisor cluster.
 // Returns true only when the VsanFileVolumeService capability is enabled AND the
@@ -350,7 +339,7 @@ func shouldSkipFVSMetadataPushGuest(pvc *v1.PersistentVolumeClaim, pv *v1.Persis
 	if !IsVsanFileVolumeServiceEnabled {
 		return false
 	}
-	if isFVSPersistentVolumeClaim(pvc) {
+	if common.IsFVSPersistentVolumeClaim(pvc) {
 		return true
 	}
 	if pv != nil && common.IsFVSStorageClassName(pv.Spec.StorageClassName) {


### PR DESCRIPTION

**What this PR does / why we need it**:

Volumes provisioned via the new vSAN FileVolumeService (FVS) on the supervisor are exposed on a sticky raw IP that is reachable to every VM in the same VPC, so no per-VM ACL is required. The legacy ControllerPublish/Unpublish flow on the guest cluster CSI creates and waits on a CnsFileAccessConfig CR to add/remove that ACL, which is unnecessary (and incorrect) for FVS volumes.

This change short-circuits the file-volume publish/unpublish in the guest cluster when the volume is FVS-backed:

- Identification: the supervisor-side volume id is opaque on the guest, so FVS PVCs are detected by their supervisor StorageClassName (vsan-file-service-policy{,-latebinding}).
- Publish: read the NFSv4.1 export endpoint from the supervisor PVC annotation csi.vsphere.exportpath.nfs41 (populated by the supervisor FVS path on CreateVolume) and return it directly as Nfsv4AccessPoint in PublishContext. No CnsFileAccessConfig CR is created.
- Unpublish: return success immediately. No CnsFileAccessConfig CR is deleted.

The FVS path is gated behind both the PVCSI internal FSS (common.VsanFileVolumeServiceSupportFSS) and the supervisor capability (common.VsanFileVolumeService), matching the gate already used during Init on the guest controller. Legacy file volumes continue to use the existing CnsFileAccessConfig flow unchanged.


**Testing done**:
WCP pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1361/ - Pass
VKS pre-checkin - 
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1090/ - Pass

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
wcpguest: skip CnsFileAccessConfig for FVS-backed file volumes on controller publish/unpublish
```
