### PR TITLE
wcp: delete file volume via FileVolumeService

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -567,6 +567,25 @@ func IsFVSVolumeHandle(volumeHandle string) bool {
 	return strings.HasPrefix(volumeHandle, FVSVolumeIDPrefix)
 }
 
+// ParseFVSVolumeHandle parses a CSI volume handle minted by the FVS workflow
+// (formatted as "fv:<instance-namespace>:<filevolume-name>", see FVSVolumeIDPrefix)
+// and returns the FileVolume CR's namespace and name. Returns an error if the
+// volume handle does not carry the FVS prefix or is malformed (missing namespace
+// or name component).
+func ParseFVSVolumeHandle(volumeHandle string) (namespace, name string, err error) {
+	if !IsFVSVolumeHandle(volumeHandle) {
+		return "", "", fmt.Errorf("volume handle %q is not an FVS volume handle (missing %q prefix)",
+			volumeHandle, FVSVolumeIDPrefix)
+	}
+	rest := strings.TrimPrefix(volumeHandle, FVSVolumeIDPrefix)
+	parts := strings.SplitN(rest, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("malformed FVS volume handle %q; expected %q<namespace>:<name>",
+			volumeHandle, FVSVolumeIDPrefix)
+	}
+	return parts[0], parts[1], nil
+}
+
 // IsFVSStorageClassName returns true if the supplied storage class name is one of
 // the vSAN file service storage classes that route provisioning through FVS on the
 // supervisor (StorageClassVsanFileServicePolicy or

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -711,6 +711,41 @@ func TestIsFVSVolumeHandle(t *testing.T) {
 	}
 }
 
+func TestParseFVSVolumeHandle(t *testing.T) {
+	tests := []struct {
+		name         string
+		volumeHandle string
+		wantNS       string
+		wantName     string
+		wantErr      bool
+	}{
+		{"empty handle", "", "", "", true},
+		{"missing prefix", "tenant-ns:fv-foo", "", "", true},
+		{"prefix only", "fv:", "", "", true},
+		{"missing name", "fv:tenant-ns:", "", "", true},
+		{"missing namespace", "fv::fv-foo", "", "", true},
+		{"missing separator", "fv:tenant-ns", "", "", true},
+		{"valid handle", "fv:tenant-ns:fv-foo", "tenant-ns", "fv-foo", false},
+		{"valid handle with colon in name preserves remaining colon",
+			"fv:tenant-ns:fv-foo:bar", "tenant-ns", "fv-foo:bar", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNS, gotName, err := ParseFVSVolumeHandle(tt.volumeHandle)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseFVSVolumeHandle(%q) err = %v, wantErr = %v", tt.volumeHandle, err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if gotNS != tt.wantNS || gotName != tt.wantName {
+				t.Fatalf("ParseFVSVolumeHandle(%q) = (%q, %q), want (%q, %q)",
+					tt.volumeHandle, gotNS, gotName, tt.wantNS, tt.wantName)
+			}
+		})
+	}
+}
+
 func TestIsFVSStorageClassName(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1890,6 +1890,12 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 			cnsVolumeType = common.GetCnsVolumeType(ctx, req.VolumeId)
 			volumeType = convertCnsVolumeType(ctx, cnsVolumeType)
 		}
