### PR TITLE
Implement CSI idempotent CreateVolume for CnsVolumeAlredydyExistsFault

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -1013,13 +1013,63 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 					log.Errorf("failed to create volume with VolumeID: %q, faultType: %q, err: %v",
 						spec.VolumeId.Id, faultType, err)
 					if IsCnsVolumeAlreadyExistsFault(ctx, faultType) {
-						log.Infof("Observed volume with Id: %q is already Exists. Deleting Volume.", spec.VolumeId.Id)
+						// Handle CnsVolumeAlreadyExistsFault per CSI Transaction Support Design Spec.
+						// See: https://vmw-confluence.broadcom.net/spaces/CNAS/pages/2208445635/Design+Spec+-+CSI+Transaction+Support
+						//
+						// Design Spec Cases:
+						// - Case 2/5: Volume on SAME datastore in request → return success (CSI idempotency)
+						// - Case 3/4: Volume on DIFFERENT datastore not in request → delete and recreate
+						log.Infof("Observed volume with Id: %q already exists. Querying to verify datastore and capacity.", spec.VolumeId.Id)
+
+						var requestedCapacityMb int64
+						if spec.BackingObjectDetails != nil {
+							requestedCapacityMb = spec.BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
+						}
+
+						// Query existing volume to check datastore and capacity
+						checkResult, queryErr := validateVolumeDatastoreAndCapacity(ctx, m, spec.VolumeId.Id,
+							requestedCapacityMb, spec.Datastores)
+						if queryErr != nil {
+							log.Errorf("Failed to query existing volume %q: %v", spec.VolumeId.Id, queryErr)
+							return nil, faultType, err
+						}
+
+						if checkResult.IsOnRequestedDatastore {
+							// Design Spec Case 2/5: Volume exists on a datastore in the requested list
+							// Per CSI spec, CreateVolume MUST be idempotent - return success
+							if checkResult.HasSufficientCapacity {
+								log.Infof("Design Spec Case 2/5: Existing volume %q is on requested datastore %q "+
+									"with sufficient capacity (%d MB >= %d MB). Returning success per CSI idempotency.",
+									spec.VolumeId.Id, checkResult.ExistingDatastoreURL,
+									checkResult.ExistingCapacityMb, requestedCapacityMb)
+								return &CnsVolumeInfo{
+									DatastoreURL: checkResult.ExistingDatastoreURL,
+									VolumeID:     *spec.VolumeId,
+								}, "", nil
+							}
+							// Volume exists on correct datastore but has insufficient capacity
+							log.Errorf("Existing volume %q on datastore %q has insufficient capacity (%d MB < %d MB).",
+								spec.VolumeId.Id, checkResult.ExistingDatastoreURL,
+								checkResult.ExistingCapacityMb, requestedCapacityMb)
+							return nil, faultType, fmt.Errorf("volume %q already exists with insufficient capacity", spec.VolumeId.Id)
+						}
+
+						// Design Spec Case 3/4: Volume exists on a datastore NOT in the requested list
+						// Per design spec: delete the existing volume and request a new one
+						log.Infof("Design Spec Case 3/4: Existing volume %q is on datastore %q which is NOT in "+
+							"the requested datastore list. Deleting volume and recreating per design spec.",
+							spec.VolumeId.Id, checkResult.ExistingDatastoreURL)
+
 						deleteFaultType, deleteError := m.deleteVolume(ctx, spec.VolumeId.Id, true)
 						if deleteError != nil {
-							log.Errorf("failed to delete volume: %q to handle CnsVolumeAlreadyExistsFault , err :%v", spec.VolumeId.Id, err)
+							log.Errorf("Failed to delete volume %q (on wrong datastore %q): %v",
+								spec.VolumeId.Id, checkResult.ExistingDatastoreURL, deleteError)
 							return nil, deleteFaultType, deleteError
 						}
-						log.Infof("Attempt to re-create volume with Id: %q", spec.VolumeId.Id)
+						log.Infof("Successfully deleted volume %q from wrong datastore %q. Retrying create on requested datastores.",
+							spec.VolumeId.Id, checkResult.ExistingDatastoreURL)
+
+						// Retry volume creation on the correct datastores
 						cnsVolumeInfo, faultType, err = m.createVolumeWithTransaction(ctx, spec, extraParams)
 						return cnsVolumeInfo, faultType, err
 					}

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -514,6 +514,122 @@ func validateVolumeCapacity(ctx context.Context, m *defaultManager, volumeID str
 		queryResult.Volumes[0].BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb >= size
 }
 
