### PR TITLE
fix(syncer): avoid double-counting StoragePolicyUsage on create retries

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -747,6 +747,20 @@ func (m *defaultManager) createVolumeWithTransaction(ctx context.Context, spec *
 	if finalErr != nil && !apierrors.IsNotFound(finalErr) {
 		return nil, csifault.CSIInternalFault, finalErr
 	}
+
+	// Idempotent-quota guard for retry paths (e.g. retry after CnsVolumeAlreadyExistsFault):
+	// If a prior invocation already completed successfully for this CR, the storage usage
+	// has been accounted for in StoragePolicyUsage. Suppress QuotaDetails.Reserved
+	// repopulation so the syncer does not see a second "Reserved 1Gi -> 0 + Success"
+	// transition and double-count used.
+	if isPodVMOnStretchSupervisorFSSEnabled && m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+		quotaInfo != nil && m.operationStore.HasPriorSuccessfulCreate(ctx, volNameFromInputSpec) {
+		log.Infof("createVolumeWithTransaction: suppressing QuotaDetails.Reserved for "+
+			"instance %s because a prior task already completed successfully. "+
+			"Storage usage already accounted in StoragePolicyUsage.", volNameFromInputSpec)
+		quotaInfo = nil
+	}
+
 	defer func() {
 		// Persist the operation details before returning. Only success or error
 		// needs to be stored as InProgress details are stored when the task is

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -441,6 +441,23 @@ func (f *fakeVolumeOperationRequestInterface) DeleteRequestDetails(
 	return nil
 }
 
+// HasPriorSuccessfulCreate checks if the stored VolumeOperationRequestDetails
+// for the given name has a successful task status.
+func (f *fakeVolumeOperationRequestInterface) HasPriorSuccessfulCreate(
+	ctx context.Context,
+	name string,
+) bool {
+	instance, ok := f.volumeOperationRequestMap[name]
+	if !ok {
+		return false
+	}
+	if instance.OperationDetails != nil &&
+		instance.OperationDetails.TaskStatus == cnsvolumeoperationrequest.TaskInvocationStatusSuccess {
+		return true
+	}
+	return false
+}
+
 // GetNodesForVolumes returns nodeNames to which the given volumeIDs are attached
 func (c *FakeK8SOrchestrator) GetNodesForVolumes(ctx context.Context, volumeID []string) map[string][]string {
 	nodeNames := make(map[string][]string)

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -63,6 +63,14 @@ type VolumeOperationRequest interface {
 	// DeleteRequestDetails deletes the details of the operation on the volume
 	// that was persisted by the VolumeOperationRequest interface.
 	DeleteRequestDetails(ctx context.Context, name string) error
+	// HasPriorSuccessfulCreate checks the full LatestOperationDetails list
+	// of the CnsVolumeOperationRequest CR identified by name and returns
+	// true if any entry has TaskStatus == Success. This is used to guard
+	// against re-populating QuotaDetails.Reserved on retry paths (e.g.
+	// after CnsVolumeAlreadyExistsFault) that would otherwise cause
+	// StoragePolicyUsage.used to be incremented more than once for the
+	// same volume.
+	HasPriorSuccessfulCreate(ctx context.Context, name string) bool
 }
 
 // operationRequestStore implements the VolumeOperationsRequest interface.
@@ -379,6 +387,32 @@ func (or *operationRequestStore) DeleteRequestDetails(ctx context.Context, name 
 		}
 	}
 	return nil
+}
+
+// HasPriorSuccessfulCreate checks if the CnsVolumeOperationRequest CR
+// identified by name has any entry in LatestOperationDetails with
+// TaskStatus == Success. This is used as an idempotency guard in the
+// CreateVolume retry path: if a prior attempt already completed
+// successfully (and was thus already accounted for in
+// StoragePolicyUsage.used), we must not re-populate
+// QuotaDetails.Reserved on the retry to avoid double-counting.
+func (or *operationRequestStore) HasPriorSuccessfulCreate(ctx context.Context, name string) bool {
+	log := logger.GetLogger(ctx)
+	instanceKey := client.ObjectKey{Name: name, Namespace: csiNamespace}
+	instance := &cnsvolumeoprequestv1alpha1.CnsVolumeOperationRequest{}
+	if err := or.k8sclient.Get(ctx, instanceKey, instance); err != nil {
+		log.Debugf("HasPriorSuccessfulCreate: could not fetch CR %s/%s: %v",
+			instanceKey.Namespace, instanceKey.Name, err)
+		return false
+	}
+	for _, op := range instance.Status.LatestOperationDetails {
+		if op.TaskStatus == TaskInvocationStatusSuccess {
+			log.Infof("HasPriorSuccessfulCreate: found prior successful task %s in CR %s",
+				op.TaskID, name)
+			return true
+		}
+	}
+	return false
 }
 
 // cleanupStaleInstances cleans up CnsVolumeOperationRequest instances

--- a/pkg/internalapis/cnsvolumeoperationrequest/has_prior_successful_create_test.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/has_prior_successful_create_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnsvolumeoperationrequest
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cnsvolumeoprequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
+)
+
+// seedCR creates a CnsVolumeOperationRequest CR directly via the fake k8s
+// client so we can exercise HasPriorSuccessfulCreate against a known
+// LatestOperationDetails history.
+func seedCR(t *testing.T, store *operationRequestStore, name string,
+	ops []cnsvolumeoprequestv1alpha1.OperationDetails) {
+	t.Helper()
+	cr := &cnsvolumeoprequestv1alpha1.CnsVolumeOperationRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: csiNamespace,
+		},
+		Status: cnsvolumeoprequestv1alpha1.CnsVolumeOperationRequestStatus{
+			LatestOperationDetails: ops,
+		},
+	}
+	if err := store.k8sclient.Create(t.Context(), cr); err != nil {
+		t.Fatalf("seedCR: failed to create CR %s: %v", name, err)
+	}
+}
+
+func mkOp(taskID, status string) cnsvolumeoprequestv1alpha1.OperationDetails {
+	return cnsvolumeoprequestv1alpha1.OperationDetails{
+		TaskInvocationTimestamp: metav1.Now(),
+		TaskID:                  taskID,
+		TaskStatus:              status,
+	}
+}
+
+// TestHasPriorSuccessfulCreate covers the controller-side idempotency guard
+// used in createVolumeWithTransaction to suppress QuotaDetails.Reserved
+// repopulation on retry paths (e.g. after CnsVolumeAlreadyExistsFault).
+func TestHasPriorSuccessfulCreate(t *testing.T) {
+	t.Run("CR not found returns false", func(t *testing.T) {
+		store, ctx := setupTestEnvironment(t, true)
+		if store.HasPriorSuccessfulCreate(ctx, "missing") {
+			t.Errorf("expected false when CR does not exist")
+		}
+	})
+
+	t.Run("empty LatestOperationDetails returns false", func(t *testing.T) {
+		store, ctx := setupTestEnvironment(t, true)
+		seedCR(t, store, "empty-ops", nil)
+		if store.HasPriorSuccessfulCreate(ctx, "empty-ops") {
+			t.Errorf("expected false when LatestOperationDetails is empty")
+		}
+	})
+
+	t.Run("only InProgress / Error returns false", func(t *testing.T) {
+		store, ctx := setupTestEnvironment(t, true)
+		seedCR(t, store, "no-success", []cnsvolumeoprequestv1alpha1.OperationDetails{
+			mkOp("task-1", TaskInvocationStatusInProgress),
+			mkOp("task-2", TaskInvocationStatusError),
+		})
+		if store.HasPriorSuccessfulCreate(ctx, "no-success") {
+			t.Errorf("expected false when no Success entries are present")
+		}
+	})
+
+	t.Run("single Success returns true", func(t *testing.T) {
+		store, ctx := setupTestEnvironment(t, true)
+		seedCR(t, store, "one-success", []cnsvolumeoprequestv1alpha1.OperationDetails{
+			mkOp("task-1", TaskInvocationStatusSuccess),
+		})
+		if !store.HasPriorSuccessfulCreate(ctx, "one-success") {
+			t.Errorf("expected true when a Success entry is present")
+		}
+	})
+
+	// Models the production CR for the bug:
+	//   task-842 Success
+	//   task-847 Error  (CnsVolumeAlreadyExistsFault)
+	//   task-854 Success
+	// The guard MUST detect the prior Success even when the most recent
+	// entry on the path is an Error or another Success.
+	t.Run("Success then Error: returns true", func(t *testing.T) {
+		store, ctx := setupTestEnvironment(t, true)
+		seedCR(t, store, "succ-then-err", []cnsvolumeoprequestv1alpha1.OperationDetails{
+			mkOp("task-842", TaskInvocationStatusSuccess),
+			mkOp("task-847", TaskInvocationStatusError),
+		})
+		if !store.HasPriorSuccessfulCreate(ctx, "succ-then-err") {
+			t.Errorf("expected true: prior Success should be detected even if latest entry is Error")
+		}
+	})
+
+	t.Run("Success, Error, Success: returns true", func(t *testing.T) {
+		store, ctx := setupTestEnvironment(t, true)
+		seedCR(t, store, "bug-shape", []cnsvolumeoprequestv1alpha1.OperationDetails{
+			mkOp("task-842", TaskInvocationStatusSuccess),
+			mkOp("task-847", TaskInvocationStatusError),
+			mkOp("task-854", TaskInvocationStatusSuccess),
+		})
+		if !store.HasPriorSuccessfulCreate(ctx, "bug-shape") {
+			t.Errorf("expected true on bug-shape CR with two Success entries and one intermediate Error")
+		}
+	})
+}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2094,17 +2094,32 @@ func cnsvolumeoperationrequestCRUpdated(oldObj interface{}, newObj interface{}) 
 				latestOps := newcnsvolumeoperationrequestObj.Status.LatestOperationDetails
 				latestOp := latestOps[len(latestOps)-1]
 				if latestOp.TaskStatus == cnsvolumeoperationrequest.TaskInvocationStatusSuccess {
-					log.Debugf("Latest task %s in %s instance %s succeeded. Incrementing \"used\" "+
-						"field in storagepolicyusage CR", latestOp.TaskID,
-						cnsvolumeoperationrequest.CRDSingular, newcnsvolumeoperationrequestObj.Name)
-					log.Infof("Increase the used value in storagePolicyUsage CR %s by %s "+
-						" since the operation was successful CnsVolumeOperationRequest: %s",
-						storagePolicyUsageCR.Name,
-						oldcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.String(),
-						cnsVolumeOperationRequestName)
-					patchedStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Used.Add(
-						*oldcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved)
-					increaseUsed = true
+					// Idempotency guard: skip the "used" bump if a prior Success entry already
+					// exists in this CR's LatestOperationDetails. A single CR represents one
+					// logical create for one volume; multiple Success entries can only arise
+					// from retry paths (e.g. after CnsVolumeAlreadyExistsFault) that should
+					// not double-count storage usage.
+					if hasPriorSuccessForVolume(latestOps, latestOp.TaskID) {
+						log.Infof("cnsvolumeoperationrequestCRUpdated: skip incrementing "+
+							"\"used\" for storagepolicyusage CR %s: a prior successful "+
+							"task already accounted for volume %q in "+
+							"CnsVolumeOperationRequest: %s (latest taskID: %s)",
+							storagePolicyUsageCR.Name,
+							newcnsvolumeoperationrequestObj.Status.VolumeID,
+							cnsVolumeOperationRequestName, latestOp.TaskID)
+					} else {
+						log.Debugf("Latest task %s in %s instance %s succeeded. Incrementing \"used\" "+
+							"field in storagepolicyusage CR", latestOp.TaskID,
+							cnsvolumeoperationrequest.CRDSingular, newcnsvolumeoperationrequestObj.Name)
+						log.Infof("Increase the used value in storagePolicyUsage CR %s by %s "+
+							" since the operation was successful CnsVolumeOperationRequest: %s",
+							storagePolicyUsageCR.Name,
+							oldcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.String(),
+							cnsVolumeOperationRequestName)
+						patchedStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Used.Add(
+							*oldcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved)
+						increaseUsed = true
+					}
 				}
 			} else {
 				log.Debug("skip increase `used` capacity, for snapshot operation cnsvolumeinfo informer will increase it")
@@ -2130,6 +2145,26 @@ func cnsvolumeoperationrequestCRUpdated(oldObj interface{}, newObj interface{}) 
 			}
 		}
 	}