+		// FVS-backed file volumes carry the "fv:<instance-namespace>:<filevolume-name>" id and are
+		// reclaimed by deleting the FileVolume CR; the FVS controllers handle the underlying vDFS
+		// volume cleanup via finalizer. Skip the legacy CNS DeleteVolume path for these handles.
+		if common.IsFVSVolumeHandle(req.VolumeId) {
+			return c.deleteFileVolumeViaFVS(ctx, req.VolumeId)
+		}
 		// Check if the volume contains CNS snapshots only for block volumes.
 		if cnsVolumeType == common.BlockVolumeType &&
 			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot) {

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1893,7 +1893,10 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		// FVS-backed file volumes carry the "fv:<instance-namespace>:<filevolume-name>" id and are
 		// reclaimed by deleting the FileVolume CR; the FVS controllers handle the underlying vDFS
 		// volume cleanup via finalizer. Skip the legacy CNS DeleteVolume path for these handles.
-		if common.IsFVSVolumeHandle(req.VolumeId) {
+		// shouldDeleteFileVolumeViaFVS gates this branch on the supports_vsan_fileservice
+		// capability (VsanFileVolumeService FSS), mirroring shouldProvisionVsanFileVolumeViaFVS on
+		// the CreateVolume path.
+		if shouldDeleteFileVolumeViaFVS(req.VolumeId) {
 			return c.deleteFileVolumeViaFVS(ctx, req.VolumeId)
 		}
 		// Check if the volume contains CNS snapshots only for block volumes.

--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -46,18 +46,23 @@ import (
 const (
 	fvsGroup   = "fvs.vcf.broadcom.com"
 	fvsVersion = "v1alpha1"
-	// fvsWaitStep is the poll interval while waiting for the FileVolume CR to reach Ready and populate
-	// status (FVS controllers reconcile asynchronously; we re-read on this cadence instead of hammering
-	// the API).
-	fvsWaitStep = 5 * time.Second
-	// fvsWaitMax is the maximum time to wait before failing CreateVolume so the CSI RPC does not block indefinitely
-	// if the FileVolume never becomes Ready or status fields stay empty.
-	fvsWaitMax = 5 * time.Minute
 	// AnnotationVPCNetworkConfig is set on supervisor namespaces; value is the VPCNetworkConfiguration CR name.
 	AnnotationVPCNetworkConfig = "nsx.vmware.com/vpc_network_config"
 	// NamespaceLabelFVSInstance marks FVS instance namespaces (supervisor namespaces that host FileVolume CRs).
 	// Expected label value is "true".
 	NamespaceLabelFVSInstance = "fvs_instance_namespace"
+)
+
+// fvsWaitStep / fvsWaitMax are exposed as package-level vars (not consts) so unit tests can dial them
+// down to keep poll loops fast.
+var (
+	// fvsWaitStep is the poll interval while waiting for the FileVolume CR to reach Ready and populate
+	// status, or to be GC'd after Delete (FVS controllers reconcile asynchronously; we re-read on this
+	// cadence instead of hammering the API).
+	fvsWaitStep = 5 * time.Second
+	// fvsWaitMax is the maximum time to wait before failing the CSI RPC so it does not block indefinitely
+	// if the FileVolume never becomes Ready (CreateVolume) or its finalizer never clears (DeleteVolume).
+	fvsWaitMax = 5 * time.Minute
 )
 
 var (
@@ -453,6 +458,79 @@ func (c *controller) createFileVolumeViaFVS(ctx context.Context, req *csi.Create
 	resp.Volume.AccessibleTopology = topo
 
 	return resp, "", nil
+}
+
+// deleteFileVolumeViaFVS reclaims a file volume by deleting the FileVolume CR backing the supplied
+// CSI volume id minted by the FVS workflow (formatted as "fv:<instance-namespace>:<filevolume-name>",
+// see common.FVSVolumeIDPrefix). The FVS controllers reconcile the deletion asynchronously through
+// a finalizer that drives the underlying vDFS volume reclaim; this function issues the Delete and
+// waits until the FileVolume CR has been fully GC'd from the supervisor before returning success
+// so the CSI RPC contract (volume gone on success) holds.
+//
+// NotFound on the initial Delete is treated as idempotent success because the external-provisioner
+// can retry DeleteVolume after a previous attempt has already removed the CR.
+func (c *controller) deleteFileVolumeViaFVS(ctx context.Context, volumeID string) (
+	*csi.DeleteVolumeResponse, string, error) {
+	log := logger.GetLogger(ctx)
+
+	instanceNS, fvName, err := common.ParseFVSVolumeHandle(volumeID)
+	if err != nil {
+		return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			"%v", err)
+	}
+
+	// fileVolumeClient is initialized in controller.Init only when the FVS FSS is enabled. If we are
+	// asked to delete an FVS-prefixed volume id while the client is nil the FSS must have been
+	// disabled after the volume was provisioned; surface a clear error rather than NPE.
+	if c.fileVolumeClient == nil {
+		return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+			"FileVolume client is not initialized; cannot delete FVS volume %q "+
+				"(supports_vsan_fileservice capability may be disabled on the supervisor)", volumeID)
+	}
+
+	fv := &fvv1alpha1.FileVolume{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: schema.GroupVersion{Group: fvsGroup, Version: fvsVersion}.String(),
+			Kind:       "FileVolume",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fvName,
+			Namespace: instanceNS,
+		},
+	}
+	log.Infof("DeleteVolume: deleting FileVolume %s/%s for CSI volume %q", instanceNS, fvName, volumeID)
+	if err := c.fileVolumeClient.Delete(ctx, fv); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Infof("FileVolume %s/%s already deleted; treating CSI volume %q delete as idempotent success",
+				instanceNS, fvName, volumeID)
+			return &csi.DeleteVolumeResponse{}, "", nil
+		}
+		return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to delete FileVolume %s/%s for CSI volume %q: %v",
+			instanceNS, fvName, volumeID, err)
+	}
+
+	// Wait for the FileVolume CR to be GC'd. The FVS controller runs a finalizer that performs the
+	// underlying vDFS volume reclaim before the CR is removed, so observing IsNotFound here is the
+	// signal that the volume is fully deleted on the supervisor side.
+	err = wait.PollUntilContextTimeout(ctx, fvsWaitStep, fvsWaitMax, true, func(ctx context.Context) (bool, error) {
+		cur := &fvv1alpha1.FileVolume{}
+		getErr := c.fileVolumeClient.Get(ctx, ctrlclient.ObjectKey{Namespace: instanceNS, Name: fvName}, cur)
+		if apierrors.IsNotFound(getErr) {
+			return true, nil
+		}
+		if getErr != nil {
+			return false, getErr
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.DeadlineExceeded,
+			"timeout or error waiting for FileVolume %s/%s to be deleted for CSI volume %q: %v",
+			instanceNS, fvName, volumeID, err)
+	}
+	log.Infof("DeleteVolume: FileVolume %s/%s removed; CSI volume %q deleted", instanceNS, fvName, volumeID)
+	return &csi.DeleteVolumeResponse{}, "", nil
 }
 
 // shouldProvisionVsanFileVolumeViaFVS encapsulates routing to the FVS CR workflow.

