### PR TITLE
wcp: expand file volume via FileVolumeService

### DIFF
--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -225,8 +225,9 @@ func UseVslmAPIs(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, err
 }
 
 // ValidateControllerExpandVolumeRequest is the helper function to validate
-// ControllerExpandVolumeRequest for all block controllers.
-// Function returns error if validation fails otherwise returns nil.
+// ControllerExpandVolumeRequest. Function returns error if validation fails otherwise returns nil.
+// Callers are responsible for rejecting unsupported volume types (e.g. legacy CNS file volumes)
+// after dispatching on volume type, since FVS-backed file volumes do support expansion.
 func ValidateControllerExpandVolumeRequest(ctx context.Context, req *csi.ControllerExpandVolumeRequest) error {
 	log := logger.GetLogger(ctx)
 	// Check for required parameters.
@@ -241,13 +242,6 @@ func ValidateControllerExpandVolumeRequest(ctx context.Context, req *csi.Control
 	volCaps := req.GetVolumeCapability()
 	if volCaps == nil {
 		return logger.LogNewErrorCode(log, codes.InvalidArgument, "volume capabilities is a required parameter")
-	}
-
-	// TODO: Remove this restriction when volume expansion is supported for
-	// File Volumes.
-	if IsFileVolumeRequest(ctx, []*csi.VolumeCapability{volCaps}) {
-		return logger.LogNewErrorCode(log, codes.Unimplemented,
-			"volume expansion is only supported for block volume type")
 	}
 
 	return nil

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -2929,6 +2929,16 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 			}
 
 		}
