### PR TITLE
Add snapshot changeID as annotation on corresponding snapshot in guest cluster, if not added during snapshot creation and present on corresponding supervisor cluster snapshot.

### DIFF
--- a/manifests/guestcluster/1.33/pvcsi.yaml
+++ b/manifests/guestcluster/1.33/pvcsi.yaml
@@ -667,6 +667,7 @@ data:
   "workload-domain-isolation": "true"
   "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "true"
+  "CSI_Backup_API": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.34/pvcsi.yaml
+++ b/manifests/guestcluster/1.34/pvcsi.yaml
@@ -744,6 +744,7 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "true"
   "vsan-file-volume-service-support": "false"
+  "CSI_Backup_API": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.35/pvcsi.yaml
+++ b/manifests/guestcluster/1.35/pvcsi.yaml
@@ -745,6 +745,7 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "true"
   "vsan-file-volume-service-support": "false"
+  "CSI_Backup_API": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.36/pvcsi.yaml
+++ b/manifests/guestcluster/1.36/pvcsi.yaml
@@ -745,6 +745,7 @@ data:
   "sv-pvc-snapshot-protection-finalizer": "true"
   "linked-clone-support": "true"
   "vsan-file-volume-service-support": "false"
+  "CSI_Backup_API": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/csi/service/wcpguest/controller_cbt.go
+++ b/pkg/csi/service/wcpguest/controller_cbt.go
@@ -120,7 +120,8 @@ func (c *controller) GetMetadataAllocated(
 					"failed to send allocated metadata to client: %v", err)
 			}
 		}
-
+		log.Infof("Successfully completed GetMetadataAllocated call to Supervisor for %s/%s (CSI handle=%s)",
+			svNamespace, svName, req.SnapshotId)
 		return nil
 	}
 
@@ -233,6 +234,9 @@ func (c *controller) GetMetadataDelta(
 					"failed to send delta metadata to client: %v", err)
 			}
 		}
+
+		log.Infof("Successfully completed GetMetadataDelta call to Supervisor:base=<change-id> target=%s/%s",
+			svNamespace, svTargetName)
 
 		return nil
 	}

--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -26,12 +26,14 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	restclient "k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
@@ -170,16 +172,22 @@ func PvcsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) er
 	// on the Supervisor PVC, which is requested from TKC Cluster
 	err = setGuestClusterDetailsOnSupervisorPVC(ctx, metadataSyncer, supervisorNamespace)
 	if err != nil {
-		log.Errorf("FullSync: Failed to set Guest Cluster data on SupervisorPVC. Err: %v", err)
-		return err
+		log.Warnf("FullSync: Failed to set Guest Cluster data on SupervisorPVC. Err: %v", err)
 	}
 	// Set csi.vsphere-volume labels and CNS finalizer on the Supervisor VolumeSnapshot which is
 	// requested from TKC Cluster, if SVPVCSnapshotProtectionFinalizer FSS enabled
 	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.SVPVCSnapshotProtectionFinalizer) {
 		err = setGuestClusterDetailsOnSupervisorSnapshot(ctx, metadataSyncer, supervisorNamespace)
 		if err != nil {
-			log.Errorf("FullSync: Failed to set Guest Cluster data on SupervisorSnapshot. Err: %v", err)
-			return err
+			log.Warnf("FullSync: Failed to set Guest Cluster data on SupervisorSnapshot. Err: %v", err)
+		}
+	}
+	// Add change-id annotation on guest cluster VolumeSnapshots from corresponding supervisor VolumeSnapshots,
+	// if it is not present yet and CSI_Backup_API FSS is enabled.
+	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSI_Backup_API_FSS) {
+		err = setChangeIDAnnotationOnGuestClusterSnapshot(ctx, metadataSyncer, supervisorNamespace)
+		if err != nil {
+			log.Warnf("FullSync: Failed to set change-id annotation on guest cluster snapshot. Err: %v", err)
 		}
 	}
 	log.Infof("FullSync: End")
@@ -559,91 +567,268 @@ func compareCnsVolumeMetadatas(guestObject *cnsvolumemetadatav1alpha1.CnsVolumeM
 	return true
 }
 
