### PR TITLE
Get snapshot changeID from CNS CreateSnapshot API response, instead of fetching from FCD explicitly

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -174,8 +174,6 @@ type Manager interface {
 	// QueryFCDChangedBlocks returns changed block ranges using FCD VSLM QueryChangedDiskAreas with baseChangeID.
 	QueryFCDChangedBlocks(ctx context.Context, volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64,
 		maxResults uint32) ([]ChangedArea, uint64, error)
-	// GetFCDSnapshotChangeID returns the CBT change ID from an FCD snapshot (VSLM RetrieveSnapshotDetails).
-	GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error)
 }
 
 // CnsVolumeInfo hold information related to volume created by CNS.
@@ -191,6 +189,7 @@ type CnsSnapshotInfo struct {
 	SnapshotDescription                 string
 	AggregatedSnapshotCapacityInMb      int64
 	SnapshotLatestOperationCompleteTime time.Time
+	ChangedBlockTrackingId              string
 }
 
 // CreateVolumeExtraParams consist of values required by the CreateVolume interface and
@@ -454,7 +453,7 @@ func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
 					(*volumeOperationDetails).QuotaDetails,
 					(*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
 					vCenterServerForVolumeOperationCR, (*volumeOperationDetails).OperationDetails.TaskID,
-					taskInvocationStatusSuccess, "")
+					taskInvocationStatusSuccess, "", "")
 				log.Debugf("Found volume %s with id %s", volNameFromInputSpec, volumeID)
 				return &CnsVolumeInfo{
 					DatastoreURL: "",
@@ -468,7 +467,7 @@ func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
 			*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 				(*volumeOperationDetails).QuotaDetails, (*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp,
 				task.Reference().Value, vCenterServerForVolumeOperationCR,
-				(*volumeOperationDetails).OperationDetails.TaskID, taskInvocationStatusError, err.Error())
+				(*volumeOperationDetails).OperationDetails.TaskID, taskInvocationStatusError, err.Error(), "")
 
 			return nil, ExtractFaultTypeFromErr(ctx, err), err
 		}
@@ -482,7 +481,7 @@ func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
 		*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 			(*volumeOperationDetails).QuotaDetails, (*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp,
 			task.Reference().Value, vCenterServerForVolumeOperationCR,
-			(*volumeOperationDetails).OperationDetails.TaskID, taskInvocationStatusError, err.Error())
+			(*volumeOperationDetails).OperationDetails.TaskID, taskInvocationStatusError, err.Error(), "")
 
 		return nil, ExtractFaultTypeFromErr(ctx, err), err
 	}
@@ -517,7 +516,7 @@ func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
 				*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, resp.VolumeID.Id, "", 0,
 					(*volumeOperationDetails).QuotaDetails,
 					(*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
-					vCenterServerForVolumeOperationCR, taskInfo.ActivationId, taskInvocationStatusSuccess, "")
+					vCenterServerForVolumeOperationCR, taskInfo.ActivationId, taskInvocationStatusSuccess, "", "")
 				return resp, faultType, err
 			}
 		}
@@ -527,7 +526,7 @@ func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
 			*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 				(*volumeOperationDetails).QuotaDetails, (*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp,
 				task.Reference().Value, vCenterServerForVolumeOperationCR, taskInfo.ActivationId,
-				taskInvocationStatusError, err.Error())
+				taskInvocationStatusError, err.Error(), "")
 			return nil, faultType, err
 		}
 	}
@@ -538,12 +537,12 @@ func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
 		*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 			(*volumeOperationDetails).QuotaDetails, (*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp,
 			task.Reference().Value, vCenterServerForVolumeOperationCR, taskInfo.ActivationId,
-			taskInvocationStatusError, err.Error())
+			taskInvocationStatusError, err.Error(), "")
 	} else {
 		*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, resp.VolumeID.Id, "", 0,
 			(*volumeOperationDetails).QuotaDetails, (*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp,
 			task.Reference().Value, vCenterServerForVolumeOperationCR, taskInfo.ActivationId,
-			taskInvocationStatusSuccess, "")
+			taskInvocationStatusSuccess, "", "")
 	}
 	return resp, faultType, err
 }
@@ -674,7 +673,7 @@ func (m *defaultManager) createVolumeWithImprovedIdempotency(ctx context.Context
 		// In both cases, invoke CNS CreateVolume again.
 		volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 			quotaInfo, metav1.Now(), "", vCenterServerForVolumeOperationCR, "",
-			taskInvocationStatusInProgress, "")
+			taskInvocationStatusInProgress, "", "")
 		err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 		if err != nil {
 			// Don't return if CreateVolume details can't be stored.
@@ -685,7 +684,7 @@ func (m *defaultManager) createVolumeWithImprovedIdempotency(ctx context.Context
 			log.Errorf("failed to create volume with error: %v", finalErr)
 			volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 				quotaInfo, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, "",
-				vCenterServerForVolumeOperationCR, "", taskInvocationStatusError, finalErr.Error())
+				vCenterServerForVolumeOperationCR, "", taskInvocationStatusError, finalErr.Error(), "")
 			faultType = ExtractFaultTypeFromErr(ctx, finalErr)
 			return nil, faultType, finalErr
 		}
@@ -693,7 +692,7 @@ func (m *defaultManager) createVolumeWithImprovedIdempotency(ctx context.Context
 			// Persist task details only for dynamically provisioned volumes.
 			volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 				quotaInfo, metav1.Now(), task.Reference().Value, vCenterServerForVolumeOperationCR, "",
-				taskInvocationStatusInProgress, "")
+				taskInvocationStatusInProgress, "", "")
 			err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 			if err != nil {
 				// Don't return if CreateVolume details can't be stored.
@@ -808,7 +807,7 @@ func (m *defaultManager) createVolumeWithTransaction(ctx context.Context, spec *
 	}()
 	volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 		quotaInfo, metav1.Now(), "", vCenterServerForVolumeOperationCR, "",
-		taskInvocationStatusInProgress, "")
+		taskInvocationStatusInProgress, "", "")
 	err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 	if err != nil {
 		// Don't return if CreateVolume details can't be stored.
@@ -819,7 +818,7 @@ func (m *defaultManager) createVolumeWithTransaction(ctx context.Context, spec *
 		log.Errorf("failed to create volume with error: %v", finalErr)
 		volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 			quotaInfo, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, "",
-			vCenterServerForVolumeOperationCR, "", taskInvocationStatusError, finalErr.Error())
+			vCenterServerForVolumeOperationCR, "", taskInvocationStatusError, finalErr.Error(), "")
 		faultType = ExtractFaultTypeFromErr(ctx, finalErr)
 		return nil, faultType, finalErr
 	}
@@ -827,7 +826,7 @@ func (m *defaultManager) createVolumeWithTransaction(ctx context.Context, spec *
 		// Persist task details only for dynamically provisioned volumes.
 		volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
 			quotaInfo, metav1.Now(), task.Reference().Value, vCenterServerForVolumeOperationCR, "",
-			taskInvocationStatusInProgress, "")
+			taskInvocationStatusInProgress, "", "")
 		err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 		if err != nil {
 			// Don't return if CreateVolume details can't be stored.
@@ -1563,7 +1562,7 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 		}
 	case apierrors.IsNotFound(err):
 		volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, nil,
-			metav1.Now(), "", "", "", taskInvocationStatusInProgress, "")
+			metav1.Now(), "", "", "", taskInvocationStatusInProgress, "", "")
 	default:
 		return csifault.CSIInternalFault, err
 	}