+		// FVS-backed file volumes carry the "fv:<instance-namespace>:<filevolume-name>" id
+		// (not considered for migrated volumes yet) and are resized by patching spec.size on the
+		// FileVolume CR; the FVS controllers reconcile the underlying vDFS volume and bump
+		// status.lastAppliedSize when the new size has landed. Skip the legacy CNS ExpandVolume
+		// path (and its block-volume validation) for these handles.
+		// shouldExpandFileVolumeViaFVS gates this branch on the supports_vsan_fileservice capability
+		// (VsanFileVolumeService FSS), mirroring shouldDeleteFileVolumeViaFVS on DeleteVolume.
+		if shouldExpandFileVolumeViaFVS(req.VolumeId) {
+			return c.expandFileVolumeViaFVS(ctx, req)
+		}
 		isOnlineExpansionEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend)
 		err = validateWCPControllerExpandVolumeRequest(ctx, req, c.manager, isOnlineExpansionEnabled)
 		if err != nil {

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -819,7 +819,7 @@ func validateControllerExpandVolumeRequestInWcp(ctx context.Context, req *csi.Co
 
 	if isFileVolumeRequestInWcp(ctx, []*csi.VolumeCapability{volCaps}) {
 		return logger.LogNewErrorCode(log, codes.Unimplemented,
-			"volume expansion is not supported for legacy file service based volume type")
+			"volume expansion is only supported for block volume type")
 	}
 
 	return nil

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -819,7 +819,7 @@ func validateControllerExpandVolumeRequestInWcp(ctx context.Context, req *csi.Co
 
 	if isFileVolumeRequestInWcp(ctx, []*csi.VolumeCapability{volCaps}) {
 		return logger.LogNewErrorCode(log, codes.Unimplemented,
-			"volume expansion is only supported for block volume type")
+			"volume expansion is not supported for legacy file service based volume type")
 	}
 
 	return nil

--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -570,6 +570,8 @@ func (c *controller) expandFileVolumeViaFVS(ctx context.Context, req *csi.Contro
 		return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCodef(log, codes.InvalidArgument,
 			"capacity range with positive required_bytes is required to expand FVS volume %q", req.GetVolumeId())
 	}
+	// GetRequiredBytes returns the size in bytes; FVS accepts byte quantities at every layer
+	// (FileVolumeSpec.Size, VolumeAssignment Capacity, vDFS gRPC), so no MB rounding is needed
 	volSizeBytes := req.GetCapacityRange().GetRequiredBytes()
 	desired := resource.NewQuantity(volSizeBytes, resource.BinarySI)
 

--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -533,6 +533,114 @@ func (c *controller) deleteFileVolumeViaFVS(ctx context.Context, volumeID string
 	return &csi.DeleteVolumeResponse{}, "", nil
 }
 
+// expandFileVolumeViaFVS resizes a file volume by patching spec.size on the FileVolume CR backing
+// the supplied CSI volume id minted by the FVS workflow (formatted as "fv:<instance-namespace>:<filevolume-name>",
+// see common.FVSVolumeIDPrefix). The FVS controllers reconcile the resize asynchronously by driving
+// the underlying vDFS volume size and then bumping status.lastAppliedSize once the new size has been
+// applied; this function issues the spec.size update (when needed) and waits until status reflects
+// the requested size before returning success so the CSI external-resizer sees a consistent capacity.
+//
+// NodeExpansionRequired is always false for FVS file volumes: NFSv4.1 shares grow transparently on
+// the server side and kubelet does not run a node-side filesystem-grow step.
+//
+// Idempotency:
+//   - if spec.size is already >= the requested size, the spec is left untouched and we just wait for
+//     status.lastAppliedSize to catch up;
+//   - shrinking the volume is rejected (CSI requires expansion-only).
+func (c *controller) expandFileVolumeViaFVS(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (
+	*csi.ControllerExpandVolumeResponse, string, error) {
+	log := logger.GetLogger(ctx)
+
+	instanceNS, fvName, err := common.ParseFVSVolumeHandle(req.GetVolumeId())
+	if err != nil {
+		return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			"%v", err)
+	}
+
+	// fileVolumeClient is initialized in controller.Init only when the FVS FSS is enabled. If we are
+	// asked to expand an FVS-prefixed volume id while the client is nil the FSS must have been
+	// disabled after the volume was provisioned; surface a clear error rather than NPE.
+	if c.fileVolumeClient == nil {
+		return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+			"FileVolume client is not initialized; cannot expand FVS volume %q "+
+				"(supports_vsan_fileservice capability may be disabled on the supervisor)", req.GetVolumeId())
+	}
+
+	if req.GetCapacityRange() == nil || req.GetCapacityRange().GetRequiredBytes() <= 0 {
+		return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			"capacity range with positive required_bytes is required to expand FVS volume %q", req.GetVolumeId())
+	}
+	volSizeBytes := req.GetCapacityRange().GetRequiredBytes()
+	desired := resource.NewQuantity(volSizeBytes, resource.BinarySI)
+
+	fv := &fvv1alpha1.FileVolume{}
+	if getErr := c.fileVolumeClient.Get(ctx,
+		ctrlclient.ObjectKey{Namespace: instanceNS, Name: fvName}, fv); getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			return nil, csifault.CSINotFoundFault, logger.LogNewErrorCodef(log, codes.NotFound,
+				"FileVolume %s/%s for CSI volume %q not found", instanceNS, fvName, req.GetVolumeId())
+		}
+		return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to get FileVolume %s/%s for CSI volume %q: %v",
+			instanceNS, fvName, req.GetVolumeId(), getErr)
+	}
+
+	// Patch spec.size only if the requested size is strictly greater than the current spec. CSI
+	// expansion is monotonic: shrinking is rejected; equal-size requests are no-ops on the spec.
+	cmp := desired.Cmp(fv.Spec.Size)
+	switch {
+	case cmp < 0:
+		return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			"shrinking FVS file volume is not supported: current spec.size %s > requested %s "+
+				"(FileVolume %s/%s, CSI volume %q)",
+			fv.Spec.Size.String(), desired.String(), instanceNS, fvName, req.GetVolumeId())
+	case cmp > 0:
+		log.Infof("ControllerExpandVolume: bumping FileVolume %s/%s spec.size from %s to %s for CSI volume %q",
+			instanceNS, fvName, fv.Spec.Size.String(), desired.String(), req.GetVolumeId())
+		fv.Spec.Size = *desired
+		if updateErr := c.fileVolumeClient.Update(ctx, fv); updateErr != nil {
+			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to update spec.size on FileVolume %s/%s for CSI volume %q: %v",
+				instanceNS, fvName, req.GetVolumeId(), updateErr)
+		}
+	default:
+		log.Infof("ControllerExpandVolume: FileVolume %s/%s spec.size already at %s; waiting for status to converge "+
+			"for CSI volume %q",
+			instanceNS, fvName, desired.String(), req.GetVolumeId())
+	}
+
+	// Wait for the FVS controller to apply the size: status.lastAppliedSize must reach (or exceed)
+	// the requested size and the FileVolume must not be in Error phase. Phase==Ready is preferred
+	// but not strictly required: lastAppliedSize is the authoritative signal that the resize has
+	// landed on the underlying vDFS volume.
+	cur := &fvv1alpha1.FileVolume{}
+	err = wait.PollUntilContextTimeout(ctx, fvsWaitStep, fvsWaitMax, true, func(ctx context.Context) (bool, error) {
+		if getErr := c.fileVolumeClient.Get(ctx,
+			ctrlclient.ObjectKey{Namespace: instanceNS, Name: fvName}, cur); getErr != nil {
+			return false, getErr
+		}
+		if strings.EqualFold(string(cur.Status.Phase), string(fvv1alpha1.FileVolumePhaseError)) {
+			return false, fmt.Errorf("FileVolume %s/%s entered Error phase during expansion", instanceNS, fvName)
+		}
+		if cur.Status.LastAppliedSize.Cmp(*desired) >= 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.DeadlineExceeded,
+			"timeout or error waiting for FileVolume %s/%s expansion to %s to be applied for CSI volume %q: %v",
+			instanceNS, fvName, desired.String(), req.GetVolumeId(), err)
+	}
+
+	log.Infof("ControllerExpandVolume: FileVolume %s/%s expanded; status.lastAppliedSize=%s for CSI volume %q",
+		instanceNS, fvName, cur.Status.LastAppliedSize.String(), req.GetVolumeId())
+	return &csi.ControllerExpandVolumeResponse{
+		CapacityBytes:         volSizeBytes,
+		NodeExpansionRequired: false, //since this is a file volume, we don't need to expand the volume on the node side
+	}, "", nil
+}
+
 // shouldProvisionVsanFileVolumeViaFVS encapsulates routing to the FVS CR workflow.
 func shouldProvisionVsanFileVolumeViaFVS(ctx context.Context, storageClassName string) (bool, error) {
 	if !isVsanFileServicePolicyStorageClass(storageClassName) {
@@ -562,6 +670,18 @@ func shouldProvisionVsanFileVolumeViaFVS(ctx context.Context, storageClassName s
 // here because by DeleteVolume time the volume already exists and its provenance is encoded in
 // the id minted by CreateVolume.
 func shouldDeleteFileVolumeViaFVS(volumeID string) bool {
+	if !isVsanFileVolumeServiceFSSEnabled {
+		return false
+	}
+	return common.IsFVSVolumeHandle(volumeID)
+}
+
+// shouldExpandFileVolumeViaFVS encapsulates routing to the FVS CR workflow on ControllerExpandVolume,
+// mirroring shouldDeleteFileVolumeViaFVS for DeleteVolume. The FVS path is only taken when the
+// supports_vsan_fileservice capability (VsanFileVolumeService FSS) is enabled and the supplied CSI
+// volume id carries the FVS prefix; otherwise the caller should fall through to the legacy CNS
+// ExpandVolume path
+func shouldExpandFileVolumeViaFVS(volumeID string) bool {
 	if !isVsanFileVolumeServiceFSSEnabled {
 		return false
 	}

--- a/pkg/csi/service/wcp/fvs_filevolume_test.go
+++ b/pkg/csi/service/wcp/fvs_filevolume_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -621,6 +622,423 @@ func TestDeleteFileVolumeViaFVS_DeleteError(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, csifault.CSIInternalFault, fault)
 	require.Contains(t, err.Error(), "failed to delete FileVolume")
+}
+
+func TestShouldExpandFileVolumeViaFVS(t *testing.T) {
+	tests := []struct {
+		name       string
+		fssEnabled bool
+		volumeID   string
+		want       bool
+	}{
+		{"FSS off, non-FVS handle", false, "abc-block-vol", false},
+		{"FSS off, FVS handle", false, common.FVSVolumeIDPrefix + "tenant-ns:fv-foo", false},
+		{"FSS off, empty handle", false, "", false},
+		{"FSS on, non-FVS handle", true, "abc-block-vol", false},
+		{"FSS on, legacy file handle", true, "file:abcd-1234", false},
+		{"FSS on, empty handle", true, "", false},
+		{"FSS on, FVS prefix only", true, common.FVSVolumeIDPrefix, true},
+		{"FSS on, FVS handle", true, common.FVSVolumeIDPrefix + "tenant-ns:fv-foo", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldFSS := isVsanFileVolumeServiceFSSEnabled
+			defer func() { isVsanFileVolumeServiceFSSEnabled = oldFSS }()
+			isVsanFileVolumeServiceFSSEnabled = tt.fssEnabled
+
+			got := shouldExpandFileVolumeViaFVS(tt.volumeID)
+			require.Equalf(t, tt.want, got,
+				"shouldExpandFileVolumeViaFVS(%q) with FSS=%v: want %v, got %v",
+				tt.volumeID, tt.fssEnabled, tt.want, got)
+		})
+	}
+}
+
+// expandRequest builds a minimal ControllerExpandVolumeRequest for the supplied FVS volume id and
+// requested size in bytes.
+func expandRequest(volumeID string, sizeBytes int64) *csi.ControllerExpandVolumeRequest {
+	return &csi.ControllerExpandVolumeRequest{
+		VolumeId: volumeID,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: sizeBytes,
+		},
+	}
+}
+
+// TestExpandFileVolumeViaFVS_Success: FVS controller reflects the new spec.size into
+// status.lastAppliedSize on Update; CSI sees lastAppliedSize == desired and returns success with
+// NodeExpansionRequired=false.
+func TestExpandFileVolumeViaFVS_Success(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-success"
+		oldGiB     = int64(1)
+		newGiB     = int64(5)
+	)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
+		Spec: fvv1alpha1.FileVolumeSpec{
+			Size: *resource.NewQuantity(oldGiB<<30, resource.BinarySI),
+		},
+		Status: fvv1alpha1.FileVolumeStatus{
+			Phase:           fvv1alpha1.FileVolumePhaseReady,
+			LastAppliedSize: *resource.NewQuantity(oldGiB<<30, resource.BinarySI),
+		},
+	}
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
+					opts ...ctrlclient.UpdateOption) error {
+					if fv, ok := obj.(*fvv1alpha1.FileVolume); ok {
+						// Simulate FVS controller reconciling spec->status in lockstep so the poll
+						// completes on the next iteration without flake.
+						fv.Status.LastAppliedSize = fv.Spec.Size
+						fv.Status.Phase = fvv1alpha1.FileVolumePhaseReady
+					}
+					return w.Update(ctx, obj, opts...)
+				},
+			}).
+			Build(),
+	}
+
+	desiredBytes := newGiB << 30
+	resp, fault, err := c.expandFileVolumeViaFVS(ctx,
+		expandRequest(common.FVSVolumeIDPrefix+instanceNS+":"+fvName, desiredBytes))
+	require.NoError(t, err)
+	require.Empty(t, fault)
+	require.NotNil(t, resp)
+	require.Equal(t, desiredBytes, resp.CapacityBytes)
+	require.False(t, resp.NodeExpansionRequired,
+		"FVS file volumes should never require node-side expansion (NFS server handles growth)")
+
+	cur := &fvv1alpha1.FileVolume{}
+	require.NoError(t, c.fileVolumeClient.Get(ctx,
+		ctrlclient.ObjectKey{Namespace: instanceNS, Name: fvName}, cur))
+	require.Equal(t, desiredBytes, cur.Spec.Size.Value(),
+		"FileVolume spec.size should have been bumped to the requested capacity")
+}
+
+// TestExpandFileVolumeViaFVS_Idempotent: spec.size is already at or above the requested size and
+// status has converged. CSI should not write to spec and should return success immediately.
+func TestExpandFileVolumeViaFVS_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-idem"
+		sizeGiB    = int64(3)
+	)
+	current := *resource.NewQuantity(sizeGiB<<30, resource.BinarySI)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
+		Spec:       fvv1alpha1.FileVolumeSpec{Size: current},
+		Status: fvv1alpha1.FileVolumeStatus{
+			Phase:           fvv1alpha1.FileVolumePhaseReady,
+			LastAppliedSize: current,
+		},
+	}
+	updateCalls := 0
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
+					opts ...ctrlclient.UpdateOption) error {
+					if _, ok := obj.(*fvv1alpha1.FileVolume); ok {
+						updateCalls++
+					}
+					return w.Update(ctx, obj, opts...)
+				},
+			}).
+			Build(),
+	}
+
+	resp, fault, err := c.expandFileVolumeViaFVS(ctx,
+		expandRequest(common.FVSVolumeIDPrefix+instanceNS+":"+fvName, sizeGiB<<30))
+	require.NoError(t, err)
+	require.Empty(t, fault)
+	require.Equal(t, sizeGiB<<30, resp.CapacityBytes)
+	require.False(t, resp.NodeExpansionRequired)
+	require.Zero(t, updateCalls,
+		"idempotent expand on already-applied size must not write to FileVolume spec")
+}
+
+func TestExpandFileVolumeViaFVS_Shrink(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-shrink"
+		currentGiB = int64(5)
+		smallerGiB = int64(2)
+	)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
+		Spec: fvv1alpha1.FileVolumeSpec{
+			Size: *resource.NewQuantity(currentGiB<<30, resource.BinarySI),
+		},
+		Status: fvv1alpha1.FileVolumeStatus{
+			Phase:           fvv1alpha1.FileVolumePhaseReady,
+			LastAppliedSize: *resource.NewQuantity(currentGiB<<30, resource.BinarySI),
+		},
+	}
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			Build(),
+	}
+
+	_, fault, err := c.expandFileVolumeViaFVS(ctx,
+		expandRequest(common.FVSVolumeIDPrefix+instanceNS+":"+fvName, smallerGiB<<30))
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInvalidArgumentFault, fault)
+	require.Contains(t, err.Error(), "shrinking FVS file volume is not supported")
+}
+
+func TestExpandFileVolumeViaFVS_InvalidVolumeID(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			Build(),
+	}
+
+	tests := []struct {
+		name     string
+		volumeID string
+	}{
+		{"missing FVS prefix", "tenant-ns:fv-foo"},
+		{"prefix only", common.FVSVolumeIDPrefix},
+		{"missing namespace", common.FVSVolumeIDPrefix + ":fv-foo"},
+		{"missing name", common.FVSVolumeIDPrefix + "tenant-ns:"},
+		{"missing separator after namespace", common.FVSVolumeIDPrefix + "tenant-ns"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, fault, err := c.expandFileVolumeViaFVS(ctx, expandRequest(tt.volumeID, 1<<30))
+			require.Error(t, err)
+			require.Equal(t, csifault.CSIInvalidArgumentFault, fault)
+		})
+	}
+}
+
+func TestExpandFileVolumeViaFVS_NilClient(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	c := &controller{}
+	_, fault, err := c.expandFileVolumeViaFVS(ctx,
+		expandRequest(common.FVSVolumeIDPrefix+"any-ns:any-fv", 1<<30))
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInternalFault, fault)
+	require.Contains(t, err.Error(), "FileVolume client is not initialized")
+}
+
+func TestExpandFileVolumeViaFVS_MissingCapacityRange(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-no-cap"
+	)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
+		Spec: fvv1alpha1.FileVolumeSpec{
+			Size: *resource.NewQuantity(1<<30, resource.BinarySI),
+		},
+	}
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			Build(),
+	}
+
+	tests := []struct {
+		name string
+		req  *csi.ControllerExpandVolumeRequest
+	}{
+		{"nil capacity range", &csi.ControllerExpandVolumeRequest{
+			VolumeId: common.FVSVolumeIDPrefix + instanceNS + ":" + fvName,
+		}},
+		{"zero required bytes", expandRequest(common.FVSVolumeIDPrefix+instanceNS+":"+fvName, 0)},
+		{"negative required bytes", expandRequest(common.FVSVolumeIDPrefix+instanceNS+":"+fvName, -1)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, fault, err := c.expandFileVolumeViaFVS(ctx, tt.req)
+			require.Error(t, err)
+			require.Equal(t, csifault.CSIInvalidArgumentFault, fault)
+			require.Contains(t, err.Error(), "capacity range with positive required_bytes is required")
+		})
+	}
+}
+
+func TestExpandFileVolumeViaFVS_NotFound(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			Build(),
+	}
+
+	_, fault, err := c.expandFileVolumeViaFVS(ctx,
+		expandRequest(common.FVSVolumeIDPrefix+"missing-ns:missing-fv", 2<<30))
+	require.Error(t, err)
+	require.Equal(t, csifault.CSINotFoundFault, fault)
+}
+
+func TestExpandFileVolumeViaFVS_UpdateError(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-update-error"
+		oldGiB     = int64(1)
+		newGiB     = int64(5)
+	)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
+		Spec: fvv1alpha1.FileVolumeSpec{
+			Size: *resource.NewQuantity(oldGiB<<30, resource.BinarySI),
+		},
+		Status: fvv1alpha1.FileVolumeStatus{
+			Phase:           fvv1alpha1.FileVolumePhaseReady,
+			LastAppliedSize: *resource.NewQuantity(oldGiB<<30, resource.BinarySI),
+		},
+	}
+	injectedErr := errors.New("api server temporarily unavailable")
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
+					opts ...ctrlclient.UpdateOption) error {
+					if _, ok := obj.(*fvv1alpha1.FileVolume); ok {
+						return injectedErr
+					}
+					return w.Update(ctx, obj, opts...)
+				},
+			}).
+			Build(),
+	}
+
+	_, fault, err := c.expandFileVolumeViaFVS(ctx,
+		expandRequest(common.FVSVolumeIDPrefix+instanceNS+":"+fvName, newGiB<<30))
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInternalFault, fault)
+	require.Contains(t, err.Error(), "failed to update spec.size on FileVolume")
+}
+
+// TestExpandFileVolumeViaFVS_StatusNeverApplies simulates an FVS controller that accepts the spec
+// update but never bumps status.lastAppliedSize: the CSI expand should fail with DeadlineExceeded
+// after fvsWaitMax expires (dialed down via withFastFVSWait).
+func TestExpandFileVolumeViaFVS_StatusNeverApplies(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-stuck-status"
+		oldGiB     = int64(1)
+		newGiB     = int64(5)
+	)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
+		Spec: fvv1alpha1.FileVolumeSpec{
+			Size: *resource.NewQuantity(oldGiB<<30, resource.BinarySI),
+		},
+		Status: fvv1alpha1.FileVolumeStatus{
+			Phase:           fvv1alpha1.FileVolumePhaseReady,
+			LastAppliedSize: *resource.NewQuantity(oldGiB<<30, resource.BinarySI),
+		},
+	}
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
+					opts ...ctrlclient.UpdateOption) error {
+					// Persist spec bump but explicitly do NOT bump status.lastAppliedSize, simulating
+					// a stuck FVS controller.
+					if fv, ok := obj.(*fvv1alpha1.FileVolume); ok {
+						fv.Status.LastAppliedSize = *resource.NewQuantity(oldGiB<<30, resource.BinarySI)
+					}
+					return w.Update(ctx, obj, opts...)
+				},
+			}).
+			Build(),
+	}
+
+	_, fault, err := c.expandFileVolumeViaFVS(ctx,
+		expandRequest(common.FVSVolumeIDPrefix+instanceNS+":"+fvName, newGiB<<30))
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInternalFault, fault)
+	require.Contains(t, err.Error(), "timeout or error waiting for FileVolume")
+}
+
+// TestExpandFileVolumeViaFVS_ErrorPhase: the FVS controller reports phase=Error mid-expansion;
+// CSI must surface a clear DeadlineExceeded with an error message naming the Error phase rather
+// than spinning until fvsWaitMax.
+func TestExpandFileVolumeViaFVS_ErrorPhase(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+
+	const (
+		instanceNS = "fvs-instance-ns"
+		fvName     = "fv-error-phase"
+		oldGiB     = int64(1)
+		newGiB     = int64(5)
+	)
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fvName, Namespace: instanceNS},
+		Spec: fvv1alpha1.FileVolumeSpec{
+			Size: *resource.NewQuantity(oldGiB<<30, resource.BinarySI),
+		},
+		Status: fvv1alpha1.FileVolumeStatus{
+			Phase:           fvv1alpha1.FileVolumePhaseReady,
+			LastAppliedSize: *resource.NewQuantity(oldGiB<<30, resource.BinarySI),
+		},
+	}
+	c := &controller{
+		fileVolumeClient: ctrlclientfake.NewClientBuilder().
+			WithScheme(fvsTestScheme(t)).
+			WithObjects(existing).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(ctx context.Context, w ctrlclient.WithWatch, obj ctrlclient.Object,
+					opts ...ctrlclient.UpdateOption) error {
+					if fv, ok := obj.(*fvv1alpha1.FileVolume); ok {
+						fv.Status.Phase = fvv1alpha1.FileVolumePhaseError
+					}
+					return w.Update(ctx, obj, opts...)
+				},
+			}).
+			Build(),
+	}
+
+	_, fault, err := c.expandFileVolumeViaFVS(ctx,
+		expandRequest(common.FVSVolumeIDPrefix+instanceNS+":"+fvName, newGiB<<30))
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInternalFault, fault)
+	require.Contains(t, err.Error(), "Error phase")
 }
 
 // TestDeleteFileVolumeViaFVS_StuckFinalizer simulates an FVS controller that has not yet drained

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -142,6 +142,10 @@ type controller struct {
 	restClientConfig            *rest.Config
 	vmOperatorClient            client.Client
 	cnsOperatorClient           client.Client
+	// supervisorRuntimeClient is a controller-runtime client for the supervisor cluster used for
+	// patch operations on supervisor PVCs. Lazily created from restClientConfig on first use;
+	// may be injected directly in unit tests via ctrlclientfake.
+	supervisorRuntimeClient     client.Client
 	vmWatcher                   *cache.ListWatch
 	supervisorNamespace         string
 	tanzukubernetesClusterUID   string
@@ -1469,11 +1473,37 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		if err != nil {
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
-		// Only block volume expand is allowed. Update this when file volume expand is also supported.
-		volumeType = prometheus.PrometheusBlockVolumeType
 
 		volumeID := req.GetVolumeId()
 		volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
+
+		// Retrieve Supervisor PVC early so we can dispatch on volume type.
+		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+			ctx, volumeID, metav1.GetOptions{})
+		if err != nil {
+			msg := fmt.Sprintf("failed to retrieve supervisor PVC %q in %q namespace. Error: %+v",
+				volumeID, c.supervisorNamespace, err)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+		}
+
+		// FVS-backed file volumes are expanded by patching the supervisor PVC and
+		// waiting for status.capacity to converge; the FVS controller drives the
+		// underlying NFS share resize. NodeExpansionRequired is false for NFS.
+		// unlike wcp, here we are checking if the volume is FVS-backed by checking the storage class name
+		if IsVsanFileVolumeServiceEnabled && common.IsFVSPersistentVolumeClaim(svPVC) {
+			volumeType = prometheus.PrometheusFileVolumeType
+			return controllerExpandForFVSFileVolume(ctx, req, svPVC, c)
+		}
+
+		// Legacy CNS file volumes do not support expansion.
+		if common.IsFileVolumeRequest(ctx, []*csi.VolumeCapability{req.GetVolumeCapability()}) {
+			return nil, csifault.CSIInvalidArgumentFault,
+				logger.LogNewErrorCode(log, codes.Unimplemented,
+					"volume expansion is only supported for block volume type")
+		}
+
+		volumeType = prometheus.PrometheusBlockVolumeType
 
 		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
 			vmList, err := utils.ListVirtualMachines(ctx, c.vmOperatorClient, c.supervisorNamespace)
@@ -1493,16 +1523,6 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 					}
 				}
 			}
