### PR TITLE
Fix PvCSI service account regex security vulnerability (SUP-VULN-0009)

### DIFF
--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -785,6 +785,9 @@ rules:
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
     verbs: ["get", "list"]
+  - apiGroups: ["vmware.infrastructure.cluster.x-k8s.io"]
+    resources: ["vsphereclusters"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -785,6 +785,9 @@ rules:
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
     verbs: ["get", "list"]
+  - apiGroups: ["vmware.infrastructure.cluster.x-k8s.io"]
+    resources: ["vsphereclusters"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -785,6 +785,9 @@ rules:
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
     verbs: ["get", "list"]
+  - apiGroups: ["vmware.infrastructure.cluster.x-k8s.io"]
+    resources: ["vsphereclusters"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -208,10 +208,10 @@ func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request
 		if featureFileVolumesWithVmServiceEnabled {
 			switch req.Operation {
 			case admissionv1.Create:
-				admissionResp := validateCreateCnsFileAccessConfig(ctx, h.clientConfig, &req.AdmissionRequest)
+				admissionResp := validateCreateCnsFileAccessConfig(ctx, h.clientConfig, &req.AdmissionRequest, h.Client)
 				resp.AdmissionResponse = *admissionResp.DeepCopy()
 			case admissionv1.Delete:
-				admissionResp := validateDeleteCnsFileAccessConfig(ctx, h.clientConfig, &req.AdmissionRequest)
+				admissionResp := validateDeleteCnsFileAccessConfig(ctx, h.clientConfig, &req.AdmissionRequest, h.Client)
 				resp.AdmissionResponse = *admissionResp.DeepCopy()
 			}
 		}
@@ -331,7 +331,7 @@ func (h *CSISupervisorMutationWebhook) mutateNewCnsFileAccessConfig(ctx context.
 	}
 
 	// If CR is created by CSI service account, do not add devops label.
-	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username)
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username, h.Client)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -331,7 +331,7 @@ func (h *CSISupervisorMutationWebhook) mutateNewCnsFileAccessConfig(ctx context.
 	}
 
 	// If CR is created by CSI service account, do not add devops label.
-	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(req.UserInfo.Username)
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
@@ -225,7 +225,7 @@ func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 }
 
 // isUserAllowedForDeletion returns true if user is either a PVCSI service account or