@@ -1599,7 +1598,7 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 			if cnsvsphere.IsNotFoundError(err) {
 				log.Infof("VolumeID: %q, not found, thus returning success", volumeID)
 				volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
-					nil, metav1.Now(), "", "", "", taskInvocationStatusSuccess, "")
+					nil, metav1.Now(), "", "", "", taskInvocationStatusSuccess, "", "")
 				err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 				if err != nil {
 					log.Warnf("failed to store DeleteVolume details with error: %v", err)
@@ -1608,7 +1607,7 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 			}
 			log.Errorf("CNS DeleteVolume failed from the  vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 			volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
-				nil, metav1.Now(), "", "", "", taskInvocationStatusError, err.Error())
+				nil, metav1.Now(), "", "", "", taskInvocationStatusError, err.Error(), "")
 			err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 			if err != nil {
 				log.Warnf("failed to store DeleteVolume details with error: %v", err)
@@ -1617,7 +1616,7 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 		}
 		volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 			nil, metav1.Now(), task.Reference().Value, "",
-			"", taskInvocationStatusInProgress, "")
+			"", taskInvocationStatusInProgress, "", "")
 		err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 		if err != nil {
 			log.Warnf("failed to store DeleteVolume details with error: %v", err)
@@ -1637,7 +1636,7 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 				// Mark the volumeOperationRequest as an error if the corresponding VC task is missing/NotFound.
 				msg := fmt.Sprintf("DeleteVolume task %s not found in vCenter.", task.Reference().Value)
 				volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
-					nil, metav1.Now(), task.Reference().Value, "", "", taskInvocationStatusError, msg)
+					nil, metav1.Now(), task.Reference().Value, "", "", taskInvocationStatusError, msg, "")
 				return faultType, logger.LogNewError(log, msg)
 			}
 		} else {
@@ -1675,7 +1674,7 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 					"fault: CnsNotRegisteredFault, opID: %q", volumeID, taskInfo.ActivationId)
 				volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 					nil, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
-					task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusError, msg)
+					task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusError, msg, "")
 				return faultType, logger.LogNewError(log, msg)
 			}
 			log.Infof("observed CnsNotRegisteredFault while deleting volume: %q. Attempting to re-register volume", volumeID)
@@ -1684,7 +1683,7 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 				msg := fmt.Sprintf("failed to re-register volume %q: %v", volumeID, err)
 				volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 					nil, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
-					task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusError, msg)
+					task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusError, msg, "")
 				return faultType, logger.LogNewErrorf(log, "failed to re-register volume %q: %v", volumeID, err)
 			}
 			log.Infof("Successfully re-registered volume %q. Retrying deleteVolumeWithImprovedIdempotency", volumeID)
@@ -1703,14 +1702,14 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 			volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 		volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 			nil, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
-			task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusError, msg)
+			task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusError, msg, "")
 		return faultType, logger.LogNewError(log, msg)
 	}
 	log.Infof("DeleteVolume: Volume deleted successfully. volumeID: %q, opId: %q",
 		volumeID, taskInfo.ActivationId)
 	volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 		nil, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
-		task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusSuccess, "")
+		task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusSuccess, "", "")
 	return "", nil
 }
 
@@ -2128,7 +2127,7 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 		// - The previous ExtendVolume task failed.
 		// In both cases, invoke CNS ExtendVolume.
 		volumeOperationDetails = createRequestDetails(instanceName, "", "", size,
-			quotaInfo, metav1.Now(), "", "", "", taskInvocationStatusInProgress, "")
+			quotaInfo, metav1.Now(), "", "", "", taskInvocationStatusInProgress, "", "")
 		err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 		if err != nil {
 			log.Warnf("failed to store ExpandVolume details with error: %v", err)
@@ -2154,11 +2153,11 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 			log.Errorf("CNS ExtendVolume failed from the vCenter %q with finalErr: %v",
 				m.virtualCenter.Config.Host, finalErr)
 			volumeOperationDetails = createRequestDetails(instanceName, "", "", size, quotaInfo,
-				metav1.Now(), "", "", "", taskInvocationStatusError, finalErr.Error())
+				metav1.Now(), "", "", "", taskInvocationStatusError, finalErr.Error(), "")
 			return faultType, finalErr
 		}
 		volumeOperationDetails = createRequestDetails(instanceName, "", "", size, quotaInfo,
-			metav1.Now(), task.Reference().Value, "", "", taskInvocationStatusInProgress, "")
+			metav1.Now(), task.Reference().Value, "", "", taskInvocationStatusInProgress, "", "")
 		err = m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 		if err != nil {
 			log.Warnf("failed to store ExpandVolume details with error: %v", err)
@@ -2179,7 +2178,7 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 				volumeOperationDetails = createRequestDetails(instanceName, "", "",
 					volumeOperationDetails.Capacity, quotaInfo,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, task.Reference().Value, "",
-					volumeOperationDetails.OperationDetails.TaskID, taskInvocationStatusSuccess, "")
+					volumeOperationDetails.OperationDetails.TaskID, taskInvocationStatusSuccess, "", "")
 				return "", nil
 			}
 		}
@@ -2192,7 +2191,7 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 		volumeOperationDetails = createRequestDetails(instanceName, "", "",
 			volumeOperationDetails.Capacity, quotaInfo, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
 			task.Reference().Value, "", volumeOperationDetails.OperationDetails.TaskID,
-			taskInvocationStatusError, finalErr.Error())
+			taskInvocationStatusError, finalErr.Error(), "")
 		return ExtractFaultTypeFromErr(ctx, finalErr), finalErr
 	}
 
@@ -2225,7 +2224,7 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 					volumeOperationDetails.Capacity, quotaInfo,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
 					task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusError,
-					volumeOperationRes.Fault.LocalizedMessage)
+					volumeOperationRes.Fault.LocalizedMessage, "")
 				return faultType, logger.LogNewErrorf(log, "failed to extend volume after re-registration. "+
 					"volumeID: %q, fault: CnsNotRegisteredFault, opID: %q", volumeID, taskInfo.ActivationId)
 			}
@@ -2237,7 +2236,7 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 				volumeOperationDetails = createRequestDetails(instanceName, "", "",
 					volumeOperationDetails.Capacity, quotaInfo, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
 					task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusError,
-					fmt.Sprintf("failed to re-register volume: %v", err))
+					fmt.Sprintf("failed to re-register volume: %v", err), "")
 				return faultType, logger.LogNewErrorf(log, "failed to re-register volume %q: %v", volumeID, err)
 			}
 			log.Infof("Successfully re-registered volume %q. Retrying expandVolumeWithImprovedIdempotency", volumeID)
@@ -2254,7 +2253,7 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 				volumeOperationDetails = createRequestDetails(instanceName, "", "",
 					volumeOperationDetails.Capacity, quotaInfo,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
-					"", volumeOperationDetails.OperationDetails.TaskID, taskInvocationStatusSuccess, "")
+					"", volumeOperationDetails.OperationDetails.TaskID, taskInvocationStatusSuccess, "", "")
 				return "", nil
 			}
 		}
@@ -2262,7 +2261,7 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 		volumeOperationDetails = createRequestDetails(instanceName, "", "",
 			volumeOperationDetails.Capacity, quotaInfo, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
 			task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusError,
-			volumeOperationRes.Fault.LocalizedMessage)
+			volumeOperationRes.Fault.LocalizedMessage, "")
 		return faultType, logger.LogNewErrorf(log, "failed to extend volume: %q, fault: %q, opID: %q",
 			volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 	}