-		}
-
-		// Retrieve Supervisor PVC
-		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
-			ctx, volumeID, metav1.GetOptions{})
-		if err != nil {
-			msg := fmt.Sprintf("failed to retrieve supervisor PVC %q in %q namespace. Error: %+v",
-				volumeID, c.supervisorNamespace, err)
-			log.Error(msg)
-			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
 		}
 
 		waitForSvPvcCondition := true

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -145,12 +145,12 @@ type controller struct {
 	// supervisorRuntimeClient is a controller-runtime client for the supervisor cluster used for
 	// patch operations on supervisor PVCs. Lazily created from restClientConfig on first use;
 	// may be injected directly in unit tests via ctrlclientfake.
-	supervisorRuntimeClient     client.Client
-	vmWatcher                   *cache.ListWatch
-	supervisorNamespace         string
-	tanzukubernetesClusterUID   string
-	tanzukubernetesClusterName  string
-	guestClusterDist            string
+	supervisorRuntimeClient    client.Client
+	vmWatcher                  *cache.ListWatch
+	supervisorNamespace        string
+	tanzukubernetesClusterUID  string
+	tanzukubernetesClusterName string
+	guestClusterDist           string
 	csi.UnimplementedControllerServer
 	csi.UnimplementedSnapshotMetadataServer
 }

