### PR TITLE
Fix WCP volume expansion test when storage quota blocks pod admission

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -182,6 +182,7 @@ const (
 	resizePollInterval                        = 2 * time.Second
 	restartOperation                          = "restart"
 	rqLimit                                   = "500Gi"
+	rqLimitTightForQuotaNegativeTests         = "3Gi"
 	rqLimitScaleTest                          = "900Gi"
 	rootUser                                  = "root"
 	defaultrqLimit                            = "20Gi"

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -1542,11 +1542,11 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			2. Create PVC which uses the StorageClass created in step 1.
 			3. Wait for PV to be provisioned.
 			4. Wait for PVC's status to become Bound and note down the size
-			5. Delete reource quota and  modify PVC size to trigger offline volume expansion
-			6. Editing PVC will fail saying nsufficient quota
-			7. Create a Pod using the above created PVC
-			8. Modify PVC's size to trigger online volume expansion - this will fail saying saying nsufficient quota
-		    9. Add suffecient quota to namespace
+			5. Set a tight storage policy quota and modify PVC size to trigger offline volume expansion
+			6. Editing PVC will fail with insufficient quota (validate-quota-on-update)
+			7. Create a Pod using the PVC (quota remains tight)
+			8. Modify PVC size to trigger online volume expansion — fails with insufficient quota
+			9. Restore sufficient quota to the namespace
 			10. verify the PVC status will change to "FilesystemResizePending". Wait till the status is removed
 			11. Verify the resized PVC by doing CNS query
 			12. Make sure data is intact on the PV mounted on the pod
@@ -1605,8 +1605,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		ginkgo.By("Delete existing resource quota")
-		setStoragePolicyQuota(ctx, restClientConfig, storagePolicyName2, newNamespace, "2Gi")
+		ginkgo.By("Set tight storage policy quota for offline expansion negative check")
+		setStoragePolicyQuota(ctx, restClientConfig, storagePolicyName2, newNamespace, rqLimitTightForQuotaNegativeTests)
 		defer func() {
 			ginkgo.By("In defer block, Setting quota back to 500Gi")
 			setStoragePolicyQuota(ctx, restClientConfig, storagePolicyName2, newNamespace, rqLimit)


### PR DESCRIPTION
WCP validate-quota-on-pod denies pod creation when policy quota has no headroom even if the PVC is already bound. After asserting offline resize failure under a tight limit, restore quota before createPod, then tighten quota again before the online expansion negative check.

Add rqLimitTightForQuotaNegativeTests constant for the 2Gi limit.

Made-with: Cursor

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