@@ -2271,7 +2270,7 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 		volumeOperationDetails.Capacity, volumeID, taskInfo.ActivationId)
 	volumeOperationDetails = createRequestDetails(instanceName, "", "",
 		volumeOperationDetails.Capacity, quotaInfo, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
-		task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusSuccess, "")
+		task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusSuccess, "", "")
 	if volumeOperationDetails.Capacity >= size {
 		return "", nil
 	}
@@ -2760,9 +2759,10 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 					instanceName, volumeOperationDetails.SnapshotID, volumeOperationDetails.VolumeID,
 					volumeOperationDetails.OperationDetails.OpID)
 				cnsSnapshotInfo := &CnsSnapshotInfo{
-					SnapshotID:          volumeOperationDetails.SnapshotID,
-					SourceVolumeID:      volumeOperationDetails.VolumeID,
-					SnapshotDescription: volumeOperationDetails.Name,
+					SnapshotID:             volumeOperationDetails.SnapshotID,
+					SourceVolumeID:         volumeOperationDetails.VolumeID,
+					SnapshotDescription:    volumeOperationDetails.Name,
+					ChangedBlockTrackingId: volumeOperationDetails.ChangedBlockTrackingId,
 				}
 				if volumeOperationDetails.QuotaDetails != nil {
 					if volumeOperationDetails.QuotaDetails.AggregatedSnapshotSize != nil {
@@ -2801,7 +2801,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 			// Instance doesn't exist. This is likely the first attempt to create the snapshot.
 			volumeOperationDetails = createRequestDetails(
 				instanceName, volumeID, "", 0, quotaInfo, metav1.Now(), "", "", "",
-				taskInvocationStatusInProgress, "")
+				taskInvocationStatusInProgress, "", "")
 		default:
 			return nil, err
 		}
@@ -2838,7 +2838,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 			if m.idempotencyHandlingEnabled {
 				volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, quotaInfo,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, "", "", "",
-					taskInvocationStatusError, err.Error())
+					taskInvocationStatusError, err.Error(), "")
 			}
 			return nil, logger.LogNewErrorf(log, "failed to create snapshot with error: %v", err)
 		}
@@ -2847,7 +2847,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 			// Persist the volume operation details.
 			volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, quotaInfo,
 				volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
-				createSnapshotsTask.Reference().Value, "", "", taskInvocationStatusInProgress, "")
+				createSnapshotsTask.Reference().Value, "", "", taskInvocationStatusInProgress, "", "")
 			if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
 				// Don't return if CreateSnapshot details can't be stored.
 				log.Warnf("failed to store CreateSnapshot details with error: %v", err)
@@ -2887,6 +2887,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 					SourceVolumeID:                      volumeID,
 					SnapshotDescription:                 snapshotName,
 					SnapshotLatestOperationCompleteTime: queriedCnsSnapshot.CreateTime,
+					ChangedBlockTrackingId:              queriedCnsSnapshot.ChangedBlockTrackingId,
 				}
 				if isStorageQuotaM2FSSEnabled && m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 					log.Infof("get aggregated Snapshot Capacity for volume with volumeID %q", volumeID)
@@ -2910,7 +2911,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 					instanceName, volumeID, queriedCnsSnapshot.SnapshotId.Id, 0, quotaInfo,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
 					createSnapshotsTask.Reference().Value, "",
-					"", taskInvocationStatusSuccess, "")
+					"", taskInvocationStatusSuccess, "", queriedCnsSnapshot.ChangedBlockTrackingId)
 				log.Warnf("Using create snapshot timestamp %q instead of create snapshot task"+
 					" completion time for snapshot %q and volumeID %q",
 					queriedCnsSnapshot.CreateTime, volumeOperationDetails.SnapshotID, volumeID)
@@ -2920,7 +2921,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 					"Marking task %s as failed.", snapshotName, volumeID, createSnapshotsTask.Reference().Value)
 				volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, quotaInfo,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
-					createSnapshotsTask.Reference().Value, "", "", taskInvocationStatusError, errMsg)
+					createSnapshotsTask.Reference().Value, "", "", taskInvocationStatusError, errMsg, "")
 				return nil, logger.LogNewError(log, errMsg)
 			}
 		}
@@ -2956,7 +2957,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 			if m.idempotencyHandlingEnabled {
 				volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, nil,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, createSnapshotsTask.Reference().Value,
-					"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusError, errMsg)
+					"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusError, errMsg, "")
 			}
 			return nil, logger.LogNewError(log, errMsg)
 		}
@@ -2974,12 +2975,12 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 				snapshotId := createSnapshotsOperationRes.Fault.Fault.(*cnstypes.CnsSnapshotCreatedFault).SnapshotId.Id
 				volumeOperationDetails = createRequestDetails(instanceName, volumeID, snapshotId, 0, nil,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, createSnapshotsTask.Reference().Value,
-					"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusPartiallyFailed, errMsg)
+					"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusPartiallyFailed, errMsg, "")
 				return nil, logger.LogNewError(log, errMsg)
 			}
 			volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, nil,
 				volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, createSnapshotsTask.Reference().Value,
-				"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusError, errMsg)
+				"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusError, errMsg, "")
 		} else {
 			// Remove the task details from map when the current task fails
 			_, ok := snapshotTaskMap[instanceName]
@@ -3005,6 +3006,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 		SourceVolumeID:                      snapshotCreateResult.Snapshot.VolumeId.Id,
 		SnapshotDescription:                 snapshotCreateResult.Snapshot.Description,
 		SnapshotLatestOperationCompleteTime: *createSnapshotsTaskInfo.CompleteTime,
+		ChangedBlockTrackingId:              snapshotCreateResult.Snapshot.ChangedBlockTrackingId,
 	}
 	if isStorageQuotaM2FSSEnabled && m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		log.Infof("For volumeID %q new AggregatedSnapshotSize is %d and SnapshotLatestOperationCompleteTime is %q",
@@ -3022,11 +3024,12 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 		volumeOperationDetails = createRequestDetails(
 			instanceName, cnsSnapshotInfo.SourceVolumeID, cnsSnapshotInfo.SnapshotID, 0, quotaInfo,
 			volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, createSnapshotsTask.Reference().Value,
-			"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusSuccess, "")
+			"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusSuccess, "", cnsSnapshotInfo.ChangedBlockTrackingId)
 	}
 
-	log.Infof("CreateSnapshot: Snapshot created successfully. VolumeID: %q, SnapshotID: %q, "+
+	log.Infof("CreateSnapshot: Snapshot created successfully. VolumeID: %q, SnapshotID: %q, changedBlockTrackingId: %q, "+
 		"SnapshotCreateTime: %q, opId: %q", cnsSnapshotInfo.SourceVolumeID, cnsSnapshotInfo.SnapshotID,
+		cnsSnapshotInfo.ChangedBlockTrackingId,
 		cnsSnapshotInfo.SnapshotLatestOperationCompleteTime, createSnapshotsTaskInfo.ActivationId)
 
 	return cnsSnapshotInfo, nil
@@ -3108,7 +3111,7 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 	}()
 	volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, quotaInfo,
 		metav1.Now(),
-		"", "", "", taskInvocationStatusInProgress, "")
+		"", "", "", taskInvocationStatusInProgress, "", "")
 	if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
 		// Don't return if CreateSnapshot details can't be stored.
 		log.Warnf("failed to store CreateSnapshot details with error: %v", err)
