### PR TITLE
enable CBT for PVC during attachment

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -92,6 +92,9 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 
 // IsFSSEnabled returns the FSS values for a given feature
 func (c *FakeK8SOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) bool {
+	if c.featureStatesLock == nil || c.featureStates == nil {
+		return false
+	}
 	var featureState bool
 	var err error
 	c.featureStatesLock.RLock()

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -525,35 +525,101 @@ func GetCNSVolumeInfoPatch(ctx context.Context, CapacityInMb int64, volumeId str
 	return patch, nil
 }
 
-// IsCBTEnabledForNamespace reports whether any CBTConfig in the namespace has status.enabled true.
-func IsCBTEnabledForNamespace(ctx context.Context, dynClient dynamic.Interface, pvcNamespace string) (bool, error) {
+// CBTStateForNamespace reports the CBT state for the given namespace by
+// inspecting the first CBTConfig CR (namespace-scoped singleton).
+//
+// Return values:
+//   - enabled: true when the CBTConfig CR is configured and status.enabled is true.
+//   - configured: true when a CBTConfig CR exists in the namespace and its
+//     status.enabled field has been set by the operator, meaning the config is
+//     actively taking effect. False when no CR exists or the operator has not
+//     yet reconciled status.enabled (nil).
+//   - err: non-nil only when the API List call fails or the unstructured
+//     conversion fails. A missing CR or an unset status.enabled are not errors.
+func CBTStateForNamespace(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	pvcNamespace string,
+) (enabled bool, configured bool, err error) {
 	log := logger.GetLogger(ctx)
 
 	gvr := cbtconfigv1alpha1.GroupVersion.WithResource(cbtconfigv1alpha1.CBTConfigResource)
 	unstructuredList, err := dynClient.Resource(gvr).Namespace(pvcNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		// CRD may not be registered yet, or the API version may be absent from discovery.
+		// CRD not yet installed or API version absent from discovery — treat as not configured.
 		if apiMeta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
-			log.Debugf("CBTConfig CR is not registered, assuming CBT disabled for namespace %s", pvcNamespace)
-			return false, nil
+			log.Debugf("CBTConfig API unavailable in namespace %s, treating as not configured", pvcNamespace)
+			return false, false, nil
 		}
-		return false, fmt.Errorf("failed to list CBTConfig CRs in namespace %s: %w", pvcNamespace, err)
+		return false, false, fmt.Errorf("failed to list CBTConfig CRs in namespace %s: %w", pvcNamespace, err)
 	}
 
 	var cbtConfigList cbtconfigv1alpha1.CBTConfigList
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredList.UnstructuredContent(), &cbtConfigList)
-	if err != nil {
-		return false, fmt.Errorf("failed to convert unstructured list to CBTConfigList: %w", err)
+	if err = runtime.DefaultUnstructuredConverter.FromUnstructured(
+		unstructuredList.UnstructuredContent(), &cbtConfigList,
+	); err != nil {
+		return false, false, fmt.Errorf("failed to convert unstructured list to CBTConfigList: %w", err)
 	}
 
-	for _, item := range cbtConfigList.Items {
-		if item.Status.Enabled != nil && *item.Status.Enabled {
-			log.Debugf("CBT is enabled for namespace %s", pvcNamespace)
-			return true, nil
+	if len(cbtConfigList.Items) == 0 {
+		log.Debugf("No CBTConfig CRs found in namespace %s", pvcNamespace)
+		return false, false, nil
+	}
+
+	// CBTConfig CR is implemented with namespace-scoped singleton pattern.
+	cbtConfig := cbtConfigList.Items[0]
+	if cbtConfig.Status.Enabled == nil {
+		// CR exists but operator has not yet written status.enabled — not yet configured.
+		log.Debugf("CBTConfig Status.Enabled is not set for namespace %s", pvcNamespace)
+		return false, false, nil
+	}
+
+	log.Debugf("CBT enabled=%t (configured) for namespace %s", *cbtConfig.Status.Enabled, pvcNamespace)
+
+	return *cbtConfig.Status.Enabled, true, nil
+}
+
+// SyncVolumeCBTState resolves the CBT intent for pvcNamespace via CBTStateForNamespace
+// and applies the resulting enable/disable operation to every volume in volumeIDs.
+// Both SetVolumeControlFlags and ClearVolumeControlFlags are idempotent, so the
+// call is safe to repeat without querying current volume state.
+//
+// The function returns early (with debug logging) when the namespace has no
+// active CBTConfig. Outcomes per volume are logged at Warnf on failure and
+// Infof on success; callers do not need additional log lines around this call.
+func SyncVolumeCBTState(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	pvcNamespace string,
+	volumeManager cnsvolume.Manager,
+	volumeIDs ...string,
+) {
+	log := logger.GetLogger(ctx)
+
+	enabled, configured, err := CBTStateForNamespace(ctx, dynClient, pvcNamespace)
+	if err != nil {
+		log.Warnf("failed to get CBTConfig for namespace %s: %+v", pvcNamespace, err)
+		return
+	}
+	if !configured {
+		log.Debugf("CBTConfig not yet configured for namespace %s, skipping CBT flag change for volumes %v",
+			pvcNamespace, volumeIDs)
+		return
+	}
+
+	for _, volumeID := range volumeIDs {
+		var applyErr error
+		if enabled {
+			applyErr = SetVolumeCbtFlagsUtil(ctx, volumeManager, volumeID)
+		} else {
+			applyErr = ClearVolumeCbtFlagsUtil(ctx, volumeManager, volumeID)
+		}
+		if applyErr != nil {
+			log.Warnf("failed to set CBT %t for volume %s: %v", enabled, volumeID, applyErr)
+		} else {
+			log.Infof("Successfully set CBT %t for volume %s", enabled, volumeID)
 		}
 	}
-
-	return false, nil
 }
 
 // IsFVSVolumeHandle returns true if the supplied CSI volume handle was minted by

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -27,18 +27,28 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	corev1 "k8s.io/api/core/v1"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/object"
+	vim25types "github.com/vmware/govmomi/vim25/types"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	cnsvolumeoperationrequest "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
 )
 
 var (
@@ -644,48 +654,120 @@ func cbtTestDynamicClient(t *testing.T, objs ...runtime.Object) dynamic.Interfac
 	return fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
 }
 
-func TestIsCBTEnabledForNamespace(t *testing.T) {
+// errDynamicClient is a minimal dynamic.Interface stub that always returns a
+// fixed error from List. Only the Resource chain is implemented; all other
+// methods panic to catch unexpected calls.
+type errDynamicClient struct{ err error }
+
+func (e *errDynamicClient) Resource(schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &errNamespaceableResource{err: e.err}
+}
+func (e *errDynamicClient) Tracker() k8stesting.ObjectTracker { panic("not implemented") }
+
+type errNamespaceableResource struct{ err error }
+
+func (r *errNamespaceableResource) Namespace(string) dynamic.ResourceInterface { return r }
+func (r *errNamespaceableResource) List(
+	_ context.Context, _ metav1.ListOptions,
+) (*unstructured.UnstructuredList, error) {
+	return nil, r.err
+}
+func (r *errNamespaceableResource) Create(
+	_ context.Context, _ *unstructured.Unstructured, _ metav1.CreateOptions, _ ...string,
+) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+func (r *errNamespaceableResource) Update(
+	_ context.Context, _ *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string,
+) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+func (r *errNamespaceableResource) UpdateStatus(
+	_ context.Context, _ *unstructured.Unstructured, _ metav1.UpdateOptions,
+) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+func (r *errNamespaceableResource) Delete(
+	_ context.Context, _ string, _ metav1.DeleteOptions, _ ...string,
+) error {
+	panic("not implemented")
+}
+func (r *errNamespaceableResource) DeleteCollection(
+	_ context.Context, _ metav1.DeleteOptions, _ metav1.ListOptions,
+) error {
+	panic("not implemented")
+}
+func (r *errNamespaceableResource) Get(
+	_ context.Context, _ string, _ metav1.GetOptions, _ ...string,
+) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+func (r *errNamespaceableResource) Watch(
+	_ context.Context, _ metav1.ListOptions,
+) (watch.Interface, error) {
+	panic("not implemented")
+}
+func (r *errNamespaceableResource) Patch(
+	_ context.Context, _ string, _ types.PatchType, _ []byte, _ metav1.PatchOptions, _ ...string,
+) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+func (r *errNamespaceableResource) Apply(
+	_ context.Context, _ string, _ *unstructured.Unstructured, _ metav1.ApplyOptions, _ ...string,
+) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+func (r *errNamespaceableResource) ApplyStatus(
+	_ context.Context, _ string, _ *unstructured.Unstructured, _ metav1.ApplyOptions,
+) (*unstructured.Unstructured, error) {
+	panic("not implemented")
+}
+
+func TestCBTStateForNamespace(t *testing.T) {
 	ctx := context.Background()
 	ns := "test-ns"
 	enabled := true
 	disabled := false
 
+	t.Run("API unavailable (NoKindMatchError)", func(t *testing.T) {
+		noMatch := &apiMeta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "cbt.vsphere.vmware.com"}}
+		dyn := &errDynamicClient{err: noMatch}
+		en, configured, err := CBTStateForNamespace(ctx, dyn, ns)
+		assert.NoError(t, err)
+		assert.False(t, configured)
+		assert.False(t, en)
+	})
+
 	t.Run("no CBTConfig objects", func(t *testing.T) {
 		dyn := cbtTestDynamicClient(t)
-		ok, err := IsCBTEnabledForNamespace(ctx, dyn, ns)
+		en, configured, err := CBTStateForNamespace(ctx, dyn, ns)
 		assert.NoError(t, err)
-		assert.False(t, ok)
+		assert.False(t, configured)
+		assert.False(t, en)
 	})
 
 	t.Run("status.enabled true", func(t *testing.T) {
 		dyn := cbtTestDynamicClient(t, cbtConfigUnstructured("default", ns, &enabled))
-		ok, err := IsCBTEnabledForNamespace(ctx, dyn, ns)
+		en, configured, err := CBTStateForNamespace(ctx, dyn, ns)
 		assert.NoError(t, err)
-		assert.True(t, ok)
+		assert.True(t, configured)
+		assert.True(t, en)
 	})
 
 	t.Run("status.enabled false", func(t *testing.T) {
 		dyn := cbtTestDynamicClient(t, cbtConfigUnstructured("default", ns, &disabled))
-		ok, err := IsCBTEnabledForNamespace(ctx, dyn, ns)
+		en, configured, err := CBTStateForNamespace(ctx, dyn, ns)
 		assert.NoError(t, err)
-		assert.False(t, ok)
+		assert.True(t, configured)
+		assert.False(t, en)
 	})
 
 	t.Run("status.enabled omitted", func(t *testing.T) {
 		dyn := cbtTestDynamicClient(t, cbtConfigUnstructured("default", ns, nil))
-		ok, err := IsCBTEnabledForNamespace(ctx, dyn, ns)
+		en, configured, err := CBTStateForNamespace(ctx, dyn, ns)
 		assert.NoError(t, err)
-		assert.False(t, ok)
-	})
-
-	t.Run("multiple CBTConfig one has enabled", func(t *testing.T) {
-		dyn := cbtTestDynamicClient(t,
-			cbtConfigUnstructured("a", ns, &disabled),
-			cbtConfigUnstructured("b", ns, &enabled),
-		)
-		ok, err := IsCBTEnabledForNamespace(ctx, dyn, ns)
-		assert.NoError(t, err)
-		assert.True(t, ok)
+		assert.False(t, configured)
+		assert.False(t, en)
 	})
 }
 
@@ -793,4 +875,190 @@ func TestIsFVSPersistentVolumeClaim(t *testing.T) {
 			}
 		})
 	}