+}
+
+// hasPriorSuccessForVolume returns true if latestOps contains a successful
+// task entry other than the one identified by currentTaskID. This guards
+// against double-counting StoragePolicyUsage.used when a retry path (e.g.
+// after CnsVolumeAlreadyExistsFault) causes multiple Success entries to
+// accumulate in a single CnsVolumeOperationRequest CR for the same volume.
+func hasPriorSuccessForVolume(
+	latestOps []cnsvolumeoperationrequestv1alpha1.OperationDetails,
+	currentTaskID string,
+) bool {
+	for i := range latestOps {
+		if latestOps[i].TaskID == currentTaskID {
+			continue
+		}
+		if latestOps[i].TaskStatus == cnsvolumeoperationrequest.TaskInvocationStatusSuccess {
+			return true
+		}
+	}
+	return false
 }
 
 // checkOperationRequestCRForSnapshot will verify if the cnsvolumeopeationrequest CR event is generated

--- a/pkg/syncer/quota_idempotency_test.go
+++ b/pkg/syncer/quota_idempotency_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
+	cnsvolumeoperationrequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
+)
+
+// TestHasPriorSuccessForVolume verifies the syncer-side idempotency guard that
+// prevents StoragePolicyUsage.used from being incremented more than once when
+// a single CnsVolumeOperationRequest CR accumulates multiple Success entries
+// (e.g. via the CnsVolumeAlreadyExistsFault retry path that does
+// CreateVolume -> AlreadyExists -> deleteVolume -> CreateVolume).
+func TestHasPriorSuccessForVolume(t *testing.T) {
+	mkOp := func(taskID, status string) cnsvolumeoperationrequestv1alpha1.OperationDetails {
+		return cnsvolumeoperationrequestv1alpha1.OperationDetails{
+			TaskInvocationTimestamp: metav1.Now(),
+			TaskID:                  taskID,
+			TaskStatus:              status,
+		}
+	}
+
+	tests := []struct {
+		name          string
+		latestOps     []cnsvolumeoperationrequestv1alpha1.OperationDetails
+		currentTaskID string
+		want          bool
+	}{
+		{
+			name:          "empty list returns false",
+			latestOps:     nil,
+			currentTaskID: "task-1",
+			want:          false,
+		},
+		{
+			name: "single Success entry which is the current task returns false",
+			latestOps: []cnsvolumeoperationrequestv1alpha1.OperationDetails{
+				mkOp("task-1", cnsvolumeoperationrequest.TaskInvocationStatusSuccess),
+			},
+			currentTaskID: "task-1",
+			want:          false,
+		},
+		{
+			name: "single Error entry returns false",
+			latestOps: []cnsvolumeoperationrequestv1alpha1.OperationDetails{
+				mkOp("task-1", cnsvolumeoperationrequest.TaskInvocationStatusError),
+			},
+			currentTaskID: "task-1",
+			want:          false,
+		},
+		{
+			// Models the bug scenario:
+			//   task-842 Success (first create)
+			//   task-847 Error   (CnsVolumeAlreadyExistsFault)
+			//   task-854 Success (recreate after delete) <- current
+			// The guard MUST fire so the syncer does not bump used a 2nd time.
+			name: "prior Success exists with intermediate Error: returns true",
+			latestOps: []cnsvolumeoperationrequestv1alpha1.OperationDetails{
+				mkOp("task-842", cnsvolumeoperationrequest.TaskInvocationStatusSuccess),
+				mkOp("task-847", cnsvolumeoperationrequest.TaskInvocationStatusError),
+				mkOp("task-854", cnsvolumeoperationrequest.TaskInvocationStatusSuccess),
+			},
+			currentTaskID: "task-854",
+			want:          true,
+		},
+		{
+			name: "two Success entries back-to-back: returns true for the latest",
+			latestOps: []cnsvolumeoperationrequestv1alpha1.OperationDetails{
+				mkOp("task-1", cnsvolumeoperationrequest.TaskInvocationStatusSuccess),
+				mkOp("task-2", cnsvolumeoperationrequest.TaskInvocationStatusSuccess),
+			},
+			currentTaskID: "task-2",
+			want:          true,
+		},
+		{
+			name: "only Errors before current Success returns false",
+			latestOps: []cnsvolumeoperationrequestv1alpha1.OperationDetails{
+				mkOp("task-1", cnsvolumeoperationrequest.TaskInvocationStatusError),
+				mkOp("task-2", cnsvolumeoperationrequest.TaskInvocationStatusError),
+				mkOp("task-3", cnsvolumeoperationrequest.TaskInvocationStatusSuccess),
+			},
+			currentTaskID: "task-3",
+			want:          false,
+		},
+		{
+			name: "in-progress entries are ignored",
+			latestOps: []cnsvolumeoperationrequestv1alpha1.OperationDetails{
+				mkOp("task-1", cnsvolumeoperationrequest.TaskInvocationStatusInProgress),
+				mkOp("task-2", cnsvolumeoperationrequest.TaskInvocationStatusSuccess),
+			},
+			currentTaskID: "task-2",
+			want:          false,
+		},
+		{
+			name: "current task id matches multiple entries: only non-current Success counts",
+			latestOps: []cnsvolumeoperationrequestv1alpha1.OperationDetails{
+				mkOp("task-1", cnsvolumeoperationrequest.TaskInvocationStatusSuccess),
+				mkOp("task-1", cnsvolumeoperationrequest.TaskInvocationStatusSuccess),
+			},
+			currentTaskID: "task-1",
+			want:          false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasPriorSuccessForVolume(tc.latestOps, tc.currentTaskID)
+			if got != tc.want {
+				t.Errorf("hasPriorSuccessForVolume() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When CSI transaction idempotency is enabled, CreateVolume may record multiple Success tasks in CnsVolumeOperationRequest (e.g. after CnsVolumeAlreadyExistsFault and delete+recreate). The syncer previously incremented StoragePolicyUsage.used on every reserved→0 transition when the latest task succeeded, which over-counted the same volume.

- Skip the used increment when another Success already exists in LatestOperationDetails (hasPriorSuccessForVolume).
- On workload clusters with PodVM-on-stretch quota, suppress QuotaDetails.Reserved repopulation in createVolumeWithTransaction if any prior task succeeded (HasPriorSuccessfulCreate).
- Implement HasPriorSuccessfulCreate on the operation request store and the fake used in unit tests.

test: cover idempotency guards for StoragePolicyUsage double-count fix

Adds unit tests for the two guards introduced:

- pkg/syncer: hasPriorSuccessForVolume — table-driven tests covering empty input, lone Success/Error/InProgress entries, the production bug shape (Success, Error CnsVolumeAlreadyExistsFault, Success), and the same-TaskID edge case.
- pkg/internalapis/cnsvolumeoperationrequest: HasPriorSuccessfulCreate — seeds CnsVolumeOperationRequest CRs through the fake client and verifies missing CR, empty / no-Success / single-Success / bug-shape histories produce the expected guard decisions.

Made-with: Cursor



**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1348/ - Pass
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1069/ - Pass

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
avoid double-counting StoragePolicyUsage on create retries
```
