### PR TITLE
Ensure PVCs are detached from VM only if VM spec does not have reference to them.

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -33,7 +33,7 @@ import (
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/conditions"
 
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -314,7 +314,7 @@ func (r *Reconciler) Reconcile(ctx context.Context,
 	} else {
 		// If VM was found on vCenter, find the volumes to be attached and detached.
 		volumesToAttach, volumesToDetach, err = getVolumesToAttachAndDetach(batchAttachCtx, instance, vm, r.client, k8sClient,
-			r.cnsOperatorClient)
+			r.cnsOperatorClient, r.vmOperatorClient)
 		if err != nil {
 			log.Errorf("failed to find volumes to detach for instance %s. Err: %s",
 				request.NamespacedName.String(), err)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -146,16 +147,51 @@ func removeFinalizerFromCRDInstance(ctx context.Context,
 	return k8s.PatchFinalizers(ctx, c, instance, finalizersOnInstance)
 }
 
+// buildVMSpecVolumeCache creates a map of PVC names referenced in the VM spec for efficient lookups.
+// Returns a map where key is PVC name and value is true if the PVC is referenced in VM spec.
+// Returns an empty map if vm is nil.
+func buildVMSpecVolumeCache(vm *vmoperatortypes.VirtualMachine) map[string]bool {
+	volumeCache := make(map[string]bool)
+
+	if vm == nil {
+		return volumeCache
+	}
+
+	for _, vmVol := range vm.Spec.Volumes {
+		if vmVol.VirtualMachineVolumeSource.PersistentVolumeClaim != nil {
+			volumeCache[vmVol.VirtualMachineVolumeSource.PersistentVolumeClaim.ClaimName] = true
+		}
+	}
+	return volumeCache
+}
+
 // getVolumesToDetachFromInstance finds out which are the volumes to detach by finding out which are
 // the volumes present in attachedFCDs but not in spec of the instance.
 func getVolumesToDetachFromInstance(ctx context.Context,
 	instance *v1alpha1.CnsNodeVMBatchAttachment,
+	vmOperatorClient client.Client,
 	attachedFCDs map[string]FCDBackingDetails,
 	volumeIdsInSpec map[string]FCDBackingDetails) (pvcsToDetach map[string]string, err error) {
 	log := logger.GetLogger(ctx)
 
 	// Map contains PVCs which need to be detached.
 	pvcsToDetach = make(map[string]string)
+
+	vmKey := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
+	vm, _, vmGetErr := utils.GetVirtualMachine(ctx, vmKey, vmOperatorClient)
+	if vmGetErr != nil {
+		if apierrors.IsNotFound(vmGetErr) {
+			log.Infof("VirtualMachine %s/%s not found; skipping VM spec safety check and continuing detach list computation",
+				instance.Namespace, instance.Name)
+			vm = nil
+		} else {
+			return pvcsToDetach, fmt.Errorf("failed to get VirtualMachine %s in namespace %s: %s",
+				instance.Name, instance.Namespace, vmGetErr.Error())
+		}
+	}
+
+	// Create a cache of all volumes in the VM spec for efficient lookups during safety checks
+	vmSpecVolumeCache := buildVMSpecVolumeCache(vm)
 
 	/// Add those volumes to to pvcsToDetach
 	// which are present in attachedFCDs list but not in
@@ -176,10 +212,13 @@ func getVolumesToDetachFromInstance(ctx context.Context,
 		}
 
 		addPVCToDetachList := false
+		performSafetyCheck := false
 
 		if volumeInSpec, ok := volumeIdsInSpec[attachedFcdId]; !ok {
 			// If PVC is not present in CR spec but is attached to the VM, then add it to PVCs to detach list.
 			addPVCToDetachList = true
+			// ensure PVC does not exist on VM spec.
+			performSafetyCheck = true
 		} else if volumeInSpec.ControllerKey != attachedFcdIdBacking.ControllerKey ||
 			volumeInSpec.UnitNumber != attachedFcdIdBacking.UnitNumber ||
 			volumeInSpec.SharingMode != attachedFcdIdBacking.SharingMode ||
@@ -210,6 +249,16 @@ func getVolumesToDetachFromInstance(ctx context.Context,
 				controllerutil.ContainsFinalizer(pvcObj, cnsoperatortypes.CNSPvcFinalizer) {
 				log.Debugf("PVC %s does not have usedby-vm annotation. PVC not attached via CnsNodeVMBatchAttachment.", pvcName)
 				continue
+			}
+
+			if performSafetyCheck && vm != nil {
+				// Ensure the PVC is not still referenced in VM spec before detaching.
+				if vmSpecVolumeCache[pvcName] {
+					log.Infof("Skipping detach for PVC %s/%s with FCD %s from VM Instance UUID %s because it is still "+
+						"referenced in VirtualMachine %s spec. This indicates the PVC is actively used by the VM.",
+						pvcNs, pvcName, attachedFcdId, instance.Spec.InstanceUUID, instance.Name)
+					continue
+				}
 			}
 			pvcsToDetach[pvcName] = attachedFcdId
 		}
@@ -385,6 +434,7 @@ func getVolumesToDetachForVmFromVC(ctx context.Context,
 	client client.Client,
 	k8sClient kubernetes.Interface,
 	cnsOperatorClient client.Client,
+	vmOperatorClient client.Client,
 	attachedFCDs map[string]FCDBackingDetails,
 	volumeIdsInSpec map[string]FCDBackingDetails,
 	volumeNamesInSpec map[string]string) (map[string]string, error) {
@@ -392,7 +442,7 @@ func getVolumesToDetachForVmFromVC(ctx context.Context,
 
 	// Find out the volumes to detach by taking a diff between
 	// the instance spec and the FCDs currently attached to the VM on vCenter.
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	if err != nil {
 		log.Errorf("failed to find volumes to attach and volumes to detach from instance spec. Err: %s", err)
 		return pvcsToDetach, err
@@ -689,7 +739,7 @@ func getVmObject(ctx context.Context, client client.Client, configInfo config.Co
 
 func getVolumesToAttachAndDetach(ctx context.Context, instance *v1alpha1.CnsNodeVMBatchAttachment,
 	vm *cnsvsphere.VirtualMachine, client client.Client, k8sClient kubernetes.Interface,
-	cnsOperatorClient client.Client) (map[string]string,
+	cnsOperatorClient client.Client, vmOperatorClient client.Client) (map[string]string,
 	map[string]string, error) {
 	log := logger.GetLogger(ctx)
 
@@ -720,7 +770,7 @@ func getVolumesToAttachAndDetach(ctx context.Context, instance *v1alpha1.CnsNode
 	}
 
 	// Find the volumes to detach from the vCenter.
-	pvcsToDetach, err = getVolumesToDetach(ctx, client, k8sClient, cnsOperatorClient, instance, vm,
+	pvcsToDetach, err = getVolumesToDetach(ctx, client, k8sClient, cnsOperatorClient, vmOperatorClient, instance, vm,
 		attachedFcdList, volumeIdsInSpec, volumeNamesInSpec)
 	if err != nil {
 		log.Errorf("failed to find volumes to detach from the vCenter for instance %s", instance.Name)
@@ -743,6 +793,7 @@ func getVolumesToAttachAndDetach(ctx context.Context, instance *v1alpha1.CnsNode
 func getVolumesToDetach(ctx context.Context, client client.Client,
 	k8sClient kubernetes.Interface,
 	cnsOperatorClient client.Client,
+	vmOperatorClient client.Client,
 	instance *v1alpha1.CnsNodeVMBatchAttachment,
 	vm *cnsvsphere.VirtualMachine, attachedFcdList map[string]FCDBackingDetails,
 	volumeIdsInSpec map[string]FCDBackingDetails, volumeNamesInSpec map[string]string) (map[string]string, error) {
@@ -750,7 +801,7 @@ func getVolumesToDetach(ctx context.Context, client client.Client,
 
 	// Find volumes to be detached from the VM by takinga diff with FCDs attached to VM on vCenter.
 	volumesToDetach, err := getVolumesToDetachForVmFromVC(ctx, instance, client, k8sClient,
-		cnsOperatorClient, attachedFcdList, volumeIdsInSpec, volumeNamesInSpec)
+		cnsOperatorClient, vmOperatorClient, attachedFcdList, volumeIdsInSpec, volumeNamesInSpec)
 	if err != nil {
 		log.Errorf("failed to find volumes to attach and detach. Err: %s", err)
 		return map[string]string{}, err

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -838,7 +838,19 @@ func schemeForCnsBatchAttachTests() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = v1.AddToScheme(s)
 	_ = cnsopapis.AddToScheme(s)
+	_ = vmoperatortypes.AddToScheme(s)
 	return s
+}
+
+// vmForBatchAttachDetachTests is a minimal VirtualMachine matching setupTestCnsNodeVMBatchAttachment
+// name/namespace so getVolumesToDetachFromInstance can load the VM API object (required for detach safety).
+func vmForBatchAttachDetachTests() *vmoperatortypes.VirtualMachine {
+	return &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testCnsNodeVMBatchAttachmentName,
+			Namespace: testNamespace,
+		},
+	}
 }
 
 func TestRemovePvcProtectionFinalizersForTrackedPVCs_AllSucceed(t *testing.T) {
@@ -1048,6 +1060,9 @@ func TestGetVolumesToDetachFromInstanceWhenAVolumeIsRemoved(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-1": {ControllerKey: 1000, UnitNumber: 1,
@@ -1060,7 +1075,7 @@ func TestGetVolumesToDetachFromInstanceWhenAVolumeIsRemoved(t *testing.T) {
 			SharingMode: "None", DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-1"}, pvcsToDetach)
 }
@@ -1070,6 +1085,9 @@ func TestGetVolumesToDetachFromInstanceWhenNothingHasChanged(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1001,
@@ -1080,7 +1098,7 @@ func TestGetVolumesToDetachFromInstanceWhenNothingHasChanged(t *testing.T) {
 			UnitNumber: 2, SharingMode: "None", DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{}, pvcsToDetach)
 }
@@ -1090,6 +1108,9 @@ func TestGetVolumesToDetachFromInstanceWhenControllerKeyIsChanged(t *testing.T) 
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1000,
@@ -1100,7 +1121,7 @@ func TestGetVolumesToDetachFromInstanceWhenControllerKeyIsChanged(t *testing.T) 
 			UnitNumber: 2, SharingMode: "None", DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-2"}, pvcsToDetach)
 }
@@ -1110,6 +1131,9 @@ func TestGetVolumesToDetachFromInstanceWhenUnitNumberIsChanged(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1000,
@@ -1120,7 +1144,7 @@ func TestGetVolumesToDetachFromInstanceWhenUnitNumberIsChanged(t *testing.T) {
 			UnitNumber: 4, SharingMode: "None", DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-2"}, pvcsToDetach)
 }
@@ -1130,6 +1154,9 @@ func TestGetVolumesToDetachFromInstanceWhenSharingIsChanged(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1000,
@@ -1141,7 +1168,7 @@ func TestGetVolumesToDetachFromInstanceWhenSharingIsChanged(t *testing.T) {
 			DiskMode: "persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-2"}, pvcsToDetach)
 }
@@ -1151,6 +1178,9 @@ func TestGetVolumesToDetachFromInstanceWhenDiskModeIsChanged(t *testing.T) {
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"with-used-by-annotation-2": {ControllerKey: 1000,
@@ -1162,7 +1192,7 @@ func TestGetVolumesToDetachFromInstanceWhenDiskModeIsChanged(t *testing.T) {
 			DiskMode: "independent_persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-2"}, pvcsToDetach)
 }
@@ -1172,6 +1202,9 @@ func TestGetVolumesToDetachFromInstanceWhenUsedByAndPvcFinalizerIsMissing(t *tes
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"no-finalizer-no-usedby-1": {ControllerKey: 1000,
@@ -1183,7 +1216,7 @@ func TestGetVolumesToDetachFromInstanceWhenUsedByAndPvcFinalizerIsMissing(t *tes
 			DiskMode: "independent_persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"no-finalizer-no-usedby-1": "no-finalizer-no-usedby-1"}, pvcsToDetach)
 }
@@ -1193,6 +1226,9 @@ func TestGetVolumesToDetachFromInstanceWhenOnlyPvcFinalizerIsMissing(t *testing.
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"no-finalizer": {ControllerKey: 1000,
@@ -1204,7 +1240,7 @@ func TestGetVolumesToDetachFromInstanceWhenOnlyPvcFinalizerIsMissing(t *testing.
 			DiskMode: "independent_persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"no-finalizer-1": "no-finalizer"}, pvcsToDetach)
 }
@@ -1214,6 +1250,9 @@ func TestGetVolumesToDetachFromInstanceWhenOnlyUsedByIsMissingFinalizerIsPresent
 	instance := setupTestCnsNodeVMBatchAttachment()
 
 	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	// Setup fake vmOperatorClient
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vmForBatchAttachDetachTests()).Build()
 
 	attachedFCDs := map[string]FCDBackingDetails{
 		"12345": {ControllerKey: 1000,
@@ -1225,9 +1264,29 @@ func TestGetVolumesToDetachFromInstanceWhenOnlyUsedByIsMissingFinalizerIsPresent
 			DiskMode: "independent_persistent"},
 	}
 
-	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, attachedFCDs, volumeIdsInSpec)
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{}, pvcsToDetach)
+}
+
+func TestGetVolumesToDetachFromInstance_VirtualMachineNotFound(t *testing.T) {
+	ctx := context.Background()
+	instance := setupTestCnsNodeVMBatchAttachment()
+
+	commonco.ContainerOrchestratorUtility = &unittestcommon.FakeK8SOrchestrator{}
+	s := schemeForCnsBatchAttachTests()
+	vmOperatorClient := fake.NewClientBuilder().WithScheme(s).Build()
+
+	attachedFCDs := map[string]FCDBackingDetails{
+		"with-used-by-annotation-1": {ControllerKey: 1000, UnitNumber: 1,
+			SharingMode: "None", DiskMode: "persistent"},
+	}
+	volumeIdsInSpec := map[string]FCDBackingDetails{}
+
+	pvcsToDetach, err := getVolumesToDetachFromInstance(ctx, &instance, vmOperatorClient, attachedFCDs, volumeIdsInSpec)
+	assert.NoError(t, err)
+	// No VM in API: safety check is skipped; volume not in spec -> PVC is eligible to detach.
+	assert.Equal(t, map[string]string{"with-used-by-annotation": "with-used-by-annotation-1"}, pvcsToDetach)
 }
 
 func TestGetVolumesToAttach(t *testing.T) {
@@ -2349,4 +2408,112 @@ func TestSyncCBTBeforeBatchAttach_DynamicClientNil(t *testing.T) {
 
 	assert.False(t, mockVM.setCalled)
 	assert.False(t, mockVM.clearCalled)
+}
+
+func TestBuildVMSpecVolumeCache(t *testing.T) {
+	tests := []struct {
+		name     string
+		vm       *vmoperatortypes.VirtualMachine
+		expected map[string]bool
+	}{
+		{
+			name: "nil vm",
+			vm:   nil,
+			expected: map[string]bool{},
+		},
+		{
+			name: "vm with no volumes",
+			vm: &vmoperatortypes.VirtualMachine{
+				Spec: vmoperatortypes.VirtualMachineSpec{
+					Volumes: []vmoperatortypes.VirtualMachineVolume{},
+				},
+			},
+			expected: map[string]bool{},
+		},
+		{
+			name: "vm with valid PVC volumes",
+			vm: &vmoperatortypes.VirtualMachine{
+				Spec: vmoperatortypes.VirtualMachineSpec{
+					Volumes: []vmoperatortypes.VirtualMachineVolume{
+						{
+							Name: "volume1",
+							VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "pvc-1",
+									},
+								},
+							},
+						},
+						{
+							Name: "volume2",
+							VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "pvc-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"pvc-1": true,
+				"pvc-2": true,
+			},
+		},
+		{
+			name: "vm with nil PersistentVolumeClaim",
+			vm: &vmoperatortypes.VirtualMachine{
+				Spec: vmoperatortypes.VirtualMachineSpec{
+					Volumes: []vmoperatortypes.VirtualMachineVolume{
+						{
+							Name: "volume1",
+							VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: nil, // This should not cause panic
+							},
+						},
+						{
+							Name: "volume2",
+							VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+								PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "pvc-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"pvc-2": true,
+			},
+		},
+		{
+			name: "vm with volumes having other volume sources (no PVC)",
+			vm: &vmoperatortypes.VirtualMachine{
+				Spec: vmoperatortypes.VirtualMachineSpec{
+					Volumes: []vmoperatortypes.VirtualMachineVolume{
+						{
+							Name: "volume1",
+							VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+								// Volume with no PersistentVolumeClaim (could have other sources)
+								PersistentVolumeClaim: nil,
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildVMSpecVolumeCache(tt.vm)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

During VM import, there is a race condition where there may be a delay from VM operator in adding a volume to batch attach spec.

In the meantime, CSI might incorrectly interpret that as a detach request (since volume is not there in batchattach spec but is attached to the VM on VM inventory).

In order to fix this, before adding a volume to detach list, it is important that CSI also validates that the volume is not being referenced in the VM spec. If it is being referenced, then skip adding that volume to detach list.

If VM object is not found, then fail the reconciliation.

As discussed on private chat, we should ignore safety check if PVC VM object is not found k8s cluster.

**Testing done**:
WCP precheckn (in progress): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1534/
VKS precheckin (in progress):  https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1157/


Successfully attached a PVC to a VM.
Sucessfully detached a PVC from a VM.
Removed PVC from batchattach spec while it was still there in VM spec. Observed that detach was denied:

```
{"level":"info","time":"2026-04-30T09:17:44.95831583Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:257","msg":"Skipping detach for PVC test/pvc-3 with FCD 52c79ef3-affe-48f5-a295-317c324684c8 from VM Instance UUID 15294371-1935-4a95-96cb-56e2862bf2e2 because it is still referenced in VirtualMachine testvm-1 spec. This indicates the PVC is actively used by the VM.","TraceId":"461e96d0-df0c-4cc0-957f-515d9bce323a"}
{"level":"info","time":"2026-04-30T09:17:44.958387493Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:266","msg":"Obtained volumes to detach map[] for instance testvm-1","TraceId":"461e96d0-df0c-4cc0-957f-515d9bce323a"}

```