@@ -3117,14 +3120,14 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 	if err != nil {
 		volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, quotaInfo,
 			volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, "", "", "",
-			taskInvocationStatusError, err.Error())
+			taskInvocationStatusError, err.Error(), "")
 		faultType := ExtractFaultTypeFromErr(ctx, err)
 		return nil, faultType, logger.LogNewErrorf(log, "failed to create snapshot with error: %v", err)
 	}
 	// Persist the volume operation details.
 	volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, quotaInfo,
 		volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
-		createSnapshotsTask.Reference().Value, "", "", taskInvocationStatusInProgress, "")
+		createSnapshotsTask.Reference().Value, "", "", taskInvocationStatusInProgress, "", "")
 	if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
 		// Don't return if CreateSnapshot details can't be stored.
 		log.Warnf("failed to store CreateSnapshot details with error: %v", err)
@@ -3142,7 +3145,7 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 		}
 		volumeOperationDetails = createRequestDetails(instanceName, volumeID, "", 0, quotaInfo,
 			volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, "", "", "",
-			taskInvocationStatusError, err.Error())
+			taskInvocationStatusError, err.Error(), "")
 		return nil, faultType, logger.LogNewErrorf(log, "Failed to get taskInfo for CreateSnapshots task "+
 			"from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 	}
@@ -3180,6 +3183,7 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 		SourceVolumeID:                      snapshotCreateResult.Snapshot.VolumeId.Id,
 		SnapshotDescription:                 snapshotCreateResult.Snapshot.Description,
 		SnapshotLatestOperationCompleteTime: *createSnapshotsTaskInfo.CompleteTime,
+		ChangedBlockTrackingId:              snapshotCreateResult.Snapshot.ChangedBlockTrackingId,
 	}
 	if isStorageQuotaM2FSSEnabled && m.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		log.Infof("For volumeID %q new AggregatedSnapshotSize is %d and SnapshotLatestOperationCompleteTime is %q",
@@ -3196,11 +3200,13 @@ func (m *defaultManager) createSnapshotWithTransaction(ctx context.Context, volu
 	volumeOperationDetails = createRequestDetails(
 		instanceName, cnsSnapshotInfo.SourceVolumeID, cnsSnapshotInfo.SnapshotID, 0, quotaInfo,
 		volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, createSnapshotsTask.Reference().Value,
-		"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusSuccess, "")
+		"", createSnapshotsTaskInfo.ActivationId, taskInvocationStatusSuccess, "", cnsSnapshotInfo.ChangedBlockTrackingId)
 
 	log.Infof("CreateSnapshot: Snapshot created successfully. VolumeID: %q, SnapshotID: %q, "+
-		"SnapshotCreateTime: %q, opId: %q", cnsSnapshotInfo.SourceVolumeID, cnsSnapshotInfo.SnapshotID,
-		cnsSnapshotInfo.SnapshotLatestOperationCompleteTime, createSnapshotsTaskInfo.ActivationId)
+		"changedBlockTrackingId: %q, SnapshotCreateTime: %q, opId: %q",
+		cnsSnapshotInfo.SourceVolumeID, cnsSnapshotInfo.SnapshotID,
+		cnsSnapshotInfo.ChangedBlockTrackingId, cnsSnapshotInfo.SnapshotLatestOperationCompleteTime,
+		createSnapshotsTaskInfo.ActivationId)
 
 	return cnsSnapshotInfo, "", nil
 }
@@ -3346,7 +3352,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 			}
 		case apierrors.IsNotFound(err):
 			volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, nil, metav1.Now(),
-				"", "", "", taskInvocationStatusInProgress, "")
+				"", "", "", taskInvocationStatusInProgress, "", "")
 		default:
 			return nil, err
 		}
@@ -3395,7 +3401,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 
 				if m.idempotencyHandlingEnabled {
 					volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, quotaInfo,
-						metav1.Now(), "", "", "", taskInvocationStatusSuccess, "")
+						metav1.Now(), "", "", "", taskInvocationStatusSuccess, "", "")
 					if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
 						log.Warnf("failed to store DeleteSnapshot operation details with error: %v", err)
 					}
@@ -3406,7 +3412,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 			if m.idempotencyHandlingEnabled {
 				volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 					nil, metav1.Now(), "", "", "", taskInvocationStatusError,
-					err.Error())
+					err.Error(), "")
 				if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
 					log.Warnf("failed to store DeleteSnapshot operation details with error: %v", err)
 				}
@@ -3416,7 +3422,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 		}
 		if m.idempotencyHandlingEnabled {
 			volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, nil,
-				metav1.Now(), deleteSnapshotTask.Reference().Value, "", "", taskInvocationStatusInProgress, "")
+				metav1.Now(), deleteSnapshotTask.Reference().Value, "", "", taskInvocationStatusInProgress, "", "")
 			if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
 				log.Warnf("failed to store DeleteSnapshot operation details with error: %v", err)
 			}
@@ -3458,7 +3464,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 					volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, quotaInfo,
 						volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
 						deleteSnapshotTask.Reference().Value, "", volumeOperationDetails.OperationDetails.OpID,
-						taskInvocationStatusSuccess, "")
+						taskInvocationStatusSuccess, "", "")
 				}
 				log.Infof("DeleteSnapshot: Snapshot %q on volume %q is confirmed to be deleted successfully",
 					snapshotID, volumeID)
@@ -3468,7 +3474,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 
 		volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, nil,
 			volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, deleteSnapshotTask.Reference().Value, "",
-			volumeOperationDetails.OperationDetails.TaskID, taskInvocationStatusError, err.Error())
+			volumeOperationDetails.OperationDetails.TaskID, taskInvocationStatusError, err.Error(), "")
 
 		return nil, logger.LogNewErrorf(log, "Failed to get taskInfo for DeleteSnapshots task from vCenter %q with err: %v",
 			m.virtualCenter.Config.Host, err)
@@ -3507,7 +3513,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 			if m.idempotencyHandlingEnabled {
 				volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, nil,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, deleteSnapshotTask.Reference().Value,
-					"", deleteSnapshotsTaskInfo.ActivationId, taskInvocationStatusError, errMsg)
+					"", deleteSnapshotsTaskInfo.ActivationId, taskInvocationStatusError, errMsg, "")
 			}
 			return nil, logger.LogNewError(log, errMsg)
 		}
@@ -3536,7 +3542,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 			if m.idempotencyHandlingEnabled {
 				volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, nil,
 					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, deleteSnapshotTask.Reference().Value,
-					"", deleteSnapshotsTaskInfo.ActivationId, taskInvocationStatusError, errMsg)
+					"", deleteSnapshotsTaskInfo.ActivationId, taskInvocationStatusError, errMsg, "")
 			}
 
 			return nil, logger.LogNewError(log, errMsg)
@@ -3561,7 +3567,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 		// create the volumeOperationDetails object for persistence
 		volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, quotaInfo,
 			volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, deleteSnapshotTask.Reference().Value, "",
-			deleteSnapshotsTaskInfo.ActivationId, taskInvocationStatusSuccess, "")
+			deleteSnapshotsTaskInfo.ActivationId, taskInvocationStatusSuccess, "", "")
 	}
 	log.Infof("DeleteSnapshot: Snapshot %q on volume %q is deleted successfully. opId: %q", snapshotID,
 		volumeID, deleteSnapshotsTaskInfo.ActivationId)
@@ -4316,31 +4322,6 @@ func (m *defaultManager) connectVirtualCenter(ctx context.Context) (*cnsvsphere.
 		return nil, err
 	}
 	return m.virtualCenter, nil