+}
+
+// cbtFlagsMockVolumeManager is a minimal volume.Manager stub that satisfies only
+// the two methods exercised by SyncVolumeCBTState, letting tests inject errors
+// and observe which operation was invoked.
+type cbtFlagsMockVolumeManager struct {
+	setCalled   bool
+	clearCalled bool
+	setErr      error
+	clearErr    error
+}
+
+func (m *cbtFlagsMockVolumeManager) SetVolumeControlFlags(
+	_ context.Context, _ string, _ []string,
+) error {
+	m.setCalled = true
+	return m.setErr
+}
+
+func (m *cbtFlagsMockVolumeManager) ClearVolumeControlFlags(
+	_ context.Context, _ string, _ []string,
+) error {
+	m.clearCalled = true
+	return m.clearErr
+}
+
+// Remaining volume.Manager methods — not exercised by SyncVolumeCBTState.
+func (m *cbtFlagsMockVolumeManager) CreateVolume(context.Context,
+	*cnstypes.CnsVolumeCreateSpec, interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+	return nil, "", nil
+}
+func (m *cbtFlagsMockVolumeManager) AttachVolume(context.Context,
+	*cnsvsphere.VirtualMachine, string, bool) (string, string, error) {
+	return "", "", nil
+}
+func (m *cbtFlagsMockVolumeManager) DetachVolume(context.Context,
+	*cnsvsphere.VirtualMachine, string) (string, error) {
+	return "", nil
+}
+func (m *cbtFlagsMockVolumeManager) DeleteVolume(context.Context, string, bool) (string, error) {
+	return "", nil
+}
+func (m *cbtFlagsMockVolumeManager) UpdateVolumeMetadata(context.Context,
+	*cnstypes.CnsVolumeMetadataUpdateSpec) error {
+	return nil
+}
+func (m *cbtFlagsMockVolumeManager) UpdateVolumeCrypto(context.Context,
+	*cnstypes.CnsVolumeCryptoUpdateSpec) error {
+	return nil
+}
+func (m *cbtFlagsMockVolumeManager) QueryVolumeInfo(context.Context,
+	[]cnstypes.CnsVolumeId) (*cnstypes.CnsQueryVolumeInfoResult, error) {
+	return nil, nil
+}
+func (m *cbtFlagsMockVolumeManager) QueryAllVolume(context.Context, cnstypes.CnsQueryFilter,
+	cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	return nil, nil
+}
+func (m *cbtFlagsMockVolumeManager) QueryVolumeAsync(context.Context, cnstypes.CnsQueryFilter,
+	*cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	return nil, nil
+}
+func (m *cbtFlagsMockVolumeManager) QueryVolume(context.Context,
+	cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+	return nil, nil
+}
+func (m *cbtFlagsMockVolumeManager) RelocateVolume(context.Context,
+	...cnstypes.BaseCnsVolumeRelocateSpec) (*object.Task, error) {
+	return nil, nil
+}
+func (m *cbtFlagsMockVolumeManager) ExpandVolume(context.Context, string, int64,
+	interface{}) (string, error) {
+	return "", nil
+}
+func (m *cbtFlagsMockVolumeManager) ResetManager(context.Context,
+	*cnsvsphere.VirtualCenter) error {
+	return nil
+}
+func (m *cbtFlagsMockVolumeManager) ConfigureVolumeACLs(context.Context,
+	cnstypes.CnsVolumeACLConfigureSpec) error {
+	return nil
+}
+func (m *cbtFlagsMockVolumeManager) RegisterDisk(context.Context, string, string) (string, error) {
+	return "", nil
+}
+func (m *cbtFlagsMockVolumeManager) RetrieveVStorageObject(context.Context,
+	string) (*vim25types.VStorageObject, error) {
+	return nil, nil
+}
+func (m *cbtFlagsMockVolumeManager) ProtectVolumeFromVMDeletion(context.Context, string) error {
+	return nil
+}
+func (m *cbtFlagsMockVolumeManager) CreateSnapshot(context.Context, string, string,
+	interface{}) (*cnsvolume.CnsSnapshotInfo, error) {
+	return nil, nil
+}
+func (m *cbtFlagsMockVolumeManager) DeleteSnapshot(context.Context, string, string,
+	interface{}) (*cnsvolume.CnsSnapshotInfo, error) {
+	return nil, nil
+}
+func (m *cbtFlagsMockVolumeManager) QuerySnapshots(context.Context,
+	cnstypes.CnsSnapshotQueryFilter) (*cnstypes.CnsSnapshotQueryResult, error) {
+	return nil, nil
+}
+func (m *cbtFlagsMockVolumeManager) MonitorCreateVolumeTask(context.Context,
+	**cnsvolumeoperationrequest.VolumeOperationRequestDetails, *object.Task,
+	string, string) (*cnsvolume.CnsVolumeInfo, string, error) {
+	return nil, "", nil
+}
+func (m *cbtFlagsMockVolumeManager) GetOperationStore() cnsvolumeoperationrequest.VolumeOperationRequest {
+	return nil
+}
+func (m *cbtFlagsMockVolumeManager) IsListViewReady() bool               { return true }
+func (m *cbtFlagsMockVolumeManager) SetListViewNotReady(context.Context) {}
+func (m *cbtFlagsMockVolumeManager) UnregisterVolume(context.Context,
+	string, bool) (string, error) {
+	return "", nil
+}
+func (m *cbtFlagsMockVolumeManager) BatchAttachVolumes(context.Context,
+	*cnsvsphere.VirtualMachine, []cnsvolume.BatchAttachRequest) ([]cnsvolume.BatchAttachResult, string, error) {
+	return nil, "", nil
+}
+func (m *cbtFlagsMockVolumeManager) SyncVolume(context.Context,
+	[]cnstypes.CnsSyncVolumeSpec) (string, error) {
+	return "", nil
+}
+func (m *cbtFlagsMockVolumeManager) ReRegisterVolume(context.Context, string) error {
+	return nil
+}
+func (m *cbtFlagsMockVolumeManager) QueryFCDAllocatedBlocks(context.Context,
+	string, string, uint64, uint32) ([]cnsvolume.AllocatedArea, uint64, error) {
+	return nil, 0, nil
+}
+func (m *cbtFlagsMockVolumeManager) QueryFCDChangedBlocks(context.Context,
+	string, string, string, uint64, uint32) ([]cnsvolume.ChangedArea, uint64, error) {
+	return nil, 0, nil
+}
+func (m *cbtFlagsMockVolumeManager) GetFCDSnapshotChangeID(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+func TestSyncVolumeCBTState(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	enabled := true
+	disabled := false
+
+	t.Run("CBT enabled calls Set for each volume", func(t *testing.T) {
+		dyn := cbtTestDynamicClient(t, cbtConfigUnstructured("default", ns, &enabled))
+		vm := &cbtFlagsMockVolumeManager{}
+		SyncVolumeCBTState(ctx, dyn, ns, vm, "vol-1", "vol-2")
+		assert.True(t, vm.setCalled)
+		assert.False(t, vm.clearCalled)
+	})
+
+	t.Run("CBT disabled calls Clear for each volume", func(t *testing.T) {
+		dyn := cbtTestDynamicClient(t, cbtConfigUnstructured("default", ns, &disabled))
+		vm := &cbtFlagsMockVolumeManager{}
+		SyncVolumeCBTState(ctx, dyn, ns, vm, "vol-1", "vol-2")
+		assert.False(t, vm.setCalled)
+		assert.True(t, vm.clearCalled)
+	})
+
+	t.Run("not configured skips flag change", func(t *testing.T) {
+		dyn := cbtTestDynamicClient(t) // no CBTConfig CR
+		vm := &cbtFlagsMockVolumeManager{}
+		SyncVolumeCBTState(ctx, dyn, ns, vm, "vol-1")
+		assert.False(t, vm.setCalled)
+		assert.False(t, vm.clearCalled)
+	})
+
+	t.Run("Set error is swallowed after logging", func(t *testing.T) {
+		dyn := cbtTestDynamicClient(t, cbtConfigUnstructured("default", ns, &enabled))
+		vm := &cbtFlagsMockVolumeManager{setErr: errors.New("set failed")}
+		SyncVolumeCBTState(ctx, dyn, ns, vm, "vol-1")
+		assert.True(t, vm.setCalled)
+		assert.False(t, vm.clearCalled)
+	})
+
+	t.Run("Clear error is swallowed after logging", func(t *testing.T) {
+		dyn := cbtTestDynamicClient(t, cbtConfigUnstructured("default", ns, &disabled))
+		vm := &cbtFlagsMockVolumeManager{clearErr: errors.New("clear failed")}
+		SyncVolumeCBTState(ctx, dyn, ns, vm, "vol-1")
+		assert.False(t, vm.setCalled)
+		assert.True(t, vm.clearCalled)
+	})
 }

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1193,19 +1193,25 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	}
 
 	if isCSIBackupAPIEnabled {
+		// It's the best effort scenario to enable the CBT before create volume.
+		// If any error occurs during CBT enablement, it may be deferred to attachment or
+		// periodic reconciler in syncer.
 		if pvcNamespace, ok := req.Parameters[common.AttributePvcNamespace]; ok && pvcNamespace != "" {
-			enableCbt, err := common.IsCBTEnabledForNamespace(ctx, c.dynamicClient, pvcNamespace)
+			// Volumes are created with CBT off by default; only enable when the
+			// namespace has CBT active. enableCbt is true only when configured.
+			enableCbt, _, err := common.CBTStateForNamespace(ctx, c.dynamicClient, pvcNamespace)
 			if err != nil {
-				log.Warnf("failed to get enable CBT for namespace %s with error %+v", pvcNamespace, err)
+				log.Warnf("failed to get CBTConfig for namespace %s: %+v", pvcNamespace, err)
 			} else if enableCbt {
-				err = common.SetVolumeCbtFlagsUtil(ctx, c.manager.VolumeManager, volumeInfo.VolumeID.Id)
-				if err != nil {
-					log.Warnf("failed to set CBT flags for volume %s with error %+v", volumeInfo.VolumeID.Id, err)
+				volumeID := volumeInfo.VolumeID.Id
+				if err := common.SetVolumeCbtFlagsUtil(ctx, c.manager.VolumeManager, volumeID); err != nil {
+					log.Warnf("failed to set CBT %t for volume %s: %v", enableCbt, volumeID, err)
+				} else {
+					log.Infof("Successfully set CBT %t for volume %s", enableCbt, volumeID)
 				}
 			}
 		} else {
-			log.Warnf("failed to set CBT flag for volume %s due to missing PVC namespace from request parameters",
-				volumeInfo.VolumeID.Id)
+			log.Warnf("failed to get PVC namespace from request parameters for volume %s", volumeInfo.VolumeID.Id)
 		}
 	}
 
@@ -2005,6 +2011,18 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 				"volumeAttachment %v already has the attached status as true. "+
 					"Assuming the attach volume is due to incorrect force sync Attach from CSI Attacher",
 				volumeAttachment)