+// isReadyVolumeSnapshotContent checks if a VolumeSnapshotContent is ready to be processed.
+// It validates that:
+// - Driver is VSphereCSIDriver
+// - VolumeSnapshotRef.Name is not empty
+// - Status is populated and SnapshotHandle is set and not empty
+// - ReadyToUse flag is true
+func isReadyVolumeSnapshotContent(vsc *snapv1.VolumeSnapshotContent) bool {
+	if vsc.Spec.Driver != common.VSphereCSIDriverName {
+		return false
+	}
+	if vsc.Spec.VolumeSnapshotRef.Name == "" {
+		return false
+	}
+	if vsc.Status == nil || vsc.Status.SnapshotHandle == nil || *vsc.Status.SnapshotHandle == "" {
+		return false
+	}
+	return vsc.Status.ReadyToUse != nil && *vsc.Status.ReadyToUse
+}
+
+// getGuestAndSupervisorSnapshotClients creates snapshotter clients for both the guest cluster
+// and the supervisor cluster, returning the supervisor's REST config alongside so callers can
+// reuse it (e.g. to build a controller-runtime client against the supervisor).
+func getGuestAndSupervisorSnapshotClients(ctx context.Context, metadataSyncer *metadataSyncInformer) (
+	snapshotterClientSet.Interface, snapshotterClientSet.Interface, *restclient.Config, error) {
+	log := logger.GetLogger(ctx)
+	guestClient, err := k8s.NewSnapshotterClient(ctx)
+	if err != nil {
+		log.Errorf("failed to create guest snapshotter client. Error: %v", err)
+		return nil, nil, nil, err
+	}
+	supervisorRestConfig := k8s.GetRestClientConfigForSupervisor(ctx,
+		metadataSyncer.configInfo.Cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)
+	supervisorClient, err := k8s.NewSupervisorSnapshotClient(ctx, supervisorRestConfig)
+	if err != nil {
+		log.Errorf("failed to create supervisor snapshotter client. Error: %v", err)
+		return nil, nil, nil, err
+	}
+	return guestClient, supervisorClient, supervisorRestConfig, nil
+}
+
+// vscProcessFunc is a function that processes a single VSC with its supervisor snapshot.
+type vscProcessFunc func(ctx context.Context, vsc *snapv1.VolumeSnapshotContent,
+	supervisorVS *snapv1.VolumeSnapshot) error
+
+// processVSCsFromGuestCluster iterates through VolumeSnapshotContents from the guest cluster with pagination,
+// validates each one, retrieves the corresponding supervisor VolumeSnapshot, and invokes
+// a processor function for each valid pair. This consolidates the common pagination and
+// retrieval logic between snapshot synchronization operations.
+func processVSCsFromGuestCluster(ctx context.Context, guestSnapshotterClient snapshotterClientSet.Interface,
+	supervisorSnapshotterClient snapshotterClientSet.Interface, supervisorNamespace string,
+	processFunc vscProcessFunc) error {
+	log := logger.GetLogger(ctx)
+
+	const pageSize = 500
+	listOptions := metav1.ListOptions{Limit: pageSize}
+	for {
+		vscList, err := guestSnapshotterClient.SnapshotV1().VolumeSnapshotContents().List(ctx, listOptions)
+		if err != nil {
+			log.Errorf("processVSCsFromGuestCluster: failed to list guest VolumeSnapshotContents. Error: %v", err)
+			return err
+		}
+		if len(vscList.Items) == 0 {
+			log.Debugf("processVSCsFromGuestCluster: No more VolumeSnapshotContents in current page")
+			break
+		}
+		log.Debugf("processVSCsFromGuestCluster: Processing page with %d VolumeSnapshotContents", len(vscList.Items))
+
+		if err := processVolumeSnapshotContents(ctx, vscList.Items, supervisorSnapshotterClient, supervisorNamespace,
+			processFunc); err != nil {
+			return err
+		}
+
+		if vscList.Continue == "" {
+			break
+		}
+		listOptions.Continue = vscList.Continue
+	}
+	return nil
+}
+
+// processVolumeSnapshotContents processes a single batch of VSCs.
+func processVolumeSnapshotContents(ctx context.Context, vscItems []snapv1.VolumeSnapshotContent,
+	supervisorSnapshotterClient snapshotterClientSet.Interface, supervisorNamespace string,
+	processFunc vscProcessFunc) error {
+	log := logger.GetLogger(ctx)
+	for _, vsc := range vscItems {
+		if !isReadyVolumeSnapshotContent(&vsc) {
+			continue
+		}
+		supervisorVS, err := supervisorSnapshotterClient.SnapshotV1().VolumeSnapshots(supervisorNamespace).
+			Get(ctx, *vsc.Status.SnapshotHandle, metav1.GetOptions{})
+		if err != nil {
+			log.Debugf("processVolumeSnapshotContents: supervisor VolumeSnapshot %q not found for VSC %q. Error: %v",
+				*vsc.Status.SnapshotHandle, vsc.Name, err)
+			continue
+		}
+		if err := processFunc(ctx, &vsc, supervisorVS); err != nil {
+			log.Debugf("processVolumeSnapshotContents: processor failed for VSC %q. Error: %v", vsc.Name, err)
+			// Continue processing other VSCs even if one fails
+			continue
+		}
+	}
+	return nil
+}
+
+// newRuntimeClientWithSnapshotScheme builds a controller-runtime client for the given REST config
+// with the VolumeSnapshot v1 scheme registered, which is required for patching VolumeSnapshot
+// and VolumeSnapshotContent objects.
+func newRuntimeClientWithSnapshotScheme(restConfig *restclient.Config) (client.Client, error) {
+	scheme := runtime.NewScheme()
+	if err := snapv1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add VolumeSnapshot scheme: %w", err)
+	}
+	return client.New(restConfig, client.Options{Scheme: scheme})
+}
+
 func setGuestClusterDetailsOnSupervisorSnapshot(ctx context.Context, metadataSyncer *metadataSyncInformer,
 	supervisorNamespace string) error {
 	log := logger.GetLogger(ctx)
 	log.Debugf("Fullsync: Querying guest cluster API server for all VSC objects.")
-	// Create snaphotter client for guest cluster
-	snapshotterClient, err := k8s.NewSnapshotterClient(ctx)
+	snapshotterClient, supervisorSnapshotterClient, supervisorRestConfig, err :=
+		getGuestAndSupervisorSnapshotClients(ctx, metadataSyncer)
 	if err != nil {
-		log.Errorf("setGuestClusterDetailsOnSupervisorSnapshot: failed to get snapshotterClient with error: %v", err)
+		log.Errorf("setGuestClusterDetailsOnSupervisorSnapshot: failed to create snapshotter clients. Error: %v", err)
 		return err
 	}
-	vscList, err := snapshotterClient.SnapshotV1().VolumeSnapshotContents().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		log.Errorf("setGuestClusterDetailsOnSupervisorSnapshot: failed to list VolumeSnapshot with"+
-			" error: %v in namespace", err)
-		return err
-	}
-	// Create snaphotter client for supervisor cluster
-	restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx,
-		metadataSyncer.configInfo.Cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)
-	supervisorSnapshotterClient, err := k8s.NewSupervisorSnapshotClient(ctx, restClientConfig)
-	if err != nil {
-		log.Errorf("setGuestClusterDetailsOnSupervisorSnapshot: failed to create supervisorSnapshotterClient. "+
-			"Error: %+v", err)
-		return err
-	}
-	for _, vsc := range vscList.Items {
-		if (vsc.Spec.VolumeSnapshotRef.Name != "") &&
-			(vsc.Status != nil && vsc.Status.ReadyToUse != nil && *vsc.Status.ReadyToUse) {
-			svVS, err := supervisorSnapshotterClient.SnapshotV1().VolumeSnapshots(supervisorNamespace).
-				Get(ctx, *vsc.Status.SnapshotHandle, metav1.GetOptions{})
+
+	// Define the processor for supervisor snapshots
+	processFunc := func(ctx context.Context, vsc *snapv1.VolumeSnapshotContent, svVS *snapv1.VolumeSnapshot) error {
+		// Add label to Supervisor Snapshot that contains guest cluster details, if not present already.
+		tkcLabelPresent := true
+		key := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
+			metadataSyncer.configInfo.Cfg.GC.ClusterDistribution)
+		if val, ok := svVS.Labels[key]; !ok || val != metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID {
+			if svVS.Labels == nil {
+				svVS.Labels = make(map[string]string)
+			}
+			svVS.Labels[key] = metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID
+			tkcLabelPresent = false
+		}
+		// Add finalizer "cns.vmware.com/volumesnapshot-protection" to Supervisor snapshot, if not present already,
+		// to prevent accidental deletion from supervisor cluster
+		cnsFinalizerPresent := slices.Contains(svVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer)
+		if !cnsFinalizerPresent || !tkcLabelPresent {
+			original := svVS.DeepCopy()
+			if !cnsFinalizerPresent {
+				svVS.ObjectMeta.Finalizers = append(svVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer)
+			}
+
+			supervisorRuntimeClient, err := newRuntimeClientWithSnapshotScheme(supervisorRestConfig)
 			if err != nil {
-				msg := fmt.Sprintf("setGuestClusterDetailsOnSupervisorSnapshot: failed to retrieve supervisor"+
-					" Snapshot %q in %q namespace. Error: %+v", *vsc.Status.SnapshotHandle, supervisorNamespace,
-					err)
-				log.Error(msg)
-				continue
+				return fmt.Errorf("failed to create controller-runtime client for supervisor cluster. Error: %w", err)
 			}
-			// Add label to Supervisor Snapshot that contains guest cluster details, if not present already.
-			tkcLabelPresent := true
-			key := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
-				metadataSyncer.configInfo.Cfg.GC.ClusterDistribution)
-			if val, ok := svVS.Labels[key]; !ok || val != metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID {
-				if svVS.Labels == nil {
-					svVS.Labels = make(map[string]string)
-				}
-				svVS.Labels[key] = metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID
-				tkcLabelPresent = false
-			}
-			// Add finalizer "cns.vmware.com/volumesnapshot-protection" to Supervisor snapshot, if not present already,
-			// to prevent accidental deletion from supervisor cluster
-			cnsFinalizerPresent := slices.Contains(svVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer)
-			if !cnsFinalizerPresent || !tkcLabelPresent {
-				original := svVS.DeepCopy()
-				if !cnsFinalizerPresent {
-					svVS.ObjectMeta.Finalizers = append(svVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer)
-				}
 
-				// Create controller-runtime client for supervisor cluster with VolumeSnapshot scheme
-				supervisorRestConfig := k8s.GetRestClientConfigForSupervisor(ctx,
-					metadataSyncer.configInfo.Cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)
-
-				// Create scheme with VolumeSnapshot support
-				scheme := runtime.NewScheme()
-				if err := snapv1.AddToScheme(scheme); err != nil {
-					msg := fmt.Sprintf("failed to add VolumeSnapshot scheme: %+v", err)
-					log.Error(msg)
-					continue
-				}
-
-				supervisorRuntimeClient, err := client.New(supervisorRestConfig, client.Options{Scheme: scheme})
-				if err != nil {
-					msg := fmt.Sprintf("failed to create controller-runtime client for supervisor cluster. Error: %+v", err)
-					log.Error(msg)
-					continue
-				}
-
-				err = k8s.PatchObject(ctx, supervisorRuntimeClient, original, svVS)
-				if err != nil {
-					msg := fmt.Sprintf("failed to patch supervisor Snapshot: %q with guest cluster labels "+
-						"in %q namespace. Error: %+v", *vsc.Status.SnapshotHandle, supervisorNamespace, err)
-					log.Error(msg)
-					continue
-				}
+			err = k8s.PatchObject(ctx, supervisorRuntimeClient, original, svVS)
+			if err != nil {
+				return fmt.Errorf("failed to patch supervisor Snapshot %q with guest cluster labels in %q namespace. Error: %w",
+					*vsc.Status.SnapshotHandle, supervisorNamespace, err)
 			}
 		}
+		return nil
 	}
+
+	return processVSCsFromGuestCluster(ctx, snapshotterClient, supervisorSnapshotterClient, supervisorNamespace,
+		processFunc)
+}
+
+// reconcileGuestSnapshotAnnotation reconciles the change-id annotation between supervisor and guest snapshots
+func reconcileGuestSnapshotAnnotation(
+	ctx context.Context,
+	supervisorVS *snapv1.VolumeSnapshot,
+	guestVS *snapv1.VolumeSnapshot,
+	guestRuntimeClient client.Client) error {
+
+	log := logger.GetLogger(ctx)
+
+	// Reconcile VolumeSnapshotChangeIDKey annotation only
+	supervisorChangeID, supervisorHasChangeID := supervisorVS.Annotations[common.VolumeSnapshotChangeIDKey]
+	guestChangeID, guestHasChangeID := guestVS.Annotations[common.VolumeSnapshotChangeIDKey]
+
+	// Add change-id annotation only if:
+	// 1. Supervisor cluster has the annotation but guest cluster doesn't
+	// 2. Supervisor cluster has a non-empty value but guest cluster has an empty value
+	if supervisorHasChangeID && supervisorChangeID != "" && (!guestHasChangeID || guestChangeID == "") {
+		log.Infof(
+			"reconcileGuestSnapshotAnnotation: Guest VolumeSnapshot %q/%q "+
+				"missing annotation %q (supervisor has value: %q)",
+			guestVS.Namespace, guestVS.Name, common.VolumeSnapshotChangeIDKey, supervisorChangeID)
+
+		// Patch the guest VolumeSnapshot with the change-id annotation
+		original := guestVS.DeepCopy()
+		if guestVS.Annotations == nil {
+			guestVS.Annotations = make(map[string]string)
+		}
+		guestVS.Annotations[common.VolumeSnapshotChangeIDKey] = supervisorChangeID
+
+		err := k8s.PatchObject(ctx, guestRuntimeClient, original, guestVS)
+		if err != nil {
+			log.Warnf(
+				"reconcileGuestSnapshotAnnotation: failed to patch guest VolumeSnapshot %q/%q "+
+					"with annotation %q=%q. Error: %v",
+				guestVS.Namespace, guestVS.Name,
+				common.VolumeSnapshotChangeIDKey, supervisorChangeID, err)
+			return err
+		}
+		log.Infof(
+			"reconcileGuestSnapshotAnnotation: Successfully patched guest VolumeSnapshot %q/%q "+
+				"with annotation %q=%q",
+			guestVS.Namespace, guestVS.Name,
+			common.VolumeSnapshotChangeIDKey, supervisorChangeID)
+		return nil
+	}
+	return nil
+}
+
+// setChangeIDAnnotationOnGuestClusterSnapshot reconciles the VolumeSnapshotChangeIDKey annotation on guest cluster
+// VolumeSnapshots from corresponding supervisor VolumeSnapshots if it is not present yet.
+// This handles the case where the change-id annotation on the supervisor is available later after
+// the initial CreateSnapshot call, or when annotation attempt failed on the guest side during
+// the initial snapshot creation but succeeded on the supervisor side.
+func setChangeIDAnnotationOnGuestClusterSnapshot(ctx context.Context, metadataSyncer *metadataSyncInformer,
+	supervisorNamespace string) error {
+	log := logger.GetLogger(ctx)
+	log.Debugf("Fullsync: setChangeIDAnnotationOnGuestClusterSnapshot called")
+	guestSnapshotterClient, supervisorSnapshotterClient, _, err :=
+		getGuestAndSupervisorSnapshotClients(ctx, metadataSyncer)
+	if err != nil {
+		log.Errorf("setChangeIDAnnotationOnGuestClusterSnapshot: failed to create snapshotter clients. Error: %v", err)
+		return err
+	}
+	guestRestConfig, err := k8s.GetKubeConfig(ctx)
+	if err != nil {
+		log.Errorf("setChangeIDAnnotationOnGuestClusterSnapshot: failed to get guest rest config. Error: %v", err)
+		return err
+	}
+	guestRuntimeClient, err := newRuntimeClientWithSnapshotScheme(guestRestConfig)
+	if err != nil {
+		log.Errorf("setChangeIDAnnotationOnGuestClusterSnapshot: failed to create guest controller-runtime client. Error: %v",
+			err)
+		return err
+	}
+
+	// Define the processor for guest snapshots
+	processFunc := func(ctx context.Context, vsc *snapv1.VolumeSnapshotContent,
+		supervisorVS *snapv1.VolumeSnapshot) error {
+		// Get the guest VolumeSnapshot referenced by the VSC
+		guestVS, err := guestSnapshotterClient.SnapshotV1().
+			VolumeSnapshots(vsc.Spec.VolumeSnapshotRef.Namespace).
+			Get(ctx, vsc.Spec.VolumeSnapshotRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("guest VolumeSnapshot %q/%q not found referenced by VSC %q. Error: %w",
+				vsc.Spec.VolumeSnapshotRef.Namespace, vsc.Spec.VolumeSnapshotRef.Name, vsc.Name, err)
+		}
+		// Reconcile the annotation
+		return reconcileGuestSnapshotAnnotation(ctx, supervisorVS, guestVS, guestRuntimeClient)
+	}
+
+	if err := processVSCsFromGuestCluster(ctx, guestSnapshotterClient, supervisorSnapshotterClient, supervisorNamespace,
+		processFunc); err != nil {
+		return err
+	}
+
+	log.Infof("setChangeIDAnnotationOnGuestClusterSnapshot: Completed. Annotated VolumeSnapshots with change-id")
 	return nil
 }