-}
-
-// GetFCDSnapshotChangeID returns ChangedBlockTrackingId from FCD snapshot details (VSLM).
-func (m *defaultManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
-	log := logger.GetLogger(ctx)
-	log.Debugf("GetFCDSnapshotChangeID: volume=%s snapshot=%s", volumeID, snapshotID)
-
-	vcenter, err := m.connectVirtualCenter(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get vCenter from volume manager: %v", err)
-	}
-
-	snapshotDetails, err := RetrieveSnapshotDetailsHook(ctx, vcenter,
-		vim25types.ID{Id: volumeID}, vim25types.ID{Id: snapshotID})
-	if err != nil {
-		return "", fmt.Errorf("failed to retrieve snapshot details via VSLM API: %v", err)
-	}
-
-	changeID := snapshotDetails.ChangedBlockTrackingId
-	if changeID == "" {
-		return "", fmt.Errorf("changeId is empty in snapshot %s (CBT may not be enabled)", snapshotID)
-	}
-
-	log.Debugf("Retrieved changeId %s for snapshot %s", changeID, snapshotID)
-	return changeID, nil
 }
 
 // QueryFCDAllocatedBlocks returns allocated block ranges using FCD VSLM QueryChangedDiskAreas with changeId "*".

--- a/pkg/common/cns-lib/volume/manager_mock.go
+++ b/pkg/common/cns-lib/volume/manager_mock.go
@@ -230,8 +230,3 @@ func (m MockManager) QueryFCDChangedBlocks(ctx context.Context,
 	//TODO implement me
 	panic("implement me")
 }
-
-func (m MockManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
-	//TODO implement me
-	panic("implement me")
-}

--- a/pkg/common/cns-lib/volume/manager_test.go
+++ b/pkg/common/cns-lib/volume/manager_test.go
@@ -744,47 +744,6 @@ func TestConnectVirtualCenter(t *testing.T) {
 	assert.Same(t, mOK.virtualCenter, vc)
 }
 
-func TestGetFCDSnapshotChangeID(t *testing.T) {
-	ctx := context.Background()
-	ctx = logger.NewContextWithLogger(ctx)
-
-	orig := RetrieveSnapshotDetailsHook
-	defer func() { RetrieveSnapshotDetailsHook = orig }()
-
-	m := &defaultManager{virtualCenter: &cnsvsphere.VirtualCenter{}}
-
-	RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-		volumeID vim25types.ID, snapshotID vim25types.ID) (*vim25types.VStorageObjectSnapshotDetails, error) {
-		assert.Equal(t, "vol-1", volumeID.Id)
-		assert.Equal(t, "snap-1", snapshotID.Id)
-		return &vim25types.VStorageObjectSnapshotDetails{ChangedBlockTrackingId: "cid-99"}, nil
-	}
-	id, err := m.GetFCDSnapshotChangeID(ctx, "vol-1", "snap-1")
-	assert.NoError(t, err)
-	assert.Equal(t, "cid-99", id)
-
-	RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-		volumeID vim25types.ID, snapshotID vim25types.ID) (*vim25types.VStorageObjectSnapshotDetails, error) {
-		return nil, fmt.Errorf("vslm failed")
-	}
-	_, err = m.GetFCDSnapshotChangeID(ctx, "v", "s")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to retrieve snapshot details")
-
-	RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-		volumeID vim25types.ID, snapshotID vim25types.ID) (*vim25types.VStorageObjectSnapshotDetails, error) {
-		return &vim25types.VStorageObjectSnapshotDetails{ChangedBlockTrackingId: ""}, nil
-	}
-	_, err = m.GetFCDSnapshotChangeID(ctx, "v", "snap-empty")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "changeId is empty")
-
-	mBad := &defaultManager{virtualCenter: nil}
-	_, err = mBad.GetFCDSnapshotChangeID(ctx, "v", "s")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get vCenter from volume manager")
-}
-
 func TestQueryFCDAllocatedBlocks(t *testing.T) {
 	ctx := context.Background()
 	ctx = logger.NewContextWithLogger(ctx)

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -183,9 +183,6 @@ func (m *MockVolumeManager) QueryFCDChangedBlocks(ctx context.Context,
 	[]cnsvolume.ChangedArea, uint64, error) {
 	return nil, 0, nil
 }
-func (m *MockVolumeManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
-	return "", nil
-}
 func (m *MockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
 	return nil
 }

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -1012,9 +1012,6 @@ func (m *cbtFlagsMockVolumeManager) QueryFCDChangedBlocks(context.Context,
 	string, string, string, uint64, uint32) ([]cnsvolume.ChangedArea, uint64, error) {
 	return nil, 0, nil
 }
-func (m *cbtFlagsMockVolumeManager) GetFCDSnapshotChangeID(context.Context, string, string) (string, error) {
-	return "", nil
-}
 
 func TestSyncVolumeCBTState(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -92,9 +92,6 @@ func (m *mockVolumeManager) QueryFCDChangedBlocks(ctx context.Context,
 	[]cnsvolume.ChangedArea, uint64, error) {
 	return nil, 0, nil
 }
-func (m *mockVolumeManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
-	return "", nil
-}
 func (m *mockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
 	return nil
 }

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -2316,7 +2316,7 @@ func TestDeleteBlockVolumeSnapshotWithManagedObjectNotFound(t *testing.T) {
 	instanceName := "deletesnapshot-" + volID + "-" + snapshotID
 	operationInstance := cnsvolumeoperationrequest.CreateVolumeOperationRequestDetails(
 		instanceName, "", "", 0, nil, metav1.Now(),
-		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "")
+		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "", "")
 	_ = ct.operationStore.StoreRequestDetails(ctx, operationInstance)
 
 	// logger.SetLoggerLevel(logger.DevelopmentLogLevel) // enable debug level log
@@ -2447,7 +2447,7 @@ func TestCreateSnapshotWithManagedObjectNotFound(t *testing.T) {
 	instanceName := snapshotName + "-" + volID
 	operationInstance := cnsvolumeoperationrequest.CreateVolumeOperationRequestDetails(
 		instanceName, volID, "", 0, nil, metav1.Now(),
-		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "")
+		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "", "")
 	_ = ct.operationStore.StoreRequestDetails(ctx, operationInstance)
 	// Attempt to create snapshot again, but the task-id is non-existent.
 	// Since the snapshot already exists, no error is expected.
@@ -2576,7 +2576,7 @@ func TestCreateSnapshotWithCnsSnapshotCreatedFault(t *testing.T) {
 	instanceName := snapshotName + "-" + volID
 	operationInstance := cnsvolumeoperationrequest.CreateVolumeOperationRequestDetails(
 		instanceName, volID, snapID, 0, nil, metav1.Now(),
-		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusPartiallyFailed, "")
+		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusPartiallyFailed, "", "")
 	_ = ct.operationStore.StoreRequestDetails(ctx, operationInstance)
 
 	// Attempt to create snapshot again.

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -2743,16 +2743,9 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 
 		volumeSnapshotName := req.Parameters[common.VolumeSnapshotNameKey]
 		annotations := map[string]string{common.VolumeSnapshotInfoKey: snapshotID}
-
-		// TODO: This code will be updated when we can retrieve change-id from CNS
-		// Retrieve change-id from FCD and add it to the annotations
-		changeId, err := c.getSnapshotChangeIdFromFCD(ctx, volumeID, cnsSnapshotInfo.SnapshotID)
-		if err != nil {
-			log.Warnf("Failed to retrieve changeId for snapshot %s: %v", snapshotID, err)
-		} else {
-			annotations[common.VolumeSnapshotChangeIDKey] = changeId
+		if cnsSnapshotInfo.ChangedBlockTrackingId != "" {
+			annotations[common.VolumeSnapshotChangeIDKey] = cnsSnapshotInfo.ChangedBlockTrackingId
 		}
-
 		log.Infof("Attempting to annotate volumesnapshot %s/%s with annotations %v",
 			volumeSnapshotNamespace, volumeSnapshotName, annotations)
 		annotated, err := commonco.ContainerOrchestratorUtility.AnnotateVolumeSnapshot(ctx, volumeSnapshotName,

--- a/pkg/csi/service/wcp/controller_cbt.go
+++ b/pkg/csi/service/wcp/controller_cbt.go
@@ -323,11 +323,6 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 	return server.Send(resp)
 }
 
-// getSnapshotChangeIdFromFCD retrieves the changeId from a snapshot using FCD VSLM APIs via the volume manager.
-func (c *controller) getSnapshotChangeIdFromFCD(ctx context.Context, volumeID, snapshotID string) (string, error) {
-	return c.manager.VolumeManager.GetFCDSnapshotChangeID(ctx, volumeID, snapshotID)
-}
-
 // validateGetMetadataAllocatedRequest validates the GetMetadataAllocated request
 func validateGetMetadataAllocatedRequest(ctx context.Context, req *csi.GetMetadataAllocatedRequest) error {
 	log := logger.GetLogger(ctx)

--- a/pkg/csi/service/wcp/controller_cbt_test.go
+++ b/pkg/csi/service/wcp/controller_cbt_test.go
@@ -728,38 +728,3 @@ func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
 	runVSLMErrorPropagationCase(t, "NotFound_FCD",
 		&types.NotFound{}, "", true, codes.NotFound)
 }
-
-// TestGetSnapshotChangeIdFromFCD tests the function that retrieves change ID
-func TestGetSnapshotChangeIdFromFCD(t *testing.T) {
-	ct := getControllerTest(t)
-
-	origHook := cnsvolume.RetrieveSnapshotDetailsHook
-	defer func() { cnsvolume.RetrieveSnapshotDetailsHook = origHook }()
-
-	cnsvolume.RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-		volumeID types.ID, snapshotID types.ID) (*types.VStorageObjectSnapshotDetails, error) {
-		return &types.VStorageObjectSnapshotDetails{
-			ChangedBlockTrackingId: "mock-change-id-from-fcd",
-		}, nil
-	}
-
-	changeId, err := ct.controller.getSnapshotChangeIdFromFCD(ctx, testVolumeName, "snapshot-123")
-	if err != nil {
-		t.Errorf("Expected success, got error: %v", err)
-	}
-	if changeId != "mock-change-id-from-fcd" {
-		t.Errorf("Expected mock-change-id-from-fcd, got: %s", changeId)
-	}
-
-	cnsvolume.RetrieveSnapshotDetailsHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-		volumeID types.ID, snapshotID types.ID) (*types.VStorageObjectSnapshotDetails, error) {
-		return &types.VStorageObjectSnapshotDetails{
-			ChangedBlockTrackingId: "", // empty
-		}, nil
-	}
-
-	_, err = ct.controller.getSnapshotChangeIdFromFCD(ctx, testVolumeName, "snapshot-123")
-	if err == nil {
-		t.Errorf("Expected error for empty change ID, got nil")
-	}
-}

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -188,7 +188,7 @@ func (or *operationRequestStore) GetRequestDetails(
 	return CreateVolumeOperationRequestDetails(instance.Spec.Name, instance.Status.VolumeID, instance.Status.SnapshotID,
 			instance.Status.Capacity, quotaDetails, operationDetailsToReturn.TaskInvocationTimestamp,
 			operationDetailsToReturn.TaskID, operationDetailsToReturn.VCenterServer, operationDetailsToReturn.OpID,
-			operationDetailsToReturn.TaskStatus, operationDetailsToReturn.Error),
+			operationDetailsToReturn.TaskStatus, operationDetailsToReturn.Error, instance.Status.ChangedBlockTrackingId),
 		nil
 }
 
