### PR TITLE
Add snapshot changeID as annotation on corresponding snapshot on Supervisor, if not added during snapshot creation.

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -117,6 +117,15 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 		}
 	}
 
+	// On Supervisor cluster, if CSI_Backup_API FSS is enabled, reconcile snapshot change-id annotations
+	// from CNS snapshot metadata. This ensures all supervisor snapshots have the change-id annotation
+	// which can then be mirrored to guest cluster snapshots.
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSI_Backup_API) {
+			setChangeIDAnnotationOnSupervisorSnapshots(ctx, metadataSyncer, vc)
+		}
+	}
+
 	defer func() {
 		fullSyncStatus := prometheus.PrometheusPassStatus
 		if err != nil {
@@ -1906,4 +1915,248 @@ func cleanupUnusedPVCsAndSnapshotsFromGuestCluster(ctx context.Context) {
 				cnsoperatortypes.CNSVolumeFinalizer, false)
 		}
 	}
+}
+
+// getSnapshotsWithoutChangeIDAnnotation lists supervisor VolumeSnapshots, filters those needing change-id annotation,
+// and returns them grouped by volumeID for selective CNS querying.
+// This is separated to enable testability with sample k8s objects.
+func getSnapshotsWithoutChangeIDAnnotation(ctx context.Context, snapshotterClient versioned.Interface) (
+	snapshotMap map[string]*snapv1.VolumeSnapshot,
+	volumeSnapMap map[string]map[string]struct{},
+	err error,
+) {
+	log := logger.GetLogger(ctx)
+
+	snapshotMap = make(map[string]*snapv1.VolumeSnapshot)
+	volumeSnapMap = make(map[string]map[string]struct{})
+
+	// Use pagination to avoid loading all snapshots at once
+	const pageSize = 500
+	listOptions := metav1.ListOptions{
+		Limit: pageSize,
+	}
+
+	for {
+		// List VolumeSnapshots across all namespaces with pagination
+		vsList, err := snapshotterClient.SnapshotV1().VolumeSnapshots("").List(ctx, listOptions)
+		if err != nil {
+			log.Errorf(
+				"getSnapshotsWithoutChangeIDAnnotation: failed to list supervisor VolumeSnapshots. Error: %v",
+				err)
+			return nil, nil, err
+		}
+
+		if len(vsList.Items) == 0 {
+			log.Debugf("getSnapshotsWithoutChangeIDAnnotation: No VolumeSnapshots found in current page")
+			break
+		}
+
+		log.Debugf(
+			"getSnapshotsWithoutChangeIDAnnotation: Processing page with %d VolumeSnapshots",
+			len(vsList.Items))
+
+		// Process each snapshot in this page
+		for i := range vsList.Items {
+			vs := &vsList.Items[i]
+			if changeID, exists := vs.Annotations[common.VolumeSnapshotChangeIDKey]; exists && changeID != "" {
+				log.Debugf(
+					"getSnapshotsWithoutChangeIDAnnotation: VolumeSnapshot %q/%q already has change-id annotation",
+					vs.Namespace, vs.Name)
+				continue
+			}
+			if vs.Status == nil {
+				log.Debugf("getSnapshotsWithoutChangeIDAnnotation: VolumeSnapshot %q/%q has no status",
+					vs.Namespace, vs.Name)
+				continue
+			}
+			if vs.Status.ReadyToUse != nil && !*vs.Status.ReadyToUse {
+				log.Debugf(
+					"getSnapshotsWithoutChangeIDAnnotation: VolumeSnapshot %q/%q is not ready to use",
+					vs.Namespace, vs.Name)
+				continue
+			}
+			if vs.Status.BoundVolumeSnapshotContentName == nil ||
+				*vs.Status.BoundVolumeSnapshotContentName == "" {
+				log.Debugf(
+					"getSnapshotsWithoutChangeIDAnnotation: VolumeSnapshot %q/%q has no bound VSC",
+					vs.Namespace, vs.Name)
+				continue
+			}
+			vsc, err := snapshotterClient.SnapshotV1().VolumeSnapshotContents().Get(ctx,
+				*vs.Status.BoundVolumeSnapshotContentName, metav1.GetOptions{})
+			if err != nil {
+				log.Errorf(
+					"getSnapshotsWithoutChangeIDAnnotation: failed to get VolumeSnapshotContent for snapshot %q/%q. Error: %v",
+					vs.Namespace, vs.Name, err)
+				continue
+			}
+			if vsc.Status == nil || vsc.Status.SnapshotHandle == nil || *vsc.Status.SnapshotHandle == "" {
+				log.Debugf(
+					"getSnapshotsWithoutChangeIDAnnotation: VolumeSnapshotContent %q has no snapshot handle",
+					vsc.Name)
+				continue
+			}
+			volumeID, snapID, err := common.ParseCSISnapshotID(*vsc.Status.SnapshotHandle)
+			if err != nil {
+				log.Errorf(
+					"getSnapshotsWithoutChangeIDAnnotation: failed to parse snapshot handle %q. Error: %v",
+					*vsc.Status.SnapshotHandle, err)
+				continue
+			}
+			snapshotMap[snapID] = vs
+			if _, ok := volumeSnapMap[volumeID]; !ok {
+				volumeSnapMap[volumeID] = make(map[string]struct{})
+			}
+			volumeSnapMap[volumeID][snapID] = struct{}{}
+		}
+
+		// Check if there are more pages
+		if vsList.Continue == "" {
+			// No more pages
+			break
+		}
+		// Set continue token for next page
+		listOptions.Continue = vsList.Continue
+	}
+
+	if len(volumeSnapMap) == 0 {
+		log.Debugf("getSnapshotsWithoutChangeIDAnnotation: No snapshots need change-id annotation")
+	}
+
+	return snapshotMap, volumeSnapMap, nil
+}
+
+// annotateSnapshotsFromCNSResults processes CNS QuerySnapshots results and annotates matching VolumeSnapshots.
+// This is separated to enable testability with mock volumeManager and coCommonInterface.
+// It delegates pagination to utils.QuerySnapshotsUtil which handles cursor management internally.
+func annotateSnapshotsFromCNSResults(
+	ctx context.Context,
+	volumeID string,
+	wantedSnapIDs map[string]struct{},
+	snapshotMap map[string]*snapv1.VolumeSnapshot,
+	volumeManager volumes.Manager,
+	coCommonInterface commonco.COCommonInterface,
+) int {
+	log := logger.GetLogger(ctx)
+
+	log.Debugf("annotateSnapshotsFromCNSResults: Processing volume %q with %d snapshots needing annotation",
+		volumeID, len(wantedSnapIDs))
+
+	// Build CnsSnapshotQueryFilter for the volume.
+	// utils.QuerySnapshotsUtil handles cursor-based pagination internally.
+	snapshotQueryFilter := cnstypes.CnsSnapshotQueryFilter{
+		SnapshotQuerySpecs: []cnstypes.CnsSnapshotQuerySpec{
+			{
+				VolumeId: cnstypes.CnsVolumeId{Id: volumeID},
+			},
+		},
+	}
+
+	// Query CNS for all snapshots of this volume; util handles pagination.
+	queryEntries, _, err := utils.QuerySnapshotsUtil(ctx, volumeManager, snapshotQueryFilter, common.QuerySnapshotLimit)
+	if err != nil {
+		log.Warnf("annotateSnapshotsFromCNSResults: QuerySnapshots failed for volume %q. Error: %v",
+			volumeID, err)
+		return 0
+	}
+
+	annotatedCount := 0
+	// Reuse single annotation map to reduce allocation pressure in loop
+	annotations := make(map[string]string, 1)
+
+	for _, entry := range queryEntries {
+		if entry.Error != nil {
+			log.Debugf("annotateSnapshotsFromCNSResults: skipping entry with fault for volume %q: %+v",
+				volumeID, entry.Error.Fault)
+			continue
+		}
+		snapID := entry.Snapshot.SnapshotId.Id
+		// Only process snapshots that need change-id annotation
+		if _, want := wantedSnapIDs[snapID]; !want {
+			continue
+		}
+		changeID := entry.Snapshot.ChangedBlockTrackingId
+		if changeID == "" {
+			log.Debugf("annotateSnapshotsFromCNSResults: No change-id found for snapshot %q in volume %q",
+				snapID, volumeID)
+			continue
+		}
+
+		vs, ok := snapshotMap[snapID]
+		if !ok {
+			log.Debugf("annotateSnapshotsFromCNSResults: VolumeSnapshot not found for snapshot %q", snapID)
+			continue
+		}
+
+		// Annotate the VolumeSnapshot - reuse annotations map
+		annotations[common.VolumeSnapshotChangeIDKey] = changeID
+		annotated, annotErr := coCommonInterface.AnnotateVolumeSnapshot(ctx, vs.Name, vs.Namespace, annotations)
+		if annotErr != nil || !annotated {
+			log.Warnf(
+				"annotateSnapshotsFromCNSResults: Failed to annotate VolumeSnapshot %q/%q with change-id. Error: %v",
+				vs.Namespace, vs.Name, annotErr)
+			continue
+		}
+		log.Infof(
+			"annotateSnapshotsFromCNSResults: Successfully set change-id annotation on "+
+				"VolumeSnapshot %q/%q with value: %q",
+			vs.Namespace, vs.Name, changeID)
+		annotatedCount++
+	}
+
+	return annotatedCount
+}
+
+// setChangeIDAnnotationOnSupervisorSnapshots reconciles the VolumeSnapshotChangeIDKey annotation on supervisor
+// VolumeSnapshots by fetching change-id from CNS snapshots using QuerySnapshots call.
+// It:
+// 1. Lists all supervisor VolumeSnapshots across all namespaces
+// 2. Resolves volumeID/snapshotID from each VolumeSnapshot's bound VolumeSnapshotContent
+// 3. Groups snapshots needing annotation by volumeID (selective - only volumes we care about)
+// 4. Queries CNS sequentially, one volume at a time (CNS does not parallelize requests)
+// 5. For each CNS query result, immediately annotates matching VolumeSnapshots
+// This ensures supervisor snapshots have complete metadata that can be mirrored to guest cluster snapshots.
+func setChangeIDAnnotationOnSupervisorSnapshots(ctx context.Context, metadataSyncer *metadataSyncInformer, vc string) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("setChangeIDAnnotationOnSupervisorSnapshots: Start for VC: %s", vc)
+
+	// Create snapshotter client for supervisor cluster
+	snapshotterClient, err := k8s.NewSnapshotterClient(ctx)
+	if err != nil {
+		log.Errorf("setChangeIDAnnotationOnSupervisorSnapshots: failed to get snapshotterClient. Error: %v", err)
+		return
+	}
+
+	// Build groupings of snapshots needing annotation
+	snapshotMap, volumeSnapMap, err := getSnapshotsWithoutChangeIDAnnotation(ctx, snapshotterClient)
+	if err != nil {
+		return
+	}
+
+	if len(volumeSnapMap) == 0 {
+		log.Debugf("setChangeIDAnnotationOnSupervisorSnapshots: No supervisor VolumeSnapshots need change-id annotation")
+		return
+	}
+
+	log.Infof(
+		"setChangeIDAnnotationOnSupervisorSnapshots: Found %d VolumeSnapshots across %d volumes needing change-id annotation",
+		len(snapshotMap), len(volumeSnapMap))
+
+	// Get volume manager and common interface for CNS queries and annotations
+	volumeManager := metadataSyncer.volumeManager
+	coCommonInterface := metadataSyncer.coCommonInterface
+
+	// Process each volume sequentially. CNS does not parallelize requests, so we
+	// query one volume at a time and annotate snapshots as results arrive.
+	totalAnnotatedCount := 0
+	for volumeID, wantedSnapIDs := range volumeSnapMap {
+		annotatedCount := annotateSnapshotsFromCNSResults(
+			ctx, volumeID, wantedSnapIDs, snapshotMap, volumeManager, coCommonInterface)
+		totalAnnotatedCount += annotatedCount
+	}
+
+	log.Infof(
+		"setChangeIDAnnotationOnSupervisorSnapshots: Completed. Annotated %d VolumeSnapshots with change-id",
+		totalAnnotatedCount)
+	log.Debugf("setChangeIDAnnotationOnSupervisorSnapshots: End for VC: %s", vc)
 }

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi"
 	cnstypes "github.com/vmware/govmomi/cns/types"