--- a/pkg/syncer/pvcsi_fullsync_test.go
+++ b/pkg/syncer/pvcsi_fullsync_test.go
@@ -18,6 +18,7 @@ package syncer
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -40,6 +41,11 @@ import (
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
+
+// Pointer helper function
+func ptrTo[T any](v T) *T {
+	return &v
+}
 
 func TestGenerateVolumeNodeAffinity(t *testing.T) {
 	tests := []struct {
@@ -941,4 +947,536 @@ func TestPatchObjectErrorScenarios(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "test-value", updatedPVC.Labels["test-key"])
 	})
+}
+
+// TestReconcileGuestSnapshotAnnotation_SuccessfulAnnotation tests adding change-id annotation from supervisor to guest
+func TestReconcileGuestSnapshotAnnotation_SuccessfulAnnotation(t *testing.T) {
+	ctx := context.Background()
+
+	// Create supervisor VolumeSnapshot with change-id annotation
+	supervisorVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snap-supervisor-1",
+			Namespace: "vmware-system-csi",
+			Annotations: map[string]string{
+				common.VolumeSnapshotChangeIDKey: "change-id-abc123",
+			},
+		},
+	}
+
+	// Create guest VolumeSnapshot without change-id annotation
+	guestVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "snap-guest-1",
+			Namespace:   "guest-ns",
+			Annotations: make(map[string]string),
+		},
+	}
+
+	// Setup fake client with guest snapshot
+	scheme := runtime.NewScheme()
+	_ = snapv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(guestVS.DeepCopy()).
+		Build()
+
+	// Call reconcile function
+	err := reconcileGuestSnapshotAnnotation(ctx, supervisorVS, guestVS, fakeClient)
+	assert.NoError(t, err)
+
+	// Verify annotation was added to guest snapshot
+	updatedGuestVS := &snapv1.VolumeSnapshot{}
+	err = fakeClient.Get(ctx, client.ObjectKey{
+		Name:      guestVS.Name,
+		Namespace: guestVS.Namespace,
+	}, updatedGuestVS)
+	assert.NoError(t, err)
+	assert.Equal(t, "change-id-abc123",
+		updatedGuestVS.Annotations[common.VolumeSnapshotChangeIDKey],
+		"Guest snapshot should have change-id annotation from supervisor")
+}
+
+// TestReconcileGuestSnapshotAnnotation_SkipsWhenNoSupervisorAnnotation checks that
+// unannotated supervisor snapshots are skipped
+func TestReconcileGuestSnapshotAnnotation_SkipsWhenNoSupervisorAnnotation(t *testing.T) {
+	ctx := context.Background()
+
+	// Create supervisor VolumeSnapshot WITHOUT change-id annotation
+	supervisorVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "snap-supervisor-no-id",
+			Namespace:   "vmware-system-csi",
+			Annotations: make(map[string]string),
+		},
+	}
+
+	// Create guest VolumeSnapshot without change-id annotation
+	guestVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "snap-guest-no-id",
+			Namespace:   "guest-ns",
+			Annotations: make(map[string]string),
+		},
+	}
+
+	// Create guest VSC
+	// Setup fake client
+	scheme := runtime.NewScheme()
+	_ = snapv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(guestVS.DeepCopy()).
+		Build()
+
+	// Call reconcile function
+	err := reconcileGuestSnapshotAnnotation(ctx, supervisorVS, guestVS, fakeClient)
+	assert.NoError(t, err)
+
+	// Verify NO annotation was added to guest snapshot
+	updatedGuestVS := &snapv1.VolumeSnapshot{}
+	err = fakeClient.Get(ctx, client.ObjectKey{
+		Name:      guestVS.Name,
+		Namespace: guestVS.Namespace,
+	}, updatedGuestVS)
+	assert.NoError(t, err)
+	assert.NotContains(t, updatedGuestVS.Annotations, common.VolumeSnapshotChangeIDKey,
+		"Guest snapshot should NOT have change-id annotation when supervisor has none")
+}
+
+// TestReconcileGuestSnapshotAnnotation_SkipsWhenAlreadyAnnotated tests skipping when guest already has annotation
+func TestReconcileGuestSnapshotAnnotation_SkipsWhenAlreadyAnnotated(t *testing.T) {
+	ctx := context.Background()
+
+	// Create supervisor VolumeSnapshot with change-id annotation
+	supervisorVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snap-supervisor-annotated",
+			Namespace: "vmware-system-csi",
+			Annotations: map[string]string{
+				common.VolumeSnapshotChangeIDKey: "change-id-new",
+			},
+		},
+	}
+
+	// Create guest VolumeSnapshot that ALREADY has a different change-id annotation
+	guestVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snap-guest-already-annotated",
+			Namespace: "guest-ns",
+			Annotations: map[string]string{
+				common.VolumeSnapshotChangeIDKey: "change-id-old",
+			},
+		},
+	}
+
+	// Create guest VSC
+	// Setup fake client
+	scheme := runtime.NewScheme()
+	_ = snapv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(guestVS.DeepCopy()).
+		Build()
+
+	// Call reconcile function
+	err := reconcileGuestSnapshotAnnotation(ctx, supervisorVS, guestVS, fakeClient)
+	assert.NoError(t, err)
+
+	// Verify annotation was NOT changed (should remain old value)
+	updatedGuestVS := &snapv1.VolumeSnapshot{}
+	err = fakeClient.Get(ctx, client.ObjectKey{
+		Name:      guestVS.Name,
+		Namespace: guestVS.Namespace,
+	}, updatedGuestVS)
+	assert.NoError(t, err)
+	assert.Equal(t, "change-id-old",
+		updatedGuestVS.Annotations[common.VolumeSnapshotChangeIDKey],
+		"Guest snapshot should keep its existing annotation")
+}
+
+// TestReconcileGuestSnapshotAnnotation_PatchError tests error handling when patch fails
+func TestReconcileGuestSnapshotAnnotation_PatchError(t *testing.T) {
+	ctx := context.Background()
+
+	// Create supervisor VolumeSnapshot with change-id annotation
+	supervisorVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snap-supervisor-error",
+			Namespace: "vmware-system-csi",
+			Annotations: map[string]string{
+				common.VolumeSnapshotChangeIDKey: "change-id-error",
+			},
+		},
+	}
+
+	// Create guest VolumeSnapshot
+	guestVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "snap-guest-error",
+			Namespace:   "guest-ns",
+			Annotations: make(map[string]string),
+		},
+	}
+
+	// Create guest VSC
+	// Setup fake client WITHOUT the guest snapshot object (to cause patch error)
+	scheme := runtime.NewScheme()
+	_ = snapv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	// Call reconcile function - should return error
+	err := reconcileGuestSnapshotAnnotation(ctx, supervisorVS, guestVS, fakeClient)
+	assert.Error(t, err, "Patch should fail when guest snapshot doesn't exist in client")
+}
+
+// TestIsReadyVolumeSnapshotContent_ValidReady tests VSC that is ready
+func TestIsReadyVolumeSnapshotContent_ValidReady(t *testing.T) {
+	vsc := &snapv1.VolumeSnapshotContent{
+		Spec: snapv1.VolumeSnapshotContentSpec{
+			Driver: common.VSphereCSIDriverName,
+			VolumeSnapshotRef: v1.ObjectReference{
+				Name: "valid-name",
+			},
+		},
+		Status: &snapv1.VolumeSnapshotContentStatus{
+			SnapshotHandle: ptrTo("handle-123"),
+			ReadyToUse:     ptrTo(true),
+		},
+	}
+	assert.True(t, isReadyVolumeSnapshotContent(vsc), "Should return true for valid ready VSC")
+}
+
+// TestIsReadyVolumeSnapshotContent_InvalidDriver tests VSC with wrong driver
+func TestIsReadyVolumeSnapshotContent_InvalidDriver(t *testing.T) {
+	vsc := &snapv1.VolumeSnapshotContent{
+		Spec: snapv1.VolumeSnapshotContentSpec{
+			Driver: "different-driver",
+			VolumeSnapshotRef: v1.ObjectReference{
+				Name: "valid-name",
+			},
+		},
+		Status: &snapv1.VolumeSnapshotContentStatus{
+			SnapshotHandle: ptrTo("handle-123"),
+			ReadyToUse:     ptrTo(true),
+		},
+	}
+	assert.False(t, isReadyVolumeSnapshotContent(vsc), "Should return false for VSC with wrong driver")
+}
+
+// TestIsReadyVolumeSnapshotContent_MissingVolumeSnapshotRef tests VSC without VolumeSnapshotRef name
+func TestIsReadyVolumeSnapshotContent_MissingVolumeSnapshotRef(t *testing.T) {
+	vsc := &snapv1.VolumeSnapshotContent{
+		Spec: snapv1.VolumeSnapshotContentSpec{
+			Driver: common.VSphereCSIDriverName,
+			VolumeSnapshotRef: v1.ObjectReference{
+				Name: "",
+			},
+		},
+		Status: &snapv1.VolumeSnapshotContentStatus{
+			SnapshotHandle: ptrTo("handle-123"),
+			ReadyToUse:     ptrTo(true),
+		},
+	}
+	assert.False(t, isReadyVolumeSnapshotContent(vsc), "Should return false for VSC without VolumeSnapshotRef name")
+}
+
+// TestIsReadyVolumeSnapshotContent_NilStatus tests VSC with nil status
+func TestIsReadyVolumeSnapshotContent_NilStatus(t *testing.T) {
+	vsc := &snapv1.VolumeSnapshotContent{
+		Spec: snapv1.VolumeSnapshotContentSpec{
+			Driver: common.VSphereCSIDriverName,
+			VolumeSnapshotRef: v1.ObjectReference{
+				Name: "valid-name",
+			},
+		},
+		Status: nil,
+	}
+	assert.False(t, isReadyVolumeSnapshotContent(vsc), "Should return false for VSC with nil status")
+}
+
+// TestIsReadyVolumeSnapshotContent_NilSnapshotHandle tests VSC with nil snapshot handle
+func TestIsReadyVolumeSnapshotContent_NilSnapshotHandle(t *testing.T) {
+	vsc := &snapv1.VolumeSnapshotContent{
+		Spec: snapv1.VolumeSnapshotContentSpec{
+			Driver: common.VSphereCSIDriverName,
+			VolumeSnapshotRef: v1.ObjectReference{
+				Name: "valid-name",
+			},
+		},
+		Status: &snapv1.VolumeSnapshotContentStatus{
+			SnapshotHandle: nil,
+			ReadyToUse:     ptrTo(true),
+		},
+	}
+	assert.False(t, isReadyVolumeSnapshotContent(vsc), "Should return false for VSC with nil snapshot handle")
+}
+
+// TestIsReadyVolumeSnapshotContent_EmptySnapshotHandle tests VSC with empty snapshot handle
+func TestIsReadyVolumeSnapshotContent_EmptySnapshotHandle(t *testing.T) {
+	vsc := &snapv1.VolumeSnapshotContent{
+		Spec: snapv1.VolumeSnapshotContentSpec{
+			Driver: common.VSphereCSIDriverName,
+			VolumeSnapshotRef: v1.ObjectReference{
+				Name: "valid-name",
+			},
+		},
+		Status: &snapv1.VolumeSnapshotContentStatus{
+			SnapshotHandle: ptrTo(""),
+			ReadyToUse:     ptrTo(true),
+		},
+	}
+	assert.False(t, isReadyVolumeSnapshotContent(vsc), "Should return false for VSC with empty snapshot handle")
+}
+
+// TestIsReadyVolumeSnapshotContent_NotReady tests VSC with ReadyToUse=false
+func TestIsReadyVolumeSnapshotContent_NotReady(t *testing.T) {
+	vsc := &snapv1.VolumeSnapshotContent{
+		Spec: snapv1.VolumeSnapshotContentSpec{
+			Driver: common.VSphereCSIDriverName,
+			VolumeSnapshotRef: v1.ObjectReference{
+				Name: "valid-name",
+			},
+		},
+		Status: &snapv1.VolumeSnapshotContentStatus{
+			SnapshotHandle: ptrTo("handle-123"),
+			ReadyToUse:     ptrTo(false),
+		},
+	}
+	assert.False(t, isReadyVolumeSnapshotContent(vsc), "Should return false for VSC with ReadyToUse=false")
+}
+
+// TestIsReadyVolumeSnapshotContent_NilReadyToUse tests VSC with nil ReadyToUse
+func TestIsReadyVolumeSnapshotContent_NilReadyToUse(t *testing.T) {
+	vsc := &snapv1.VolumeSnapshotContent{
+		Spec: snapv1.VolumeSnapshotContentSpec{
+			Driver: common.VSphereCSIDriverName,
+			VolumeSnapshotRef: v1.ObjectReference{
+				Name: "valid-name",
+			},
+		},
+		Status: &snapv1.VolumeSnapshotContentStatus{
+			SnapshotHandle: ptrTo("handle-123"),
+			ReadyToUse:     nil,
+		},
+	}
+	assert.False(t, isReadyVolumeSnapshotContent(vsc), "Should return false for VSC with nil ReadyToUse")
+}
+
+// ============================================================================
+// High-Level Integration Tests for setGuestClusterDetailsOnSupervisorSnapshot and
+// setChangeIDAnnotationOnGuestClusterSnapshot
+// ============================================================================
+
+// TestSetGuestClusterDetailsOnSupervisorSnapshot_AddsLabelsAndFinalizers tests the high-level function
+func TestSetGuestClusterDetailsOnSupervisorSnapshot_AddsLabelsAndFinalizers(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup supervisor snapshot without labels or finalizers
+	supervisorVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "supervisor-snap",
+			Namespace:  "vmware-system-csi",
+			Labels:     make(map[string]string),
+			Finalizers: []string{},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = snapv1.AddToScheme(scheme)
+
+	// Create fake supervisor client with the snapshot
+	supervisorClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(supervisorVS).
+		Build()
+
+	// Test the logic of adding labels and finalizers
+	key := "test-cluster/tkgs"
+	expected := "test-cluster-uid"
+
+	// Simulate what setGuestClusterDetailsOnSupervisorSnapshot does
+	if supervisorVS.Labels == nil {
+		supervisorVS.Labels = make(map[string]string)
+	}
+	supervisorVS.Labels[key] = expected
+
+	if !slices.Contains(supervisorVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer) {
+		supervisorVS.ObjectMeta.Finalizers = append(supervisorVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer)
+	}
+
+	// Patch the object
+	original := supervisorVS.DeepCopy()
+	original.Labels = make(map[string]string)
+	original.Finalizers = []string{}
+
+	err := k8s.PatchObject(ctx, supervisorClient, original, supervisorVS)
+	assert.NoError(t, err)
+
+	// Verify the patch was applied
+	updatedVS := &snapv1.VolumeSnapshot{}
+	err = supervisorClient.Get(ctx, client.ObjectKey{
+		Name:      supervisorVS.Name,
+		Namespace: supervisorVS.Namespace,
+	}, updatedVS)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, updatedVS.Labels[key], "Label should be set correctly")
+	assert.Contains(t, updatedVS.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer, "Finalizer should be added")
+}
+
+// TestSetGuestClusterDetailsOnSupervisorSnapshot_PreservesExistingLabelsAndFinalizers tests that existing
+// labels/finalizers are preserved
+func TestSetGuestClusterDetailsOnSupervisorSnapshot_PreservesExistingLabelsAndFinalizers(t *testing.T) {
+	ctx := context.Background()
+
+	supervisorVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "supervisor-snap",
+			Namespace: "vmware-system-csi",
+			Labels: map[string]string{
+				"existing-label": "existing-value",
+			},
+			Finalizers: []string{"existing-finalizer"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = snapv1.AddToScheme(scheme)
+
+	supervisorClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(supervisorVS).
+		Build()
+
+	// Simulate adding new label while preserving existing one
+	key := "test-cluster/tkgs"
+	supervisorVS.Labels[key] = "test-cluster-uid"
+
+	// Add finalizer if not present
+	if !slices.Contains(supervisorVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer) {
+		supervisorVS.ObjectMeta.Finalizers = append(supervisorVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer)
+	}
+
+	// Patch the object
+	original := supervisorVS.DeepCopy()
+	original.Labels = map[string]string{"existing-label": "existing-value"}
+	original.Finalizers = []string{"existing-finalizer"}
+
+	err := k8s.PatchObject(ctx, supervisorClient, original, supervisorVS)
+	assert.NoError(t, err)
+
+	// Verify both old and new labels/finalizers are present
+	updatedVS := &snapv1.VolumeSnapshot{}
+	err = supervisorClient.Get(ctx, client.ObjectKey{
+		Name:      supervisorVS.Name,
+		Namespace: supervisorVS.Namespace,
+	}, updatedVS)
+	assert.NoError(t, err)
+	assert.Equal(t, "existing-value", updatedVS.Labels["existing-label"], "Existing label should be preserved")
+	assert.Equal(t, "test-cluster-uid", updatedVS.Labels["test-cluster/tkgs"], "New label should be added")
+	assert.Contains(t, updatedVS.Finalizers, "existing-finalizer", "Existing finalizer should be preserved")
+	assert.Contains(t, updatedVS.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer, "New finalizer should be added")
+}
+
+// TestSetChangeIDAnnotationOnGuestClusterSnapshot_AddsChangeIDAnnotation tests annotation reconciliation
+func TestSetChangeIDAnnotationOnGuestClusterSnapshot_AddsChangeIDAnnotation(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup supervisor snapshot with change-id annotation
+	supervisorVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "supervisor-snap",
+			Namespace: "vmware-system-csi",
+			Annotations: map[string]string{
+				common.VolumeSnapshotChangeIDKey: "change-id-123",
+			},
+		},
+	}
+
+	// Setup guest snapshot without change-id annotation
+	guestVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "guest-snap",
+			Namespace:   "default",
+			Annotations: make(map[string]string),
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = snapv1.AddToScheme(scheme)
+
+	guestClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(guestVS).
+		Build()
+
+	// Simulate what reconcileGuestSnapshotAnnotation does
+	supervisorChangeID := supervisorVS.Annotations[common.VolumeSnapshotChangeIDKey]
+	if guestVS.Annotations == nil {
+		guestVS.Annotations = make(map[string]string)
+	}
+	guestVS.Annotations[common.VolumeSnapshotChangeIDKey] = supervisorChangeID
+
+	// Patch the object
+	original := guestVS.DeepCopy()
+	original.Annotations = make(map[string]string)
+
+	err := k8s.PatchObject(ctx, guestClient, original, guestVS)
+	assert.NoError(t, err)
+
+	// Verify the annotation was added
+	updatedVS := &snapv1.VolumeSnapshot{}
+	err = guestClient.Get(ctx, client.ObjectKey{
+		Name:      guestVS.Name,
+		Namespace: guestVS.Namespace,
+	}, updatedVS)
+	assert.NoError(t, err)
+	assert.Equal(t, "change-id-123", updatedVS.Annotations[common.VolumeSnapshotChangeIDKey],
+		"Change-id annotation should be added from supervisor")
+}
+
+// TestSetChangeIDAnnotationOnGuestClusterSnapshot_SkipsWhenAlreadyAnnotated tests that existing
+// annotation is not overwritten
+func TestSetChangeIDAnnotationOnGuestClusterSnapshot_SkipsWhenAlreadyAnnotated(t *testing.T) {
+	supervisorVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "supervisor-snap",
+			Namespace: "vmware-system-csi",
+			Annotations: map[string]string{
+				common.VolumeSnapshotChangeIDKey: "new-change-id",
+			},
+		},
+	}
+
+	guestVS := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guest-snap",
+			Namespace: "default",
+			Annotations: map[string]string{
+				common.VolumeSnapshotChangeIDKey: "old-change-id",
+			},
+		},
+	}
+
+	// Simulate reconcileGuestSnapshotAnnotation logic - should not update if guest already has annotation
+	supervisorChangeID := supervisorVS.Annotations[common.VolumeSnapshotChangeIDKey]
+	guestChangeID, guestHasChangeID := guestVS.Annotations[common.VolumeSnapshotChangeIDKey]
+
+	// The reconcile function only adds/updates if supervisor has annotation and guest doesn't or has empty value
+	if guestHasChangeID && guestChangeID != "" {
+		// Skip - guest already has a non-empty change-id
+		// so we don't patch
+	} else {
+		// Would patch in real function
+		if guestVS.Annotations == nil {
+			guestVS.Annotations = make(map[string]string)
+		}
+		guestVS.Annotations[common.VolumeSnapshotChangeIDKey] = supervisorChangeID
+	}
+
+	// Verify guest annotation was NOT changed (still has old value)
+	assert.Equal(t, "old-change-id", guestVS.Annotations[common.VolumeSnapshotChangeIDKey],
+		"Existing guest annotation should not be overwritten")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds snapshot changeID as annotation on corresponding snapshot, if not added during snapshot creation, required by clients for CBT support. During snapshot creation, if CSI_Backup_API FSS is enabled, we added changeID associated with created snapshot as annotation on that snapshot in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3957 if already present on underlying Supervisor snapshot, however it is a best effort operation, that might fail.
In such case, in order to populate the annotation, full sync queries underlying supervisor snapshot to fetch changeID (assigned during creation) and adds that as annotation on guest cluster snapshot.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* Unittests passed
* VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1144/
```
Ran 6 of 2357 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2351 Skipped | 0 Flaked
```
* WCP precheckin failed (failure not related to change, also seen in other runs) - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1499/
```
Ran 14 of 1275 Specs
FAILURE! -- 10 Passed | 4 Failed | 0 Pending | 1261 Skipped | 0 Flaked
```

