### PR TITLE
Address review comments on FVS file volume provisioning

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1829,6 +1829,11 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			if useFVS {
 				return c.createFileVolumeViaFVS(ctx, req)
 			}
+			if isVsanFileServicePolicyStorageClass(scName) {
+				return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+					"invalid file volume provisioning request: reserved StorageClass %q requires FileVolumeService",
+					scName)
+			}
 			// Block file volume provisioning if FSS Workload_Domain_Isolation_Supported is enabled but
 			// 'fileVolumeActivated' field is set to false in vSphere config secret.
 			if isWorkloadDomainIsolationEnabled &&

--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -46,6 +46,11 @@ import (
 const (
 	fvsGroup   = "fvs.vcf.broadcom.com"
 	fvsVersion = "v1alpha1"
+	// fvsServiceReadyConditionType is the condition type on a FileVolumeService CR that aggregates
+	// the readiness of its underlying components (ProtocolService, VolumeManager, Telegraf). The
+	// service is considered usable for creating FileVolume CRs only when this condition has
+	// status "True" and the top-level status.healthState is "Ready".
+	fvsServiceReadyConditionType = "Service-Ready"
 	// AnnotationVPCNetworkConfig is set on supervisor namespaces; value is the VPCNetworkConfiguration CR name.
 	AnnotationVPCNetworkConfig = "nsx.vmware.com/vpc_network_config"
 	// NamespaceLabelFVSInstance marks FVS instance namespaces (supervisor namespaces that host FileVolume CRs).
@@ -223,9 +228,14 @@ func (c *controller) listFVSCandidateInstanceNamespaces(ctx context.Context, pvc
 }
 
 // instanceNamespaceHasReadyFileVolumeService returns nil if the namespace has at least one
-// FileVolumeService (fvs.vcf.broadcom.com/v1alpha1) whose status.healthState is Ready (case-insensitive).
-// Otherwise it returns an error describing a missing list, no CRs, or no healthy service.
+// FileVolumeService (fvs.vcf.broadcom.com/v1alpha1) that satisfies BOTH:
+//   - status.healthState == "Ready" (case-insensitive)
+//   - a status.conditions[] entry with type "Service-Ready" and status "True" (case-insensitive)
+//
+// FileVolumeService instances that fail either check are logged and skipped; an aggregate error is
+// returned only when no instance in the namespace qualifies (or the namespace has none).
 func (c *controller) instanceNamespaceHasReadyFileVolumeService(ctx context.Context, instanceNS string) error {
+	log := logger.GetLogger(ctx)
 	list, err := c.dynamicClient.Resource(fvsFileVolumeServiceGVR).Namespace(instanceNS).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -235,12 +245,44 @@ func (c *controller) instanceNamespaceHasReadyFileVolumeService(ctx context.Cont
 	}
 	for _, item := range list.Items {
 		obj := item.Object
-		if hs, found, _ := unstructured.NestedString(obj, "status", "healthState"); found &&
-			strings.EqualFold(hs, "Ready") {
-			return nil
+		name := item.GetName()
+
+		hs, hsFound, _ := unstructured.NestedString(obj, "status", "healthState")
+		if !hsFound || !strings.EqualFold(hs, "Ready") {
+			log.Infof("skipping FileVolumeService %s/%s: healthState=%q (want Ready)",
+				instanceNS, name, hs)
+			continue
+		}
+		if !fileVolumeServiceHasServiceReadyCondition(obj) {
+			log.Infof("skipping FileVolumeService %s/%s: missing %q condition with status=True",
+				instanceNS, name, fvsServiceReadyConditionType)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("no FileVolumeService in namespace %q has healthState=Ready and "+
+		"%q condition with status=True", instanceNS, fvsServiceReadyConditionType)
+}
+
+// fileVolumeServiceHasServiceReadyCondition reports whether the unstructured FileVolumeService object
+// has a status.conditions[] entry of type "Service-Ready" with status "True" (case-insensitive).
+func fileVolumeServiceHasServiceReadyCondition(obj map[string]interface{}) bool {
+	conds, found, err := unstructured.NestedSlice(obj, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, c := range conds {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		t, _, _ := unstructured.NestedString(cm, "type")
+		s, _, _ := unstructured.NestedString(cm, "status")
+		if strings.EqualFold(t, fvsServiceReadyConditionType) && strings.EqualFold(s, "True") {
+			return true
 		}
 	}
-	return fmt.Errorf("no healthy FileVolumeService in namespace %q", instanceNS)
+	return false
 }
 
 // namespaceHasAnyRequestedZone reports whether the supervisor namespace is associated with at least one
@@ -352,10 +394,15 @@ func (c *controller) createFileVolumeViaFVS(ctx context.Context, req *csi.Create
 			log.Infof("reusing existing FileVolume %s/%s for PVC %s/%s", ns, fvName, pvcNamespace, pvcName)
 			break
 		}
-		if !apierrors.IsNotFound(getErr) {
+		if apierrors.IsNotFound(getErr) {
 			log.Warnf("could not get FileVolume %q in namespace %q (will try next candidate): %v",
 				fvName, ns, getErr)
 			continue
+		} else {
+			// If unable to get the FileVolume due to an unexpected error, return an internal fault.
+			// This helps leaving behing orphaned FileVolume CRs in the namespace.
+			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to check for existing FileVolume %q in namespace %q: error :%v", fvName, ns, getErr)
 		}
 	}
 
@@ -645,6 +692,9 @@ func (c *controller) expandFileVolumeViaFVS(ctx context.Context, req *csi.Contro
 
 // shouldProvisionVsanFileVolumeViaFVS encapsulates routing to the FVS CR workflow.
 func shouldProvisionVsanFileVolumeViaFVS(ctx context.Context, storageClassName string) (bool, error) {
+	if !isVsanFileVolumeServiceFSSEnabled {
+		return false, nil
+	}
 	if !isVsanFileServicePolicyStorageClass(storageClassName) {
 		return false, nil
 	}
@@ -656,9 +706,6 @@ func shouldProvisionVsanFileVolumeViaFVS(ctx context.Context, storageClassName s
 		return false, status.Errorf(codes.FailedPrecondition,
 			"storage class %q requires NSX_VPC network provider (current network provider: %q)",
 			storageClassName, np)
-	}
-	if !isVsanFileVolumeServiceFSSEnabled {
-		return false, nil
 	}
 	return true, nil
 }

--- a/pkg/csi/service/wcp/fvs_filevolume_test.go
+++ b/pkg/csi/service/wcp/fvs_filevolume_test.go
@@ -38,7 +38,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	fvsapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume"
@@ -323,45 +323,76 @@ func TestListFVSCandidateInstanceNamespaces(t *testing.T) {
 	require.Error(t, err)
 }
 
+// fvsObj builds an unstructured FileVolumeService CR for tests with the given healthState and
+// optional Service-Ready condition status (pass "" to omit the condition entirely).
+func fvsObj(name, namespace, healthState, serviceReadyStatus string) *unstructured.Unstructured {
+	status := map[string]interface{}{
+		"healthState": healthState,
+	}
+	if serviceReadyStatus != "" {
+		status["conditions"] = []interface{}{
+			map[string]interface{}{
+				"type":   fvsServiceReadyConditionType,
+				"status": serviceReadyStatus,
+			},
+		}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "fvs.vcf.broadcom.com/v1alpha1",
+			"kind":       "FileVolumeService",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"status": status,
+		},
+	}
+}
+
 func TestInstanceNamespaceHasReadyFileVolumeService(t *testing.T) {
 	ctx := context.Background()
-	fvs := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "fvs.vcf.broadcom.com/v1alpha1",
-			"kind":       "FileVolumeService",
-			"metadata": map[string]interface{}{
-				"name":      "fvs1",
-				"namespace": "ns1",
-			},
-			"status": map[string]interface{}{
-				"healthState": "Ready",
-			},
-		},
-	}
-	dyn := newTestDynamicClient(t, fvs)
-	c := &controller{dynamicClient: dyn}
-	require.NoError(t, c.instanceNamespaceHasReadyFileVolumeService(ctx, "ns1"))
 
-	notReady := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "fvs.vcf.broadcom.com/v1alpha1",
-			"kind":       "FileVolumeService",
-			"metadata": map[string]interface{}{
-				"name":      "fvs2",
-				"namespace": "ns2",
-			},
-			"status": map[string]interface{}{
-				"healthState": "NotReady",
-			},
-		},
-	}
-	dyn2 := newTestDynamicClient(t, notReady)
-	c2 := &controller{dynamicClient: dyn2}
-	require.Error(t, c2.instanceNamespaceHasReadyFileVolumeService(ctx, "ns2"))
+	t.Run("healthState Ready and Service-Ready True", func(t *testing.T) {
+		dyn := newTestDynamicClient(t, fvsObj("fvs1", "ns1", "Ready", "True"))
+		c := &controller{dynamicClient: dyn}
+		require.NoError(t, c.instanceNamespaceHasReadyFileVolumeService(ctx, "ns1"))
+	})
 
-	dynEmpty := newTestDynamicClient(t)
-	c3 := &controller{dynamicClient: dynEmpty}
-	require.Error(t, c3.instanceNamespaceHasReadyFileVolumeService(ctx, "empty"))
+	t.Run("healthState NotReady is rejected", func(t *testing.T) {
+		dyn := newTestDynamicClient(t, fvsObj("fvs2", "ns2", "NotReady", "True"))
+		c := &controller{dynamicClient: dyn}
+		require.Error(t, c.instanceNamespaceHasReadyFileVolumeService(ctx, "ns2"))
+	})
+
+	t.Run("healthState Ready but no Service-Ready condition is rejected", func(t *testing.T) {
+		dyn := newTestDynamicClient(t, fvsObj("fvs3", "ns3", "Ready", ""))
+		c := &controller{dynamicClient: dyn}
+		err := c.instanceNamespaceHasReadyFileVolumeService(ctx, "ns3")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Service-Ready")
+	})
+
+	t.Run("healthState Ready but Service-Ready=False is rejected", func(t *testing.T) {
+		dyn := newTestDynamicClient(t, fvsObj("fvs4", "ns4", "Ready", "False"))
+		c := &controller{dynamicClient: dyn}
+		require.Error(t, c.instanceNamespaceHasReadyFileVolumeService(ctx, "ns4"))
+	})
+
+	t.Run("skips unhealthy item and finds qualifying one", func(t *testing.T) {
+		dyn := newTestDynamicClient(t,
+			fvsObj("bad", "ns5", "NotReady", "False"),
+			fvsObj("good", "ns5", "Ready", "True"),
+		)
+		c := &controller{dynamicClient: dyn}
+		require.NoError(t, c.instanceNamespaceHasReadyFileVolumeService(ctx, "ns5"))
+	})
+
+	t.Run("empty namespace returns error", func(t *testing.T) {
+		dyn := newTestDynamicClient(t)
+		c := &controller{dynamicClient: dyn}
+		require.Error(t, c.instanceNamespaceHasReadyFileVolumeService(ctx, "empty"))
+	})
 }
 
 func TestCreateFileVolumeViaFVS_ValidationAndPVC(t *testing.T) {
@@ -418,6 +449,9 @@ func TestShouldProvisionVsanFileVolumeViaFVS(t *testing.T) {
 		cnsoperatorutil.GetNetworkProviderFunc = func(ctx context.Context) (string, error) {
 			return "NSX_T", nil
 		}
+		oldFSS := isVsanFileVolumeServiceFSSEnabled
+		defer func() { isVsanFileVolumeServiceFSSEnabled = oldFSS }()
+		isVsanFileVolumeServiceFSSEnabled = true
 		_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, common.StorageClassVsanFileServicePolicy)
 		require.Error(t, err)
 	})
@@ -481,9 +515,9 @@ func TestShouldDeleteFileVolumeViaFVS(t *testing.T) {
 	}
 }
 