@@ -224,10 +224,11 @@ func (or *operationRequestStore) StoreRequestDetails(
 					Name: instanceKey.Name,
 				},
 				Status: cnsvolumeoprequestv1alpha1.CnsVolumeOperationRequestStatus{
-					VolumeID:              operationToStore.VolumeID,
-					SnapshotID:            operationToStore.SnapshotID,
-					Capacity:              operationToStore.Capacity,
-					FirstOperationDetails: *operationDetailsToStore,
+					VolumeID:               operationToStore.VolumeID,
+					SnapshotID:             operationToStore.SnapshotID,
+					Capacity:               operationToStore.Capacity,
+					ChangedBlockTrackingId: operationToStore.ChangedBlockTrackingId,
+					FirstOperationDetails:  *operationDetailsToStore,
 					LatestOperationDetails: []cnsvolumeoprequestv1alpha1.OperationDetails{
 						*operationDetailsToStore,
 					},
@@ -299,10 +300,11 @@ func (or *operationRequestStore) StoreRequestDetails(
 		}
 	}
 
-	// Modify VolumeID, SnapshotID and Capacity
+	// Modify VolumeID, SnapshotID, Capacity, and ChangedBlockTrackingId
 	updatedInstance.Status.VolumeID = operationToStore.VolumeID
 	updatedInstance.Status.SnapshotID = operationToStore.SnapshotID
 	updatedInstance.Status.Capacity = operationToStore.Capacity
+	updatedInstance.Status.ChangedBlockTrackingId = operationToStore.ChangedBlockTrackingId
 	if isPodVMOnStretchSupervisorFSSEnabled && operationToStore.QuotaDetails != nil {
 		updatedInstance.Status.StorageQuotaDetails = &cnsvolumeoprequestv1alpha1.QuotaDetails{
 			Reserved:                            operationToStore.QuotaDetails.Reserved,

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest_test.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest_test.go
@@ -665,3 +665,111 @@ func TestStoreRequestDetails_RealWorkflowTransitions(t *testing.T) {
 		}
 	})
 }