Manually verified changeID added to guest cluster snapshot if not present already but present on supervisor snapshot.

```
Given snapshot example-raw-block-snapshot present in guest cluster with no annotation for changeid

root@423b421ebb85d942dab0f953e9d77849 [ ~ ]# k get vs -A -o yaml
apiVersion: v1
items:
- apiVersion: snapshot.storage.k8s.io/v1
  kind: VolumeSnapshot
  metadata:
    annotations:  
      csi.vsphere.volume/snapshot: f42d2f22-f4cf-4a03-9ece-59f115da343a+a893f6b1-08e7-4a47-af68-64c2b31ed21e      <<<< no change id 
    creationTimestamp: "2026-05-11T07:04:45Z"
    finalizers:
    - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
    generation: 1
    name: example-raw-block-snapshot
    namespace: default
    resourceVersion: "1306219"
    uid: 50a542bf-51cb-4897-8e58-49429d9ef096
  spec:
    source:
      persistentVolumeClaimName: example-raw-block-pvc
    volumeSnapshotClassName: volumesnapshotclass-delete
  status:
    boundVolumeSnapshotContentName: snapcontent-50a542bf-51cb-4897-8e58-49429d9ef096
    creationTime: "2026-05-11T07:04:53Z"
    readyToUse: true
    restoreSize: 1Gi
kind: List
metadata:
  resourceVersion: ""
root@423b421ebb85d942dab0f953e9d77849 [ ~ ]#

root@423b421ebb85d942dab0f953e9d77849 [ ~ ]# k edit deploy -n vmware-system-csi vsphere-csi-controller
root@423b421ebb85d942dab0f953e9d77849 [ ~ ]# k edit cm -n vmware-system-csi internal-feature-states.csi.vsphere.vmware.com   << enable internal FSS manually in guest cluster

After full sync run after pod startup, annotation got added to corresponding snapshot

root@423b421ebb85d942dab0f953e9d77849 [ ~ ]# k get vs -A -o yaml
apiVersion: v1
items:
- apiVersion: snapshot.storage.k8s.io/v1
  kind: VolumeSnapshot
  metadata:
    annotations:
      csi.vsphere.volume/change-id: 52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d/5
      csi.vsphere.volume/snapshot: f42d2f22-f4cf-4a03-9ece-59f115da343a+a893f6b1-08e7-4a47-af68-64c2b31ed21e
    creationTimestamp: "2026-05-11T07:04:45Z"
    finalizers:
    - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
    generation: 1
    name: example-raw-block-snapshot
    namespace: default
    resourceVersion: "1312907"
    uid: 50a542bf-51cb-4897-8e58-49429d9ef096
  spec:
    source:
      persistentVolumeClaimName: example-raw-block-pvc
    volumeSnapshotClassName: volumesnapshotclass-delete
  status:
    boundVolumeSnapshotContentName: snapcontent-50a542bf-51cb-4897-8e58-49429d9ef096
    creationTime: "2026-05-11T07:04:53Z"
    readyToUse: true
    restoreSize: 1Gi
kind: List
metadata:
  resourceVersion: ""
root@423b421ebb85d942dab0f953e9d77849 [ ~ ]#
```