--- a/pkg/csi/service/wcpguest/fvs_expand.go
+++ b/pkg/csi/service/wcpguest/fvs_expand.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// ControllerExpandVolume handling for the new vSAN FileVolumeService (FVS)
+// workflow on the guest cluster.
+//
+// Background:
+// For legacy CNS file volumes, volume expansion is not supported (the storage
+// backend does not allow it, and there is no node-side filesystem resize step).
+//
+// For FVS-backed file volumes the supervisor controller drives the resize by
+// updating the FileVolume CR when the supervisor PVC's
+// spec.resources.requests.storage is increased (see the supervisor-side
+// expandFileVolumeViaFVS). The guest cluster's role is:
+//   1. Patch spec.resources.requests.storage on the supervisor PVC.
+//   2. Wait until status.capacity reflects the new size (set by the supervisor
+//      FVS controller once the underlying NFS share has grown).
+//   3. Return NodeExpansionRequired=false — NFS shares grow on the server side
+//      so no kubelet filesystem resize step is needed on the guest node.
+//
+// Identification: the controller must gate on IsVsanFileVolumeServiceEnabled
+// and common.IsFVSPersistentVolumeClaim(supervisor PVC) before calling the
+// helpers in this file.
+
+package wcpguest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	clientset "k8s.io/client-go/kubernetes"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+)
+
+// controllerExpandForFVSFileVolume handles a ControllerExpandVolume request for
+// a file volume provisioned by the new vSAN FileVolumeService. It patches the
+// supervisor PVC's spec.resources.requests.storage to trigger the supervisor-side
+// FVS expansion reconciler, then waits for status.capacity to reflect the new
+// size before returning success with NodeExpansionRequired=false.
+//
+// The caller must have verified FVS (IsVsanFileVolumeServiceEnabled &&
+// common.IsFVSPersistentVolumeClaim on the supervisor PVC) before invoking this
+// function.
+func controllerExpandForFVSFileVolume(ctx context.Context,
+	req *csi.ControllerExpandVolumeRequest,
+	svPVC *corev1.PersistentVolumeClaim,
+	c *controller) (*csi.ControllerExpandVolumeResponse, string, error) {
+
+	log := logger.GetLogger(ctx)
+	volumeID := req.GetVolumeId()
+	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
+	gcPvcRequestSize := resource.NewQuantity(volSizeBytes, resource.BinarySI)
+	svPvcRequestSize := svPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+	timeout := time.Duration(getResizeTimeoutInMin(ctx)) * time.Minute
+
+	switch gcPvcRequestSize.Cmp(svPvcRequestSize) {
+	case 1:
+		// Requested size is larger than the current supervisor PVC spec: patch it
+		// so the FVS expansion reconciler on the supervisor can act on it.
+		original := svPVC.DeepCopy()
+		clone := svPVC.DeepCopy()
+		clone.Spec.Resources.Requests[corev1.ResourceStorage] = *gcPvcRequestSize
+
+		supervisorRuntimeClient := c.supervisorRuntimeClient
+		if supervisorRuntimeClient == nil {
+			rc, rcErr := ctrlclient.New(c.restClientConfig, ctrlclient.Options{})
+			if rcErr != nil {
+				msg := fmt.Sprintf("failed to create controller-runtime client for supervisor cluster. Error: %+v", rcErr)
+				log.Error(msg)
+				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+			}
+			supervisorRuntimeClient = rc
+		}
+		log.Infof("ControllerExpandVolume: increasing supervisor PVC %s/%s from %s to %s for FVS file volume",
+			c.supervisorNamespace, volumeID, svPvcRequestSize.String(), gcPvcRequestSize.String())
+		if patchErr := k8s.PatchObject(ctx, supervisorRuntimeClient, original, clone); patchErr != nil {
+			msg := fmt.Sprintf("failed to patch supervisor PVC %q in %q namespace. Error: %+v",
+				volumeID, c.supervisorNamespace, patchErr)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+		}
+		// Wait for the FVS controller to reflect the new size in status.capacity.
+		if waitErr := checkForSupervisorPVCCapacityReached(ctx, c.supervisorClient, clone,
+			gcPvcRequestSize, timeout); waitErr != nil {
+			msg := fmt.Sprintf("failed to expand FVS file volume %s: %+v", volumeID, waitErr)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+		}
+	case 0:
+		// Supervisor PVC spec already at the requested size. If status.capacity
+		// has not caught up yet (e.g. a previous attempt patched the spec but
+		// timed out waiting), wait for convergence.
+		svPvcCapacity := svPVC.Status.Capacity[corev1.ResourceStorage]
+		if gcPvcRequestSize.Cmp(svPvcCapacity) > 0 {
+			log.Infof("ControllerExpandVolume: supervisor PVC %s/%s spec already at %s but "+
+				"status.capacity is %s; waiting for FVS controller to converge",
+				c.supervisorNamespace, volumeID, gcPvcRequestSize.String(), svPvcCapacity.String())
+			if err := checkForSupervisorPVCCapacityReached(ctx, c.supervisorClient, svPVC,
+				gcPvcRequestSize, timeout); err != nil {
+				msg := fmt.Sprintf("failed to expand FVS file volume %s: %+v", volumeID, err)
+				log.Error(msg)
+				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+			}
+		} else {
+			log.Infof("ControllerExpandVolume: FVS file volume %s already at requested size %s; skipping resize",
+				volumeID, gcPvcRequestSize.String())
+		}
+	default:
+		// Requested size is smaller than current supervisor PVC spec: reject.
+		msg := fmt.Sprintf("the requested size of the Supervisor PVC %s in namespace %s is %s "+
+			"which is greater than the requested size of %s",
+			volumeID, c.supervisorNamespace, svPvcRequestSize.String(), gcPvcRequestSize.String())
+		log.Error(msg)
+		return nil, csifault.CSIInternalFault, status.Error(codes.InvalidArgument, msg)
+	}
+
+	log.Infof("ControllerExpandVolume: FVS file volume %s expanded to %s; NodeExpansionRequired=false",
+		volumeID, gcPvcRequestSize.String())
+	return &csi.ControllerExpandVolumeResponse{
+		CapacityBytes:         volSizeBytes,
+		NodeExpansionRequired: false,
+	}, "", nil
+}
+
+// checkForSupervisorPVCCapacityReached watches the supervisor PVC and returns
+// nil when status.capacity.storage reaches reqSize, or an error if timeout
+// elapses first. Unlike checkForSupervisorPVCCondition (which waits for the
+// FileSystemResizePending condition used by block volumes), this helper is used
+// for FVS file volumes whose NFS share grows on the server side; the supervisor
+// FVS controller signals completion by updating status.capacity rather than
+// setting a filesystem-resize condition.
+func checkForSupervisorPVCCapacityReached(ctx context.Context, svClient clientset.Interface,
+	claim *corev1.PersistentVolumeClaim, reqSize *resource.Quantity, timeout time.Duration) error {
+
+	log := logger.GetLogger(ctx)
+	pvcName := claim.Name
+	ns := claim.Namespace
+	timeoutSeconds := int64(timeout.Seconds())
+
+	log.Infof("Waiting up to %d seconds for supervisor PVC %s/%s status.capacity to reach %s",
+		timeoutSeconds, ns, pvcName, reqSize.String())
+
+	watchClaim, err := svClient.CoreV1().PersistentVolumeClaims(ns).Watch(
+		ctx,
+		metav1.ListOptions{
+			FieldSelector:  fields.OneTermEqualSelector("metadata.name", pvcName).String(),
+			TimeoutSeconds: &timeoutSeconds,
+			Watch:          true,
+		})
+	if err != nil {
+		return fmt.Errorf("failed to watch supervisor PVC %s/%s: %w", ns, pvcName, err)
+	}
+	defer watchClaim.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled waiting for supervisor PVC %s/%s status.capacity to reach %s: %v",
+				ns, pvcName, reqSize.String(), ctx.Err())
+		case event, ok := <-watchClaim.ResultChan():
+			if !ok {
+				return fmt.Errorf("supervisor PVC %s/%s status.capacity did not reach %s within %d seconds",
+					ns, pvcName, reqSize.String(), timeoutSeconds)
+			}
+			pvc, ok := event.Object.(*corev1.PersistentVolumeClaim)
+			if !ok {
+				continue
+			}
+			cap := pvc.Status.Capacity[corev1.ResourceStorage]
+			if cap.Cmp(*reqSize) >= 0 {
+				log.Infof("Supervisor PVC %s/%s status.capacity reached %s (requested %s)",
+					ns, pvcName, cap.String(), reqSize.String())
+				return nil
+			}
+			log.Debugf("Supervisor PVC %s/%s status.capacity is %s, waiting for %s",
+				ns, pvcName, cap.String(), reqSize.String())
+		}
+	}
+}