--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -552,3 +552,18 @@ func shouldProvisionVsanFileVolumeViaFVS(ctx context.Context, storageClassName s
 	}
 	return true, nil
 }
+
+// shouldDeleteFileVolumeViaFVS encapsulates routing to the FVS CR workflow on DeleteVolume,
+// mirroring shouldProvisionVsanFileVolumeViaFVS for CreateVolume. The FVS path is only taken
+// when the supports_vsan_fileservice capability (VsanFileVolumeService FSS) is enabled and
+// the supplied CSI volume id carries the FVS prefix ("fv:<instance-namespace>:<filevolume-name>",
+// see common.FVSVolumeIDPrefix); otherwise the caller should fall through to the legacy CNS
+// DeleteVolume path. Routing on the volume-id prefix (and not the storage class) is sufficient
+// here because by DeleteVolume time the volume already exists and its provenance is encoded in
+// the id minted by CreateVolume.
+func shouldDeleteFileVolumeViaFVS(volumeID string) bool {
+	if !isVsanFileVolumeServiceFSSEnabled {
+		return false
+	}
+	return common.IsFVSVolumeHandle(volumeID)
+}

--- a/pkg/csi/service/wcp/fvs_filevolume_test.go
+++ b/pkg/csi/service/wcp/fvs_filevolume_test.go
@@ -18,11 +18,14 @@ package wcp
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +36,12 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	fvsapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume"
+	fvv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume/v1alpha1"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
@@ -435,4 +443,179 @@ func TestShouldProvisionVsanFileVolumeViaFVS(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ok)
 	})
