### PR TITLE
Changes required in periodic sync for storage quota for PodVM

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -141,6 +141,7 @@ const (
 	SnapQuotaExtensionServiceName        = "snapshot.cns.vsphere.vmware.com"
 	VMExtensionServiceName               = "vmware-system-vmop-webhook-service"
 	VMSnapshotExtensionServiceName       = "snapshot-vmware-system-vmop-webhook-service"
+	PodVMQuotaExtensionServiceName       = "podvm.cns.vsphere.vmware.com"
 	scParamStoragePolicyID               = "storagePolicyID"
 	StorageQuotaPeriodicSyncInstanceName = "storage-quota-periodic-sync"
 	FileVolumePrefix                     = "file:"
@@ -1121,23 +1122,24 @@ func syncStorageQuotaReserved(ctx context.Context,
 		totalStoragePolicyReserved = make(map[string]*resource.Quantity)
 		hasValidData = false
 		log.Debugf("syncStorageQuotaReserved: processing storage quota sync for namespace %q", ns)
-		// calculate VM service's storagepolicyusage reserved values for given namespace
-		spuVmServiceReserved, err := calculateVMServiceStoragePolicyUsageReservedForNamespace(ctx,
+		// calculate extension resource's storagepolicyusage reserved values for given namespace
+		// (includes VM, VM Snapshot, PodVM etc. extension resources)
+		spuExtensionReserved, err := calculateExtensionResourceSPUReservedForNamespace(ctx,
 			cnsOperatorClient, ns)
 		if err != nil {
-			log.Errorf("syncStorageQuotaReserved: error while calculating expected VmService StoragePolicyUsage"+
-				" reserved value, Error: %v", err)
+			log.Errorf("syncStorageQuotaReserved: error while calculating expected extension "+
+				"StoragePolicyUsage reserved value, Error: %v", err)
 			continue
 		}
-		if spuVmServiceReserved != nil {
-			if !validateReservedValues(spuVmServiceReserved) {
-				log.Errorf("syncStorageQuotaReserved: error while calculating expected VmService StoragePolicyUsage"+
-					" reserved value for namespace %s, Error: %v", ns,
+		if spuExtensionReserved != nil {
+			if !validateReservedValues(spuExtensionReserved) {
+				log.Errorf("syncStorageQuotaReserved: error while calculating expected extension "+
+					"StoragePolicyUsage reserved value for namespace %s, Error: %v", ns,
 					errors.New("expected reserved is negative value"))
 				continue
 			}
 			hasValidData = true
-			totalStoragePolicyReserved = mergeStoragePolicyReserved(spuVmServiceReserved, totalStoragePolicyReserved)
+			totalStoragePolicyReserved = mergeStoragePolicyReserved(spuExtensionReserved, totalStoragePolicyReserved)
 		}
 
 		// calculate pending and under expansion PVC's reserved values for given namespace
@@ -1228,13 +1230,13 @@ func mergeStoragePolicyReserved(storagePolicyReserved,
 	return totalStoragepolicyReserved
 }
 
-// calculateVMServiceStoragePolicyUsageReservedForNamespace calculate the expected
-// reserved for StoragePolicyUsage for VMService
-func calculateVMServiceStoragePolicyUsageReservedForNamespace(ctx context.Context, cnsOperatorClient client.Client,
-	namespace string) (map[string]*resource.Quantity, error) {
+// calculateExtensionResourceSPUReservedForNamespace computes the expected reserved
+// values for StoragePolicyUsage (SPU) for extension-managed resources (VM, VM Snapshot, PodVM etc.)
+func calculateExtensionResourceSPUReservedForNamespace(ctx context.Context,
+	cnsOperatorClient client.Client, namespace string) (map[string]*resource.Quantity, error) {
 	log := logger.GetLogger(ctx)
-	log.Debugf("calculateVMServiceStoragePolicyUsageReservedForNamespace: Fetching StoragePolicyUsage for namespace %q",
-		namespace)
+	log.Debugf("calculateExtensionResourceSPUReservedForNamespace: Fetching "+
+		"StoragePolicyUsage for namespace %q", namespace)
 	supList := &storagepolicyv1alpha2.StoragePolicyUsageList{}
 	err := cnsOperatorClient.List(ctx, supList, &client.ListOptions{Namespace: namespace})
 	if err != nil {
@@ -1243,20 +1245,22 @@ func calculateVMServiceStoragePolicyUsageReservedForNamespace(ctx context.Contex
 	storagePolicyToReservedMap := make(map[string]*resource.Quantity)
 	for _, storagePolicyUsage := range supList.Items {
 		if storagePolicyUsage.Spec.ResourceExtensionName == VMExtensionServiceName ||
-			storagePolicyUsage.Spec.ResourceExtensionName == VMSnapshotExtensionServiceName {
-			log.Debugf("calculateVMServiceStoragePolicyUsageReservedForNamespace: Processing StoragePolicyUsage"+
-				" Name: %q, Namespace: %q", storagePolicyUsage.Name, storagePolicyUsage.Namespace)
+			storagePolicyUsage.Spec.ResourceExtensionName == VMSnapshotExtensionServiceName ||
+			storagePolicyUsage.Spec.ResourceExtensionName == PodVMQuotaExtensionServiceName {
+			log.Debugf("calculateExtensionResourceSPUReservedForNamespace: Processing "+
+				"StoragePolicyUsage Name: %q, Namespace: %q", storagePolicyUsage.Name,
+				storagePolicyUsage.Namespace)
 			if storagePolicyUsage.DeletionTimestamp != nil {
-				log.Debugf("calculateVMServiceStoragePolicyUsageReservedForNamespace:"+
+				log.Debugf("calculateExtensionResourceSPUReservedForNamespace:"+
 					" StoragePolicyUsage is marked for deletion, ignoring Name: %q, Namespace: %q",
 					storagePolicyUsage.Name, storagePolicyUsage.Namespace)
 				continue
 			}
 			if storagePolicyUsage.Status.ResourceTypeLevelQuotaUsage == nil ||
 				storagePolicyUsage.Status.ResourceTypeLevelQuotaUsage.Reserved == nil {
-				log.Debugf("calculateVMServiceStoragePolicyUsageReservedForNamespace: StoragePolicyUsage"+
-					" status not populated, continue processing other PVCs Name: %q, Namespace: %q",
-					storagePolicyUsage.Name, storagePolicyUsage.Namespace)
+				log.Debugf("calculateExtensionResourceSPUReservedForNamespace: "+
+					"StoragePolicyUsage status not populated, continue processing other resources "+
+					"Name: %q, Namespace: %q", storagePolicyUsage.Name, storagePolicyUsage.Namespace)
 				continue
 			}
 			if storagePolicyToReservedMap[storagePolicyUsage.Spec.StoragePolicyId] == nil {

--- a/pkg/syncer/metadatasyncer_test.go
+++ b/pkg/syncer/metadatasyncer_test.go
@@ -234,7 +234,7 @@ func (e *errorClient) List(ctx context.Context, list client.ObjectList, opts ...
 	return e.err
 }
 
-func TestCalculateVMServiceStoragePolicyUsageReservedForNamespace(t *testing.T) {
+func TestCalculateExtensionResourceSPUReservedForNamespace(t *testing.T) {
 	ctx := context.Background()
 	namespace := "test-namespace"
 
@@ -742,24 +742,132 @@ func TestCalculateVMServiceStoragePolicyUsageReservedForNamespace(t *testing.T) 
 			}(),
 			expectError: false,
 		},
+		{
+			name: "Success with single StoragePolicyUsage for PodVM extension",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				threeGi := resource.MustParse("3Gi")
+				spu := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-podvm",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-podvm",
+						ResourceExtensionName: PodVMQuotaExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &threeGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu).
+					Build()
+			},
+			expectedResult: func() map[string]*resource.Quantity {
+				threeGi := resource.MustParse("3Gi")
+				return map[string]*resource.Quantity{
+					"policy-podvm": resource.NewQuantity(threeGi.Value(), resource.BinarySI),
+				}
+			}(),
+			expectError: false,
+		},
+		{
+			name: "Success with multiple extensions including PodVM",
+			setupClient: func() client.Client {
+				scheme := runtime.NewScheme()
+				_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+
+				tenGi := resource.MustParse("10Gi")
+				fiveGi := resource.MustParse("5Gi")
+				threeGi := resource.MustParse("3Gi")
+				spu1 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-1",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &tenGi,
+						},
+					},
+				}
+				spu2 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-2",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: VMSnapshotExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &fiveGi,
+						},
+					},
+				}
+				spu3 := &storagepolicyv1alpha2.StoragePolicyUsage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spu-3",
+						Namespace: namespace,
+					},
+					Spec: storagepolicyv1alpha2.StoragePolicyUsageSpec{
+						StoragePolicyId:       "policy-1",
+						ResourceExtensionName: PodVMQuotaExtensionServiceName,
+					},
+					Status: storagepolicyv1alpha2.StoragePolicyUsageStatus{
+						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha2.QuotaUsageDetails{
+							Reserved: &threeGi,
+						},
+					},
+				}
+
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(spu1, spu2, spu3).
+					Build()
+			},
+			expectedResult: func() map[string]*resource.Quantity {
+				eighteenGi := resource.MustParse("18Gi")
+				return map[string]*resource.Quantity{
+					"policy-1": resource.NewQuantity(eighteenGi.Value(), resource.BinarySI),
+				}
+			}(),
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := tt.setupClient()
-			result, err := calculateVMServiceStoragePolicyUsageReservedForNamespace(ctx, fakeClient, namespace)
+			result, err := calculateExtensionResourceSPUReservedForNamespace(ctx, fakeClient,
+				namespace)
 
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("calculateVMServiceStoragePolicyUsageReservedForNamespace() expected error but got nil")
+					t.Errorf(
+						"calculateExtensionResourceSPUReservedForNamespace() expected " +
+							"error but got nil")
 				}
 			} else {
 				if err != nil {
-					t.Errorf("calculateVMServiceStoragePolicyUsageReservedForNamespace() returned error: %v", err)
+					t.Errorf("calculateExtensionResourceSPUReservedForNamespace() "+
+						"returned error: %v", err)
 				}
 				if !quantitiesEqual(result, tt.expectedResult) {
-					t.Errorf("calculateVMServiceStoragePolicyUsageReservedForNamespace() result = %v; want %v",
-						result, tt.expectedResult)
+					t.Errorf("calculateExtensionResourceSPUReservedForNamespace() "+
+						"result = %v; want %v", result, tt.expectedResult)
 				}
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR takes care of changes required in periodic sync for storage quota for PodVM. We need to consider SPU reserved values for PodVM along with VMservice and VMserviceSnapshot SPUs for periodic sync calculations.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
All periodic sync specific unit tests are passing.
WCP pre-checkin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1339/ (passed)
```
Ran 16 of 2324 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2308 Skipped | 0 Flaked
```
VKS pre-checkin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1059/ (passed)
```
Ran 6 of 2324 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2318 Skipped | 0 Flaked
```

*Manual testing logs*:

Verified that there is no problem in periodic sync logic after these changes. Observed couple of periodic sync cycles and it worked as usual.
```
# k get storagequotaperiodicsyncs.cns.vmware.com -n vmware-system-csi -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StorageQuotaPeriodicSync
  metadata:
..
    name: storage-quota-periodic-sync
    namespace: vmware-system-csi
  spec:
    syncIntervalInMinutes: 10
  status:
    expectedReservedValues:
    - namespace: pod-spq
      reserved:
        aa6d5a82-1c88-45da-85d3-3d74b91a5bad: "0"     <<<<
    - namespace: svc-cci-ns-4arsz
      reserved:
        4d5f673c-536f-11e6-beb8-9e71128cae77: "0"
        a9423670-7455-11e8-adc0-fa7ae01bbebc: "0"
        aa6d5a82-1c88-45da-85d3-3d74b91a5bad: "0"
        b1263970-8662-69e2-adc6-fa8ae01abecc: "0"
...


# k get storagequota -n pod-spq -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha3
  kind: StorageQuota
  metadata:
    name: total-quota
    namespace: pod-spq
  spec:
    limit: 10Gi
    storagePolicyLevelLimits:
      aa6d5a82-1c88-45da-85d3-3d74b91a5bad: "9223372036854775807"
  status:
    appliedLimit: 10Gi
    appliedStoragePolicyLevelLimits:
      aa6d5a82-1c88-45da-85d3-3d74b91a5bad: "9223372036854775807"
    total:
    - policyQuotaUsage:
        reserved: "0"
        used: 1877Mi
      storagePolicyId: aa6d5a82-1c88-45da-85d3-3d74b91a5bad



# k get storagepolicyusages.cns.vmware.com -n pod-spq vsan-default-storage-policy-podvm-usage -o yaml
apiVersion: cns.vmware.com/v1alpha3
kind: StoragePolicyUsage
metadata:
  name: vsan-default-storage-policy-podvm-usage
  namespace: pod-spq
spec:
  resourceApiGroup: ""
  resourceExtensionName: podvm.cns.vsphere.vmware.com
  resourceExtensionNamespace: kube-system
  resourceKind: Pod
  storageClassName: vsan-default-storage-policy
  storagePolicyId: aa6d5a82-1c88-45da-85d3-3d74b91a5bad
status:
  quotaUsage:
    reserved: "0"
    used: 853Mi
...
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Changes required in periodic sync for storage quota for PodVM
```