--- a/pkg/csi/service/wcpguest/fvs_expand_test.go
+++ b/pkg/csi/service/wcpguest/fvs_expand_test.go
@@ -1,0 +1,547 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wcpguest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+)
+
+// ---- helpers ---------------------------------------------------------------
+
+// fvsExpandScheme returns a runtime.Scheme with corev1 registered.
+func fvsExpandScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return s
+}
+
+// newPVCForExpand builds a supervisor PVC with the given spec-request and
+// status-capacity sizes (empty string → no status capacity set).
+func newPVCForExpand(name, sc, specSize, statusCap string) *corev1.PersistentVolumeClaim {
+	scCopy := sc
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: fvsTestNamespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scCopy,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(specSize),
+				},
+			},
+		},
+	}
+	if statusCap != "" {
+		pvc.Status = corev1.PersistentVolumeClaimStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse(statusCap),
+			},
+		}
+	}
+	return pvc
+}
+
+// fvsExpandController builds a *controller wired with fake clients for expand tests.
+// runtimePVC is the PVC registered in the fake controller-runtime client (for patching);
+// watchPVC is registered in the fake k8s clientset (for watching status.capacity changes).
+func fvsExpandController(t *testing.T, runtimePVC, watchPVC *corev1.PersistentVolumeClaim) *controller {
+	t.Helper()
+	rtClient := ctrlclientfake.NewClientBuilder().
+		WithScheme(fvsExpandScheme(t)).
+		WithObjects(runtimePVC).
+		Build()
+	svClient := testclient.NewClientset(watchPVC)
+	return &controller{
+		supervisorClient:        svClient,
+		supervisorRuntimeClient: rtClient,
+		supervisorNamespace:     fvsTestNamespace,
+	}
+}
+
+// expandReqRWX returns a ControllerExpandVolumeRequest with MULTI_NODE_MULTI_WRITER
+// access mode and the given required size in bytes.
+func expandReqRWX(volumeID string, sizeBytes int64) *csi.ControllerExpandVolumeRequest {
+	return &csi.ControllerExpandVolumeRequest{
+		VolumeId: volumeID,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: sizeBytes,
+		},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			},
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
+		},
+	}
+}
+
+const (
+	fvsExpandPVC      = "sv-pvc-expand-1"
+	gi5               = 5 * common.GbInBytes
+	gi10              = 10 * common.GbInBytes
+)
+
+// ---- checkForSupervisorPVCCapacityReached -----------------------------------
+
+// TestCheckForSupervisorPVCCapacityReached_ContextCancelled verifies that the
+// function returns promptly (error) when the context is already cancelled.
+func TestCheckForSupervisorPVCCapacityReached_ContextCancelled(t *testing.T) {
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "5Gi", "5Gi")
+	svClient := testclient.NewClientset(pvc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	err := checkForSupervisorPVCCapacityReached(ctx, svClient, pvc,
+		mustParseQuantity("10Gi"), 30*time.Second)
+	if err == nil {
+		t.Fatal("expected error when context is cancelled, got nil")
+	}
+}
+
+// TestCheckForSupervisorPVCCapacityReached_CapacityReachedViaUpdate verifies
+// that the function returns nil when the PVC's status.capacity is updated to
+// the requested size from a concurrent goroutine.
+func TestCheckForSupervisorPVCCapacityReached_CapacityReachedViaUpdate(t *testing.T) {
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "10Gi", "5Gi")
+	svClient := testclient.NewClientset(pvc)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- checkForSupervisorPVCCapacityReached(ctx, svClient, pvc,
+			mustParseQuantity("10Gi"), 30*time.Second)
+	}()
+
+	// Give the goroutine time to start the watch, then update capacity.
+	time.Sleep(50 * time.Millisecond)
+	updated := pvc.DeepCopy()
+	updated.Status.Capacity = corev1.ResourceList{
+		corev1.ResourceStorage: resource.MustParse("10Gi"),
+	}
+	if _, err := svClient.CoreV1().PersistentVolumeClaims(fvsTestNamespace).UpdateStatus(
+		ctx, updated, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for checkForSupervisorPVCCapacityReached to return")
+	}
+}
+
+// TestCheckForSupervisorPVCCapacityReached_WatchChannelClosed verifies that
+// the function returns an error when the watch channel is closed (simulated by
+// cancelling the context after the watch has started).
+func TestCheckForSupervisorPVCCapacityReached_WatchChannelClosed(t *testing.T) {
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "10Gi", "5Gi")
+	svClient := testclient.NewClientset(pvc)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- checkForSupervisorPVCCapacityReached(ctx, svClient, pvc,
+			mustParseQuantity("10Gi"), 30*time.Second)
+	}()
+
+	// Cancel context after a short delay to simulate watch timeout / closure.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error when context is cancelled, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for checkForSupervisorPVCCapacityReached to return after context cancel")
+	}
+}
+
+// ---- controllerExpandForFVSFileVolume ---------------------------------------
+
+// TestControllerExpandForFVSFileVolume_Shrink_Rejected verifies that requesting a
+// size smaller than the current supervisor PVC spec is rejected with InvalidArgument.
+func TestControllerExpandForFVSFileVolume_Shrink_Rejected(t *testing.T) {
+	// PVC spec already at 10Gi; request only 5Gi → shrink
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "10Gi", "10Gi")
+	c := fvsExpandController(t, pvc, pvc)
+
+	req := expandReqRWX(fvsExpandPVC, gi5)
+	_, faultType, err := controllerExpandForFVSFileVolume(context.Background(), req, pvc.DeepCopy(), c)
+	if err == nil {
+		t.Fatal("expected error for shrink request, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got ok=%v code=%v err=%v", ok, st.Code(), err)
+	}
+	if faultType != csifault.CSIInternalFault {
+		t.Fatalf("faultType=%q want %q", faultType, csifault.CSIInternalFault)
+	}
+}
+
+// TestControllerExpandForFVSFileVolume_Equal_CapacityAlreadyMet verifies that
+// when the spec and status.capacity are both already at the requested size, the
+// function returns success immediately without patching or waiting.
+func TestControllerExpandForFVSFileVolume_Equal_CapacityAlreadyMet(t *testing.T) {
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "10Gi", "10Gi")
+	c := fvsExpandController(t, pvc, pvc)
+
+	req := expandReqRWX(fvsExpandPVC, gi10)
+	resp, faultType, err := controllerExpandForFVSFileVolume(context.Background(), req, pvc.DeepCopy(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v (fault=%q)", err, faultType)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if resp.NodeExpansionRequired {
+		t.Error("NodeExpansionRequired must be false for FVS file volumes")
+	}
+	if resp.CapacityBytes != gi10 {
+		t.Errorf("CapacityBytes=%d want %d", resp.CapacityBytes, gi10)
+	}
+}
+
+// TestControllerExpandForFVSFileVolume_Equal_CapacityNotYet_Success verifies
+// that when spec is already at the requested size but status.capacity has not
+// caught up, the function waits and returns success once capacity is updated.
+func TestControllerExpandForFVSFileVolume_Equal_CapacityNotYet_Success(t *testing.T) {
+	// spec=10Gi (already patched), status.capacity=5Gi (FVS not yet converged)
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "10Gi", "5Gi")
+	c := fvsExpandController(t, pvc, pvc)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	respCh := make(chan *csi.ControllerExpandVolumeResponse, 1)
+	go func() {
+		req := expandReqRWX(fvsExpandPVC, gi10)
+		resp, _, err := controllerExpandForFVSFileVolume(ctx, req, pvc.DeepCopy(), c)
+		respCh <- resp
+		errCh <- err
+	}()
+
+	// Simulate the FVS controller updating status.capacity on the supervisor PVC.
+	time.Sleep(50 * time.Millisecond)
+	updated := pvc.DeepCopy()
+	updated.Status.Capacity = corev1.ResourceList{
+		corev1.ResourceStorage: resource.MustParse("10Gi"),
+	}
+	if _, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(fvsTestNamespace).UpdateStatus(
+		ctx, updated, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		resp := <-respCh
+		if resp == nil || resp.NodeExpansionRequired {
+			t.Errorf("unexpected response: %+v", resp)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out")
+	}
+}
+
+// TestControllerExpandForFVSFileVolume_Equal_CapacityNotYet_ContextCancelled verifies
+// that when the context is cancelled while waiting for capacity, an error is returned.
+func TestControllerExpandForFVSFileVolume_Equal_CapacityNotYet_ContextCancelled(t *testing.T) {
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "10Gi", "5Gi")
+	c := fvsExpandController(t, pvc, pvc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		req := expandReqRWX(fvsExpandPVC, gi10)
+		_, _, err := controllerExpandForFVSFileVolume(ctx, req, pvc.DeepCopy(), c)
+		errCh <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error when context cancelled, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for function to return after context cancel")
+	}
+}
+
+// TestControllerExpandForFVSFileVolume_Grow_Success verifies the full grow path:
+// spec < requested → patch spec via runtime client, wait for capacity → success.
+func TestControllerExpandForFVSFileVolume_Grow_Success(t *testing.T) {
+	// Supervisor PVC starts at 5Gi spec and 5Gi capacity.
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "5Gi", "5Gi")
+	c := fvsExpandController(t, pvc, pvc)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	respCh := make(chan *csi.ControllerExpandVolumeResponse, 1)
+	go func() {
+		req := expandReqRWX(fvsExpandPVC, gi10)
+		resp, _, err := controllerExpandForFVSFileVolume(ctx, req, pvc.DeepCopy(), c)
+		respCh <- resp
+		errCh <- err
+	}()
+
+	// After the function patches spec, it watches status.capacity. Simulate the
+	// supervisor updating status.capacity once it has grown the underlying volume.
+	time.Sleep(80 * time.Millisecond)
+	updated := pvc.DeepCopy()
+	updated.Status.Capacity = corev1.ResourceList{
+		corev1.ResourceStorage: resource.MustParse("10Gi"),
+	}
+	if _, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(fvsTestNamespace).UpdateStatus(
+		ctx, updated, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		resp := <-respCh
+		if resp == nil {
+			t.Fatal("expected non-nil response")
+		}
+		if resp.NodeExpansionRequired {
+			t.Error("NodeExpansionRequired must be false for FVS file volumes")
+		}
+		if resp.CapacityBytes != gi10 {
+			t.Errorf("CapacityBytes=%d want %d", resp.CapacityBytes, gi10)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for grow to complete")
+	}
+}
+
+// TestControllerExpandForFVSFileVolume_Grow_NilRuntimeClientConfig verifies that
+// a nil restClientConfig (and no cached supervisorRuntimeClient) surfaces a clear
+// Internal error rather than a nil-pointer panic.
+func TestControllerExpandForFVSFileVolume_Grow_NilRuntimeClientConfig(t *testing.T) {
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "5Gi", "5Gi")
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(pvc),
+		supervisorNamespace: fvsTestNamespace,
+		// supervisorRuntimeClient is nil AND restClientConfig is nil → ctrlclient.New fails
+	}
+
+	req := expandReqRWX(fvsExpandPVC, gi10)
+	_, faultType, err := controllerExpandForFVSFileVolume(context.Background(), req, pvc.DeepCopy(), c)
+	if err == nil {
+		t.Fatal("expected error when runtime client cannot be created, got nil")
+	}
+	if faultType != csifault.CSIInternalFault {
+		t.Fatalf("faultType=%q want %q", faultType, csifault.CSIInternalFault)
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Internal {
+		t.Fatalf("expected Internal, got ok=%v code=%v err=%v", ok, st.Code(), err)
+	}
+}
+
+// ---- ControllerExpandVolume routing (FVS gate) ------------------------------
+
+// TestControllerExpandVolume_FVS_RoutedToFVSExpand verifies that with the FVS
+// gate on and a FVS supervisor PVC (spec=capacity=requested), ControllerExpandVolume
+// succeeds and sets NodeExpansionRequired=false.
+func TestControllerExpandVolume_FVS_RoutedToFVSExpand(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicy, "10Gi", "10Gi")
+	c := fvsExpandController(t, pvc, pvc)
+
+	req := expandReqRWX(fvsExpandPVC, gi10)
+	resp, err := c.ControllerExpandVolume(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if resp.NodeExpansionRequired {
+		t.Error("NodeExpansionRequired must be false for FVS file volumes")
+	}
+}
+
+// TestControllerExpandVolume_FVS_GateDisabled_LegacyFileRejected verifies that
+// when the FVS gate is off and the request is for a file (RWX) volume, the
+// legacy guard returns Unimplemented.
+func TestControllerExpandVolume_FVS_GateDisabled_LegacyFileRejected(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, false)
+
+	// non-FVS storage class so IsFVSPersistentVolumeClaim is false
+	pvc := newPVCForExpand(fvsExpandPVC, "standard-sc", "10Gi", "10Gi")
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(pvc),
+		supervisorNamespace: fvsTestNamespace,
+	}
+
+	req := expandReqRWX(fvsExpandPVC, gi10)
+	_, err := c.ControllerExpandVolume(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for legacy file volume expansion, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Unimplemented {
+		t.Fatalf("expected Unimplemented, got ok=%v code=%v err=%v", ok, st.Code(), err)
+	}
+}
+
+// TestControllerExpandVolume_FVS_Enabled_NonFVSPVC_LegacyFileRejected verifies that
+// even with the FVS gate on, a non-FVS PVC with file capability goes to the legacy
+// guard and returns Unimplemented.
+func TestControllerExpandVolume_FVS_Enabled_NonFVSPVC_LegacyFileRejected(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+
+	pvc := newPVCForExpand(fvsExpandPVC, "standard-sc", "10Gi", "10Gi")
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(pvc),
+		supervisorNamespace: fvsTestNamespace,
+	}
+
+	req := expandReqRWX(fvsExpandPVC, gi10)
+	_, err := c.ControllerExpandVolume(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for legacy file volume, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Unimplemented {
+		t.Fatalf("expected Unimplemented, got ok=%v code=%v err=%v", ok, st.Code(), err)
+	}
+}
+
+// TestControllerExpandVolume_FVS_SupervisorPVCNotFound verifies that a missing
+// supervisor PVC surfaces a retriable Internal error.
+func TestControllerExpandVolume_FVS_SupervisorPVCNotFound(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(), // empty — no PVCs
+		supervisorNamespace: fvsTestNamespace,
+	}
+
+	req := expandReqRWX("missing-pvc", gi10)
+	_, err := c.ControllerExpandVolume(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error when supervisor PVC not found, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Internal {
+		t.Fatalf("expected Internal, got ok=%v code=%v err=%v", ok, st.Code(), err)
+	}
+}
+
+// TestControllerExpandVolume_FVS_InvalidRequest_NoVolumeID verifies that a
+// request with no volume ID is rejected with InvalidArgument.
+func TestControllerExpandVolume_FVS_InvalidRequest_NoVolumeID(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+
+	c := &controller{
+		supervisorClient:    testclient.NewClientset(),
+		supervisorNamespace: fvsTestNamespace,
+	}
+
+	req := &csi.ControllerExpandVolumeRequest{
+		VolumeId: "",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: gi10,
+		},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			},
+		},
+	}
+	_, err := c.ControllerExpandVolume(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for missing volume ID, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got ok=%v code=%v err=%v", ok, st.Code(), err)
+	}
+}
+
+// TestControllerExpandVolume_FVS_LateBinding_RoutedToFVSExpand verifies that the
+// late-binding FVS storage class is also routed to the FVS expand path.
+func TestControllerExpandVolume_FVS_LateBinding_RoutedToFVSExpand(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+
+	pvc := newPVCForExpand(fvsExpandPVC, common.StorageClassVsanFileServicePolicyLateBinding, "10Gi", "10Gi")
+	c := fvsExpandController(t, pvc, pvc)
+
+	req := expandReqRWX(fvsExpandPVC, gi10)
+	resp, err := c.ControllerExpandVolume(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil || resp.NodeExpansionRequired {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+}
+
+// ---- utilities -------------------------------------------------------------
+
+func mustParseQuantity(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}

--- a/pkg/csi/service/wcpguest/fvs_expand_test.go
+++ b/pkg/csi/service/wcpguest/fvs_expand_test.go
@@ -113,9 +113,9 @@ func expandReqRWX(volumeID string, sizeBytes int64) *csi.ControllerExpandVolumeR
 }
 
 const (
-	fvsExpandPVC      = "sv-pvc-expand-1"
-	gi5               = 5 * common.GbInBytes
-	gi10              = 10 * common.GbInBytes
+	fvsExpandPVC = "sv-pvc-expand-1"
+	gi5          = 5 * common.GbInBytes
+	gi10         = 10 * common.GbInBytes
 )
 
 // ---- checkForSupervisorPVCCapacityReached -----------------------------------


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add ControllerExpandVolume support for file volumes provisioned through the new vSAN FileVolumeService (FVS) on the supervisor (volume id prefix "fv:"). FVS volumes are resized by patching spec.size on the FileVolume CR; the FVS controllers reconcile the underlying vDFS volume and reflect the applied size in status.lastAppliedSize once the new size has landed.

Note: Not considered migrated file volume in this review.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://vmw-jira.broadcom.net/browse/CNAS-10985

**Testing done**:
unit test:
kb@CQVXQ7104Q vsphere-csi-driver % go test -count=1 ./pkg/csi/service/wcp/ -run 'FVS|Fvs' -v | grep -E '^(=== RUN|--- (PASS|FAIL)|PASS$|FAIL$|ok|FAIL\s+sigs)'
=== RUN   TestFvsAccessibleTopology
--- PASS: TestFvsAccessibleTopology (0.00s)
=== RUN   TestListFVSCandidateInstanceNamespaces
--- PASS: TestListFVSCandidateInstanceNamespaces (0.14s)
=== RUN   TestCreateFileVolumeViaFVS_ValidationAndPVC
=== RUN   TestCreateFileVolumeViaFVS_ValidationAndPVC/missing_PVC_parameters
=== RUN   TestCreateFileVolumeViaFVS_ValidationAndPVC/missing_accessibility_requirements
=== RUN   TestCreateFileVolumeViaFVS_ValidationAndPVC/volume_name_without_extractable_PVC_UID
--- PASS: TestCreateFileVolumeViaFVS_ValidationAndPVC (0.00s)
=== RUN   TestShouldProvisionVsanFileVolumeViaFVS
=== RUN   TestShouldProvisionVsanFileVolumeViaFVS/non-VPC_network_provider_returns_FailedPrecondition
=== RUN   TestShouldProvisionVsanFileVolumeViaFVS/VPC_provider_FSS_disabled
=== RUN   TestShouldProvisionVsanFileVolumeViaFVS/VPC_provider_FSS_enabled
--- PASS: TestShouldProvisionVsanFileVolumeViaFVS (0.00s)
=== RUN   TestShouldDeleteFileVolumeViaFVS
=== RUN   TestShouldDeleteFileVolumeViaFVS/FSS_off,_non-FVS_handle
=== RUN   TestShouldDeleteFileVolumeViaFVS/FSS_off,_FVS_handle
=== RUN   TestShouldDeleteFileVolumeViaFVS/FSS_off,_empty_handle
=== RUN   TestShouldDeleteFileVolumeViaFVS/FSS_on,_non-FVS_handle
=== RUN   TestShouldDeleteFileVolumeViaFVS/FSS_on,_legacy_file_handle
=== RUN   TestShouldDeleteFileVolumeViaFVS/FSS_on,_empty_handle
=== RUN   TestShouldDeleteFileVolumeViaFVS/FSS_on,_FVS_prefix_only
=== RUN   TestShouldDeleteFileVolumeViaFVS/FSS_on,_FVS_handle
--- PASS: TestShouldDeleteFileVolumeViaFVS (0.00s)
=== RUN   TestDeleteFileVolumeViaFVS_Success
--- PASS: TestDeleteFileVolumeViaFVS_Success (0.00s)
=== RUN   TestDeleteFileVolumeViaFVS_NotFoundIsIdempotent
--- PASS: TestDeleteFileVolumeViaFVS_NotFoundIsIdempotent (0.00s)
=== RUN   TestDeleteFileVolumeViaFVS_InvalidVolumeID
=== RUN   TestDeleteFileVolumeViaFVS_InvalidVolumeID/missing_FVS_prefix
=== RUN   TestDeleteFileVolumeViaFVS_InvalidVolumeID/prefix_only
=== RUN   TestDeleteFileVolumeViaFVS_InvalidVolumeID/missing_namespace
=== RUN   TestDeleteFileVolumeViaFVS_InvalidVolumeID/missing_name
=== RUN   TestDeleteFileVolumeViaFVS_InvalidVolumeID/missing_separator_after_namespace
--- PASS: TestDeleteFileVolumeViaFVS_InvalidVolumeID (0.00s)
=== RUN   TestDeleteFileVolumeViaFVS_NilClient
--- PASS: TestDeleteFileVolumeViaFVS_NilClient (0.00s)
=== RUN   TestDeleteFileVolumeViaFVS_DeleteError
--- PASS: TestDeleteFileVolumeViaFVS_DeleteError (0.00s)
=== RUN   TestShouldExpandFileVolumeViaFVS
=== RUN   TestShouldExpandFileVolumeViaFVS/FSS_off,_non-FVS_handle
=== RUN   TestShouldExpandFileVolumeViaFVS/FSS_off,_FVS_handle
=== RUN   TestShouldExpandFileVolumeViaFVS/FSS_off,_empty_handle
=== RUN   TestShouldExpandFileVolumeViaFVS/FSS_on,_non-FVS_handle
=== RUN   TestShouldExpandFileVolumeViaFVS/FSS_on,_legacy_file_handle
=== RUN   TestShouldExpandFileVolumeViaFVS/FSS_on,_empty_handle
=== RUN   TestShouldExpandFileVolumeViaFVS/FSS_on,_FVS_prefix_only
=== RUN   TestShouldExpandFileVolumeViaFVS/FSS_on,_FVS_handle
--- PASS: TestShouldExpandFileVolumeViaFVS (0.00s)
=== RUN   TestExpandFileVolumeViaFVS_Success
--- PASS: TestExpandFileVolumeViaFVS_Success (0.00s)
=== RUN   TestExpandFileVolumeViaFVS_Idempotent
--- PASS: TestExpandFileVolumeViaFVS_Idempotent (0.00s)
=== RUN   TestExpandFileVolumeViaFVS_Shrink
--- PASS: TestExpandFileVolumeViaFVS_Shrink (0.00s)
=== RUN   TestExpandFileVolumeViaFVS_InvalidVolumeID
=== RUN   TestExpandFileVolumeViaFVS_InvalidVolumeID/missing_FVS_prefix
=== RUN   TestExpandFileVolumeViaFVS_InvalidVolumeID/prefix_only
=== RUN   TestExpandFileVolumeViaFVS_InvalidVolumeID/missing_namespace
=== RUN   TestExpandFileVolumeViaFVS_InvalidVolumeID/missing_name
=== RUN   TestExpandFileVolumeViaFVS_InvalidVolumeID/missing_separator_after_namespace
--- PASS: TestExpandFileVolumeViaFVS_InvalidVolumeID (0.00s)
=== RUN   TestExpandFileVolumeViaFVS_NilClient
--- PASS: TestExpandFileVolumeViaFVS_NilClient (0.00s)
=== RUN   TestExpandFileVolumeViaFVS_MissingCapacityRange
=== RUN   TestExpandFileVolumeViaFVS_MissingCapacityRange/nil_capacity_range
=== RUN   TestExpandFileVolumeViaFVS_MissingCapacityRange/zero_required_bytes
=== RUN   TestExpandFileVolumeViaFVS_MissingCapacityRange/negative_required_bytes
--- PASS: TestExpandFileVolumeViaFVS_MissingCapacityRange (0.00s)
=== RUN   TestExpandFileVolumeViaFVS_NotFound
--- PASS: TestExpandFileVolumeViaFVS_NotFound (0.00s)
=== RUN   TestExpandFileVolumeViaFVS_UpdateError
--- PASS: TestExpandFileVolumeViaFVS_UpdateError (0.00s)
=== RUN   TestExpandFileVolumeViaFVS_StatusNeverApplies
--- PASS: TestExpandFileVolumeViaFVS_StatusNeverApplies (0.20s)
=== RUN   TestExpandFileVolumeViaFVS_ErrorPhase
--- PASS: TestExpandFileVolumeViaFVS_ErrorPhase (0.00s)
=== RUN   TestDeleteFileVolumeViaFVS_StuckFinalizer
--- PASS: TestDeleteFileVolumeViaFVS_StuckFinalizer (0.20s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp   1.311s

**Special notes for your reviewer**:

VKS Pre-checkin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1123/ - PASS
WCP Pre-checkin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1461/ - Pass

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add Supervisor CSI expand support for vSAN File Service volumes via FVS
```

cc: @divyenpatel 