+
+// TestStoreAndRetrieveChangedBlockTrackingId tests that the ChangedBlockTrackingId field
+// is properly stored and retrieved for snapshot operations
+func TestStoreAndRetrieveChangedBlockTrackingId(t *testing.T) {
+	store, ctx := setupTestEnvironment(t, false)
+
+	t.Run("ChangedBlockTrackingId is persisted and retrieved", func(t *testing.T) {
+		instanceName := "snapshot-with-cbt"
+		volumeID := "volume-cbt-123"
+		snapshotID := "snapshot-cbt-456"
+		changedBlockTrackingId := "cbt-id-789"
+		quotaDetails := createTestQuotaDetails(1024 * 1024 * 1024) // 1GB
+
+		// Create operation details with ChangedBlockTrackingId
+		operationDetails := &VolumeOperationRequestDetails{
+			Name:                   instanceName,
+			VolumeID:               volumeID,
+			SnapshotID:             snapshotID,
+			ChangedBlockTrackingId: changedBlockTrackingId,
+			QuotaDetails:           quotaDetails,
+			OperationDetails: &OperationDetails{
+				TaskInvocationTimestamp: metav1.Now(),
+				TaskID:                  "task-cbt-123",
+				TaskStatus:              TaskInvocationStatusSuccess,
+				Error:                   "",
+			},
+		}
+
+		// Store the details
+		err := store.StoreRequestDetails(ctx, operationDetails)
+		if err != nil {
+			t.Errorf("Failed to store operation details: %v", err)
+			return
+		}
+
+		// Retrieve the details
+		retrievedDetails, err := store.GetRequestDetails(ctx, instanceName)
+		if err != nil {
+			t.Errorf("Failed to retrieve operation details: %v", err)
+			return
+		}
+
+		if retrievedDetails == nil {
+			t.Error("Retrieved details should not be nil")
+			return
+		}
+
+		// Verify ChangedBlockTrackingId is correctly persisted and retrieved
+		if retrievedDetails.ChangedBlockTrackingId != changedBlockTrackingId {
+			t.Errorf("Expected ChangedBlockTrackingId %s, got %s",
+				changedBlockTrackingId, retrievedDetails.ChangedBlockTrackingId)
+		}
+
+		// Also verify other fields are still correct
+		if retrievedDetails.VolumeID != volumeID {
+			t.Errorf("Expected VolumeID %s, got %s", volumeID, retrievedDetails.VolumeID)
+		}
+		if retrievedDetails.SnapshotID != snapshotID {
+			t.Errorf("Expected SnapshotID %s, got %s", snapshotID, retrievedDetails.SnapshotID)
+		}
+	})
+
+	t.Run("empty ChangedBlockTrackingId is preserved", func(t *testing.T) {
+		instanceName := "snapshot-no-cbt"
+		volumeID := "volume-no-cbt-123"
+		snapshotID := "snapshot-no-cbt-456"
+		quotaDetails := createTestQuotaDetails(512 * 1024 * 1024) // 512MB
+
+		// Create operation details without ChangedBlockTrackingId (empty string)
+		operationDetails := &VolumeOperationRequestDetails{
+			Name:                   instanceName,
+			VolumeID:               volumeID,
+			SnapshotID:             snapshotID,
+			ChangedBlockTrackingId: "", // Empty is valid for non-CBT snapshots
+			QuotaDetails:           quotaDetails,
+			OperationDetails: &OperationDetails{
+				TaskInvocationTimestamp: metav1.Now(),
+				TaskID:                  "task-no-cbt-123",
+				TaskStatus:              TaskInvocationStatusSuccess,
+				Error:                   "",
+			},
+		}
+
+		// Store the details
+		err := store.StoreRequestDetails(ctx, operationDetails)
+		if err != nil {
+			t.Errorf("Failed to store operation details: %v", err)
+			return
+		}
+
+		// Retrieve the details
+		retrievedDetails, err := store.GetRequestDetails(ctx, instanceName)
+		if err != nil {
+			t.Errorf("Failed to retrieve operation details: %v", err)
+			return
+		}
+
+		if retrievedDetails == nil {
+			t.Error("Retrieved details should not be nil")
+			return
+		}
+
+		// Verify empty ChangedBlockTrackingId is preserved
+		if retrievedDetails.ChangedBlockTrackingId != "" {
+			t.Errorf("Expected empty ChangedBlockTrackingId, got %s", retrievedDetails.ChangedBlockTrackingId)
+		}
+	})
+}