+		}
+
+		isBlockRequest := !isFileVolumeRequestInWcp(ctx, []*csi.VolumeCapability{req.GetVolumeCapability()})
+		if isCSIBackupAPIEnabled && isBlockRequest {
+			_, pvcNamespace, ok := commonco.ContainerOrchestratorUtility.GetPVCNameFromCSIVolumeID(req.VolumeId)
+			// Best-effort: sync CBT state before attach. Any failure is deferred
+			// to the periodic reconciler in the syncer.
+			if ok && pvcNamespace != "" {
+				common.SyncVolumeCBTState(ctx, c.dynamicClient, pvcNamespace, c.manager.VolumeManager, req.VolumeId)
+			} else {
+				log.Warnf("failed to get PVC namespace from request parameters for volume %s", req.VolumeId)
+			}
 		}
 
 		vmuuid, err := getPodVMUUID(ctx, req.VolumeId, req.NodeId)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -32,6 +32,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -72,6 +73,7 @@ var (
 	backOffDuration         map[k8stypes.NamespacedName]time.Duration
 	backOffDurationMapMutex = sync.Mutex{}
 	isSharedDiskEnabled     bool
+	isCSIBackupAPIEnabled   bool
 )
 
 // Mockable function variables for testing
@@ -141,15 +143,26 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	// If the capability gets enabled at a later point, then container
 	// will be restarted and this value will be reinitialized.
 	isSharedDiskEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SharedDiskFss)