-// K8s' namespace-cotnroller.
+// K8s' namespace-controller.
 func isUserAllowedForDeletion(ctx context.Context, username string, k8sClient client.Client) (bool, error) {
 	kubernetesServiceAccount, err := regexp.Compile(KubernetesServiceAccount)
 	if err != nil {
@@ -307,7 +307,7 @@ func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccou
 	// validate VSphereCluster resource exists
 	found, err := validateVSphereClusterResource(ctx, clusterName, namespace, k8sClient)
 	if err != nil {
-		return false, fmt.Errorf("failed to check VSphereCluster resource: %v", err)
+		return false, fmt.Errorf("failed to check VSphereCluster resource: %w", err)
 	}
 	if found {
 		log.Infof("Found VSphereCluster '%s' in namespace '%s', service account '%s' is valid",

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
@@ -280,7 +280,7 @@ func validatePvCSIServiceAccount(ctx context.Context, username string) (bool, er
 	// For any namespace, check if service account follows guest cluster PvCSI pattern
 	// Guest cluster PvCSI service accounts follow the pattern: {cluster-name}-pvcsi
 	if strings.HasSuffix(serviceAccountName, "-pvcsi") {
-		log.Errorf("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
+		log.Infof("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
 		return validateProviderServiceAccount(ctx, namespace, serviceAccountName)
 	}
 
@@ -316,7 +316,7 @@ func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccou
 	// validate VSphereCluster resource exists
 	found, err := validateVSphereClusterResource(ctx, clusterName, namespace)
 	if err != nil {
-		log.Warnf("Failed to check VSphereCluster resource: %v", err)
+		return false, fmt.Errorf("Failed to check VSphereCluster resource: %v", err)
 	}
 	if found {
 		log.Infof("Found VSphereCluster '%s' in namespace '%s', service account '%s' is valid",

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package admissionhandler
 
 import (
@@ -5,11 +21,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	admissionv1 "k8s.io/api/admission/v1"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 
@@ -21,7 +41,6 @@ import (
 
 const (
 	KubernetesServiceAccount = "system:serviceaccount:kube-system"
-	PvCsiServiceAccountregex = "^system:serviceaccount.*-pvcsi$"
 	KubernetesAdmin          = "kubernetes-admin"
 )
 
@@ -132,7 +151,7 @@ func cnsFileAccessConfigAlreadyExists(ctx context.Context, clientConfig *rest.Co
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
-		log.Errorf("failed to list CnsFileAccessConfigList CRs from %s namesapace. Error: %+v",
+		log.Errorf("failed to list CnsFileAccessConfigList CRs from %s namespace. Error: %+v",
 			namespace, err)
 		return "", err
 	}
@@ -209,33 +228,153 @@ func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 // isUserAllowedForDeletion returns true if user is either a PVCSI service account or
 // K8s' namespace-cotnroller.
 func isUserAllowedForDeletion(username string) (bool, error) {
-	pvcCsiServiceAccountRegex, err := regexp.Compile(PvCsiServiceAccountregex)
-	if err != nil {
-		return false, err
-	}
-
 	kubernetesServiceAccount, err := regexp.Compile(KubernetesServiceAccount)
 	if err != nil {
 		return false, err
 	}
 
+	// Check if user is a valid PVCSI service account using the new validation logic
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(username)
+	if err != nil {
+		return false, err
+	}
+	if isPvCSIServiceAccount {
+		return true, nil
+	}
+
 	// Allowed users are :
-	// 1. PVCSI service account
+	// 1. PVCSI service account (checked above using new validation logic)
 	// 2. K8s service account (like namespace-controller or generic-garbage-collector)
 	// 3. K8s admin
-	if pvcCsiServiceAccountRegex.MatchString(username) ||
-		kubernetesServiceAccount.MatchString(username) || username == KubernetesAdmin {
+	if kubernetesServiceAccount.MatchString(username) || username == KubernetesAdmin {
 		return true, nil
-
 	}
 
 	return false, nil
 }
 
 func validatePvCSIServiceAccount(username string) (bool, error) {
-	pvcCsiServiceAccountRegex, err := regexp.Compile(PvCsiServiceAccountregex)
-	if err != nil {
-		return false, err // fail open
+	ctx := context.TODO()
+	log := logger.GetLogger(ctx)
+
+	log.Infof("Validating PvCSI service account: username=%s", username)
+
+	// Expected format: "system:serviceaccount:namespace:service-account-name"
+	// Parse the username to extract namespace and service account name
+	const prefix = "system:serviceaccount:"
+	if !strings.HasPrefix(username, prefix) {
+		log.Infof("Username doesn't have service account prefix, returning false")
+		return false, nil
 	}
-	return pvcCsiServiceAccountRegex.MatchString(username), nil
+
+	remaining := strings.TrimPrefix(username, prefix)
+	parts := strings.Split(remaining, ":")
+	log.Infof("Parsed service account parts: %v (count: %d)", parts, len(parts))
+
+	if len(parts) != 2 {
+		log.Infof("Invalid service account format - expected 2 parts, got %d, returning false", len(parts))
+		return false, nil
+	}
+
+	namespace := parts[0]
+	serviceAccountName := parts[1]
+	log.Infof("Extracted namespace=%s, serviceAccountName=%s", namespace, serviceAccountName)
+
+	// For any namespace, check if service account follows guest cluster PvCSI pattern
+	// Guest cluster PvCSI service accounts follow the pattern: {cluster-name}-pvcsi
+	if strings.HasSuffix(serviceAccountName, "-pvcsi") {
+		log.Infof("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
+		return validateProviderServiceAccount(ctx, namespace, serviceAccountName)
+	}
+
+	log.Infof("Service account doesn't match any PvCSI patterns, returning false")
+	return false, nil
+}
+
+// getVSphereClusterClient creates a Kubernetes client for VSphere cluster API operations using dynamic client
+func getVSphereClusterClient(ctx context.Context) (client.Client, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Use a dynamic client that can work with any API group/version
+	return client.New(config, client.Options{})
+}
+
+// validateProviderServiceAccount validates the service account name against all available clusters
+func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccountName string) (bool, error) {
+	log := logger.GetLogger(ctx)
+	log.Infof("Validating provider service account '%s' in namespace '%s'", serviceAccountName, namespace)
+
+	// Extract expected vsphere cluster name from service account name
+	// serviceAccountName format: "{vsphere-cluster-name}-pvcsi"
+	if !strings.HasSuffix(serviceAccountName, "-pvcsi") {
+		log.Infof("Service account '%s' does not follow cluster pattern (missing -pvcsi suffix)", serviceAccountName)
+		return false, nil
+	}
+
+	clusterName := strings.TrimSuffix(serviceAccountName, "-pvcsi")
+	if clusterName == "" {
+		log.Warnf("Empty vsphere cluster name extracted from service account '%s'", serviceAccountName)
+		return false, nil
+	}
+
+	log.Infof("Extracted vsphere cluster name '%s' from service account '%s', searching in namespace '%s'",
+		clusterName, serviceAccountName, namespace)
+
+	// validate VSphereCluster resource exists
+	found, err := validateVSphereClusterResource(ctx, clusterName, namespace)
+	if err != nil {
+		log.Warnf("Failed to check VSphereCluster resource: %v", err)
+	}
+	if found {
+		log.Infof("Found VSphereCluster '%s' in namespace '%s', service account '%s' is valid",
+			clusterName, namespace, serviceAccountName)
+		return true, nil
+	}
+
+	log.Infof("VSphereCluster with name :'%s' not found in namespace '%s', So service account '%s' is not valid",
+		clusterName, namespace, serviceAccountName)
+	return false, nil
+}
+
+// validateVSphereClusterResource checks if a VSphereCluster resource exists using dynamic client
+func validateVSphereClusterResource(ctx context.Context, clusterName, namespace string) (bool, error) {
+	log := logger.GetLogger(ctx)
+
+	k8sClient, err := getVSphereClusterClient(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to create VSphere cluster API client: %w", err)
+	}
+
+	// Use unstructured object to work with the actual VSphereCluster API group/version deployed in the cluster
+	vsphereCluster := &unstructured.Unstructured{}
+	vsphereCluster.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "vmware.infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2", // Use the version we saw in kubectl api-resources
+		Kind:    "VSphereCluster",
+	})
+
+	err = k8sClient.Get(ctx, client.ObjectKey{
+		Name:      clusterName,
+		Namespace: namespace,
+	}, vsphereCluster)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Infof("VSphereCluster '%s' not found in namespace '%s'", clusterName, namespace)
+			return false, nil
+		}
+
+		if errors.IsForbidden(err) {
+			log.Warnf("Access denied when checking VSphereCluster '%s' in namespace '%s'", clusterName, namespace)
+			return false, fmt.Errorf("insufficient permissions to validate VSphere cluster: %w", err)
+		}
+
+		return false, fmt.Errorf("failed to get VSphereCluster '%s' in namespace '%s': %w", clusterName, namespace, err)
+	}
+
+	log.Infof("Found VSphereCluster '%s' in namespace '%s'", clusterName, namespace)
+	return true, nil
 }

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
@@ -254,7 +254,7 @@ func isUserAllowedForDeletion(ctx context.Context, username string, k8sClient cl
 func validatePvCSIServiceAccount(ctx context.Context, username string, k8sClient client.Client) (bool, error) {
 	log := logger.GetLogger(ctx)
 
-	log.Infof("Validating PvCSI service account: username=%s", username)
+	log.Debugf("Validating PvCSI service account: username=%s", username)
 
 	// Expected format: "system:serviceaccount:namespace:service-account-name"
 	// Parse the username to extract namespace and service account name
@@ -266,7 +266,7 @@ func validatePvCSIServiceAccount(ctx context.Context, username string, k8sClient
 
 	remaining := strings.TrimPrefix(username, prefix)
 	parts := strings.Split(remaining, ":")
-	log.Infof("Parsed service account parts: %v (count: %d)", parts, len(parts))
+	log.Debugf("Parsed service account parts: %v (count: %d)", parts, len(parts))
 
 	if len(parts) != 2 {
 		log.Errorf("Invalid service account format - expected 2 parts, got %d, returning false", len(parts))
@@ -275,21 +275,23 @@ func validatePvCSIServiceAccount(ctx context.Context, username string, k8sClient
 
 	namespace := parts[0]
 	serviceAccountName := parts[1]
-	log.Infof("Extracted namespace=%s, serviceAccountName=%s", namespace, serviceAccountName)
+	log.Debugf("Extracted namespace=%s, serviceAccountName=%s", namespace, serviceAccountName)
 
 	// For any namespace, check if service account follows guest cluster PvCSI pattern
 	// Guest cluster PvCSI service accounts follow the pattern: {cluster-name}-pvcsi
 	if strings.HasSuffix(serviceAccountName, "-pvcsi") {
-		log.Infof("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
+		log.Debugf("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
 		return validateProviderServiceAccount(ctx, namespace, serviceAccountName, k8sClient)
 	}
 
-	log.Infof("Service account doesn't match any PvCSI patterns, returning false")
+	log.Debugf("Service account doesn't match any PvCSI patterns, returning false")
 	return false, nil
 }
 
-// validateProviderServiceAccount validates the service account name against all available clusters
-func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccountName string, k8sClient client.Client) (bool, error) {
+// validateProviderServiceAccount validates the service account name matches an existing
+// VSphereCluster
+func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccountName string,
+	k8sClient client.Client) (bool, error) {
 	log := logger.GetLogger(ctx)
 	log.Infof("Validating provider service account '%s' in namespace '%s'", serviceAccountName, namespace)
 
@@ -319,14 +321,15 @@ func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccou
 }
 
 // validateVSphereClusterResource checks if a VSphereCluster resource exists using dynamic client
-func validateVSphereClusterResource(ctx context.Context, clusterName, namespace string, k8sClient client.Client) (bool, error) {
+func validateVSphereClusterResource(ctx context.Context, clusterName, namespace string,
+	k8sClient client.Client) (bool, error) {
 	log := logger.GetLogger(ctx)
 
 	// Use unstructured object to work with the actual VSphereCluster API group/version deployed in the cluster
 	vsphereCluster := &unstructured.Unstructured{}
 	vsphereCluster.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "vmware.infrastructure.cluster.x-k8s.io",
-		Version: "v1beta2", // Use the version we saw in kubectl api-resources
+		Version: "v1beta2",
 		Kind:    "VSphereCluster",
 	})
 

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
@@ -316,7 +316,7 @@ func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccou
 	// validate VSphereCluster resource exists
 	found, err := validateVSphereClusterResource(ctx, clusterName, namespace)
 	if err != nil {
-		return false, fmt.Errorf("Failed to check VSphereCluster resource: %v", err)
+		return false, fmt.Errorf("failed to check VSphereCluster resource: %v", err)
 	}
 	if found {
 		log.Infof("Found VSphereCluster '%s' in namespace '%s', service account '%s' is valid",

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
@@ -46,7 +46,7 @@ const (
 // validateCreateCnsFileAccessConfig validates if a CnsFileAccessConfig CR with the same VM and PVC already exists.
 // If it already exists, do not allow creation of another CR.
 func validateCreateCnsFileAccessConfig(ctx context.Context, clientConfig *rest.Config,
-	req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	req *admissionv1.AdmissionRequest, k8sClient client.Client) *admissionv1.AdmissionResponse {
 	log := logger.GetLogger(ctx)
 
 	cnsFileAccessConfig := cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
@@ -63,7 +63,7 @@ func validateCreateCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 	}
 
 	// This validation is not required for PVCSI service account.
-	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username)
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username, k8sClient)
 	if err != nil {
 		// return AdmissionResponse result
 		return &admissionv1.AdmissionResponse{
@@ -173,7 +173,7 @@ func cnsFileAccessConfigAlreadyExists(ctx context.Context, clientConfig *rest.Co
 // devops label (indicates that it is a CR being used by guest cluster) if user deleting the instance
 // is a CSI or K8s system user or K8s admin.
 func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.Config,
-	req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	req *admissionv1.AdmissionRequest, k8sClient client.Client) *admissionv1.AdmissionResponse {
 	log := logger.GetLogger(ctx)
 
 	cnsFileAccessConfig := cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
@@ -200,7 +200,7 @@ func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 	}
 
 	// Check if user is allowed to delete this CR.
-	allowed, err := isUserAllowedForDeletion(ctx, req.UserInfo.Username)
+	allowed, err := isUserAllowedForDeletion(ctx, req.UserInfo.Username, k8sClient)
 	if err != nil {
 		return &admissionv1.AdmissionResponse{
 			Allowed: false,
@@ -226,14 +226,14 @@ func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 
 // isUserAllowedForDeletion returns true if user is either a PVCSI service account or
 // K8s' namespace-cotnroller.
-func isUserAllowedForDeletion(ctx context.Context, username string) (bool, error) {
+func isUserAllowedForDeletion(ctx context.Context, username string, k8sClient client.Client) (bool, error) {
 	kubernetesServiceAccount, err := regexp.Compile(KubernetesServiceAccount)
 	if err != nil {
 		return false, err
 	}
 
 	// Check if user is a valid PVCSI service account using the new validation logic
-	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, username)
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, username, k8sClient)
 	if err != nil {
 		return false, err
 	}
@@ -251,7 +251,7 @@ func isUserAllowedForDeletion(ctx context.Context, username string) (bool, error
 	return false, nil
 }
 
-func validatePvCSIServiceAccount(ctx context.Context, username string) (bool, error) {
+func validatePvCSIServiceAccount(ctx context.Context, username string, k8sClient client.Client) (bool, error) {
 	log := logger.GetLogger(ctx)
 
 	log.Infof("Validating PvCSI service account: username=%s", username)
@@ -281,26 +281,15 @@ func validatePvCSIServiceAccount(ctx context.Context, username string) (bool, er
 	// Guest cluster PvCSI service accounts follow the pattern: {cluster-name}-pvcsi
 	if strings.HasSuffix(serviceAccountName, "-pvcsi") {
 		log.Infof("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
-		return validateProviderServiceAccount(ctx, namespace, serviceAccountName)
+		return validateProviderServiceAccount(ctx, namespace, serviceAccountName, k8sClient)
 	}
 
 	log.Infof("Service account doesn't match any PvCSI patterns, returning false")
 	return false, nil
 }
 
-// getVSphereClusterClient creates a Kubernetes client for VSphere cluster API operations using dynamic client
-func getVSphereClusterClient(ctx context.Context) (client.Client, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	// Use a dynamic client that can work with any API group/version
-	return client.New(config, client.Options{})
-}
-
 // validateProviderServiceAccount validates the service account name against all available clusters
-func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccountName string) (bool, error) {
+func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccountName string, k8sClient client.Client) (bool, error) {
 	log := logger.GetLogger(ctx)
 	log.Infof("Validating provider service account '%s' in namespace '%s'", serviceAccountName, namespace)
 
@@ -314,7 +303,7 @@ func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccou
 		clusterName, serviceAccountName, namespace)
 
 	// validate VSphereCluster resource exists
-	found, err := validateVSphereClusterResource(ctx, clusterName, namespace)
+	found, err := validateVSphereClusterResource(ctx, clusterName, namespace, k8sClient)
 	if err != nil {
 		return false, fmt.Errorf("failed to check VSphereCluster resource: %v", err)
 	}
@@ -330,13 +319,8 @@ func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccou
 }
 
 // validateVSphereClusterResource checks if a VSphereCluster resource exists using dynamic client
-func validateVSphereClusterResource(ctx context.Context, clusterName, namespace string) (bool, error) {
+func validateVSphereClusterResource(ctx context.Context, clusterName, namespace string, k8sClient client.Client) (bool, error) {
 	log := logger.GetLogger(ctx)
-
-	k8sClient, err := getVSphereClusterClient(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to create VSphere cluster API client: %w", err)
-	}
 
 	// Use unstructured object to work with the actual VSphereCluster API group/version deployed in the cluster
 	vsphereCluster := &unstructured.Unstructured{}
@@ -346,7 +330,7 @@ func validateVSphereClusterResource(ctx context.Context, clusterName, namespace 
 		Kind:    "VSphereCluster",
 	})
 
-	err = k8sClient.Get(ctx, client.ObjectKey{
+	err := k8sClient.Get(ctx, client.ObjectKey{
 		Name:      clusterName,
 		Namespace: namespace,
 	}, vsphereCluster)

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
@@ -25,7 +25,6 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -64,7 +63,7 @@ func validateCreateCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 	}
 
 	// This validation is not required for PVCSI service account.
-	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(req.UserInfo.Username)
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username)
 	if err != nil {
 		// return AdmissionResponse result
 		return &admissionv1.AdmissionResponse{
@@ -201,7 +200,7 @@ func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 	}
 
 	// Check if user is allowed to delete this CR.
-	allowed, err := isUserAllowedForDeletion(req.UserInfo.Username)
+	allowed, err := isUserAllowedForDeletion(ctx, req.UserInfo.Username)
 	if err != nil {
 		return &admissionv1.AdmissionResponse{
 			Allowed: false,
@@ -227,14 +226,14 @@ func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 
 // isUserAllowedForDeletion returns true if user is either a PVCSI service account or
 // K8s' namespace-cotnroller.
-func isUserAllowedForDeletion(username string) (bool, error) {
+func isUserAllowedForDeletion(ctx context.Context, username string) (bool, error) {
 	kubernetesServiceAccount, err := regexp.Compile(KubernetesServiceAccount)
 	if err != nil {
 		return false, err
 	}
 
 	// Check if user is a valid PVCSI service account using the new validation logic
-	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(username)
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, username)
 	if err != nil {
 		return false, err
 	}
@@ -243,9 +242,8 @@ func isUserAllowedForDeletion(username string) (bool, error) {
 	}
 
 	// Allowed users are :
-	// 1. PVCSI service account (checked above using new validation logic)
-	// 2. K8s service account (like namespace-controller or generic-garbage-collector)
-	// 3. K8s admin
+	// 1. K8s service account (like namespace-controller or generic-garbage-collector)
+	// 2. K8s admin
 	if kubernetesServiceAccount.MatchString(username) || username == KubernetesAdmin {
 		return true, nil
 	}
@@ -253,8 +251,7 @@ func isUserAllowedForDeletion(username string) (bool, error) {
 	return false, nil
 }
 
-func validatePvCSIServiceAccount(username string) (bool, error) {
-	ctx := context.TODO()
+func validatePvCSIServiceAccount(ctx context.Context, username string) (bool, error) {
 	log := logger.GetLogger(ctx)
 
 	log.Infof("Validating PvCSI service account: username=%s", username)
@@ -272,7 +269,7 @@ func validatePvCSIServiceAccount(username string) (bool, error) {
 	log.Infof("Parsed service account parts: %v (count: %d)", parts, len(parts))
 
 	if len(parts) != 2 {
-		log.Infof("Invalid service account format - expected 2 parts, got %d, returning false", len(parts))
+		log.Errorf("Invalid service account format - expected 2 parts, got %d, returning false", len(parts))
 		return false, nil
 	}
 
@@ -283,7 +280,7 @@ func validatePvCSIServiceAccount(username string) (bool, error) {
 	// For any namespace, check if service account follows guest cluster PvCSI pattern
 	// Guest cluster PvCSI service accounts follow the pattern: {cluster-name}-pvcsi
 	if strings.HasSuffix(serviceAccountName, "-pvcsi") {
-		log.Infof("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
+		log.Errorf("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
 		return validateProviderServiceAccount(ctx, namespace, serviceAccountName)
 	}
 
@@ -306,13 +303,6 @@ func getVSphereClusterClient(ctx context.Context) (client.Client, error) {
 func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccountName string) (bool, error) {
 	log := logger.GetLogger(ctx)
 	log.Infof("Validating provider service account '%s' in namespace '%s'", serviceAccountName, namespace)
-
-	// Extract expected vsphere cluster name from service account name
-	// serviceAccountName format: "{vsphere-cluster-name}-pvcsi"
-	if !strings.HasSuffix(serviceAccountName, "-pvcsi") {
-		log.Infof("Service account '%s' does not follow cluster pattern (missing -pvcsi suffix)", serviceAccountName)
-		return false, nil
-	}
 
 	clusterName := strings.TrimSuffix(serviceAccountName, "-pvcsi")
 	if clusterName == "" {
@@ -362,16 +352,6 @@ func validateVSphereClusterResource(ctx context.Context, clusterName, namespace 
 	}, vsphereCluster)
 
 	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Infof("VSphereCluster '%s' not found in namespace '%s'", clusterName, namespace)
-			return false, nil
-		}
-
-		if errors.IsForbidden(err) {
-			log.Warnf("Access denied when checking VSphereCluster '%s' in namespace '%s'", clusterName, namespace)
-			return false, fmt.Errorf("insufficient permissions to validate VSphere cluster: %w", err)
-		}
-
 		return false, fmt.Errorf("failed to get VSphereCluster '%s' in namespace '%s': %w", clusterName, namespace, err)
 	}
 

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
@@ -105,7 +105,7 @@ func TestValidatePvCSIServiceAccount(t *testing.T) {
 		errorSubstring string // Optional: partial error message to match
 	}{
 		{
-			name:        "Valid vsphere-csi-controller in valid namespace",
+			name:        "CSI controller service account (not PvCSI)",
 			username:    "system:serviceaccount:vmware-system-csi:vsphere-csi-controller",
 			expected:    false,
 			expectError: false,
@@ -285,7 +285,7 @@ func TestIsUserAllowedForDeletion(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "Valid PvCSI service account",
+			name:     "CSI controller service account (not PvCSI)",
 			username: "system:serviceaccount:vmware-system-csi:vsphere-csi-controller",
 			expected: false,
 		},

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionhandler
+
+import (
+	"context"
+	goruntime "runtime"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ccV1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// setupSchemeForTest creates a runtime scheme with Cluster API types registered
+func setupSchemeForTest() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = ccV1beta2.AddToScheme(scheme)
+	return scheme
+}
+
+// createTestVSphereClusters creates realistic VSphereCluster objects for different test scenarios
+func createTestVSphereClusters() []*unstructured.Unstructured {
+	clusters := []*unstructured.Unstructured{}
+
+	clusterData := []struct {
+		name      string
+		namespace string
+	}{
+		{"test-cluster", "default"},
+		{"guest-cluster", "vmware-system-csi"},
+		{"test-cluster-e2e-script-95jxs", "test-gc-e2e-demo-ns"},
+		{"prod-cluster", "production"},
+	}
+
+	for _, data := range clusterData {
+		cluster := &unstructured.Unstructured{}
+		cluster.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "vmware.infrastructure.cluster.x-k8s.io",
+			Version: "v1beta2",
+			Kind:    "VSphereCluster",
+		})
+		cluster.SetName(data.name)
+		cluster.SetNamespace(data.namespace)
+
+		clusters = append(clusters, cluster)
+	}
+
+	return clusters
+}
+
+// convertVSphereClustersToObjects converts VSphereCluster objects to runtime.Object for fake client
+func convertVSphereClustersToObjects(clusters []*unstructured.Unstructured) []client.Object {
+	objects := make([]client.Object, len(clusters))
+	for i := range clusters {
+		objects[i] = clusters[i]
+	}
+	return objects
+}
+
+// setupClusterAPIMocking sets up gomonkey patches for VSphere cluster validation with realistic test data
+// Returns patches that must be reset with defer patches.Reset()
+func setupClusterAPIMocking(t *testing.T) *gomonkey.Patches {
+	// Skip test on ARM64 due to gomonkey limitations
+	if goruntime.GOARCH == "arm64" {
+		t.Skip("Skipping test on ARM64 due to gomonkey function patching limitations")
+	}
+
+	// Setup fake client with VSphere cluster test data
+	scheme := setupSchemeForTest()
+	testVSphereClusters := createTestVSphereClusters()
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(convertVSphereClustersToObjects(testVSphereClusters)...).
+		Build()
+
+	// Mock getVSphereClusterClient to return our fake client with VSphere cluster test data
+	patches := gomonkey.ApplyFunc(getVSphereClusterClient,
+		func(ctx context.Context) (client.Client, error) {
+			return fakeClient, nil
+		})
+
+	return patches
+}
+
+func TestValidatePvCSIServiceAccount(t *testing.T) {
+	// Setup cluster API mocking with realistic test data
+	patches := setupClusterAPIMocking(t)
+	defer patches.Reset()
+	testCases := []struct {
+		name     string
+		username string
+		expected bool
+	}{
+		{
+			name:     "Valid vsphere-csi-controller in valid namespace",
+			username: "system:serviceaccount:vmware-system-csi:vsphere-csi-controller",
+			expected: false,
+		},
+		{
+			name:     "Valid vsphere-csi-node in valid namespace",
+			username: "system:serviceaccount:vmware-system-csi:vsphere-csi-node",
+			expected: false,
+		},
+		{
+			name:     "Valid legacy pvcsi service account",
+			username: "system:serviceaccount:kube-system:pvcsi",
+			expected: false,
+		},
+		{
+			name:     "Invalid namespace for test-cluster VSphereCluster validation",
+			username: "system:serviceaccount:vmware-system-csi:test-cluster-pvcsi",
+			expected: false, // "test-cluster" VSphereCluster exists in "default" namespace, not "vmware-system-csi"
+		},
+		{
+			name:     "Valid VSphereCluster validation for test-cluster-e2e-script-95jxs",
+			username: "system:serviceaccount:test-gc-e2e-demo-ns:test-cluster-e2e-script-95jxs-pvcsi",
+			expected: true, // Matches "test-cluster-e2e-script-95jxs" VSphereCluster in our fake cluster list
+		},
+		{
+			name:     "Valid VSphereCluster validation for guest-cluster",
+			username: "system:serviceaccount:vmware-system-csi:guest-cluster-pvcsi",
+			expected: true, // Matches "guest-cluster" VSphereCluster in our fake cluster list
+		},
+		{
+			name:     "SECURITY FIX: malicious service account in wrong namespace blocked",
+			username: "system:serviceaccount:malicious-ns:evil-pvcsi",
+			expected: false, // Now properly blocked - wrong namespace
+		},
+		{
+			name:     "SECURITY FIX: attempt to bypass with multiple colons blocked",
+			username: "system:serviceaccount:namespace:extra:vsphere-csi-controller",
+			expected: false,
+		},
+		{
+			name:     "Invalid - wrong service account name in valid namespace",
+			username: "system:serviceaccount:vmware-system-csi:invalid-service-account",
+			expected: false,
+		},
+		{
+			name:     "Invalid - missing namespace",
+			username: "system:serviceaccount::vsphere-csi-controller",
+			expected: false,
+		},
+		{
+			name:     "Invalid - empty username",
+			username: "",
+			expected: false,
+		},
+		{
+			name:     "Invalid - not a service account",
+			username: "regular-user",
+			expected: false,
+		},
+		{
+			name:     "Invalid - kubernetes admin user",
+			username: "kubernetes-admin",
+			expected: false,
+		},
+		{
+			name:     "Invalid - missing colon separators",
+			username: "system:serviceaccountnamespacevsphere-csi-controller",
+			expected: false,
+		},
+		{
+			name:     "Invalid - partial match",
+			username: "system:serviceaccount:namespace:vsphere-csi-contro",
+			expected: false,
+		},
+		{
+			name:     "Invalid - extra text after valid pattern",
+			username: "system:serviceaccount:namespace:vsphere-csi-controller-extra",
+			expected: false,
+		},
+		{
+			name:     "Invalid - valid service account in unauthorized namespace",
+			username: "system:serviceaccount:my-namespace-with-dashes:vsphere-csi-node",
+			expected: false, // Wrong namespace - only vmware-system-csi allowed for CSI service accounts
+		},
+		{
+			name:     "Invalid - valid service account in unauthorized namespace",
+			username: "system:serviceaccount:namespace123:vsphere-csi-controller",
+			expected: false, // Wrong namespace - only vmware-system-csi allowed for CSI service accounts
+		},
+		{
+			name:     "Invalid - pvcsi service account in wrong namespace",
+			username: "system:serviceaccount:some-namespace:pvcsi",
+			expected: false, // pvcsi only allowed in kube-system namespace
+		},
+		{
+			name:     "SECURITY FIX: multiple colon bypass attempt blocked",
+			username: "system:serviceaccount:malicious:namespace:attacker-pvcsi",
+			expected: false,
+		},
+		{
+			name:     "SECURITY FIX: service account with colon in name blocked",
+			username: "system:serviceaccount:vmware-system-csi:service:account-pvcsi",
+			expected: false, // Colon in cluster name blocked by fallback validation
+		},
+		{
+			name:     "Invalid - empty cluster name with -pvcsi suffix",
+			username: "system:serviceaccount:vmware-system-csi:-pvcsi",
+			expected: false, // Empty cluster name blocked by fallback validation
+		},
+		// Note: VSphereCluster validation tests are omitted as they require a real cluster
+		// The dynamic client approach will work with actual deployed API groups
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := validatePvCSIServiceAccount(tc.username)
+			if err != nil {
+				t.Errorf("validatePvCSIServiceAccount() returned error: %v", err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("validatePvCSIServiceAccount(%q) = %v, want %v", tc.username, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsUserAllowedForDeletion(t *testing.T) {
+	// Setup cluster API mocking with realistic test data
+	// This is needed because isUserAllowedForDeletion() calls validatePvCSIServiceAccount()
+	// which requires cluster API access
+	patches := setupClusterAPIMocking(t)
+	defer patches.Reset()
+
+	testCases := []struct {
+		name     string
+		username string
+		expected bool
+	}{
+		{
+			name:     "Valid PvCSI service account",
+			username: "system:serviceaccount:vmware-system-csi:vsphere-csi-controller",
+			expected: false,
+		},
+		{
+			name:     "Valid Kubernetes service account",
+			username: "system:serviceaccount:kube-system:namespace-controller",
+			expected: true,
+		},
+		{
+			name:     "Valid Kubernetes admin",
+			username: "kubernetes-admin",
+			expected: true,
+		},
+		{
+			name:     "Invalid user",
+			username: "regular-user",
+			expected: false,
+		},
+		{
+			name:     "Malicious service account that should not be allowed",
+			username: "system:serviceaccount:malicious:evil-service",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := isUserAllowedForDeletion(tc.username)
+			if err != nil {
+				t.Errorf("isUserAllowedForDeletion() returned error: %v", err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("isUserAllowedForDeletion(%q) = %v, want %v", tc.username, result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
@@ -139,7 +139,7 @@ func TestValidatePvCSIServiceAccount(t *testing.T) {
 			username:       "system:serviceaccount:vmware-system-csi:test-cluster-pvcsi",
 			expected:       false,
 			expectError:    true,
-			errorSubstring: "failed to check VSphereCluster resource", // "test-cluster" VSphereCluster exists in "default" namespace, not "vmware-system-csi"
+			errorSubstring: "failed to check VSphereCluster resource", // Namespace mismatch expected
 		},
 		{
 			name:        "Valid VSphereCluster validation for test-cluster-e2e-script-95jxs",

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
@@ -19,6 +19,7 @@ package admissionhandler
 import (
 	"context"
 	goruntime "runtime"
+	"strings"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -109,119 +110,145 @@ func TestValidatePvCSIServiceAccount(t *testing.T) {
 	patches := setupClusterAPIMocking(t)
 	defer patches.Reset()
 	testCases := []struct {
-		name     string
-		username string
-		expected bool
+		name           string
+		username       string
+		expected       bool
+		expectError    bool
+		errorSubstring string // Optional: partial error message to match
 	}{
 		{
-			name:     "Valid vsphere-csi-controller in valid namespace",
-			username: "system:serviceaccount:vmware-system-csi:vsphere-csi-controller",
-			expected: false,
+			name:        "Valid vsphere-csi-controller in valid namespace",
+			username:    "system:serviceaccount:vmware-system-csi:vsphere-csi-controller",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Valid vsphere-csi-node in valid namespace",
-			username: "system:serviceaccount:vmware-system-csi:vsphere-csi-node",
-			expected: false,
+			name:        "Valid vsphere-csi-node in valid namespace",
+			username:    "system:serviceaccount:vmware-system-csi:vsphere-csi-node",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Valid legacy pvcsi service account",
-			username: "system:serviceaccount:kube-system:pvcsi",
-			expected: false,
+			name:        "Valid legacy pvcsi service account",
+			username:    "system:serviceaccount:kube-system:pvcsi",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid namespace for test-cluster VSphereCluster validation",
-			username: "system:serviceaccount:vmware-system-csi:test-cluster-pvcsi",
-			expected: false, // "test-cluster" VSphereCluster exists in "default" namespace, not "vmware-system-csi"
+			name:           "Invalid namespace for test-cluster VSphereCluster validation",
+			username:       "system:serviceaccount:vmware-system-csi:test-cluster-pvcsi",
+			expected:       false,
+			expectError:    true,
+			errorSubstring: "failed to check VSphereCluster resource", // "test-cluster" VSphereCluster exists in "default" namespace, not "vmware-system-csi"
 		},
 		{
-			name:     "Valid VSphereCluster validation for test-cluster-e2e-script-95jxs",
-			username: "system:serviceaccount:test-gc-e2e-demo-ns:test-cluster-e2e-script-95jxs-pvcsi",
-			expected: true, // Matches "test-cluster-e2e-script-95jxs" VSphereCluster in our fake cluster list
+			name:        "Valid VSphereCluster validation for test-cluster-e2e-script-95jxs",
+			username:    "system:serviceaccount:test-gc-e2e-demo-ns:test-cluster-e2e-script-95jxs-pvcsi",
+			expected:    true, // Matches "test-cluster-e2e-script-95jxs" VSphereCluster in our fake cluster list
+			expectError: false,
 		},
 		{
-			name:     "Valid VSphereCluster validation for guest-cluster",
-			username: "system:serviceaccount:vmware-system-csi:guest-cluster-pvcsi",
-			expected: true, // Matches "guest-cluster" VSphereCluster in our fake cluster list
+			name:        "Valid VSphereCluster validation for guest-cluster",
+			username:    "system:serviceaccount:vmware-system-csi:guest-cluster-pvcsi",
+			expected:    true, // Matches "guest-cluster" VSphereCluster in our fake cluster list
+			expectError: false,
 		},
 		{
-			name:     "SECURITY FIX: malicious service account in wrong namespace blocked",
-			username: "system:serviceaccount:malicious-ns:evil-pvcsi",
-			expected: false, // Now properly blocked - wrong namespace
+			name:           "SECURITY FIX: malicious service account in wrong namespace blocked",
+			username:       "system:serviceaccount:malicious-ns:evil-pvcsi",
+			expected:       false,
+			expectError:    true,
+			errorSubstring: "failed to check VSphereCluster resource", // Now properly blocked - wrong namespace
 		},
 		{
-			name:     "SECURITY FIX: attempt to bypass with multiple colons blocked",
-			username: "system:serviceaccount:namespace:extra:vsphere-csi-controller",
-			expected: false,
+			name:        "SECURITY FIX: attempt to bypass with multiple colons blocked",
+			username:    "system:serviceaccount:namespace:extra:vsphere-csi-controller",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid - wrong service account name in valid namespace",
-			username: "system:serviceaccount:vmware-system-csi:invalid-service-account",
-			expected: false,
+			name:        "Invalid - wrong service account name in valid namespace",
+			username:    "system:serviceaccount:vmware-system-csi:invalid-service-account",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid - missing namespace",
-			username: "system:serviceaccount::vsphere-csi-controller",
-			expected: false,
+			name:        "Invalid - missing namespace",
+			username:    "system:serviceaccount::vsphere-csi-controller",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid - empty username",
-			username: "",
-			expected: false,
+			name:        "Invalid - empty username",
+			username:    "",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid - not a service account",
-			username: "regular-user",
-			expected: false,
+			name:        "Invalid - not a service account",
+			username:    "regular-user",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid - kubernetes admin user",
-			username: "kubernetes-admin",
-			expected: false,
+			name:        "Invalid - kubernetes admin user",
+			username:    "kubernetes-admin",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid - missing colon separators",
-			username: "system:serviceaccountnamespacevsphere-csi-controller",
-			expected: false,
+			name:        "Invalid - missing colon separators",
+			username:    "system:serviceaccountnamespacevsphere-csi-controller",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid - partial match",
-			username: "system:serviceaccount:namespace:vsphere-csi-contro",
-			expected: false,
+			name:        "Invalid - partial match",
+			username:    "system:serviceaccount:namespace:vsphere-csi-contro",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid - extra text after valid pattern",
-			username: "system:serviceaccount:namespace:vsphere-csi-controller-extra",
-			expected: false,
+			name:        "Invalid - extra text after valid pattern",
+			username:    "system:serviceaccount:namespace:vsphere-csi-controller-extra",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Invalid - valid service account in unauthorized namespace",
-			username: "system:serviceaccount:my-namespace-with-dashes:vsphere-csi-node",
-			expected: false, // Wrong namespace - only vmware-system-csi allowed for CSI service accounts
+			name:        "Invalid - valid service account in unauthorized namespace",
+			username:    "system:serviceaccount:my-namespace-with-dashes:vsphere-csi-node",
+			expected:    false, // Wrong namespace - only vmware-system-csi allowed for CSI service accounts
+			expectError: false,
 		},
 		{
-			name:     "Invalid - valid service account in unauthorized namespace",
-			username: "system:serviceaccount:namespace123:vsphere-csi-controller",
-			expected: false, // Wrong namespace - only vmware-system-csi allowed for CSI service accounts
+			name:        "Invalid - valid service account in unauthorized namespace",
+			username:    "system:serviceaccount:namespace123:vsphere-csi-controller",
+			expected:    false, // Wrong namespace - only vmware-system-csi allowed for CSI service accounts
+			expectError: false,
 		},
 		{
-			name:     "Invalid - pvcsi service account in wrong namespace",
-			username: "system:serviceaccount:some-namespace:pvcsi",
-			expected: false, // pvcsi only allowed in kube-system namespace
+			name:        "Invalid - pvcsi service account in wrong namespace",
+			username:    "system:serviceaccount:some-namespace:pvcsi",
+			expected:    false, // pvcsi only allowed in kube-system namespace
+			expectError: false,
 		},
 		{
-			name:     "SECURITY FIX: multiple colon bypass attempt blocked",
-			username: "system:serviceaccount:malicious:namespace:attacker-pvcsi",
-			expected: false,
+			name:        "SECURITY FIX: multiple colon bypass attempt blocked",
+			username:    "system:serviceaccount:malicious:namespace:attacker-pvcsi",
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "SECURITY FIX: service account with colon in name blocked",
-			username: "system:serviceaccount:vmware-system-csi:service:account-pvcsi",
-			expected: false, // Colon in cluster name blocked by fallback validation
+			name:        "SECURITY FIX: service account with colon in name blocked",
+			username:    "system:serviceaccount:vmware-system-csi:service:account-pvcsi",
+			expected:    false, // Colon in cluster name blocked by fallback validation
+			expectError: false,
 		},
 		{
-			name:     "Invalid - empty cluster name with -pvcsi suffix",
-			username: "system:serviceaccount:vmware-system-csi:-pvcsi",
-			expected: false, // Empty cluster name blocked by fallback validation
+			name:        "Invalid - empty cluster name with -pvcsi suffix",
+			username:    "system:serviceaccount:vmware-system-csi:-pvcsi",
+			expected:    false, // Empty cluster name blocked by fallback validation
+			expectError: false,
 		},
 		// Note: VSphereCluster validation tests are omitted as they require a real cluster
 		// The dynamic client approach will work with actual deployed API groups
@@ -230,10 +257,27 @@ func TestValidatePvCSIServiceAccount(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := validatePvCSIServiceAccount(context.TODO(), tc.username)
-			if err != nil {
-				t.Errorf("validatePvCSIServiceAccount() returned error: %v", err)
-				return
+
+			// Check error expectation
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("validatePvCSIServiceAccount() expected error but got none")
+					return
+				}
+				// Check if error contains expected substring if specified
+				if tc.errorSubstring != "" && !strings.Contains(err.Error(), tc.errorSubstring) {
+					t.Errorf("validatePvCSIServiceAccount() error = %v, want error containing %q", err, tc.errorSubstring)
+					return
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validatePvCSIServiceAccount() returned unexpected error: %v", err)
+					return
+				}
 			}
+
+			// For error cases, we might not need to check the boolean result as it's less meaningful
+			// But we can still check it for completeness
 			if result != tc.expected {
 				t.Errorf("validatePvCSIServiceAccount(%q) = %v, want %v", tc.username, result, tc.expected)
 			}

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
@@ -18,11 +18,9 @@ package admissionhandler
 
 import (
 	"context"
-	goruntime "runtime"
 	"strings"
 	"testing"
 
-	"github.com/agiledragon/gomonkey/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -81,11 +79,7 @@ func convertVSphereClustersToObjects(clusters []*unstructured.Unstructured) []cl
 
 // setupClusterAPIMocking sets up gomonkey patches for VSphere cluster validation with realistic test data
 // Returns patches that must be reset with defer patches.Reset()
-func setupClusterAPIMocking(t *testing.T) *gomonkey.Patches {
-	// Skip test on ARM64 due to gomonkey limitations
-	if goruntime.GOARCH == "arm64" {
-		t.Skip("Skipping test on ARM64 due to gomonkey function patching limitations")
-	}
+func setupClusterAPIMocking(t *testing.T) client.Client {
 
 	// Setup fake client with VSphere cluster test data
 	scheme := setupSchemeForTest()
@@ -96,19 +90,13 @@ func setupClusterAPIMocking(t *testing.T) *gomonkey.Patches {
 		WithObjects(convertVSphereClustersToObjects(testVSphereClusters)...).
 		Build()
 
-	// Mock getVSphereClusterClient to return our fake client with VSphere cluster test data
-	patches := gomonkey.ApplyFunc(getVSphereClusterClient,
-		func(ctx context.Context) (client.Client, error) {
-			return fakeClient, nil
-		})
-
-	return patches
+	// Return the fake client directly for use in tests
+	return fakeClient
 }
 
 func TestValidatePvCSIServiceAccount(t *testing.T) {
 	// Setup cluster API mocking with realistic test data
-	patches := setupClusterAPIMocking(t)
-	defer patches.Reset()
+	fakeClient := setupClusterAPIMocking(t)
 	testCases := []struct {
 		name           string
 		username       string
@@ -256,7 +244,7 @@ func TestValidatePvCSIServiceAccount(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := validatePvCSIServiceAccount(context.TODO(), tc.username)
+			result, err := validatePvCSIServiceAccount(context.TODO(), tc.username, fakeClient)
 
 			// Check error expectation
 			if tc.expectError {
@@ -289,8 +277,7 @@ func TestIsUserAllowedForDeletion(t *testing.T) {
 	// Setup cluster API mocking with realistic test data
 	// This is needed because isUserAllowedForDeletion() calls validatePvCSIServiceAccount()
 	// which requires cluster API access
-	patches := setupClusterAPIMocking(t)
-	defer patches.Reset()
+	fakeClient := setupClusterAPIMocking(t)
 
 	testCases := []struct {
 		name     string
@@ -326,7 +313,7 @@ func TestIsUserAllowedForDeletion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := isUserAllowedForDeletion(context.TODO(), tc.username)
+			result, err := isUserAllowedForDeletion(context.TODO(), tc.username, fakeClient)
 			if err != nil {
 				t.Errorf("isUserAllowedForDeletion() returned error: %v", err)
 				return

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
@@ -229,7 +229,7 @@ func TestValidatePvCSIServiceAccount(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := validatePvCSIServiceAccount(tc.username)
+			result, err := validatePvCSIServiceAccount(context.TODO(), tc.username)
 			if err != nil {
 				t.Errorf("validatePvCSIServiceAccount() returned error: %v", err)
 				return
@@ -282,7 +282,7 @@ func TestIsUserAllowedForDeletion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := isUserAllowedForDeletion(tc.username)
+			result, err := isUserAllowedForDeletion(context.TODO(), tc.username)
 			if err != nil {
 				t.Errorf("isUserAllowedForDeletion() returned error: %v", err)
 				return


### PR DESCRIPTION
The original regex ^system:serviceaccount.*-pvcsi$ was vulnerable to colon injection attacks. A malicious user could create a service account named 'evil-pvcsi' in their namespace and bypass webhook security checks by having their username appear as:
system:serviceaccount:malicious-namespace:evil-pvcsi

This would match the regex and be treated as a trusted PvCSI service account.

Fixed by replacing the overly broad .* pattern with matching the username with the service account name which is "vsphereClusterName"-pvcsi

This prevents colon injection while maintaining compatibility with legitimate PvCSI service accounts.

Added comprehensive test coverage to prevent regression.

Security Impact: MEDIUM - Prevents authentication bypass for CnsFileAccessConfig operations.



**Testing done**: Both VKS and WCP precheckins are passed
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1266/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1661/

File share tests on vks cluster:
https://github-vcf.devops.broadcom.net/gist/ab002488/1b0c822cd048ab45f6b20015a9f407de
 
Tested attaching vm service with a file share locally
Tested deleting cnsfileaccessconfig, pvc locally