@@ -45,8 +46,10 @@ import (
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
-	commonco "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 	cnsvolumeoperationrequest "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
@@ -608,11 +611,13 @@ func (m *mockCOCommonForFullSync) ClearFakeAttached(ctx context.Context, volumeI
 
 func (m *mockCOCommonForFullSync) InitTopologyServiceInController(
 	ctx context.Context,
-) (commonco.ControllerTopologyService, error) {
+) (commoncotypes.ControllerTopologyService, error) {
 	return nil, nil
 }
 
-func (m *mockCOCommonForFullSync) InitTopologyServiceInNode(ctx context.Context) (commonco.NodeTopologyService, error) {
+func (m *mockCOCommonForFullSync) InitTopologyServiceInNode(
+	ctx context.Context,
+) (commoncotypes.NodeTopologyService, error) {
 	return nil, nil
 }
 
@@ -1295,4 +1300,242 @@ func TestSetFileShareAnnotationsOnPVC_ExistingAnnotations(t *testing.T) {
 	assert.Equal(t, "existing-value", pvc.Annotations["existing-annotation"])
 	assert.Equal(t, "192.168.1.100:/nfs/v3/path", pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
 	assert.Empty(t, pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+}
+
+// fakeVolumeManager is a test-only mock of volumes.Manager. It embeds
+// unittestcommon.MockVolumeManager (which implements all interface methods) and
+// overrides QuerySnapshots to return user-defined results for testing.
+type fakeVolumeManager struct {
+	*unittestcommon.MockVolumeManager
+	querySnapshotsFunc func(ctx context.Context, filter cnstypes.CnsSnapshotQueryFilter) (
+		*cnstypes.CnsSnapshotQueryResult, error)
+}
+
+func (f *fakeVolumeManager) QuerySnapshots(ctx context.Context,
+	filter cnstypes.CnsSnapshotQueryFilter) (*cnstypes.CnsSnapshotQueryResult, error) {
+	if f.querySnapshotsFunc != nil {
+		return f.querySnapshotsFunc(ctx, filter)
+	}
+	return nil, nil
+}
+
+// testCOCommonInterface embeds the FakeK8SOrchestrator from unittestcommon (which already
+// implements all COCommonInterface methods) and overrides only AnnotateVolumeSnapshot
+// to make it customizable per test.
+type testCOCommonInterface struct {
+	commonco.COCommonInterface
+	annotateFunc func(context.Context, string, string, map[string]string) (bool, error)
+}
+
+func (m *testCOCommonInterface) AnnotateVolumeSnapshot(
+	ctx context.Context,
+	name, namespace string,
+	annotations map[string]string,
+) (bool, error) {
+	if m.annotateFunc != nil {
+		return m.annotateFunc(ctx, name, namespace, annotations)
+	}
+	return m.COCommonInterface.AnnotateVolumeSnapshot(ctx, name, namespace, annotations)
+}
+
+// newTestCOInterface creates a testCOCommonInterface using the FakeK8SOrchestrator as a base.
+func newTestCOInterface(t *testing.T,
+	annotateFunc func(context.Context, string, string, map[string]string) (bool, error),
+) *testCOCommonInterface {
+	t.Helper()
+	base, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("failed to create fake CO interface: %v", err)
+	}
+	return &testCOCommonInterface{
+		COCommonInterface: base,
+		annotateFunc:      annotateFunc,
+	}
+}
+
+// TestAnnotateSnapshotsFromCNSResults_SuccessfulAnnotation tests annotation with sample data
+func TestAnnotateSnapshotsFromCNSResults_SuccessfulAnnotation(t *testing.T) {
+	ctx := context.Background()
+
+	// Create sample VolumeSnapshot
+	vs := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "snap-1",
+			Namespace:   "ns-1",
+			Annotations: make(map[string]string),
+		},
+	}
+
+	snapshotMap := map[string]*snapv1.VolumeSnapshot{"snap-id-123": vs}
+	wantedSnapIDs := map[string]struct{}{"snap-id-123": {}}
+
+	// Mock volume manager that returns CNS results with change-id when QuerySnapshots is called
+	mockVM := &fakeVolumeManager{
+		MockVolumeManager: &unittestcommon.MockVolumeManager{},
+		querySnapshotsFunc: func(ctx context.Context,
+			filter cnstypes.CnsSnapshotQueryFilter) (*cnstypes.CnsSnapshotQueryResult, error) {
+			// Verify that the filter is for the correct volume
+			if len(filter.SnapshotQuerySpecs) > 0 {
+				assert.Equal(t, "vol-123", filter.SnapshotQuerySpecs[0].VolumeId.Id)
+			}
+			return &cnstypes.CnsSnapshotQueryResult{
+				Entries: []cnstypes.CnsSnapshotQueryResultEntry{
+					{
+						Snapshot: cnstypes.CnsSnapshot{
+							SnapshotId:             cnstypes.CnsSnapshotId{Id: "snap-id-123"},
+							ChangedBlockTrackingId: "change-id-abc-123",
+						},
+					},
+				},
+				// Set Offset == TotalRecords to signal end of pagination
+				Cursor: cnstypes.CnsCursor{Offset: 1, TotalRecords: 1},
+			}, nil
+		},
+	}
+
+	// Create a mock coCommonInterface
+	mockCOInterface := newTestCOInterface(t,
+		func(ctx context.Context, name, namespace string, annotations map[string]string) (bool, error) {
+			assert.Equal(t, "snap-1", name)
+			assert.Equal(t, "ns-1", namespace)
+			assert.Equal(t, "change-id-abc-123", annotations[common.VolumeSnapshotChangeIDKey])
+			return true, nil
+		})
+
+	count := annotateSnapshotsFromCNSResults(ctx, "vol-123", wantedSnapIDs, snapshotMap, mockVM, mockCOInterface)
+
+	assert.Equal(t, 1, count)
+}
+
+// TestAnnotateSnapshotsFromCNSResults_NoChangeID tests handling of snapshots without change-id
+func TestAnnotateSnapshotsFromCNSResults_NoChangeID(t *testing.T) {
+	ctx := context.Background()
+
+	vs := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "snap-1",
+			Namespace:   "ns-1",
+			Annotations: make(map[string]string),
+		},
+	}
+
+	snapshotMap := map[string]*snapv1.VolumeSnapshot{"snap-id-123": vs}
+	wantedSnapIDs := map[string]struct{}{"snap-id-123": {}}
+
+	// Mock volume manager that returns CNS results with empty change-id
+	mockVM := &fakeVolumeManager{
+		MockVolumeManager: &unittestcommon.MockVolumeManager{},
+		querySnapshotsFunc: func(ctx context.Context,
+			filter cnstypes.CnsSnapshotQueryFilter) (*cnstypes.CnsSnapshotQueryResult, error) {
+			return &cnstypes.CnsSnapshotQueryResult{
+				Entries: []cnstypes.CnsSnapshotQueryResultEntry{
+					{
+						Snapshot: cnstypes.CnsSnapshot{
+							SnapshotId:             cnstypes.CnsSnapshotId{Id: "snap-id-123"},
+							ChangedBlockTrackingId: "",
+						},
+					},
+				},
+				Cursor: cnstypes.CnsCursor{Offset: 1, TotalRecords: 1},
+			}, nil
+		},
+	}
+
+	mockCOInterface := newTestCOInterface(t, nil)
+
+	count := annotateSnapshotsFromCNSResults(ctx, "vol-123", wantedSnapIDs, snapshotMap, mockVM, mockCOInterface)
+
+	// Should not annotate since change-id is empty
+	assert.Equal(t, 0, count)
+}
+
+// TestAnnotateSnapshotsFromCNSResults_QueryError tests error handling on CNS query failure
+func TestAnnotateSnapshotsFromCNSResults_QueryError(t *testing.T) {
+	ctx := context.Background()
+
+	vs := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "snap-1", Namespace: "ns-1"},
+	}
+
+	snapshotMap := map[string]*snapv1.VolumeSnapshot{"snap-id-123": vs}
+	wantedSnapIDs := map[string]struct{}{"snap-id-123": {}}
+
+	// Mock volume manager that returns CNS query error
+	mockVM := &fakeVolumeManager{
+		MockVolumeManager: &unittestcommon.MockVolumeManager{},
+		querySnapshotsFunc: func(ctx context.Context,
+			filter cnstypes.CnsSnapshotQueryFilter) (*cnstypes.CnsSnapshotQueryResult, error) {
+			return nil, errors.New("CNS query failed")
+		},
+	}
+
+	mockCOInterface := newTestCOInterface(t, nil)
+
+	count := annotateSnapshotsFromCNSResults(ctx, "vol-123", wantedSnapIDs, snapshotMap, mockVM, mockCOInterface)
+
+	// Should not annotate on error
+	assert.Equal(t, 0, count)
+}
+
+// TestAnnotateSnapshotsFromCNSResults_AnnotationFailure tests handling of annotation failures
+func TestAnnotateSnapshotsFromCNSResults_AnnotationFailure(t *testing.T) {
+	ctx := context.Background()
+
+	vs := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "snap-1", Namespace: "ns-1"},
+	}
+
+	snapshotMap := map[string]*snapv1.VolumeSnapshot{"snap-id-123": vs}
+	wantedSnapIDs := map[string]struct{}{"snap-id-123": {}}
+
+	// Mock volume manager returning a snapshot with valid change-id
+	mockVM := &fakeVolumeManager{
+		MockVolumeManager: &unittestcommon.MockVolumeManager{},
+		querySnapshotsFunc: func(ctx context.Context,
+			filter cnstypes.CnsSnapshotQueryFilter) (*cnstypes.CnsSnapshotQueryResult, error) {
+			return &cnstypes.CnsSnapshotQueryResult{
+				Entries: []cnstypes.CnsSnapshotQueryResultEntry{
+					{
+						Snapshot: cnstypes.CnsSnapshot{
+							SnapshotId:             cnstypes.CnsSnapshotId{Id: "snap-id-123"},
+							ChangedBlockTrackingId: "change-id-123",
+						},
+					},
+				},
+				Cursor: cnstypes.CnsCursor{Offset: 1, TotalRecords: 1},
+			}, nil
+		},
+	}
+
+	// Mock annotation failure
+	mockCOInterface := newTestCOInterface(t,
+		func(ctx context.Context, name, namespace string, annotations map[string]string) (bool, error) {
+			return false, errors.New("annotation failed")
+		})
+
+	count := annotateSnapshotsFromCNSResults(ctx, "vol-123", wantedSnapIDs, snapshotMap, mockVM, mockCOInterface)
+
+	// Should not count as annotated on failure
+	assert.Equal(t, 0, count)
+}
+
+// TestSetChangeIDAnnotationOnSupervisorSnapshots tests error handling when no snapshots exist
+func TestSetChangeIDAnnotationOnSupervisorSnapshots(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a mock metadataSyncer with minimal required fields
+	mockMetadataSyncer := &metadataSyncInformer{
+		volumeManager:     nil, // Will be patched
+		coCommonInterface: nil, // Will be patched
+	}
+
+	// Patch NewSnapshotterClient to return error
+	patchSnapshotClient := gomonkey.ApplyFunc(k8s.NewSnapshotterClient, func(_ context.Context) (interface{}, error) {
+		return nil, errors.New("test error - no snapshots")
+	})
+	defer patchSnapshotClient.Reset()
+
+	// Call should handle error gracefully
+	setChangeIDAnnotationOnSupervisorSnapshots(ctx, mockMetadataSyncer, "test-vc")
+	// If we get here without panicking, test passes
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds snapshot changeID as annotation on corresponding snapshot, if not added during snapshot creation, required by clients for CBT support. During snapshot creation, if CSI_Backup_API FSS is enabled, we added changeID associated with created snapshot as annotation on that snapshot in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3965, however it is a best effort operation, that might fail.
In such case, in order to populate the annotation and propogate it to guest cluster, full sync in supervisor cluster, queries underlying snapshot to fetch changeID (assigned during creation) and adds that as annotation on supervisor snapshot.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* Unittests passed

* VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1121/
```
Ran 6 of 2324 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2318 Skipped | 0 Flaked
```
* WCP precheckin failed (failure not related to change, also seen in other runs) - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1465/
```
Ran 12 of 1275 Specs
FAILURE! -- 11 Passed | 1 Failed | 1 Pending | 0 Skipped | 0 Flaked
```


Manually tested the logic that we query snapshot to get changeID, however CNS QueryVolume API changes to return changeID are still in progress, so could not get actual changeID

```
2026-05-05T10:03:51.170Z        DEBUG   syncer/fullsync.go:2111 setChangeIDAnnotationOnSupervisorSnapshots: Start for VC: lvn-dvm-10-161-217-241.dvm.lvn.broadcom.net   {"TraceId": "1daad12b-7c35-49cb-930e-99534a18465c"}
...
2026-05-05T10:03:51.227Z        INFO    syncer/fullsync.go:2131 setChangeIDAnnotationOnSupervisorSnapshots: Found 2 VolumeSnapshots across 2 volumes needing change-id annotation       {"TraceId": "1daad12b-7c35-49cb-930e-99534a18465c"}
2026-05-05T10:03:51.227Z        DEBUG   syncer/fullsync.go:2014 annotateSnapshotsFromCNSResults: Processing volume "bd20d5af-9f2c-48fd-a18b-fecbb0dde3a9" with 1 snapshots needing annotation   {"TraceId": "1daad12b-7c35-49cb-930e-99534a18465c"}
...
2026-05-05T10:03:51.326Z        DEBUG   syncer/fullsync.go:2059 annotateSnapshotsFromCNSResults: No change-id found for snapshot "106998fb-8fe1-43be-86b2-4a298864d8a1" in volume "bd20d5af-9f2c-48fd-a18b-fecbb0dde3a9"  {"TraceId": "1daad12b-7c35-49cb-930e-99534a18465c"}
2026-05-05T10:03:51.326Z        DEBUG   syncer/fullsync.go:2014 annotateSnapshotsFromCNSResults: Processing volume "18640273-dd1d-4196-bb7f-6e3478925285" with 1 snapshots needing annotation   {"TraceId": "1daad12b-7c35-49cb-930e-99534a18465c"}
...
2026-05-05T10:03:51.417Z        DEBUG   syncer/fullsync.go:2059 annotateSnapshotsFromCNSResults: No change-id found for snapshot "320b9fc3-0de1-4305-b3cf-df97740af1bf" in volume "18640273-dd1d-4196-bb7f-6e3478925285"  {"TraceId": "1daad12b-7c35-49cb-930e-99534a18465c"}
2026-05-05T10:03:51.417Z        INFO    syncer/fullsync.go:2146 setChangeIDAnnotationOnSupervisorSnapshots: Completed. Annotated 0 VolumeSnapshots with change-id       {"TraceId": "1daad12b-7c35-49cb-930e-99534a18465c"}
2026-05-05T10:03:51.417Z        DEBUG   syncer/fullsync.go:2147 setChangeIDAnnotationOnSupervisorSnapshots: End for VC: lvn-dvm-10-161-217-241.dvm.lvn.broadcom.net     {"TraceId": "1daad12b-7c35-49cb-930e-99534a18465c"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add snapshot changeID as annotation on corresponding snapshot on Supervisor, if not added during snapshot creation.
```