--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -46,12 +46,13 @@ const (
 // VolumeOperationRequestInterface and the persisted details will be
 // returned by the interface on request by the caller via this structure.
 type VolumeOperationRequestDetails struct {
-	Name             string
-	VolumeID         string
-	SnapshotID       string
-	Capacity         int64
-	QuotaDetails     *QuotaDetails
-	OperationDetails *OperationDetails
+	Name                   string
+	VolumeID               string
+	SnapshotID             string
+	Capacity               int64
+	QuotaDetails           *QuotaDetails
+	OperationDetails       *OperationDetails
+	ChangedBlockTrackingId string
 }
 
 // QuotaDetails stores information required to interact with the custom
@@ -79,7 +80,7 @@ type OperationDetails struct {
 // VolumeOperationRequestDetails from the input parameters.
 func CreateVolumeOperationRequestDetails(name, volumeID, snapshotID string, capacity int64,
 	quotaDetails *QuotaDetails, taskInvocationTimestamp metav1.Time, taskID, vCenterServer, opID,
-	taskStatus, error string) *VolumeOperationRequestDetails {
+	taskStatus, error, changedBlockTrackingId string) *VolumeOperationRequestDetails {
 	return &VolumeOperationRequestDetails{
 		Name:         name,
 		VolumeID:     volumeID,
@@ -94,6 +95,7 @@ func CreateVolumeOperationRequestDetails(name, volumeID, snapshotID string, capa
 			TaskStatus:              taskStatus,
 			Error:                   error,
 		},
+		ChangedBlockTrackingId: changedBlockTrackingId,
 	}
 }
 

--- a/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
@@ -52,6 +52,9 @@ type CnsVolumeOperationRequestStatus struct {
 	// LatestOperationDetails stores the details of the latest operations performed
 	// on the volume. Should have a maximum of 10 entries.
 	LatestOperationDetails []OperationDetails `json:"latestOperationDetails,omitempty"`
+	// ChangedBlockTrackingId is the unique changed block tracking ID of the backend snapshot.
+	// Populated during successful CreateSnapshot calls.
+	ChangedBlockTrackingId string `json:"changedBlockTrackingId,omitempty"`
 }
 type QuotaDetails struct {
 	// Reserved keeps a track of the quantity that should be reserved in

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -152,11 +152,6 @@ func (m *mockVolumeManager) QueryFCDChangedBlocks(ctx context.Context,
 	panic("implement me")
 }
 
-func (m *mockVolumeManager) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (string, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
 func (m *mockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
 	//TODO implement me
 	panic("implement me")

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -862,11 +862,6 @@ func (m *mockVolumeManagerForFullSync) QueryFCDChangedBlocks(ctx context.Context
 	return nil, 0, nil
 }
 
-func (m *mockVolumeManagerForFullSync) GetFCDSnapshotChangeID(ctx context.Context, volumeID, snapshotID string) (
-	string, error) {
-	return "", nil
-}
-
 func (m *mockVolumeManagerForFullSync) ConfigureVolumeACLs(
 	ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec,
 ) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
As a part of CSI CBT support, for CBT enabled volume, when a snapshot gets created, changeID gets associated with the snapshot. This changeID gets used by backup user to query CBT metadata w.r.t. snapshot copies taken. This changeID assigned is currently stored as annotation on snapshot, immediately after its creation, similar to snapshothandle (change done via https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3965/changes).
However, on supervisor cluster, we fetch the changeid from FCD directly and then add it as annotation, whereas CNS CreateSnapshot API itself has been updated to return the changeID in the response.
This PR tries to fetch snapshot changeID from CNS CreateSnapshot API response, instead of fetching from FCD explicitly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1127/
```
Ran 6 of 2357 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2351 Skipped | 0 Flaked
```
* WCP precheckin failed (failure not related to change, also seen in other runs) - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1469/
```
Ran 12 of 1275 Specs
FAILURE! -- 11 Passed | 1 Failed | 1 Pending | 0 Skipped | 0 Flaked
```
* Manually verified change on setup with CBT enabled volume, new snapshot created gets annotation added from value fetched from CNS API call

On guest cluster: 
```
root@4219c92096f3e617aae9d8f243af2366 [ ~ ]# k create -f vs.yaml
volumesnapshot.snapshot.storage.k8s.io/cbt-snap-3 created
root@4219c92096f3e617aae9d8f243af2366 [ ~ ]#

root@4219c92096f3e617aae9d8f243af2366 [ ~ ]# k get vs -A
NAMESPACE   NAME         READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
cbt-e2e     cbt-snap-1   true         cbt-pvc                             1Gi           volumesnapshotclass-delete   snapcontent-b9df2a96-7857-4d0d-beb2-7b677e4cfab4   5d12h          5d12h
cbt-e2e     cbt-snap-2   true         cbt-pvc                             1Gi           volumesnapshotclass-delete   snapcontent-e749cd77-fc76-4bdd-8a4a-8739571e34c1   5d12h          5d12h
cbt-e2e     cbt-snap-3   true         cbt-pvc                             1Gi           volumesnapshotclass-delete   snapcontent-cd39db54-6993-4fbe-a939-b0337a96cb1f   <invalid>      20s
root@4219c92096f3e617aae9d8f243af2366 [ ~ ]#

root@4219c92096f3e617aae9d8f243af2366 [ ~ ]# k get vs -n cbt-e2e cbt-snap-3 -o yaml
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  annotations:
    csi.vsphere.volume/change-id: 52 a9 ce fa bd f6 ac 6c-d1 5c 5e 62 90 ff e7 3c/7                <<<<<<<<<
    csi.vsphere.volume/snapshot: df5e9445-0c7f-4722-8b57-ce10e81c3a3c+1db8ad65-c006-4f88-9f9c-b2622fd811be
  creationTimestamp: "2026-05-07T06:23:54Z"
  finalizers:
  - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
  - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
  generation: 1
  name: cbt-snap-3
  namespace: cbt-e2e
  resourceVersion: "1586363"
  uid: cd39db54-6993-4fbe-a939-b0337a96cb1f
spec:
  source:
    persistentVolumeClaimName: cbt-pvc
  volumeSnapshotClassName: volumesnapshotclass-delete
status:
  boundVolumeSnapshotContentName: snapcontent-cd39db54-6993-4fbe-a939-b0337a96cb1f
  creationTime: "2026-05-07T06:24:20Z"
  readyToUse: true
  restoreSize: 1Gi
root@4219c92096f3e617aae9d8f243af2366 [ ~ ]#
```

On Supervisor cluster, CSI log show that changeID obtained from CNS task result - CnsSnapshotInfo

```
2026-05-07T06:23:56.021Z        INFO    wcp/controller.go:2599  WCP CreateSnapshot: called with args source_volume_id:"df5e9445-0c7f-4722-8b57-ce10e81c3a3c"  name:"snapshot-1db8ad65-c006-4f88-9f9c-b2622fd811be"  parameters:{key:"csi.storage.k8s.io/volumesnapshot/name"  value:"cb2971df-d952-43ef-b758-17aed490a2d2-cd39db54-6993-4fbe-a939-b0337a96cb1f"}  parameters:{key:"csi.storage.k8s.io/volumesnapshot/namespace"  value:"test-gc-e2e-demo-ns"}  parameters:{key:"csi.storage.k8s.io/volumesnapshotcontent/name"  value:"snapcontent-1db8ad65-c006-4f88-9f9c-b2622fd811be"}       {"TraceId": "e549927d-90ea-4ef7-98ea-df7e0bde0b90"}
..
2026-05-07T06:24:07.940Z        INFO    volume/manager.go:3205  CreateSnapshot: Snapshot created successfully. VolumeID: "df5e9445-0c7f-4722-8b57-ce10e81c3a3c", SnapshotID: "1db8ad65-c006-4f88-9f9c-b2622fd811be", changedBlockTrackingId: "52 a9 ce fa bd f6 ac 6c-d1 5c 5e 62 90 ff e7 3c/7"SnapshotCreateTime: "2026-05-07 06:24:20.555337 +0000 UTC", opId: "59c55f0b"    {"TraceId": "e549927d-90ea-4ef7-98ea-df7e0bde0b90"}
2026-05-07T06:24:07.940Z        INFO    volume/manager.go:3103  Setting the reserved field for VolumeOperationDetails instance snapshot-1db8ad65-c006-4f88-9f9c-b2622fd811be-df5e9445-0c7f-4722-8b57-ce10e81c3a3c to 0  {"TraceId": "e549927d-90ea-4ef7-98ea-df7e0bde0b90"}                                                                                                                                                         2026-05-07T06:24:07.941Z        DEBUG   cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:207      Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0x17bbf3cfa540)({                                                                                                                                                                                            Name: (string) (len=82) "snapshot-1db8ad65-c006-4f88-9f9c-b2622fd811be-df5e9445-0c7f-4722-8b57-ce10e81c3a3c",
 VolumeID: (string) (len=36) "df5e9445-0c7f-4722-8b57-ce10e81c3a3c",
 SnapshotID: (string) (len=36) "1db8ad65-c006-4f88-9f9c-b2622fd811be",
 Capacity: (int64) 0,
 QuotaDetails: (*cnsvolumeoperationrequest.QuotaDetails)(0x17bbf3b3e840)({
  Reserved: (*resource.Quantity)(0x17bbf4074200)(0),
  StoragePolicyId: (string) (len=36) "e58b0c19-8a73-47c1-be62-5fde873ce8d2",
  StorageClassName: (string) (len=18) "gc-storage-profile",
  Namespace: (string) (len=19) "test-gc-e2e-demo-ns",
  AggregatedSnapshotSize: (*resource.Quantity)(0x17bbf40741c0)(420Mi),
  SnapshotLatestOperationCompleteTime: (v1.Time) 2026-05-07 06:24:20.555337 +0000 UTC                                                                                                                              }),
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0x17bbf3679570)({                                                                                                                                  TaskInvocationTimestamp: (v1.Time) 2026-05-07 06:23:56.207684804 +0000 UTC m=+107.170336694,                                                                                                                      TaskID: (string) (len=9) "task-3457",                                                                                                                                                                             VCenterServer: (string) "",
  OpID: (string) (len=8) "59c55f0b",
  TaskStatus: (string) (len=7) "Success",
  Error: (string) ""
 }),
 ChangedBlockTrackingId: (string) (len=49) "52 a9 ce fa bd f6 ac 6c-d1 5c 5e 62 90 ff e7 3c/7"
})
        {"TraceId": "e549927d-90ea-4ef7-98ea-df7e0bde0b90"}
...
2026-05-07T06:24:08.053Z        INFO    wcp/controller.go:2749  Attempting to annotate volumesnapshot test-gc-e2e-demo-ns/cb2971df-d952-43ef-b758-17aed490a2d2-cd39db54-6993-4fbe-a939-b0337a96cb1f with annotations map[csi.vsphere.volume/change-id:52 a9 ce fa bd f6 ac 6c-d1 5c 5e 62 90 ff e7 3c/7 csi.vsphere.volume/snapshot:df5e9445-0c7f-4722-8b57-ce10e81c3a3c+1db8ad65-c006-4f88-9f9c-b2622fd811be]  {"TraceId": "e549927d-90ea-4ef7-98ea-df7e0bde0b90"}
2026-05-07T06:24:08.111Z        INFO    k8sorchestrator/k8sorchestrator_helper.go:189   attempt: 1, Successfully patched volumesnapshot test-gc-e2e-demo-ns/cb2971df-d952-43ef-b758-17aed490a2d2-cd39db54-6993-4fbe-a939-b0337a96cb1f with latest annotations map[csi.vsphere.guest-initiated-csi-snapshot:true csi.vsphere.volume/change-id:52 a9 ce fa bd f6 ac 6c-d1 5c 5e 62 90 ff e7 3c/7 csi.vsphere.volume/snapshot:df5e9445-0c7f-4722-8b57-ce10e81c3a3c+1db8ad65-c006-4f88-9f9c-b2622fd811be]   {"TraceId": "e549927d-90ea-4ef7-98ea-df7e0bde0b90"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Get snapshot changeID from CNS CreateSnapshot API response, instead of fetching from FCD explicitly
```