+}
+
+// fvsTestScheme returns a runtime.Scheme with the FVS FileVolume types registered for use with
+// the controller-runtime fake client.
+func fvsTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, fvsapis.AddToScheme(s))
+	return s
+}
+
+// withFastFVSWait dials fvsWaitStep / fvsWaitMax down for tests that exercise the delete-poll loop
+// so a missed-NotFound iteration costs milliseconds, not seconds.
+func withFastFVSWait(t *testing.T) {
+	t.Helper()
+	prevStep, prevMax := fvsWaitStep, fvsWaitMax
+	fvsWaitStep = 5 * time.Millisecond
+	fvsWaitMax = 200 * time.Millisecond
+	t.Cleanup(func() { fvsWaitStep, fvsWaitMax = prevStep, prevMax })
+}
+
+func TestDeleteFileVolumeViaFVS_Success(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-success"
+	)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
+	}
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			Build(),
+	}
+
+	resp, fault, err := c.deleteFileVolumeViaFVS(ctx, common.FVSVolumeIDPrefix+instanceNS+":"+fvName)
+	require.NoError(t, err)
+	require.Empty(t, fault)
+	require.NotNil(t, resp)
+
+	cur := &fvv1alpha1.FileVolume{}
+	getErr := c.fileVolumeClient.Get(ctx,
+		ctrlclient.ObjectKey{Namespace: instanceNS, Name: fvName}, cur)
+	require.True(t, apierrors.IsNotFound(getErr),
+		"FileVolume %s/%s should be gone after deleteFileVolumeViaFVS, got err %v",
+		instanceNS, fvName, getErr)
+}
+
+func TestDeleteFileVolumeViaFVS_NotFoundIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			Build(),
+	}
+
+	resp, fault, err := c.deleteFileVolumeViaFVS(ctx,
+		common.FVSVolumeIDPrefix+"missing-ns:missing-fv")
+	require.NoError(t, err)
+	require.Empty(t, fault)
+	require.NotNil(t, resp)
+}
+
+func TestDeleteFileVolumeViaFVS_InvalidVolumeID(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			Build(),
+	}
+
+	tests := []struct {
+		name     string
+		volumeID string
+	}{
+		{"missing FVS prefix", "tenant-ns:fv-foo"},
+		{"prefix only", common.FVSVolumeIDPrefix},
+		{"missing namespace", common.FVSVolumeIDPrefix + ":fv-foo"},
+		{"missing name", common.FVSVolumeIDPrefix + "tenant-ns:"},
+		{"missing separator after namespace", common.FVSVolumeIDPrefix + "tenant-ns"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, fault, err := c.deleteFileVolumeViaFVS(ctx, tt.volumeID)
+			require.Error(t, err)
+			require.Equal(t, csifault.CSIInvalidArgumentFault, fault)
+		})
+	}
+}
+
+func TestDeleteFileVolumeViaFVS_NilClient(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	c := &controller{}
+	_, fault, err := c.deleteFileVolumeViaFVS(ctx,
+		common.FVSVolumeIDPrefix+"any-ns:any-fv")
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInternalFault, fault)
+	require.Contains(t, err.Error(), "FileVolume client is not initialized")
+}
+
+func TestDeleteFileVolumeViaFVS_DeleteError(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-error"
+	)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
+	}
+	injectedErr := errors.New("api server temporarily unavailable")
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
+					opts ...ctrlclient.DeleteOption) error {
+					if _, ok := obj.(*fvv1alpha1.FileVolume); ok {
+						return injectedErr
+					}
+					return w.Delete(ctx, obj, opts...)
+				},
+			}).
+			Build(),
+	}
+
+	_, fault, err := c.deleteFileVolumeViaFVS(ctx,
+		common.FVSVolumeIDPrefix+instanceNS+":"+fvName)
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInternalFault, fault)
+	require.Contains(t, err.Error(), "failed to delete FileVolume")
+}
+
+// TestDeleteFileVolumeViaFVS_StuckFinalizer simulates an FVS controller that has not yet drained
+// its finalizer: Delete returns success but Get keeps returning the CR. The CSI delete should fail
+// with DeadlineExceeded after fvsWaitMax expires (dialed down via withFastFVSWait).
+func TestDeleteFileVolumeViaFVS_StuckFinalizer(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-stuck"
+	)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       fvName,
+			Namespace:  instanceNS,
+			Finalizers: []string{"fvs.vcf.broadcom.com/finalizer"},
+		},
+	}
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			Build(),
+	}
+
+	_, fault, err := c.deleteFileVolumeViaFVS(ctx,
+		common.FVSVolumeIDPrefix+instanceNS+":"+fvName)
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInternalFault, fault)
+	require.Contains(t, err.Error(), "timeout or error waiting for FileVolume")
 }