+	isCSIBackupAPIEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API)
+
+	var cbtDynClient dynamic.Interface
+	if isCSIBackupAPIEnabled {
+		dyn, err := dynamic.NewForConfig(restClientConfig)
+		if err != nil {
+			log.Errorf("Creating dynamic client for CBT lookup failed. Err: %v", err)
+			return err
+		}
+		cbtDynClient = dyn
+	}
 
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: cnsoperatorapis.GroupName})
-	return add(mgr, newReconciler(mgr, configInfo, volumeManager, vmOperatorClient, recorder))
+	return add(mgr, newReconciler(mgr, configInfo, volumeManager, vmOperatorClient, recorder, cbtDynClient))
 }
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 	volumeManager volumes.Manager, vmOperatorClient client.Client,
-	recorder record.EventRecorder) reconcile.Reconciler {
+	recorder record.EventRecorder, cbtDynamicClient dynamic.Interface) reconcile.Reconciler {
 	ctx, _ := logger.GetNewContextWithLogger()
 	return &ReconcileCnsNodeVMAttachment{
 		client:           mgr.GetClient(),
@@ -159,6 +172,7 @@ func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 		vmOperatorClient: vmOperatorClient,
 		nodeManager:      cnsnode.GetManager(ctx),
 		recorder:         recorder,
+		cbtDynamicClient: cbtDynamicClient,
 	}
 }
 
