### PR TITLE
Security Enhancement - Bind profiling endpoints to `127.0.0.1`

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -104,7 +104,7 @@ func main() {
 	if *enableProfileServer {
 		go func() {
 			log.Info("Starting the http server to expose profiling metrics..")
-			err := http.ListenAndServe(":9501", nil)
+			err := http.ListenAndServe("127.0.0.1:9501", nil)
 			if err != nil {
 				log.Fatalf("Unable to start profiling server: %s", err)
 			}

--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -61,7 +61,7 @@ func main() {
 	if *enableProfileServer {
 		go func() {
 			log.Info("Starting the http server to expose profiling metrics..")
-			err := http.ListenAndServe(":9500", nil)
+			err := http.ListenAndServe("127.0.0.1:9500", nil)
 			if err != nil {
 				log.Fatalf("Unable to start profiling server: %s", err)
 			}


### PR DESCRIPTION
## Summary
The vsphere-csi-driver and vsphere-syncer processes expose Go pprof debug endpoints on ports 9500 and 9501 (all interfaces) without authentication. These are reachable from the node network and any hostNetwork pod, exposing goroutine stacks, allocation metadata, and enabling CPU profiling DoS.

This PR addresses this security gap by explicitly binding the ports to `127.0.0.1`. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes **N/A**

## Testing
Enabled the port-forwarding to ports 9500(controller) and 9501(syncer), and verified that the endpoints are accessible only from `127.0.0.1`.

| IP | Container | Port | Result | 
|--------|--------|--------|--------|
| 192.168.128.0 | Syncer | 9501 | Inaccessible |
| 192.168.128.0 | Container | 9500 | Inaccessbile |
| 127.0.0.1 | Syncer | 9501 | Accessible |
| 127.0.0.1 | Container | 9500 | Accessible |

**Special notes for your reviewer**: N/A

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enhanced security of the profiling endpoints.
```