--- a/pkg/csi/service/wcp/fvs_filevolume_test.go
+++ b/pkg/csi/service/wcp/fvs_filevolume_test.go
@@ -445,6 +445,36 @@ func TestShouldProvisionVsanFileVolumeViaFVS(t *testing.T) {
 	})
 }
 
+func TestShouldDeleteFileVolumeViaFVS(t *testing.T) {
+	tests := []struct {
+		name       string
+		fssEnabled bool
+		volumeID   string
+		want       bool
+	}{
+		{"FSS off, non-FVS handle", false, "abc-block-vol", false},
+		{"FSS off, FVS handle", false, common.FVSVolumeIDPrefix + "tenant-ns:fv-foo", false},
+		{"FSS off, empty handle", false, "", false},
+		{"FSS on, non-FVS handle", true, "abc-block-vol", false},
+		{"FSS on, legacy file handle", true, "file:abcd-1234", false},
+		{"FSS on, empty handle", true, "", false},
+		{"FSS on, FVS prefix only", true, common.FVSVolumeIDPrefix, true},
+		{"FSS on, FVS handle", true, common.FVSVolumeIDPrefix + "tenant-ns:fv-foo", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldFSS := isVsanFileVolumeServiceFSSEnabled
+			defer func() { isVsanFileVolumeServiceFSSEnabled = oldFSS }()
+			isVsanFileVolumeServiceFSSEnabled = tt.fssEnabled
+
+			got := shouldDeleteFileVolumeViaFVS(tt.volumeID)
+			require.Equalf(t, tt.want, got,
+				"shouldDeleteFileVolumeViaFVS(%q) with FSS=%v: want %v, got %v",
+				tt.volumeID, tt.fssEnabled, tt.want, got)
+		})
+	}
+}
+
 // fvsTestScheme returns a runtime.Scheme with the FVS FileVolume types registered for use with
 // the controller-runtime fake client.
 func fvsTestScheme(t *testing.T) *runtime.Scheme {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Implemented the DeleteVolume workflow in the supervisor for FVS-backed file volumes. Volumes carrying the fv:<instance-namespace>:<filevolume-name> id (minted by the FVS create path in PRs [#3972](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3972) and [#4012](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/4012)) are now reclaimed by deleting the FileVolume CR; the FVS controllers handle the underlying vDFS volume cleanup via finalizer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://vmw-jira.broadcom.net/browse/CNAS-11308

**Testing done**:
unit test:
kb@CQVXQ7104Q vsphere-csi-driver % go test -count=1 ./pkg/csi/service/wcp/ -run 'Test(IsVsanFileServicePolicyStorageClass|VPCPathFromVPCNetworkConfiguration|TopologyListFromZoneMap|NamespaceHasAnyRequestedZone|FvsAccessibleTopology|FindVPCNetworkConfigurationForNamespace|GetVPCPathForNamespace|ListFVSCandidateInstanceNamespaces|InstanceNamespaceHasReadyFileVolumeService|CreateFileVolumeViaFVS_ValidationAndPVC|ShouldProvisionVsanFileVolumeViaFVS|TestDeleteFileVolumeViaFVS_Success|TestDeleteFileVolumeViaFVS_NotFoundIsIdempotent|TestDeleteFileVolumeViaFVS_InvalidVolumeID|TestDeleteFileVolumeViaFVS_NilClient|TestDeleteFileVolumeViaFVS_DeleteError|TestDeleteFileVolumeViaFVS_StuckFinalizer|)$' -v

=== RUN   TestIsVsanFileServicePolicyStorageClass
--- PASS: TestIsVsanFileServicePolicyStorageClass (0.00s)
=== RUN   TestVPCPathFromVPCNetworkConfiguration
--- PASS: TestVPCPathFromVPCNetworkConfiguration (0.00s)
=== RUN   TestTopologyListFromZoneMap
--- PASS: TestTopologyListFromZoneMap (0.00s)
=== RUN   TestFvsAccessibleTopology
--- PASS: TestFvsAccessibleTopology (0.00s)
=== RUN   TestFindVPCNetworkConfigurationForNamespace
--- PASS: TestFindVPCNetworkConfigurationForNamespace (0.24s)
=== RUN   TestGetVPCPathForNamespace
--- PASS: TestGetVPCPathForNamespace (0.20s)
=== RUN   TestListFVSCandidateInstanceNamespaces
{"level":"info","time":"2026-05-04T13:54:00.938541+05:30","caller":"wcp/fvs_filevolume.go:171","msg":"listFVSCandidateInstanceNamespaces: consumer namespace \"pvc-ns\" uses VPC path \"/orgs/default/projects/default/vpcs/same-vpc\", requested zones [zone-a]"}
{"level":"info","time":"2026-05-04T13:54:00.941015+05:30","caller":"wcp/fvs_filevolume.go:204","msg":"listFVSCandidateInstanceNamespaces: namespace \"inst-ns\" matches consumer VPC path \"/orgs/default/projects/default/vpcs/same-vpc\" (VPCNetworkConfiguration \"inst-ns-44444444-4444-4444-4444-444444444444\")"}
{"level":"info","time":"2026-05-04T13:54:00.941042+05:30","caller":"wcp/fvs_filevolume.go:213","msg":"listFVSCandidateInstanceNamespaces: adding namespace \"inst-ns\" to FVS candidate list (VPC path \"/orgs/default/projects/default/vpcs/same-vpc\", requested zones [zone-a])"}
--- PASS: TestListFVSCandidateInstanceNamespaces (0.10s)
=== RUN   TestInstanceNamespaceHasReadyFileVolumeService
--- PASS: TestInstanceNamespaceHasReadyFileVolumeService (0.00s)
=== RUN   TestCreateFileVolumeViaFVS_ValidationAndPVC
=== RUN   TestCreateFileVolumeViaFVS_ValidationAndPVC/missing_PVC_parameters
{"level":"error","time":"2026-05-04T13:54:00.941278+05:30","caller":"wcp/fvs_filevolume.go:311","msg":"missing PVC name or namespace in CreateVolume parameters","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).createFileVolumeViaFVS\n\t/Users/kb/csi-driver/vsphere-csi-driver/pkg/csi/service/wcp/fvs_filevolume.go:311\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.TestCreateFileVolumeViaFVS_ValidationAndPVC.func1\n\t/Users/kb/csi-driver/vsphere-csi-driver/pkg/csi/service/wcp/fvs_filevolume_test.go:367\ntesting.tRunner\n\t/Users/kb/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.darwin-arm64/src/testing/testing.go:2036"}
=== RUN   TestCreateFileVolumeViaFVS_ValidationAndPVC/missing_accessibility_requirements
{"level":"error","time":"2026-05-04T13:54:00.941391+05:30","caller":"wcp/fvs_filevolume.go:316","msg":"accessibility requirements are required for FVS file volume provisioning","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).createFileVolumeViaFVS\n\t/Users/kb/csi-driver/vsphere-csi-driver/pkg/csi/service/wcp/fvs_filevolume.go:316\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.TestCreateFileVolumeViaFVS_ValidationAndPVC.func2\n\t/Users/kb/csi-driver/vsphere-csi-driver/pkg/csi/service/wcp/fvs_filevolume_test.go:379\ntesting.tRunner\n\t/Users/kb/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.darwin-arm64/src/testing/testing.go:2036"}
=== RUN   TestCreateFileVolumeViaFVS_ValidationAndPVC/volume_name_without_extractable_PVC_UID
{"level":"error","time":"2026-05-04T13:54:00.941504+05:30","caller":"common/util.go:486","msg":"failed to extract UID from volumeName name: \"invalid-volume-name\"","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common.ExtractVolumeIDFromPVName\n\t/Users/kb/csi-driver/vsphere-csi-driver/pkg/csi/service/common/util.go:486\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).createFileVolumeViaFVS\n\t/Users/kb/csi-driver/vsphere-csi-driver/pkg/csi/service/wcp/fvs_filevolume.go:320\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.TestCreateFileVolumeViaFVS_ValidationAndPVC.func3\n\t/Users/kb/csi-driver/vsphere-csi-driver/pkg/csi/service/wcp/fvs_filevolume_test.go:395\ntesting.tRunner\n\t/Users/kb/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.darwin-arm64/src/testing/testing.go:2036"}
{"level":"error","time":"2026-05-04T13:54:00.941559+05:30","caller":"wcp/fvs_filevolume.go:322","msg":"failed to extract PVC UID from volume name \"invalid-volume-name\": failed to extract UID from volumeName name: \"invalid-volume-name\"","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).createFileVolumeViaFVS\n\t/Users/kb/csi-driver/vsphere-csi-driver/pkg/csi/service/wcp/fvs_filevolume.go:322\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.TestCreateFileVolumeViaFVS_ValidationAndPVC.func3\n\t/Users/kb/csi-driver/vsphere-csi-driver/pkg/csi/service/wcp/fvs_filevolume_test.go:395\ntesting.tRunner\n\t/Users/kb/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.darwin-arm64/src/testing/testing.go:2036"}
--- PASS: TestCreateFileVolumeViaFVS_ValidationAndPVC (0.00s)
    --- PASS: TestCreateFileVolumeViaFVS_ValidationAndPVC/missing_PVC_parameters (0.00s)
    --- PASS: TestCreateFileVolumeViaFVS_ValidationAndPVC/missing_accessibility_requirements (0.00s)
    --- PASS: TestCreateFileVolumeViaFVS_ValidationAndPVC/volume_name_without_extractable_PVC_UID (0.00s)
=== RUN   TestShouldProvisionVsanFileVolumeViaFVS
=== RUN   TestShouldProvisionVsanFileVolumeViaFVS/non-VPC_network_provider_returns_FailedPrecondition
=== RUN   TestShouldProvisionVsanFileVolumeViaFVS/VPC_provider_FSS_disabled
=== RUN   TestShouldProvisionVsanFileVolumeViaFVS/VPC_provider_FSS_enabled
--- PASS: TestShouldProvisionVsanFileVolumeViaFVS (0.00s)
    --- PASS: TestShouldProvisionVsanFileVolumeViaFVS/non-VPC_network_provider_returns_FailedPrecondition (0.00s)
    --- PASS: TestShouldProvisionVsanFileVolumeViaFVS/VPC_provider_FSS_disabled (0.00s)
    --- PASS: TestShouldProvisionVsanFileVolumeViaFVS/VPC_provider_FSS_enabled (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp   1.290s

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add Supervisor CSI DeleteVolume support for vSAN File Service volumes via FVS
```

cc: @divyenpatel 