@@ -198,6 +212,9 @@ type ReconcileCnsNodeVMAttachment struct {
 	vmOperatorClient client.Client
 	nodeManager      cnsnode.Manager
 	recorder         record.EventRecorder
+	// cbtDynamicClient is set when isCSIBackupAPIEnabled (CSI_Backup_API FSS on); used for
+	// namespace-scoped CBTConfig lookups before attach.
+	cbtDynamicClient dynamic.Interface
 }
 
 // Reconcile reads that state of the cluster for a CnsNodeVMAttachment object
@@ -410,6 +427,12 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 			}
 
 			log.Debugf("instance after the patch: %s", instance)
+
+			if isCSIBackupAPIEnabled && r.cbtDynamicClient != nil {
+				common.SyncVolumeCBTState(internalCtx, r.cbtDynamicClient, instance.Namespace,
+					r.volumeManager, volumeID)
+			}
+
 			log.Infof("vSphere CSI driver is attaching volume: %q to nodevm: %+v for "+
 				"CnsNodeVmAttachment request with name: %q on namespace: %q",
 				volumeID, nodeVM, request.Name, request.Namespace)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
@@ -26,9 +26,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,6 +41,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 
+	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
 	v1a1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -732,4 +736,111 @@ func TestPatchObjectWithDeepCopy(t *testing.T) {
 		assert.NotContains(t, updatedPVC.Finalizers, cnsoptypes.CNSPvcFinalizer)
 		assert.Contains(t, updatedPVC.Finalizers, "other-finalizer")
 	})