-// fvsTestScheme returns a runtime.Scheme with the FVS FileVolume types registered for use with
-// the controller-runtime fake client.
-func fvsTestScheme(t *testing.T) *runtime.Scheme {
+// newFileVolumeSchemeForTest returns a runtime.Scheme with the FVS FileVolume types registered so
+// the controller-runtime fake client can serialize FileVolume objects.
+func newFileVolumeSchemeForTest(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
 	require.NoError(t, fvsapis.AddToScheme(s))
@@ -512,8 +546,8 @@ func TestDeleteFileVolumeViaFVS_Success(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
 	}
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			Build(),
 	}
@@ -536,8 +570,8 @@ func TestDeleteFileVolumeViaFVS_NotFoundIsIdempotent(t *testing.T) {
 	withFastFVSWait(t)
 
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			Build(),
 	}
 
@@ -553,8 +587,8 @@ func TestDeleteFileVolumeViaFVS_InvalidVolumeID(t *testing.T) {
 	withFastFVSWait(t)
 
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			Build(),
 	}
 
@@ -602,8 +636,8 @@ func TestDeleteFileVolumeViaFVS_DeleteError(t *testing.T) {
 	}
 	injectedErr := errors.New("api server temporarily unavailable")
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Delete: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
@@ -689,8 +723,8 @@ func TestExpandFileVolumeViaFVS_Success(t *testing.T) {
 		},
 	}
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
@@ -746,8 +780,8 @@ func TestExpandFileVolumeViaFVS_Idempotent(t *testing.T) {
 	}
 	updateCalls := 0
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
@@ -792,8 +826,8 @@ func TestExpandFileVolumeViaFVS_Shrink(t *testing.T) {
 		},
 	}
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			Build(),
 	}