+// VolumeDatastoreCheckResult contains the result of checking if an existing volume
+// is on a compatible datastore.
+type VolumeDatastoreCheckResult struct {
+	// IsOnRequestedDatastore is true if the volume's datastore is in the requested list
+	IsOnRequestedDatastore bool
+	// HasSufficientCapacity is true if the volume capacity >= requested capacity
+	HasSufficientCapacity bool
+	// ExistingDatastoreURL is the datastore URL where the volume currently resides
+	ExistingDatastoreURL string
+	// ExistingCapacityMb is the current capacity of the volume
+	ExistingCapacityMb int64
+}
+
+// validateVolumeDatastoreAndCapacity queries the CNS volume and validates:
+// 1. Whether the volume's datastore is in the requested datastore list
+// 2. Whether the volume's capacity meets or exceeds the requested capacity
+//
+// This implements the CSI Transaction Support design spec handling for CnsVolumeAlreadyExistsFault:
+// - Design Spec Case 2/5: Volume on same datastore → return success (IsOnRequestedDatastore=true)
+// - Design Spec Case 3/4: Volume on different datastore → delete and recreate (IsOnRequestedDatastore=false)
+//
+// See: https://vmw-confluence.broadcom.net/spaces/CNAS/pages/2208445635/Design+Spec+-+CSI+Transaction+Support
+func validateVolumeDatastoreAndCapacity(ctx context.Context, m *defaultManager, volumeID string,
+	requestedCapacityMb int64, requestedDatastores []types.ManagedObjectReference) (*VolumeDatastoreCheckResult, error) {
+	log := logger.GetLogger(ctx)
+
+	// Query volume to get datastore URL and capacity
+	queryFilter := cnstypes.CnsQueryFilter{
+		VolumeIds: []cnstypes.CnsVolumeId{{Id: volumeID}},
+	}
+	querySelection := cnstypes.CnsQuerySelection{
+		Names: []string{
+			string(cnstypes.QuerySelectionNameTypeDataStoreUrl),
+			string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
+		},
+	}
+	queryResult, err := m.QueryAllVolume(ctx, queryFilter, querySelection)
+	if err != nil {
+		log.Errorf("failed to query CNS for volume %s: %v", volumeID, err)
+		return nil, err
+	}
+	if len(queryResult.Volumes) == 0 {
+		log.Errorf("volume %s not found in CNS query result", volumeID)
+		return nil, errors.New("volume not found")
+	}
+
+	existingVolume := queryResult.Volumes[0]
+	existingDatastoreURL := existingVolume.DatastoreUrl
+	existingCapacityMb := existingVolume.BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
+
+	result := &VolumeDatastoreCheckResult{
+		ExistingDatastoreURL:  existingDatastoreURL,
+		ExistingCapacityMb:    existingCapacityMb,
+		HasSufficientCapacity: existingCapacityMb >= requestedCapacityMb,
+	}
+
+	// Check if the existing volume's datastore is in the requested datastore list
+	// Per design spec: CSI must verify whether the datastore is part of the list of
+	// datastores provided for volume provisioning
+	if len(requestedDatastores) == 0 {
+		// If no specific datastores were requested, consider any datastore as valid
+		log.Debugf("No specific datastores requested, accepting existing datastore %q for volume %q",
+			existingDatastoreURL, volumeID)
+		result.IsOnRequestedDatastore = true
+		return result, nil
+	}
+
+	// Get datastore URLs for the requested datastores to compare
+	for _, requestedDS := range requestedDatastores {
+		dsURL, dsErr := getDatastoreURL(ctx, m.virtualCenter, requestedDS)
+		if dsErr != nil {
+			log.Warnf("Failed to get URL for datastore %v: %v", requestedDS, dsErr)
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(dsURL), strings.TrimSpace(existingDatastoreURL)) {
+			log.Infof("Volume %q exists on datastore %q which is in the requested datastore list",
+				volumeID, existingDatastoreURL)
+			result.IsOnRequestedDatastore = true
+			return result, nil
+		}
+	}
+
+	log.Infof("Volume %q exists on datastore %q which is NOT in the requested datastore list",
+		volumeID, existingDatastoreURL)
+	result.IsOnRequestedDatastore = false
+	return result, nil
+}
+
+// getDatastoreURL retrieves the URL for a given datastore ManagedObjectReference.
+func getDatastoreURL(ctx context.Context, vc *cnsvsphere.VirtualCenter, dsRef types.ManagedObjectReference) (string, error) {
+	log := logger.GetLogger(ctx)
+
+	// Get property collector
+	pc := property.DefaultCollector(vc.Client.Client)
+
+	// Retrieve the datastore info
+	var dsMo mo.Datastore
+	err := pc.RetrieveOne(ctx, dsRef, []string{"info"}, &dsMo)
+	if err != nil {
+		log.Errorf("Failed to retrieve datastore info for %v: %v", dsRef, err)
+		return "", err
+	}
+
+	if dsMo.Info == nil {
+		return "", errors.New("datastore info is nil")
+	}
+
+	// Get the URL from the datastore info
+	dsInfo := dsMo.Info.GetDatastoreInfo()
+	if dsInfo == nil {
+		return "", errors.New("datastore info is nil")
+	}
+
+	return dsInfo.Url, nil
+}
+
 // validateSnapshotDeleted queries the CNS snapshot and validates whether the specific snapshot is deleted
 // returns true if the specific snapshot is deleted
 func validateSnapshotDeleted(ctx context.Context, m *defaultManager, volumeID string, snapshotID string) bool {

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -549,21 +549,80 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{},
 		log.Errorf("failed to create disk %s on vCenter %q with error %+v faultType %q",
 			params.Spec.Name, params.Vcenter.Config.Host, err, faultType)
 		if cnsvolume.IsCnsVolumeAlreadyExistsFault(ctx, faultType) {
-			log.Infof("Observed volume with Id: %q is already Exists. Deleting Volume.", createSpec.VolumeId.Id)
+			// Handle CnsVolumeAlreadyExistsFault per CSI Transaction Support Design Spec.
+			// See: https://vmw-confluence.broadcom.net/spaces/CNAS/pages/2208445635/Design+Spec+-+CSI+Transaction+Support
+			//
+			// Design Spec Cases:
+			// - Case 2/5: Volume on SAME datastore in request → return success (CSI idempotency)
+			// - Case 3/4: Volume on DIFFERENT datastore not in request → delete and recreate
+			log.Infof("Observed volume with Id: %q already exists. Querying to verify datastore and capacity.",
+				createSpec.VolumeId.Id)
+
+			querySelection := &cnstypes.CnsQuerySelection{
+				Names: []string{
+					string(cnstypes.QuerySelectionNameTypeDataStoreUrl),
+					string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
+				},
+			}
+			existingVolume, queryErr := QueryVolumeByID(ctx, params.VolumeManager, createSpec.VolumeId.Id, querySelection)
+			if queryErr != nil {
+				log.Errorf("failed to query existing volume %q: %v", createSpec.VolumeId.Id, queryErr)
+				return nil, faultType, err
+			}
+
+			requestedCapacityMb := createSpec.BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
+			existingCapacityMb := existingVolume.BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
+			existingDatastoreURL := existingVolume.DatastoreUrl
+
+			// Check if the existing volume's datastore is in the requested datastore list
+			isOnRequestedDatastore := false
+			for _, sharedDs := range params.SharedDatastores {
+				if strings.EqualFold(strings.TrimSpace(sharedDs.Info.Url), strings.TrimSpace(existingDatastoreURL)) {
+					isOnRequestedDatastore = true
+					break
+				}
+			}
+
+			if isOnRequestedDatastore {
+				// Design Spec Case 2/5: Volume exists on a datastore in the requested list
+				// Per CSI spec, CreateVolume MUST be idempotent - return success
+				if existingCapacityMb >= requestedCapacityMb {
+					log.Infof("Design Spec Case 2/5: Existing volume %q is on requested datastore %q "+
+						"with sufficient capacity (%d MB >= %d MB). Returning success per CSI idempotency.",
+						createSpec.VolumeId.Id, existingDatastoreURL, existingCapacityMb, requestedCapacityMb)
+					return &cnsvolume.CnsVolumeInfo{
+						DatastoreURL: existingDatastoreURL,
+						VolumeID:     *createSpec.VolumeId,
+					}, "", nil
+				}
+				// Volume exists on correct datastore but has insufficient capacity
+				log.Errorf("Existing volume %q on datastore %q has insufficient capacity (%d MB < %d MB).",
+					createSpec.VolumeId.Id, existingDatastoreURL, existingCapacityMb, requestedCapacityMb)
+				return nil, faultType, fmt.Errorf("volume %q already exists with insufficient capacity", createSpec.VolumeId.Id)
+			}
+
+			// Design Spec Case 3/4: Volume exists on a datastore NOT in the requested list
+			// Per design spec: delete the existing volume and request a new one
+			log.Infof("Design Spec Case 3/4: Existing volume %q is on datastore %q which is NOT in "+
+				"the requested datastore list. Deleting volume and recreating per design spec.",
+				createSpec.VolumeId.Id, existingDatastoreURL)
+
 			_, deleteError := params.VolumeManager.DeleteVolume(ctx, createSpec.VolumeId.Id, true)
 			if deleteError != nil {
-				log.Errorf("failed to delete volume: %q, err :%v", createSpec.VolumeId.Id, err)
+				log.Errorf("Failed to delete volume %q (on wrong datastore %q): %v",
+					createSpec.VolumeId.Id, existingDatastoreURL, deleteError)
 				return nil, faultType, err
 			}
-			log.Infof("Attempt to re-create volume with Id: %q", createSpec.VolumeId.Id)
-			volumeInfo, faultType, err := params.VolumeManager.CreateVolume(ctx, createSpec, nil)
+			log.Infof("Successfully deleted volume %q from wrong datastore %q. Retrying create on requested datastores.",
+				createSpec.VolumeId.Id, existingDatastoreURL)
+
+			// Retry volume creation on the correct datastores
+			volumeInfo, faultType, err = params.VolumeManager.CreateVolume(ctx, createSpec, nil)
 			if err != nil {
-				log.Errorf("failed to re-create disk %s on vCenter %q with error %+v faultType %q",
-					params.Spec.Name, params.Vcenter.Config.Host, err, faultType)
+				log.Errorf("Failed to recreate volume %q on requested datastores: %v", createSpec.VolumeId.Id, err)
 				return nil, faultType, err
-			} else {
-				return volumeInfo, "", nil
 			}
+			return volumeInfo, "", nil
 		}
 		return nil, faultType, err
 	}


### PR DESCRIPTION
Implement CSI idempotent CreateVolume for CnsVolumeAlredydyExistsFault
Per CSI spec, CreateVolume MUST be idempotent. When a volume with the same name already exists and is compatible (capacity >= requested), the plugin MUST return success with the existing volume info.

Previously, when CnsVolumeAlreadyExistsFault was returned by CNS, the driver would delete the existing volume and re-create it. This caused:
- Double quota consumption during race conditions
- Potential data loss if volume was already mounted
- Quota validation failures in tests

This change fixes the handling to:
1. Query the existing volume when CnsVolumeAlreadyExistsFault is received
2. Verify the existing volume's capacity meets or exceeds the requested capacity
3. Return success with the existing volume info if compatible (idempotent)
4. Return an error if the existing volume has insufficient capacity

This properly handles race conditions where the kubernetes-csi external-provisioner sends duplicate CreateVolume requests due to workqueue re-queuing.

Bug Number: 3682916

Testing Done: In progress