+}
+
+func cbtConfigUnstructured(name, namespace string, statusEnabled *bool) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   cbtconfigv1alpha1.GroupName,
+		Version: cbtconfigv1alpha1.Version,
+		Kind:    "CBTConfig",
+	})
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	_ = unstructured.SetNestedField(u.Object, true, "spec", "enabled")
+	if statusEnabled != nil {
+		_ = unstructured.SetNestedField(u.Object, *statusEnabled, "status", "enabled")
+	}
+	return u
+}
+
+func newCBTTestDynamicClient(t *testing.T, objs ...runtime.Object) dynamic.Interface {
+	t.Helper()
+	cbtGVR := cbtconfigv1alpha1.GroupVersion.WithResource(cbtconfigv1alpha1.CBTConfigResource)
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		cbtGVR: "CBTConfigList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
+}
+
+// withCSIBackupAPIEnabled sets the package isCSIBackupAPIEnabled flag for tests that
+// exercise CBT paths (mirrors Add() when CSI_Backup_API FSS is on).
+
+// TestSyncCBTBeforeAttach_NoCBTConfig skips flag changes when CBTStateForNamespace
+// reports no CBTConfig CR in the namespace (configured=false).
+func TestSyncCBTBeforeAttach_NoCBTConfigSkipsFlagChange(t *testing.T) {
+	ctx := context.Background()
+
+	mockVM := &trackingMockVolumeManager{}
+	dyn := newCBTTestDynamicClient(t)
+	common.SyncVolumeCBTState(ctx, dyn, "unknown-ns", mockVM, "vol-1")
+
+	assert.False(t, mockVM.setCalled)
+	assert.False(t, mockVM.clearCalled)
+}
+
+// TestSyncCBTBeforeAttach_CBTEnabled verifies that when CBTConfig has status.enabled true,
+// SetVolumeControlFlags is called.
+func TestSyncCBTBeforeAttach_CBTEnabled(t *testing.T) {
+	ctx := context.Background()
+
+	enabled := true
+	dyn := newCBTTestDynamicClient(t, cbtConfigUnstructured("default", "ns-cbt", &enabled))
+	mockVM := &trackingMockVolumeManager{}
+	common.SyncVolumeCBTState(ctx, dyn, "ns-cbt", mockVM, "vol-cbt-on")
+
+	assert.True(t, mockVM.setCalled)
+	assert.False(t, mockVM.clearCalled)
+}
+
+// TestSyncCBTBeforeAttach_CBTDisabled verifies that when CBTConfig has status.enabled false,
+// ClearVolumeControlFlags is called.
+func TestSyncCBTBeforeAttach_CBTDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	disabled := false
+	dyn := newCBTTestDynamicClient(t, cbtConfigUnstructured("default", "ns-nocbt", &disabled))
+	mockVM := &trackingMockVolumeManager{}
+	common.SyncVolumeCBTState(ctx, dyn, "ns-nocbt", mockVM, "vol-cbt-off")
+
+	assert.False(t, mockVM.setCalled)
+	assert.True(t, mockVM.clearCalled)
+}
+
+// TestSyncCBTBeforeAttach_DynamicClientNil verifies that a nil dynamic client is a no-op.
+func TestSyncCBTBeforeAttach_DynamicClientNil(t *testing.T) {
+	ctx := context.Background()
+
+	mockVM := &trackingMockVolumeManager{}
+	r := &ReconcileCnsNodeVMAttachment{
+		volumeManager:    mockVM,
+		cbtDynamicClient: nil,
+	}
+
+	// Guard in the call site: nil client means SyncVolumeCBTState is never called.
+	if r.cbtDynamicClient != nil {
+		common.SyncVolumeCBTState(ctx, r.cbtDynamicClient, "ns-cbt", mockVM, "vol-cbt-on")
+	}
+
+	assert.False(t, mockVM.setCalled)
+	assert.False(t, mockVM.clearCalled)
+}
+
+// trackingMockVolumeManager wraps MockVolumeManager and records CBT flag calls.
+type trackingMockVolumeManager struct {
+	unittestcommon.MockVolumeManager
+	setCalled   bool
+	clearCalled bool
+}
+
+func (m *trackingMockVolumeManager) SetVolumeControlFlags(ctx context.Context,
+	volumeID string, controlFlags []string) error {
+	m.setCalled = true
+	return nil
+}
+
+func (m *trackingMockVolumeManager) ClearVolumeControlFlags(ctx context.Context,
+	volumeID string, controlFlags []string) error {
+	m.clearCalled = true
+	return nil
 }

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"k8s.io/client-go/dynamic"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
@@ -72,7 +73,8 @@ var (
 	// Keys are strings representing namespace + PVC name.
 	// Values are individual sync.Mutex locks that need to be held
 	// to make updates to the PVC on the API server.
-	VolumeLock *sync.Map
+	VolumeLock            *sync.Map
+	isCSIBackupAPIEnabled bool
 )
 
 const (
@@ -138,25 +140,42 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 
 	cnsOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, "cns.vmware.com")
 	if err != nil {
-		msg := fmt.Sprintf("Failed to initialize vmOperatorClient. Error: %+v", err)
+		msg := fmt.Sprintf("Failed to initialize cnsOperatorClient. Error: %+v", err)
 		log.Error(msg)
 		return err
 	}
 
+	// If the capability gets enabled at a later point, then container
+	// will be restarted and this value will be reinitialized.
+	isCSIBackupAPIEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API)
+
+	var cbtDynClient dynamic.Interface
+	if isCSIBackupAPIEnabled {
+		dyn, err := dynamic.NewForConfig(restClientConfig)
+		if err != nil {
+			log.Errorf("Creating dynamic client for CBT lookup failed. Err: %v", err)
+			return err
+		}
+		cbtDynClient = dyn
+	}
+
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: cnsoperatorapis.GroupName})
-	return add(mgr, newReconciler(mgr, configInfo, volumeManager, vmOperatorClient, cnsOperatorClient, recorder))
+	return add(mgr, newReconciler(mgr, configInfo, volumeManager, vmOperatorClient, cnsOperatorClient,
+		recorder, cbtDynClient))
 }
 
 func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 	volumeManager volumes.Manager, vmOperatorClient client.Client,
 	cnsOperatorClient client.Client,
