### PR TITLE
syncer: propagate FileVolume CR conditions to PVC volume health annotation

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -304,6 +304,14 @@ const (
 	// VolHealthStatusInaccessible is volume health status for inaccessible volume.
 	VolHealthStatusInaccessible = "inaccessible"
 
+	// FileVolumeConditionBackendReady is the condition type on a FileVolume CR
+	// indicating that the VDFS backend volume is created and accessible.
+	FileVolumeConditionBackendReady = "BackendReady"
+
+	// FileVolumeConditionExportReady is the condition type on a FileVolume CR
+	// indicating that the NFS export is configured and active.
+	FileVolumeConditionExportReady = "ExportReady"
+
 	// AnnIgnoreInaccessiblePV is annotation key on volume claim to indicate
 	// if inaccessible PV can be fake attached.
 	AnnIgnoreInaccessiblePV = "pv.attach.kubernetes.io/ignore-if-inaccessible"

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -56,6 +56,7 @@ import (
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
 	sqperiodicsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagequotaperiodicsync/v1alpha1"
+	fvsapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -382,6 +383,21 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupportsPerNamespaceNetworkProviders) {
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,
 				common.SupportsPerNamespaceNetworkProviders, "", "")
+		}
+		if IsVsanFileVolumeServiceEnabled {
+			fvsScheme := runtime.NewScheme()
+			if err = fvsapis.AddToScheme(fvsScheme); err != nil {
+				return logger.LogNewErrorf(log, "failed to add FileVolume API types to scheme: %v", err)
+			}
+			restConfig, cfgErr := config.GetConfig()
+			if cfgErr != nil {
+				return logger.LogNewErrorf(log, "failed to get Kubernetes config for FileVolume client: %v", cfgErr)
+			}
+			metadataSyncer.fileVolumeClient, err = client.New(restConfig, client.Options{Scheme: fvsScheme})
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to create FileVolume client: %v", err)
+			}
+			log.Info("Initialized FileVolume client for volume health")
 		}
 	}
 

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -118,6 +118,10 @@ type metadataSyncInformer struct {
 	pvcLister          corelisters.PersistentVolumeClaimLister
 	podLister          corelisters.PodLister
 	coCommonInterface  commonco.COCommonInterface
+	// fileVolumeClient is a controller-runtime client for reading FileVolume CRs
+	// (fvs.vcf.broadcom.com/v1alpha1). Initialized only when IsVsanFileVolumeServiceEnabled
+	// is true; nil otherwise.
+	fileVolumeClient client.Client
 	// topologyVCMap maintains a cache of topology tags to the vCenter IP/FQDN which holds the tag.
 	// Example - {region1: {VC1: struct{}{}, VC2: struct{}{}},
 	//            zone1: {VC1: struct{}{}},

--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -26,6 +26,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fvv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
@@ -37,17 +39,6 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 	metadataSyncer *metadataSyncInformer) {
 	log := logger.GetLogger(ctx)
 	log.Infof("csiGetVolumeHealthStatus: start")
-	querySelection := cnstypes.CnsQuerySelection{
-		Names: []string{
-			string(cnstypes.QuerySelectionNameTypeHealthStatus),
-		},
-	}
-	queryAllResult, err := utils.QueryAllVolumesForCluster(ctx, metadataSyncer.volumeManager,
-		clusterIDforVolumeMetadata, querySelection)
-	if err != nil {
-		log.Errorf("csiGetVolumeHealthStatus: failed to QueryAllVolume with err=%+v", err.Error())
-		return
-	}
 
 	// Get K8s PVs in State "Bound".
 	k8sPVs, err := getBoundPVs(ctx, metadataSyncer)
@@ -59,6 +50,12 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 	// volumeHandleToPvcMap maps pv.Spec.CSI.VolumeHandle to the pvc object which
 	// bounded to the pv.
 	volumeHandleToPvcMap := make(volumeHandlePVCMap, len(k8sPVs))
+	// fvsVolumeHandleToPvcMap holds FVS-backed PVs separately when the FSS is enabled.
+	var fvsVolumeHandleToPvcMap volumeHandlePVCMap
+
+	if IsVsanFileVolumeServiceEnabled {
+		fvsVolumeHandleToPvcMap = make(volumeHandlePVCMap)
+	}
 
 	for _, pv := range k8sPVs {
 		if pv.Spec.ClaimRef != nil && pv.Status.Phase == v1.VolumeBound {
@@ -69,62 +66,153 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 					pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name, err)
 				continue
 			}
-			volumeHandleToPvcMap[pv.Spec.CSI.VolumeHandle] = pvc
-			log.Debugf("csiGetVolumeHealthStatus: pvc %s/%s is backed by pv %s volumeHandle %s",
-				pvc.Namespace, pvc.Name, pv.Name, pv.Spec.CSI.VolumeHandle)
+			if IsVsanFileVolumeServiceEnabled && common.IsFVSStorageClassName(pv.Spec.StorageClassName) {
+				fvsVolumeHandleToPvcMap[pv.Spec.CSI.VolumeHandle] = pvc
+				log.Debugf("csiGetVolumeHealthStatus: FVS pvc %s/%s is backed by pv %s volumeHandle %s",
+					pvc.Namespace, pvc.Name, pv.Name, pv.Spec.CSI.VolumeHandle)
+			} else {
+				volumeHandleToPvcMap[pv.Spec.CSI.VolumeHandle] = pvc
+				log.Debugf("csiGetVolumeHealthStatus: pvc %s/%s is backed by pv %s volumeHandle %s",
+					pvc.Namespace, pvc.Name, pv.Name, pv.Spec.CSI.VolumeHandle)
+			}
 		}