Full sync logs:

```
2026-05-11T07:40:09.560Z        DEBUG   k8sorchestrator/k8sorchestrator.go:1502 Supervisor capability "supports_CSI_Backup_API" is set to true  {"TraceId": "cc77cc0c-87de-4d35-93bc-9b2f20fc1672"}
2026-05-11T07:40:09.560Z        DEBUG   syncer/pvcsi_fullsync.go:791    Fullsync: setChangeIDAnnotationOnGuestClusterSnapshot called    {"TraceId": "cc77cc0c-87de-4d35-93bc-9b2f20fc1672"}

2026-05-11T07:40:09.569Z        DEBUG   syncer/pvcsi_fullsync.go:634    processVSCsFromGuestCluster: Processing page with 1 VolumeSnapshotContents      {"TraceId": "cc77cc0c-87de-4d35-93bc-9b2f20fc1672"}
2026-05-11T07:40:09.599Z        INFO    syncer/pvcsi_fullsync.go:752    reconcileGuestSnapshotAnnotation: Guest VolumeSnapshot "default"/"example-raw-block-snapshot" missing annotation "csi.vsphere.volume/change-id" (supervisor has value: "52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d/5")       {"TraceId": "cc77cc0c-87de-4d35-93bc-9b2f20fc1672"}

2026-05-11T07:40:09.654Z        DEBUG   kubernetes/kubernetes.go:915    PatchObject: Successfully patched object default/example-raw-block-snapshot     {"TraceId": "cc77cc0c-87de-4d35-93bc-9b2f20fc1672"}
2026-05-11T07:40:09.654Z        INFO    syncer/pvcsi_fullsync.go:773    reconcileGuestSnapshotAnnotation: Successfully patched guest VolumeSnapshot "default"/"example-raw-block-snapshot" with annotation "csi.vsphere.volume/change-id"="52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d/5"     {"TraceId": "cc77cc0c-87de-4d35-93bc-9b2f20fc1672"}
2026-05-11T07:40:09.655Z        INFO    syncer/pvcsi_fullsync.go:829    setChangeIDAnnotationOnGuestClusterSnapshot: Completed. Annotated VolumeSnapshots with change-id        {"TraceId": "cc77cc0c-87de-4d35-93bc-9b2f20fc1672"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add snapshot changeID as annotation on corresponding snapshot in guest cluster, if not added during snapshot creation and present on corresponding supervisor cluster snapshot.
```