@@ -810,8 +844,8 @@ func TestExpandFileVolumeViaFVS_InvalidVolumeID(t *testing.T) {
 	withFastFVSWait(t)
 
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			Build(),
 	}
 
@@ -861,8 +895,8 @@ func TestExpandFileVolumeViaFVS_MissingCapacityRange(t *testing.T) {
 		},
 	}
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			Build(),
 	}
@@ -892,8 +926,8 @@ func TestExpandFileVolumeViaFVS_NotFound(t *testing.T) {
 	withFastFVSWait(t)
 
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			Build(),
 	}
 
@@ -925,8 +959,8 @@ func TestExpandFileVolumeViaFVS_UpdateError(t *testing.T) {
 	}
 	injectedErr := errors.New("api server temporarily unavailable")
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
@@ -971,8 +1005,8 @@ func TestExpandFileVolumeViaFVS_StatusNeverApplies(t *testing.T) {
 		},
 	}
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
@@ -1019,8 +1053,8 @@ func TestExpandFileVolumeViaFVS_ErrorPhase(t *testing.T) {
 		},
 	}
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			WithInterceptorFuncs(interceptor.Funcs{
 				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
@@ -1060,8 +1094,8 @@ func TestDeleteFileVolumeViaFVS_StuckFinalizer(t *testing.T) {
 		},
 	}
 	c := &controller{
-		fileVolumeClient: ctrlclientfake.NewClientBuilder().
-			WithScheme(fvsTestScheme(t)).
+		fileVolumeClient: ctrlfake.NewClientBuilder().
+			WithScheme(newFileVolumeSchemeForTest(t)).
 			WithObjects(existing).
 			Build(),
 	}
@@ -1071,4 +1105,111 @@ func TestDeleteFileVolumeViaFVS_StuckFinalizer(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, csifault.CSIInternalFault, fault)
 	require.Contains(t, err.Error(), "timeout or error waiting for FileVolume")
+}
+
+// TestCreateFileVolumeViaFVS_ExistingFVGetError verifies that when the candidate FileVolume Get
+// returns a non-NotFound error, createFileVolumeViaFVS returns CSIInternalFault rather than
+// silently moving on, which would risk creating a duplicate FileVolume CR (orphan risk).
+func TestCreateFileVolumeViaFVS_ExistingFVGetError(t *testing.T) {
+	ctx := context.Background()
+	consumerAnn := "pvc-ns-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	instAnn := "inst-ns-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	sameVPCPath := "/orgs/default/projects/default/vpcs/same-vpc"
+
+	k8s := k8sfake.NewClientset(
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pvc-ns",
+				Annotations: map[string]string{
+					AnnotationVPCNetworkConfig: consumerAnn,
+				},
+			},
+		},
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "inst-ns",
+				Labels: map[string]string{
+					NamespaceLabelFVSInstance: "true",
+				},
+				Annotations: map[string]string{
+					AnnotationVPCNetworkConfig: instAnn,
+				},
+			},
+		},
+	)
+	dyn := newTestDynamicClient(t,
+		testVPCNetworkConfigurationCR(consumerAnn, sameVPCPath),
+		testVPCNetworkConfigurationCR(instAnn, sameVPCPath),
+	)
+
+	origZones := fvsZonesForNamespace
+	defer func() { fvsZonesForNamespace = origZones }()
+	fvsZonesForNamespace = func(ns string) map[string]struct{} {
+		if ns == "pvc-ns" || ns == "inst-ns" {
+			return map[string]struct{}{"zone-a": {}}
+		}
+		return nil
+	}
+
+	scheme := newFileVolumeSchemeForTest(t)
+	base := ctrlfake.NewClientBuilder().WithScheme(scheme).Build()
+	injectedErr := errors.New("simulated transient API error")
+	fvClient := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, _ ctrlclient.WithWatch, _ ctrlclient.ObjectKey,
+			_ ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+			return injectedErr
+		},
+	})
+
+	c := &controller{
+		k8sClient:        k8s,
+		dynamicClient:    dyn,
+		namespaceLister:  testNamespaceLister(t, k8s),
+		fileVolumeClient: fvClient,
+	}
+
+	req := &csi.CreateVolumeRequest{
+		Name: "pvc-cccccccc-cccc-cccc-cccc-cccccccccccc",
+		Parameters: map[string]string{
+			common.AttributePvcNamespace: "pvc-ns",
+			common.AttributePvcName:      "my-pvc",
+		},
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Preferred: []*csi.Topology{{Segments: map[string]string{v1.LabelTopologyZone: "zone-a"}}},
+		},
+	}
+
+	resp, fault, err := c.createFileVolumeViaFVS(ctx, req)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInternalFault, fault)
+	require.Contains(t, err.Error(), "failed to check for existing FileVolume")
+}
+
+// TestReservedFVSStorageClassGuard documents the invariant the new CreateVolume guard relies on:
+// the reserved vSAN file-service storage classes are recognised by isVsanFileServicePolicyStorageClass,
+// and when the FVS FSS is disabled, shouldProvisionVsanFileVolumeViaFVS returns useFVS=false. The
+// conjunction of these two booleans is what the guard at controller.go uses to reject requests for
+// the reserved StorageClass when FVS routing is unavailable.
+func TestReservedFVSStorageClassGuard(t *testing.T) {
+	ctx := context.Background()
+
+	require.True(t, isVsanFileServicePolicyStorageClass(common.StorageClassVsanFileServicePolicy))
+	require.True(t, isVsanFileServicePolicyStorageClass(common.StorageClassVsanFileServicePolicyLateBinding))
+	require.False(t, isVsanFileServicePolicyStorageClass("ordinary-sc"))
+
+	oldFSS := isVsanFileVolumeServiceFSSEnabled
+	defer func() { isVsanFileVolumeServiceFSSEnabled = oldFSS }()
+	isVsanFileVolumeServiceFSSEnabled = false
+
+	for _, sc := range []string{
+		common.StorageClassVsanFileServicePolicy,
+		common.StorageClassVsanFileServicePolicyLateBinding,
+	} {
+		useFVS, err := shouldProvisionVsanFileVolumeViaFVS(ctx, sc)
+		require.NoError(t, err, "sc=%s", sc)
+		require.False(t, useFVS, "sc=%s: with FSS disabled the guard must reject by hitting the reserved-SC branch", sc)
+		require.True(t, isVsanFileServicePolicyStorageClass(sc),
+			"sc=%s: reserved-SC predicate must remain true so the guard rejects rather than falling through", sc)
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Tighten FileVolumeService readiness check to require both status.healthState == "Ready" and a status.conditions[] entry of type "Service-Ready" with status "True" before selecting an instance namespace for FileVolume CR creation. Previously only healthState was checked. Per-item failures are now logged with the specific reason (bad healthState or missing/False Service-Ready condition) so operators can diagnose unhealthy services without digging into raw CRs.

Add fileVolumeServiceHasServiceReadyCondition helper and the fvsServiceReadyConditionType constant to encapsulate the condition lookup.

Fix logic inversion in the existing-FileVolume Get loop: a non-NotFound error now returns CSIInternalFault immediately instead of continuing to the next candidate namespace, eliminating the risk of creating duplicate/orphaned FileVolume CRs.

Add reserved-StorageClass guard in CreateVolume: when the FVS feature flag is disabled but the request targets the reserved vsan-file-service- policy or vsan-file-service-policy-latebinding StorageClass, return CSIInvalidArgumentFault with a clear message rather than falling through to the legacy file volume path. Refactored the guard to avoid fmt.Errorf(msg) (govet S1039) and a non-ASCII em-dash.

Move the isVsanFileVolumeServiceFSSEnabled guard to the top of shouldProvisionVsanFileVolumeViaFVS so the FSS check short-circuits before the network-provider lookup, which is a no-op when the feature is disabled.

Test coverage:
- Expand TestInstanceNamespaceHasReadyFileVolumeService into subtests covering: both checks passing, bad healthState, missing Service-Ready condition, Service-Ready=False, skip-then-find (two services where first is unhealthy), and empty namespace.
- Add TestCreateFileVolumeViaFVS_ExistingFVGetError: uses controller-runtime interceptor to inject a transient Get error and asserts CSIInternalFault with the expected message.
- Add TestReservedFVSStorageClassGuard: documents the boolean invariant the new CreateVolume guard relies on.
- Fix TestShouldProvisionVsanFileVolumeViaFVS/non-VPC subtest to enable the FSS before asserting FailedPrecondition, consistent with the reordered FSS-first check.


**Which issue this PR fixes**
Addressed review comments from @kirankumarbasavaraju-broadcom for PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3972

**Testing done**:

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1501/
```
16:17:25    [FAIL] statefulset [It] [ef-vanilla-block][pq-n1-vanilla-block][pq-n2-vanilla-block] [ef-wcp][csi-block-vanilla][csi-supervisor][csi-block-vanilla-parallelized] Statefulset testing with parallel podManagementPolicy [p0, vanilla, block, wcp, core, vc70]
16:17:25    /home/worker/workspace/wcp-instapp-e2e-pre-checkin/Results/1501/go/pkg/mod/k8s.io/kubernetes@v1.36.0/test/e2e/framework/statefulset/wait.go:129
16:17:25  
16:17:25  Ran 14 of 1275 Specs in 3070.527 seconds
16:17:25  FAIL! -- 13 Passed | 1 Failed | 1 Flaked | 0 Pending | 1261 Skipped
```

Failed flaky test is not related to this change.

vks-precheckin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1114/ 
```
Ran 6 of 2357 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2351 Skipped | 0 Flaked
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Address review comments on FVS file volume provisioning
```