-	}
-
-	// volumeIdToHealthStatusMap maps vol.VolumeId.Id to vol.HealthStatus.
-	volumeIdToHealthStatusMap := make(volumeIdHealthStatusMap, len(queryAllResult.Volumes))
-
-	for _, vol := range queryAllResult.Volumes {
-		volumeIdToHealthStatusMap[vol.VolumeId.Id] = vol.HealthStatus
 	}
 
 	accessibleVolumeCount := 0
 	inaccessibleVolumeCount := 0
-	for volID, pvc := range volumeHandleToPvcMap {
-		var volHealthStatusAnn string
-		if volHealthStatus, ok := volumeIdToHealthStatusMap[volID]; ok {
-			// Only update PVC health annotation if the HealthStatus of volume is
-			// not "unknown".
-			if volHealthStatus != string(pbmtypes.PbmHealthStatusForEntityUnknown) {
-				volHealthStatusAnn, err = common.ConvertVolumeHealthStatus(ctx, volID, volHealthStatus)
-				if err != nil {
-					log.Errorf("csiGetVolumeHealthStatus: invalid health status %q for volume %q", volHealthStatus, volID)
-				}
-				updateVolumeHealthStatus(ctx, k8sclient, pvc, volHealthStatusAnn)
-			}
-		} else {
-			// Set volume health status as "Inaccessible" when PVC is not found in
-			// CNS. When a Datastore is removed from VC (like vSAN direct disk
-			// decommisson with noAction does), the CNS Volumes on that Datastore
-			// are eventually removed from CNS DB, but the PVCs still remain in
-			// the K8S cluster. We are making the design choice of reflecting the
-			// CNS cached status of health on the PVC's health annotation at any
-			// given point of time. The vDPp operators are advised to look at the
-			// health change timestamp and wait "long enough" (like an hour) before
-			// taking any corrective actions. So if the PVC health is getting
-			// updated every 5 mins, wait for an hour or so before taking any
-			// corrective actions. This is an acceptable level of eventual
-			// consistency.
-			volHealthStatusAnn = common.VolHealthStatusInaccessible
-			updateVolumeHealthStatus(ctx, k8sclient, pvc, volHealthStatusAnn)
+
+	// Process FVS-backed volumes by reading FileVolume CR conditions.
+	if IsVsanFileVolumeServiceEnabled && len(fvsVolumeHandleToPvcMap) > 0 {
+		fvsAccessible, fvsInaccessible := getFileVolumeHealthStatus(ctx, k8sclient,
+			metadataSyncer.fileVolumeClient, fvsVolumeHandleToPvcMap)
+		accessibleVolumeCount += fvsAccessible
+		inaccessibleVolumeCount += fvsInaccessible
+	}
+
+	// Process non-FVS volumes via CNS query (legacy path).
+	if len(volumeHandleToPvcMap) > 0 {
+		querySelection := cnstypes.CnsQuerySelection{
+			Names: []string{
+				string(cnstypes.QuerySelectionNameTypeHealthStatus),
+			},
 		}
-		switch volHealthStatusAnn {
-		case common.VolHealthStatusAccessible:
-			accessibleVolumeCount += 1
-		case common.VolHealthStatusInaccessible:
-			inaccessibleVolumeCount += 1
+		queryAllResult, err := utils.QueryAllVolumesForCluster(ctx, metadataSyncer.volumeManager,
+			clusterIDforVolumeMetadata, querySelection)
+		if err != nil {
+			log.Errorf("csiGetVolumeHealthStatus: failed to QueryAllVolume with err=%+v", err.Error())
+		} else {
+			volumeIdToHealthStatusMap := make(volumeIdHealthStatusMap, len(queryAllResult.Volumes))
+			for _, vol := range queryAllResult.Volumes {
+				volumeIdToHealthStatusMap[vol.VolumeId.Id] = vol.HealthStatus
+			}
+
+			for volID, pvc := range volumeHandleToPvcMap {
+				var volHealthStatusAnn string
+				if volHealthStatus, ok := volumeIdToHealthStatusMap[volID]; ok {
+					if volHealthStatus != string(pbmtypes.PbmHealthStatusForEntityUnknown) {
+						volHealthStatusAnn, err = common.ConvertVolumeHealthStatus(ctx, volID, volHealthStatus)
+						if err != nil {
+							log.Errorf("csiGetVolumeHealthStatus: invalid health status %q for volume %q",
+								volHealthStatus, volID)
+						}
+						updateVolumeHealthStatus(ctx, k8sclient, pvc, volHealthStatusAnn)
+					}
+				} else {
+					// Set volume health status as "Inaccessible" when PVC is not found in
+					// CNS. When a Datastore is removed from VC (like vSAN direct disk
+					// decommisson with noAction does), the CNS Volumes on that Datastore
+					// are eventually removed from CNS DB, but the PVCs still remain in
+					// the K8S cluster. We are making the design choice of reflecting the
+					// CNS cached status of health on the PVC's health annotation at any
+					// given point of time. The vDPp operators are advised to look at the
+					// health change timestamp and wait "long enough" (like an hour) before
+					// taking any corrective actions. So if the PVC health is getting
+					// updated every 5 mins, wait for an hour or so before taking any
+					// corrective actions. This is an acceptable level of eventual
+					// consistency.
+					volHealthStatusAnn = common.VolHealthStatusInaccessible
+					updateVolumeHealthStatus(ctx, k8sclient, pvc, volHealthStatusAnn)
+				}
+				switch volHealthStatusAnn {
+				case common.VolHealthStatusAccessible:
+					accessibleVolumeCount++
+				case common.VolHealthStatusInaccessible:
+					inaccessibleVolumeCount++
+				}
+			}
 		}
 	}
+
 	prometheus.VolumeHealthGaugeVec.WithLabelValues(
 		prometheus.PrometheusAccessibleVolumes).Set(float64(accessibleVolumeCount))
 	prometheus.VolumeHealthGaugeVec.WithLabelValues(
 		prometheus.PrometheusInaccessibleVolumes).Set(float64(inaccessibleVolumeCount))
 
-	log.Infof("GetVolumeHealthStatus: end")
+	log.Infof("csiGetVolumeHealthStatus: end")
+}
+
+// getFileVolumeHealthStatus derives volume health from FileVolume CR conditions
+// for FVS-backed PVCs. A volume is "accessible" only when both BackendReady and
+// ExportReady conditions are True; any other state (False, absent, or still
+// provisioning) is "inaccessible".
+// Returns the count of accessible and inaccessible volumes processed.
+func getFileVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface,
+	fvClient ctrlclient.Client, fvsVolumes volumeHandlePVCMap) (int, int) {
+	log := logger.GetLogger(ctx)
+	accessibleCount := 0
+	inaccessibleCount := 0
+
+	for volHandle, pvc := range fvsVolumes {
+		instanceNS, fvName, err := common.ParseFVSVolumeHandle(volHandle)
+		if err != nil {
+			log.Errorf("getFileVolumeHealthStatus: %v, marking pvc %s/%s inaccessible",
+				err, pvc.Namespace, pvc.Name)
+			updateVolumeHealthStatus(ctx, k8sclient, pvc, common.VolHealthStatusInaccessible)
+			inaccessibleCount++
+			continue
+		}
+
+		fv := &fvv1alpha1.FileVolume{}
+		if err := fvClient.Get(ctx, ctrlclient.ObjectKey{Namespace: instanceNS, Name: fvName}, fv); err != nil {
+			log.Errorf("getFileVolumeHealthStatus: failed to get FileVolume %s/%s for pvc %s/%s: %v",
+				instanceNS, fvName, pvc.Namespace, pvc.Name, err)
+			updateVolumeHealthStatus(ctx, k8sclient, pvc, common.VolHealthStatusInaccessible)
+			inaccessibleCount++
+			continue
+		}
+
+		healthStatus := deriveHealthFromFileVolumeConditions(fv.Status.Conditions)
+		log.Infof("getFileVolumeHealthStatus: FileVolume %s/%s health=%s for pvc %s/%s",
+			instanceNS, fvName, healthStatus, pvc.Namespace, pvc.Name)
+		updateVolumeHealthStatus(ctx, k8sclient, pvc, healthStatus)
+
+		switch healthStatus {
+		case common.VolHealthStatusAccessible:
+			accessibleCount++
+		case common.VolHealthStatusInaccessible:
+			inaccessibleCount++
+		}
+	}
+	return accessibleCount, inaccessibleCount
+}
+
+// deriveHealthFromFileVolumeConditions examines the FileVolume CR conditions and
+// returns "accessible" only when both BackendReady and ExportReady are True.
+func deriveHealthFromFileVolumeConditions(conditions []metav1.Condition) string {
+	backendReady := false
+	exportReady := false
+	for _, c := range conditions {
+		if c.Type == common.FileVolumeConditionBackendReady && c.Status == metav1.ConditionTrue {
+			backendReady = true
+		}
+		if c.Type == common.FileVolumeConditionExportReady && c.Status == metav1.ConditionTrue {
+			exportReady = true
+		}
+	}
+	if backendReady && exportReady {
+		return common.VolHealthStatusAccessible
+	}
+	return common.VolHealthStatusInaccessible
 }
 
 func updateVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface,

--- a/pkg/syncer/volume_health_test.go
+++ b/pkg/syncer/volume_health_test.go
@@ -22,10 +22,17 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	fvsapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume"
+	fvv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 )
 
 func TestUpdateVolumeHealthStatus(t *testing.T) {
@@ -230,4 +237,269 @@ func TestVolumeHealthStatusUpdate_EmptyStatus(t *testing.T) {
 
 	// Verify timestamp annotation is still set
 	assert.NotEmpty(t, updatedPVC.Annotations[annVolumeHealthTS])
+}
+
+// newFVSScheme returns a runtime.Scheme with FileVolume types registered.
+func newFVSScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = fvsapis.AddToScheme(s)
+	return s
+}
+
+// newTestFileVolume creates a FileVolume CR for testing with the given conditions.
+func newTestFileVolume(namespace, name string, conditions []metav1.Condition) *fvv1alpha1.FileVolume {
+	return &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: fvv1alpha1.FileVolumeSpec{
+			Size:   resource.MustParse("10Gi"),
+			PvcUID: name,
+		},
+		Status: fvv1alpha1.FileVolumeStatus{
+			Phase:      fvv1alpha1.FileVolumePhaseReady,
+			Conditions: conditions,
+		},
+	}
+}
+
+func TestDeriveHealthFromFileVolumeConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		want       string
+	}{
+		{
+			name: "Scenario 1: BackendReady=True AND ExportReady=True -> accessible",
+			conditions: []metav1.Condition{
+				{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionTrue},
+				{Type: common.FileVolumeConditionExportReady, Status: metav1.ConditionTrue},
+			},
+			want: common.VolHealthStatusAccessible,
+		},
+		{
+			name: "Scenario 2: BackendReady=True, ExportReady=False -> inaccessible",
+			conditions: []metav1.Condition{
+				{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionTrue},
+				{Type: common.FileVolumeConditionExportReady, Status: metav1.ConditionFalse,
+					Reason: "ExportDrift", Message: "ShowExports found no export for this volume"},
+			},
+			want: common.VolHealthStatusInaccessible,
+		},
+		{
+			name: "Scenario 3: BackendReady=False, ExportReady absent -> inaccessible",
+			conditions: []metav1.Condition{
+				{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionFalse,
+					Reason: "VdfsInsufficientSpace"},
+			},
+			want: common.VolHealthStatusInaccessible,
+		},
+		{
+			name: "Scenario 4: BackendReady=True, ExportReady absent (provisioning) -> inaccessible",
+			conditions: []metav1.Condition{
+				{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionTrue,
+					Reason: "Created"},
+			},
+			want: common.VolHealthStatusInaccessible,
+		},
+		{
+			name:       "No conditions at all -> inaccessible",
+			conditions: nil,
+			want:       common.VolHealthStatusInaccessible,
+		},
+		{
+			name: "Both conditions present but both False -> inaccessible",
+			conditions: []metav1.Condition{
+				{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionFalse},
+				{Type: common.FileVolumeConditionExportReady, Status: metav1.ConditionFalse},
+			},
+			want: common.VolHealthStatusInaccessible,
+		},
+		{
+			name: "Ready condition True but BackendReady/ExportReady absent -> inaccessible",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: metav1.ConditionTrue},
+			},
+			want: common.VolHealthStatusInaccessible,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveHealthFromFileVolumeConditions(tt.conditions)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetFileVolumeHealthStatus(t *testing.T) {
+	ctx := context.Background()
+	fvsScheme := newFVSScheme()
+
+	t.Run("Scenario 1: both conditions true -> accessible", func(t *testing.T) {
+		fv := newTestFileVolume("nsfvs-1234", "pvc-abc123", []metav1.Condition{
+			{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionTrue},
+			{Type: common.FileVolumeConditionExportReady, Status: metav1.ConditionTrue},
+		})
+		fvClient := ctrlclientfake.NewClientBuilder().WithScheme(fvsScheme).WithObjects(fv).Build()
+
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: "default", UID: "uid-1"},
+		}
+		k8sclient := testclient.NewClientset(pvc)
+		fvsVolumes := volumeHandlePVCMap{
+			"fv:nsfvs-1234:pvc-abc123": pvc,
+		}
+
+		accessible, inaccessible := getFileVolumeHealthStatus(ctx, k8sclient, fvClient, fvsVolumes)
+		assert.Equal(t, 1, accessible)
+		assert.Equal(t, 0, inaccessible)
+
+		updatedPVC, err := k8sclient.CoreV1().PersistentVolumeClaims("default").Get(ctx, "my-pvc", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, common.VolHealthStatusAccessible, updatedPVC.Annotations[annVolumeHealth])
+	})
+
+	t.Run("Scenario 2: ExportReady=False -> inaccessible", func(t *testing.T) {
+		fv := newTestFileVolume("nsfvs-1234", "pvc-def456", []metav1.Condition{
+			{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionTrue},
+			{Type: common.FileVolumeConditionExportReady, Status: metav1.ConditionFalse},
+		})
+		fvClient := ctrlclientfake.NewClientBuilder().WithScheme(fvsScheme).WithObjects(fv).Build()
+
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pvc-2", Namespace: "default", UID: "uid-2"},
+		}
+		k8sclient := testclient.NewClientset(pvc)
+		fvsVolumes := volumeHandlePVCMap{
+			"fv:nsfvs-1234:pvc-def456": pvc,
+		}
+
+		accessible, inaccessible := getFileVolumeHealthStatus(ctx, k8sclient, fvClient, fvsVolumes)
+		assert.Equal(t, 0, accessible)
+		assert.Equal(t, 1, inaccessible)
+
+		updatedPVC, err := k8sclient.CoreV1().PersistentVolumeClaims("default").Get(ctx, "my-pvc-2", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, common.VolHealthStatusInaccessible, updatedPVC.Annotations[annVolumeHealth])
+	})
+
+	t.Run("Scenario 3: BackendReady=False, ExportReady absent -> inaccessible", func(t *testing.T) {
+		fv := newTestFileVolume("nsfvs-5678", "pvc-ghi789", []metav1.Condition{
+			{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionFalse,
+				Reason: "VdfsInsufficientSpace"},
+		})
+		fvClient := ctrlclientfake.NewClientBuilder().WithScheme(fvsScheme).WithObjects(fv).Build()
+
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pvc-3", Namespace: "default", UID: "uid-3"},
+		}
+		k8sclient := testclient.NewClientset(pvc)
+		fvsVolumes := volumeHandlePVCMap{
+			"fv:nsfvs-5678:pvc-ghi789": pvc,
+		}
+
+		accessible, inaccessible := getFileVolumeHealthStatus(ctx, k8sclient, fvClient, fvsVolumes)
+		assert.Equal(t, 0, accessible)
+		assert.Equal(t, 1, inaccessible)
+
+		updatedPVC, err := k8sclient.CoreV1().PersistentVolumeClaims("default").Get(ctx, "my-pvc-3", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, common.VolHealthStatusInaccessible, updatedPVC.Annotations[annVolumeHealth])
+	})
+
+	t.Run("Scenario 4: provisioning - BackendReady=True, ExportReady absent -> inaccessible", func(t *testing.T) {
+		fv := newTestFileVolume("nsfvs-5678", "pvc-jkl012", []metav1.Condition{
+			{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionTrue,
+				Reason: "Created"},
+		})
+		fv.Status.Phase = fvv1alpha1.FileVolumePhaseProvisioning
+		fvClient := ctrlclientfake.NewClientBuilder().WithScheme(fvsScheme).WithObjects(fv).Build()
+
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pvc-4", Namespace: "default", UID: "uid-4"},
+		}
+		k8sclient := testclient.NewClientset(pvc)
+		fvsVolumes := volumeHandlePVCMap{
+			"fv:nsfvs-5678:pvc-jkl012": pvc,
+		}
+
+		accessible, inaccessible := getFileVolumeHealthStatus(ctx, k8sclient, fvClient, fvsVolumes)
+		assert.Equal(t, 0, accessible)
+		assert.Equal(t, 1, inaccessible)
+
+		updatedPVC, err := k8sclient.CoreV1().PersistentVolumeClaims("default").Get(ctx, "my-pvc-4", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, common.VolHealthStatusInaccessible, updatedPVC.Annotations[annVolumeHealth])
+	})
+
+	t.Run("FileVolume CR not found -> inaccessible", func(t *testing.T) {
+		fvClient := ctrlclientfake.NewClientBuilder().WithScheme(fvsScheme).Build()
+
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pvc-5", Namespace: "default", UID: "uid-5"},
+		}
+		k8sclient := testclient.NewClientset(pvc)
+		fvsVolumes := volumeHandlePVCMap{
+			"fv:nsfvs-gone:pvc-missing": pvc,
+		}
+
+		accessible, inaccessible := getFileVolumeHealthStatus(ctx, k8sclient, fvClient, fvsVolumes)
+		assert.Equal(t, 0, accessible)
+		assert.Equal(t, 1, inaccessible)
+
+		updatedPVC, err := k8sclient.CoreV1().PersistentVolumeClaims("default").Get(ctx, "my-pvc-5", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, common.VolHealthStatusInaccessible, updatedPVC.Annotations[annVolumeHealth])
+	})
+
+	t.Run("Malformed volume handle -> inaccessible", func(t *testing.T) {
+		fvClient := ctrlclientfake.NewClientBuilder().WithScheme(fvsScheme).Build()
+
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pvc-6", Namespace: "default", UID: "uid-6"},
+		}
+		k8sclient := testclient.NewClientset(pvc)
+		fvsVolumes := volumeHandlePVCMap{
+			"not-fvs-handle": pvc,
+		}
+
+		accessible, inaccessible := getFileVolumeHealthStatus(ctx, k8sclient, fvClient, fvsVolumes)
+		assert.Equal(t, 0, accessible)
+		assert.Equal(t, 1, inaccessible)
+
+		updatedPVC, err := k8sclient.CoreV1().PersistentVolumeClaims("default").Get(ctx, "my-pvc-6", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, common.VolHealthStatusInaccessible, updatedPVC.Annotations[annVolumeHealth])
+	})
+
+	t.Run("Multiple FVS volumes - mixed health", func(t *testing.T) {
+		fvHealthy := newTestFileVolume("nsfvs-a", "pvc-healthy", []metav1.Condition{
+			{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionTrue},
+			{Type: common.FileVolumeConditionExportReady, Status: metav1.ConditionTrue},
+		})
+		fvUnhealthy := newTestFileVolume("nsfvs-a", "pvc-unhealthy", []metav1.Condition{
+			{Type: common.FileVolumeConditionBackendReady, Status: metav1.ConditionTrue},
+			{Type: common.FileVolumeConditionExportReady, Status: metav1.ConditionFalse},
+		})
+		fvClient := ctrlclientfake.NewClientBuilder().WithScheme(fvsScheme).
+			WithObjects(fvHealthy, fvUnhealthy).Build()
+
+		pvcH := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-h", Namespace: "default", UID: "uid-h"},
+		}
+		pvcU := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-u", Namespace: "default", UID: "uid-u"},
+		}
+		k8sclient := testclient.NewClientset(pvcH, pvcU)
+		fvsVolumes := volumeHandlePVCMap{
+			"fv:nsfvs-a:pvc-healthy":   pvcH,
+			"fv:nsfvs-a:pvc-unhealthy": pvcU,
+		}
+
+		accessible, inaccessible := getFileVolumeHealthStatus(ctx, k8sclient, fvClient, fvsVolumes)
+		assert.Equal(t, 1, accessible)
+		assert.Equal(t, 1, inaccessible)
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When the VsanFileVolumeService FSS is enabled, FVS-backed PVCs (identified by their reserved storage class vsan-file-service-policy[|-latebinding]) are excluded from the CNS health query path and instead have their health derived from the FileVolume CR status.conditions:

- BackendReady=True AND ExportReady=True  -> annotation: accessible
- Any other state (False, absent, or provisioning) -> annotation: inaccessible

Changes:
- pkg/csi/service/common/constants.go: add FileVolumeConditionBackendReady and FileVolumeConditionExportReady condition type constants
- pkg/csi/service/common/util.go: add ParseFVSVolumeHandle() to split "fv:<namespace>:<name>" volume handles into their components
- pkg/csi/service/common/util_test.go: tests for ParseFVSVolumeHandle
- pkg/syncer/types.go: add fileVolumeClient field to metadataSyncInformer
- pkg/syncer/metadatasyncer.go: initialize fileVolumeClient with FVS scheme when IsVsanFileVolumeServiceEnabled is true
- pkg/syncer/volume_health.go: split bound PVs into FVS and non-FVS sets when FSS is enabled; add getFileVolumeHealthStatus() and deriveHealthFromFileVolumeConditions() for the CR-based health path
- pkg/syncer/volume_health_test.go: unit tests covering all 4 health scenarios (both ready, export failed, backend failed, provisioning) plus CR-not-found, malformed handle, and mixed-health cases

<!-- Thanks for sending a pull request! -->


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
pre-checkin
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1500/

```
Ran 14 of 1275 Specs
FAILURE! -- 13 Passed | 1 Failed | 1 Pending | 0 Skipped | 0 Flaked


14:27:31  Summarizing 1 Failure:
14:27:31    [FAIL] statefulset [It] [ef-vanilla-block][pq-n1-vanilla-block][pq-n2-vanilla-block] [ef-wcp][csi-block-vanilla][csi-supervisor][csi-block-vanilla-parallelized] Statefulset testing with parallel podManagementPolicy [p0, vanilla, block, wcp, core, vc70]
14:27:31    /home/worker/workspace/wcp-instapp-e2e-pre-checkin/Results/1500/go/pkg/mod/k8s.io/kubernetes@v1.36.0/test/e2e/framework/statefulset/wait.go:63
14:27:31  
14:27:31  Ran 14 of 1275 Specs in 3473.968 seconds
14:27:31  FAIL! -- 13 Passed | 1 Failed | 1 Flaked | 0 Pending | 1261 Skipped

```


https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1137/
```
Ran 6 of 2357 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2351 Skipped | 0 Flaked
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
syncer: propagate FileVolume CR conditions to PVC volume health annotation
```