-	recorder record.EventRecorder) reconcile.Reconciler {
+	recorder record.EventRecorder, cbtDynamicClient dynamic.Interface) reconcile.Reconciler {
 	return &Reconciler{client: mgr.GetClient(),
 		scheme:     mgr.GetScheme(),
 		configInfo: *configInfo, volumeManager: volumeManager,
 		vmOperatorClient:  vmOperatorClient,
 		cnsOperatorClient: cnsOperatorClient,
-		recorder:          recorder, instanceLock: sync.Map{}}
+		recorder:          recorder,
+		cbtDynamicClient:  cbtDynamicClient,
+		instanceLock:      sync.Map{}}
 }
 
 // add adds this package's controller to the provided manager.
@@ -195,6 +214,9 @@ type Reconciler struct {
 	vmOperatorClient  client.Client
 	cnsOperatorClient client.Client
 	recorder          record.EventRecorder
+	// cbtDynamicClient is set when isCSIBackupAPIEnabled (CSI_Backup_API FSS on); used for
+	// namespace-scoped CBTConfig lookups before batch attach.
+	cbtDynamicClient dynamic.Interface
 	// instanceLock to ensure that for an instance we have only
 	// one reconciliation at a time.
 	instanceLock sync.Map
@@ -535,6 +557,17 @@ func (r *Reconciler) processBatchAttach(ctx context.Context, k8sClient kubernete
 	if err != nil {
 		log.Errorf("failed to construct batch attach request. Err: %s", err)
 		return err
+	}
+
+	// Manage CBT for each volume before batch attach.
+	batchVolumeIDs := make([]string, 0, len(batchAttachRequest))
+	for _, req := range batchAttachRequest {
+		batchVolumeIDs = append(batchVolumeIDs, req.VolumeID)
+	}
+
+	if isCSIBackupAPIEnabled && r.cbtDynamicClient != nil {
+		common.SyncVolumeCBTState(ctx, r.cbtDynamicClient, instance.Namespace,
+			r.volumeManager, batchVolumeIDs...)
 	}
 
 	// Call CNS AttachVolume

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -34,8 +34,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	k8sFake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -46,6 +49,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	vim25types "github.com/vmware/govmomi/vim25/types"
+	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
 	cnsopapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsopv1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -2242,4 +2246,107 @@ func TestIsVmInSameNamespace_NotFound(t *testing.T) {
 	if found {
 		t.Fatalf("expected VM not to be found, got true")
 	}
+}
+
+// batchTrackingMockVolumeManager records CBT flag calls for SyncVolumeCBTState tests.
+type batchTrackingMockVolumeManager struct {
+	unittestcommon.MockVolumeManager
+	setCalled   bool
+	clearCalled bool
+}
+
+func (m *batchTrackingMockVolumeManager) SetVolumeControlFlags(ctx context.Context,
+	volumeID string, controlFlags []string) error {
+	m.setCalled = true
+	return nil
+}
+
+func (m *batchTrackingMockVolumeManager) ClearVolumeControlFlags(ctx context.Context,
+	volumeID string, controlFlags []string) error {
+	m.clearCalled = true
+	return nil
+}
+
+func batchCbtConfigUnstructured(name, namespace string, statusEnabled *bool) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   cbtconfigv1alpha1.GroupName,
+		Version: cbtconfigv1alpha1.Version,
+		Kind:    "CBTConfig",
+	})
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	_ = unstructured.SetNestedField(u.Object, true, "spec", "enabled")
+	if statusEnabled != nil {
+		_ = unstructured.SetNestedField(u.Object, *statusEnabled, "status", "enabled")
+	}
+	return u
+}
+
+func newBatchCBTTestDynamicClient(t *testing.T, objs ...runtime.Object) dynamic.Interface {
+	t.Helper()
+	cbtGVR := cbtconfigv1alpha1.GroupVersion.WithResource(cbtconfigv1alpha1.CBTConfigResource)
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		cbtGVR: "CBTConfigList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
+}
+
+// withCSIBackupAPIEnabled sets the package isCSIBackupAPIEnabled flag for tests that
+// exercise CBT paths (mirrors Add() when CSI_Backup_API FSS is on).
+
+// TestSyncCBTBeforeBatchAttach_NoCBTConfig skips flag changes when CBTStateForNamespace
+// reports no CBTConfig CR in the namespace (configured=false).
+func TestSyncCBTBeforeBatchAttach_NoCBTConfigSkipsFlagChange(t *testing.T) {
+	ctx := context.Background()
+
+	mockVM := &batchTrackingMockVolumeManager{}
+	dyn := newBatchCBTTestDynamicClient(t)
+	common.SyncVolumeCBTState(ctx, dyn, "unknown-ns", mockVM, "vol-1", "vol-2")
+
+	assert.False(t, mockVM.setCalled)
+	assert.False(t, mockVM.clearCalled)
+}
+
+func TestSyncCBTBeforeBatchAttach_CBTEnabled(t *testing.T) {
+	ctx := context.Background()
+
+	enabled := true
+	dyn := newBatchCBTTestDynamicClient(t, batchCbtConfigUnstructured("default", "ns-cbt", &enabled))
+	mockVM := &batchTrackingMockVolumeManager{}
+	common.SyncVolumeCBTState(ctx, dyn, "ns-cbt", mockVM, "vol-a", "vol-b")
+
+	assert.True(t, mockVM.setCalled)
+	assert.False(t, mockVM.clearCalled)
+}
+
+func TestSyncCBTBeforeBatchAttach_CBTDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	disabled := false
+	dyn := newBatchCBTTestDynamicClient(t, batchCbtConfigUnstructured("default", "ns-off", &disabled))
+	mockVM := &batchTrackingMockVolumeManager{}
+	common.SyncVolumeCBTState(ctx, dyn, "ns-off", mockVM, "vol-x", "vol-y")
+
+	assert.False(t, mockVM.setCalled)
+	assert.True(t, mockVM.clearCalled)
+}
+
+// TestSyncCBTBeforeBatchAttach_DynamicClientNil verifies that a nil dynamic client is a no-op.
+func TestSyncCBTBeforeBatchAttach_DynamicClientNil(t *testing.T) {
+	ctx := context.Background()
+
+	mockVM := &batchTrackingMockVolumeManager{}
+	r := &Reconciler{
+		volumeManager:    mockVM,
+		cbtDynamicClient: nil,
+	}
+
+	// Guard in the call site: nil client means SyncVolumeCBTState is never called.
+	if r.cbtDynamicClient != nil {
+		common.SyncVolumeCBTState(ctx, r.cbtDynamicClient, "any-ns", mockVM, "vol-1", "vol-2")
+	}
+
+	assert.False(t, mockVM.setCalled)
+	assert.False(t, mockVM.clearCalled)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is part of CSI CBT enablement in WCP gated by FSS CSI_Backup_API.
It implements CBT enablement for PVC during attachment.
a.  PVC attachment to Pod VM
b.  PVC attachment to VM (include VKS Node VM and VM Service VM)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
unit test passed
[unittest-4005.log](https://github.com/user-attachments/files/27344161/unittest-4005.log)


regression tests
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1089/ Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1418/ failures not related to this change

**Manual Test**:
1, enable cbt for the test namespace test-vadp-supervisor-ns
2,  attached PVC (cbt-disabled-fcd) to Pod VM
``` Pod VM attaching
2026-04-30T12:25:16.870Z        INFO    wcp/controller.go:1958  ControllerPublishVolume: called with args volume_id:"dc7a9372-7bd9-4dfd-aaf2-365422ae8823" node_id:"lvn-dvm-10-162-199-109.dvm.lvn.broadcom.net" volume_capability:{mount:{fs_type:"ext4"} access_mode:{mode:SINGLE_NODE_
WRITER}} volume_context:{key:"storage.kubernetes.io/csiProvisionerIdentity" value:"1777547952441-6408-csi.vsphere.vmware.com"} volume_context:{key:"type" value:"vSphere CNS Block Volume"}     {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
2026-04-30T12:25:16.871Z        DEBUG   k8sorchestrator/k8sorchestrator.go:1365 Feature "supports_shared_disks_with_VM_service_VMs" is a WCP defined feature state. Reading the capabilities CR "supervisor-capabilities".      {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
2026-04-30T12:25:16.871Z        DEBUG   k8sorchestrator/k8sorchestrator.go:1387 Supervisor capability "supports_shared_disks_with_VM_service_VMs" is set to true        {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
2026-04-30T12:25:16.871Z        DEBUG   k8sorchestrator/k8sorchestrator.go:1365 Feature "supports_shared_disks_with_VM_service_VMs" is a WCP defined feature state. Reading the capabilities CR "supervisor-capabilities".      {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
2026-04-30T12:25:16.871Z        DEBUG   k8sorchestrator/k8sorchestrator.go:1387 Supervisor capability "supports_shared_disks_with_VM_service_VMs" is set to true        {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
2026-04-30T12:25:16.871Z        DEBUG   k8sorchestrator/k8sorchestrator.go:1365 Feature "supports_shared_disks_with_VM_service_VMs" is a WCP defined feature state. Reading the capabilities CR "supervisor-capabilities".      {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
2026-04-30T12:25:16.871Z        DEBUG   k8sorchestrator/k8sorchestrator.go:1387 Supervisor capability "supports_shared_disks_with_VM_service_VMs" is set to true        {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
2026-04-30T12:25:16.959Z        DEBUG   common/util.go:564      CBT Enabled is set to true for namespace test-vadp-supervisor-ns        {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
...
...
2026-04-30T12:25:16.976Z        INFO    volume/manager.go:3688  Setting control flags [enableChangedBlockTracking] for volumeID: "dc7a9372-7bd9-4dfd-aaf2-365422ae8823" {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
2026-04-30T12:25:17.344Z        INFO    volume/manager.go:3697  Successfully set control flags [enableChangedBlockTracking] for volumeID: "dc7a9372-7bd9-4dfd-aaf2-365422ae8823"        {"TraceId": "c345f47d-f5bb-42b9-affb-471d6d93c975"}
```
3,  attached PVC (cbt-disabled-fcd) in VKS to Node VM
```
2026-04-30T08:41:06.525Z        DEBUG   common/util.go:564      CBT Enabled is set to true for namespace test-vadp-supervisor-ns        {"TraceId": "196eb0c5-0e58-4acf-beed-195d76464306"}
...
...
2026-04-30T08:41:06.537Z        INFO    volume/manager.go:3688  Setting control flags [enableChangedBlockTracking] for volumeID: "fb211f6d-2469-4be2-82a2-9070bf497368" {"TraceId": "196eb0c5
-0e58-4acf-beed-195d76464306"}
2026-04-30T08:41:08.903Z        INFO    volume/manager.go:3697  Successfully set control flags [enableChangedBlockTracking] for volumeID: "fb211f6d-2469-4be2-82a2-9070bf497368"        {"Tra
ceId": "196eb0c5-0e58-4acf-beed-195d76464306"}
2026-04-30T08:41:08.903Z        INFO    cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:712     Successfully enabled CBT for volume fb211f6d-2469-4be2-82a2-9070bf497368 in namespace test-vadp-supervisor-ns        {"TraceId": "196eb0c5-0e58-4acf-beed-195d76464306"}
2026-04-30T08:41:08.903Z        INFO    volume/manager.go:3933  Starting batch attach for VM fa2fe4b9-5922-497d-ac44-d185e80def57       {"TraceId": "196eb0c5-0e58-4acf-beed-195d76464306"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
enable CBT for PVC during attachment
```
