### PR TITLE
manage CBT state for PVC unattached

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/admissionhandler"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/manager"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/dpoperator"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8soperator"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/storagepool"
@@ -413,6 +414,34 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 			}()
 		}
 
+		if clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API) {
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Info("Cleaning up vc sessions Data Protection(DP) operator")
+						cleanupSessions(ctx, r)
+					}
+				}()
+				// The CSI_Backup_API feature relies on the Data Protection Operator service for CbtConfig CRD definition.
+				installed, err := commonco.ContainerOrchestratorUtility.IsDPOServiceInstalled(ctx)
+				if err != nil {
+					log.Errorf("Error checking Data Protection Operator service installation. Error: %+v", err)
+					utils.LogoutAllvCenterSessions(ctx)
+					os.Exit(1)
+				}
+				if !installed {
+					commonco.ContainerOrchestratorUtility.HandleLateInstallationOfDPOService(ctx)
+					return
+				}
+				if err := startDpOperator(ctx, configInfo); err != nil {
+					log.Errorf("Error initializing Data Protection(DP) operator. Error: %+v", err)
+					utils.LogoutAllvCenterSessions(ctx)
+					os.Exit(1)
+				}
+			}()
+		}
+
 		syncer.PeriodicSyncIntervalInMin = *periodicSyncIntervalInMin
 		if err := syncer.InitMetadataSyncer(ctx, clusterFlavor, configInfo); err != nil {
 			log.Errorf("Error initializing Metadata Syncer. Error: %+v", err)
@@ -438,6 +467,15 @@ func startK8sOperator(ctx context.Context,
 	clusterFlavor cnstypes.CnsClusterFlavor) error {
 
 	mgr, err := k8soperator.NewManager(ctx, clusterFlavor)
+	if err != nil {
+		return err
+	}
+
+	return mgr.Start(ctx)
+}
+
+func startDpOperator(ctx context.Context, configInfo *config.ConfigurationInfo) error {
+	mgr, err := dpoperator.NewManager(ctx, configInfo)
 	if err != nil {
 		return err
 	}

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -519,6 +519,8 @@ spec:
               value: "6443"
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
+            - name: CBT_SYNC_INTERVAL_MINUTES
+              value: "30"
             - name: VOLUME_HEALTH_INTERVAL_MINUTES
               value: "5"
             - name: WORKER_THREADS_NODEVM_ATTACH

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -519,6 +519,8 @@ spec:
               value: "6443"
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
+            - name: CBT_SYNC_INTERVAL_MINUTES
+              value: "30"
             - name: VOLUME_HEALTH_INTERVAL_MINUTES
               value: "5"
             - name: WORKER_THREADS_NODEVM_ATTACH

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -519,6 +519,8 @@ spec:
               value: "6443"
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
+            - name: CBT_SYNC_INTERVAL_MINUTES
+              value: "30"
             - name: VOLUME_HEALTH_INTERVAL_MINUTES
               value: "5"
             - name: WORKER_THREADS_NODEVM_ATTACH

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -309,6 +309,13 @@ func (c *FakeK8SOrchestrator) HandleLateEnablementOfCapability(
 	panic("implement me")
 }
 
+func (c *FakeK8SOrchestrator) IsDPOServiceInstalled(ctx context.Context) (bool, error) {
+	return true, nil
+}
+
+func (c *FakeK8SOrchestrator) HandleLateInstallationOfDPOService(ctx context.Context) {
+}
+
 // GetNodeTopologyLabels fetches the topology information of a node from the CSINodeTopology CR.
 func (nodeTopology *mockNodeVolumeTopology) GetNodeTopologyLabels(ctx context.Context, info *commoncotypes.NodeInfo) (
 	map[string]string, error) {

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -125,6 +125,11 @@ type COCommonInterface interface {
 	GetPvcObjectByName(ctx context.Context, pvcName string, namespace string) (*v1.PersistentVolumeClaim, error)
 	HandleLateEnablementOfCapability(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, capability,
 		gcPort, gcEndpoint string)
+	// IsDPOServiceInstalled returns whether the Data Protection Operator service is installed on the cluster.
+	IsDPOServiceInstalled(ctx context.Context) (bool, error)
+	// HandleLateInstallationOfDPOService polls until the Data Protection Operator service is installed, then restarts
+	// the container so DP controllers can be initialised.
+	HandleLateInstallationOfDPOService(ctx context.Context)
 	// GetPVCNamespacedNameByUID returns the PVC's namespaced name (namespace/name) for the given UID.
 	// If the PVC is not found in the cache, it returns an empty string and false.
 	GetPVCNamespacedNameByUID(uid string) (k8stypes.NamespacedName, bool)

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -56,6 +56,7 @@ import (
 	wcpcapv1alph1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/wcpcapabilities/v1alpha1"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
@@ -66,6 +67,14 @@ import (
 )
 
 const informerCreateRetryInterval = 5 * time.Minute
+
+// cbtConfigCRDName is the cluster-scoped name of the CBTConfig CustomResourceDefinition
+// (plural.group, matching cnsdp.vmware.com / cbtconfigs).
+const cbtConfigCRDName = "cbtconfigs.cnsdp.vmware.com"
+
+// cbtConfigCRDPollInterval is how often HandleLateInstallationOfDPOService polls the
+// API server for the CBTConfig CRD when it is not yet installed.
+const cbtConfigCRDPollInterval = 5 * time.Minute
 
 // operationModeWebHookServer indicates container running as webhook server
 const operationModeWebHookServer = "WEBHOOK_SERVER"
@@ -1260,6 +1269,65 @@ func (c *K8sOrchestrator) HandleLateEnablementOfCapability(ctx context.Context,
 				log.Infof("Successfully updated CNS-CSI FSS: %q to true", common.WorkloadDomainIsolationFSS)
 			}
 			os.Exit(1)
+		}
+	}
+}
+
+// IsDPOServiceInstalled reports whether the Data Protection Operator service is installed by checking if the
+// CBTConfig CRD is present on the API server. Only meaningful on workload (WCP) clusters.
+func (c *K8sOrchestrator) IsDPOServiceInstalled(ctx context.Context) (bool, error) {
+	log := logger.GetLogger(ctx)
+	restClientConfig, err := clientconfig.GetConfig()
+	if err != nil {
+		return false, fmt.Errorf("failed to get Kubernetes config. Err: %w", err)
+	}
+	apiextensionsClientSet, err := apiextensionsclientset.NewForConfig(restClientConfig)
+	if err != nil {
+		return false, fmt.Errorf("failed to create apiextensions clientset. Err: %w", err)
+	}
+	_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Get(ctx,
+		cbtConfigCRDName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debugf("Data Protection Operator service is not installed on the cluster.")
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check if DPO service is installed. Err: %w", err)
+	}
+
+	log.Infof("Data Protection Operator service is installed on the cluster.")
+
+	return true, nil
+}
+
+// HandleLateInstallationOfDPOService polls every cbtConfigCRDPollInterval until the Data Protection Operator service's
+// CBTConfig CRD appears, then exits with status 0 so the pod restarts and DP controllers
+// initialise. Transient API errors are retried silently.
+func (c *K8sOrchestrator) HandleLateInstallationOfDPOService(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+	log.Infof("Waiting for Data Protection Operator service installation (poll interval: %s)",
+		cbtConfigCRDPollInterval)
+	ticker := time.NewTicker(cbtConfigCRDPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Infof("Stopped waiting for Data Protection Operator service: context cancelled")
+			return
+		case <-ticker.C:
+			installed, err := c.IsDPOServiceInstalled(ctx)
+			if err != nil {
+				log.Warnf("transient error checking Data Protection Operator service installation, will retry: %+v",
+					err)
+				continue
+			}
+			if installed {
+				log.Infof("Data Protection Operator service installed." +
+					" Restarting container to initialize DP controllers.")
+				utils.LogoutAllvCenterSessions(ctx)
+				os.Exit(0)
+			}
+			log.Debugf("Data Protection Operator service not yet installed.")
 		}
 	}
 }

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/sample-controller/pkg/signals"
 
@@ -257,13 +258,22 @@ func (im *InformerManager) AddPodListener(ctx context.Context, add func(obj inte
 	return nil
 }
 
+// InitVolumeAttachmentInformer registers the cluster VolumeAttachment shared informer with the
+// factory (no event handlers). Idempotent. Call before Listen when only the VolumeAttachment
+// lister/cache is needed (e.g. DP operator).
+func (im *InformerManager) InitVolumeAttachmentInformer() {
+	if im.volumeAttachmentInformer != nil {
+		return
+	}
+	im.volumeAttachmentInformer = im.informerFactory.Storage().V1().VolumeAttachments().Informer()
+	im.volumeAttachmentSynced = im.volumeAttachmentInformer.HasSynced
+}
+
 // AddVolumeAttachmentListener hooks up add, update, delete callbacks.
 func (im *InformerManager) AddVolumeAttachmentListener(ctx context.Context, add func(obj interface{}),
 	update func(oldObj, newObj interface{}), remove func(obj interface{})) error {
 	log := logger.GetLogger(ctx)
-	if im.volumeAttachmentInformer == nil {
-		im.volumeAttachmentInformer = im.informerFactory.Storage().V1().VolumeAttachments().Informer()
-	}
+	im.InitVolumeAttachmentInformer()
 
 	_, err := im.volumeAttachmentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    add,
@@ -297,6 +307,16 @@ func (im *InformerManager) GetPodLister() corelisters.PodLister {
 	return im.informerFactory.Core().V1().Pods().Lister()
 }
 
+// GetVolumeAttachmentLister returns the VolumeAttachment lister backed by the shared informer
+// factory. The caller must register the underlying informer first via
+// InitVolumeAttachmentInformer (or AddVolumeAttachmentListener) before Listen() so the cache
+// is started and waited on. On Workload and Vanilla-controller flavors the k8sorchestrator
+// also registers a VolumeAttachment listener on the same singleton, so callers reuse that
+// informer instead of starting a second one.
+func (im *InformerManager) GetVolumeAttachmentLister() storagelistersv1.VolumeAttachmentLister {
+	return im.informerFactory.Storage().V1().VolumeAttachments().Lister()
+}
+
 // Client returns the Kubernetes clientset associated with this informer manager.
 func (im *InformerManager) Client() clientset.Interface {
 	return im.client
@@ -313,14 +333,25 @@ func (im *InformerManager) NamespaceInformerSynced() cache.InformerSynced {
 	return im.namespaceSynced
 }
 
-// Listen starts the Informers.
+// Listen starts the Informers and waits for every registered informer's cache to sync.
+// Only informers whose HasSynced func has been captured (via Add*Listener or Init*Informer)
+// are waited on; unregistered ones are skipped, so callers don't have to register all
+// informers to get a cache-sync wait for the ones they do register.
 func (im *InformerManager) Listen() (stopCh <-chan struct{}) {
 	go im.informerFactory.Start(im.stopCh)
-	if im.pvSynced != nil && im.pvcSynced != nil && im.podSynced != nil && im.configMapSynced != nil {
-		if !cache.WaitForCacheSync(im.stopCh, im.pvSynced, im.pvcSynced, im.podSynced, im.configMapSynced) {
+	var synced []cache.InformerSynced
+	for _, fn := range []cache.InformerSynced{
+		im.pvSynced, im.pvcSynced, im.podSynced, im.configMapSynced,
+		im.namespaceSynced, im.volumeAttachmentSynced,
+	} {
+		if fn != nil {
+			synced = append(synced, fn)
+		}
+	}
+	if len(synced) > 0 {
+		if !cache.WaitForCacheSync(im.stopCh, synced...) {
 			return
 		}
-
 	}
 	return im.stopCh
 }

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -83,4 +83,6 @@ type InformerManager struct {
 
 	// volume attachment informer
 	volumeAttachmentInformer cache.SharedInformer
+	// Function to determine if volumeAttachmentInformer has been synced
+	volumeAttachmentSynced cache.InformerSynced
 }

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -264,6 +264,15 @@ func (m *MockCOCommonInterface) HandleLateEnablementOfCapability(ctx context.Con
 	m.Called(ctx, clusterFlavor, capability, gcPort, gcEndpoint)
 }
 
+func (m *MockCOCommonInterface) IsDPOServiceInstalled(ctx context.Context) (bool, error) {
+	args := m.Called(ctx)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockCOCommonInterface) HandleLateInstallationOfDPOService(ctx context.Context) {
+	m.Called(ctx)
+}
+
 // MockCryptoClient is a mock implementation of crypto.Client
 type MockCryptoClient struct {
 	mock.Mock

--- a/pkg/syncer/cbtsync.go
+++ b/pkg/syncer/cbtsync.go
@@ -1,0 +1,563 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
+	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
+)
+
+var cbtConfigResource = schema.GroupVersionResource{
+	Group:    cbtconfigv1alpha1.GroupName,
+	Version:  cbtconfigv1alpha1.Version,
+	Resource: cbtconfigv1alpha1.CBTConfigResource,
+}
+
+const (
+	workerThreadsCBTReconcileOpsEnvVar  = "WORKER_THREADS_CBT_RECONCILE_OPS"
+	defaultWorkerThreadsCBTReconcileOps = 4
+
+	vmServiceVMAnnotationPrefix = "cns.vmware.com/usedby-vm-"
+)
+
+// cbtWorkQueue is a fixed-size buffered channel used as a counting semaphore that
+// bounds the number of in-flight ReconcileCBTForNamespace goroutines across all
+// namespaces. Sized once on first use from WORKER_THREADS_CBT_RECONCILE_OPS so the
+// CBTConfig controller's Reconcile thread is never blocked behind a slow CNS call —
+// when the queue is full, Reconcile returns an error and controller-runtime requeues.
+var (
+	cbtWorkQueueOnce sync.Once
+	cbtWorkQueue     chan struct{}
+)
+
+func getCBTWorkQueue(ctx context.Context) chan struct{} {
+	cbtWorkQueueOnce.Do(func() {
+		size := util.GetMaxWorkerThreads(ctx, workerThreadsCBTReconcileOpsEnvVar,
+			defaultWorkerThreadsCBTReconcileOps)
+		cbtWorkQueue = make(chan struct{}, size)
+	})
+	return cbtWorkQueue
+}
+
+// cbtWork is the cancel handle for one in-flight syncCBTWork invocation, regardless of
+// whether it was started by the periodic sync or by the controller reconcile. Pointer
+// identity (the *cbtWork stored in cbtWorkMap) is what the owning goroutine compares
+// against on exit so it doesn't stomp a successor that has already replaced it.
+type cbtWork struct {
+	cancel context.CancelFunc
+}
+
+var (
+	cbtWorkMu sync.Mutex
+	// cbtWorkMap tracks the in-flight CBT work per namespace. An entry is inserted when
+	// syncCBTForNamespace or ReconcileCBTForNamespace starts work for a namespace, and
+	// deleted by the owning goroutine on exit, so the map does not grow without bound
+	// on clusters that churn namespaces over time.
+	cbtWorkMap = make(map[string]*cbtWork)
+)
+
+// runPeriodicCBTSync reconciles PVC CBT states with CNS changed-block-tracking state.
+// It is invoked on the interval configured by CBT_SYNC_INTERVAL_MINUTES (see getCBTSyncIntervalInMin).
+// InitMetadataSyncer starts the periodic caller only on Supervisor when supports_CSI_Backup_API is
+// enabled at startup. This function no-ops if no CBTConfig CR exists in the cluster.
+func runPeriodicCBTSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
+	log := logger.GetLogger(ctx)
+	// Single cluster-wide List populates both the namespace set and the enable flag per namespace,
+	// avoiding a separate per-namespace API call inside the sync loop.
+	namespaceCBTState, err := listCBTStatesByNamespace(ctx)
+	if err != nil {
+		log.Errorf("runPeriodicCBTSync: failed to list CBTConfig CRs: %v", err)
+		return
+	}
+	if len(namespaceCBTState) == 0 {
+		log.Debugf("runPeriodicCBTSync: no CBTConfig CR found in cluster, skipping periodic reconciliation")
+		return
+	}
+	log.Infof("runPeriodicCBTSync: starting periodic CBT reconciliation for %d namespace(s)",
+		len(namespaceCBTState))
+	periodicCBTSync(ctx, metadataSyncer, namespaceCBTState)
+}
+
+// listCBTStatesByNamespace returns a map of namespace to the CBT enable flag (true/false)
+// for every CBTConfig CR found in the cluster.
+func listCBTStatesByNamespace(ctx context.Context) (map[string]bool, error) {
+	log := logger.GetLogger(ctx)
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	unstructuredList, err := dynClient.Resource(cbtConfigResource).
+		Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		// CRD may be installed after the syncer starts; treat a missing API as "no CBTConfig objects".
+		if apiMeta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+			log.Debugf("listCBTStatesByNamespace: CBTConfig CRD not found, skipping")
+			return nil, nil
+		}
+		return nil, err
+	}
+	var list cbtconfigv1alpha1.CBTConfigList
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+		unstructuredList.UnstructuredContent(), &list); err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(list.Items))
+	for i := range list.Items {
+		item := &list.Items[i]
+		if item.Status.Enabled != nil {
+			out[item.Namespace] = *item.Status.Enabled
+		} else {
+			log.Debugf("listCBTStatesByNamespace: namespace %q CBTConfig CR status.Enabled is not set",
+				item.Namespace)
+		}
+	}
+	return out, nil
+}
+
+func periodicCBTSync(ctx context.Context, metadataSyncer *metadataSyncInformer,
+	namespaceCBTState map[string]bool) {
+	log := logger.GetLogger(ctx)
+	vc := metadataSyncer.configInfo.Cfg.Global.VCenterIP
+	// CBT sync is gated to Workload flavor in InitMetadataSyncer, so metadataSyncer.volumeManager
+	// is guaranteed initialised by the time the periodic loop runs.
+	volManager := metadataSyncer.volumeManager
+	for ns, enable := range namespaceCBTState {
+		if err := syncCBTForNamespace(ctx, volManager,
+			metadataSyncer.pvLister, metadataSyncer.pvcLister, metadataSyncer.vaLister,
+			ns, enable); err != nil {
+			log.Warnf("periodicCBTSync: namespace %q CBT reconciliation failed: %v"+
+				" - continuing with next namespace", ns, err)
+		}
+	}
+	log.Infof("periodicCBTSync: finished periodic CBT reconciliation for VC %s", vc)
+}
+
+// pvcWithVolume pairs a PVC with its resolved CNS volume ID.
+type pvcWithVolume struct {
+	pvc      *v1.PersistentVolumeClaim
+	volumeID string
+}
+
+// syncCBTForNamespace is the periodic-syncer entry point called by periodicCBTSync.
+// If a background controller reconcile is already in flight for the namespace it skips
+// immediately. Otherwise it registers its own cancel handle so a concurrent
+// ReconcileCBTForNamespace call can abort it mid-flight and take over.
+func syncCBTForNamespace(ctx context.Context,
+	volManager volumes.Manager,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister,
+	namespace string,
+	enable bool,
+) error {
+	log := logger.GetLogger(ctx)
+
+	ctx, cancel := context.WithCancel(ctx)
+	myWork := &cbtWork{cancel: cancel}
+	cbtWorkMu.Lock()
+	if cbtWorkMap[namespace] != nil {
+		cbtWorkMu.Unlock()
+		cancel()
+		log.Infof("syncCBTForNamespace: namespace %q has in-flight CBT work; skipping periodic sync",
+			namespace)
+		return nil
+	}
+	cbtWorkMap[namespace] = myWork
+	cbtWorkMu.Unlock()
+
+	defer func() {
+		cancel()
+		cbtWorkMu.Lock()
+		if cbtWorkMap[namespace] == myWork {
+			delete(cbtWorkMap, namespace)
+		}
+		cbtWorkMu.Unlock()
+	}()
+
+	return syncCBTWork(ctx, volManager, pvLister, pvcLister, vaLister, namespace, enable)
+}
+
+// ReconcileCBTForNamespace is the controller entry point called by the CBTConfig reconciler.
+// It cancels any in-flight CBT work for the namespace (periodic sync or a previous
+// background reconcile), then enqueues a fresh reconcile onto the bounded background
+// pool returned by getCBTReconcileQueue. The actual syncCBTWork pipeline runs on a
+// separate goroutine so a slow CNS call cannot block the controller's Reconcile thread.
+//
+// Returns nil once the work has been scheduled. Returns a non-nil error only when the
+// background pool is fully busy; the caller is expected to requeue and retry, by which
+// time slots typically free up. Per-volume failures inside the pipeline are best-effort
+// and do not surface here — the periodic sync re-converges on the next interval.
+func ReconcileCBTForNamespace(ctx context.Context,
+	volManager volumes.Manager,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister,
+	namespace string,
+	enable bool,
+) error {
+	log := logger.GetLogger(ctx)
+
+	cbtWorkMu.Lock()
+	if existing := cbtWorkMap[namespace]; existing != nil {
+		log.Infof("ReconcileCBTForNamespace: cancelling in-flight CBT work for namespace %q"+
+			" to take over with new reconcile", namespace)
+		existing.cancel()
+	}
+	cbtWorkMu.Unlock()
+
+	queue := getCBTWorkQueue(ctx)
+	select {
+	case queue <- struct{}{}:
+	default:
+		return fmt.Errorf("CBT work queue is full for namespace %q; will retry", namespace)
+	}
+
+	// Detach from the controller's Reconcile context (which is cancelled when Reconcile
+	// returns) but preserve its values — notably the request-scoped logger — so the
+	// background goroutine logs with the same trace metadata as its caller.
+	workCtx, workCancel := context.WithCancel(context.WithoutCancel(ctx))
+	myWork := &cbtWork{cancel: workCancel}
+	cbtWorkMu.Lock()
+	if existing := cbtWorkMap[namespace]; existing != nil {
+		existing.cancel()
+	}
+	cbtWorkMap[namespace] = myWork
+	cbtWorkMu.Unlock()
+
+	go func() {
+		defer func() {
+			workCancel()
+			<-queue
+			cbtWorkMu.Lock()
+			if cbtWorkMap[namespace] == myWork {
+				delete(cbtWorkMap, namespace)
+			}
+			cbtWorkMu.Unlock()
+		}()
+		reconcileCBTWork(workCtx, volManager, pvLister, pvcLister, vaLister, namespace, enable)
+	}()
+
+	return nil
+}
+
+// reconcileCBTWork is the body run by the background goroutine launched from
+// ReconcileCBTForNamespace. It invokes the shared syncCBTWork pipeline and only logs
+// the outcome — there is no caller to return an error to. Cancellation triggered by a
+// newer reconcile taking over is logged at Info level since it's an expected transition,
+// not a failure.
+func reconcileCBTWork(ctx context.Context,
+	volManager volumes.Manager,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister,
+	namespace string,
+	enable bool,
+) {
+	log := logger.GetLogger(ctx)
+	if err := syncCBTWork(ctx, volManager, pvLister, pvcLister, vaLister, namespace, enable); err != nil {
+		if errors.Is(err, context.Canceled) {
+			log.Infof("reconcileCBTWork: namespace %q background CBT reconcile cancelled (superseded): %v",
+				namespace, err)
+			return
+		}
+		log.Errorf("reconcileCBTWork: namespace %q background CBT reconcile failed: %+v", namespace, err)
+	}
+}
+
+// syncCBTWork drives the three CBT reconcile phases shared by syncCBTForNamespace (periodic
+// path) and ReconcileCBTForNamespace (controller path). It honours ctx cancellation at each
+// phase boundary so the periodic path can be aborted quickly when the controller takes over.
+//
+//  1. Build candidates: collect eligible vSphere block PVCs and resolve their volume IDs.
+//  2. Filter by CBT state: query CNS and keep only volumes whose state differs from target.
+//  3. Apply CBT flags: set/clear CBT flag on each surviving candidate.
+func syncCBTWork(ctx context.Context,
+	volManager volumes.Manager,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister,
+	namespace string,
+	enable bool,
+) error {
+	log := logger.GetLogger(ctx)
+	log.Infof("syncCBTWork: reconciling CBT(enable=%t) for namespace %q", enable, namespace)
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	candidates, err := buildPVCCandidates(ctx, pvLister, pvcLister, vaLister, namespace)
+	if err != nil {
+		log.Errorf("syncCBTWork: namespace %q phase 1 (build candidates) failed: %v", namespace, err)
+		return err
+	}
+	log.Infof("syncCBTWork: namespace %q phase 1: %d candidate(s)", namespace, len(candidates))
+
+	if err := ctx.Err(); err != nil {
+		log.Infof("syncCBTWork: namespace %q CBT reconcile cancelled at phase 1: %v", namespace, err)
+		return err
+	}
+	candidates, err = filterCandidatesByCBTState(ctx, volManager, namespace, candidates, enable)
+	if err != nil {
+		log.Errorf("syncCBTWork: namespace %q phase 2 (CNS state query) failed: %v", namespace, err)
+		return err
+	}
+	log.Infof("syncCBTWork: namespace %q phase 2: %d candidate(s) need CBT flip", namespace, len(candidates))
+
+	if err := ctx.Err(); err != nil {
+		log.Infof("syncCBTWork: namespace %q CBT reconcile cancelled at phase 2: %v", namespace, err)
+		return err
+	}
+	if err = applyCnsCbtFlags(ctx, volManager, namespace, candidates, enable); err != nil {
+		log.Errorf("syncCBTWork: namespace %q phase 3 (apply CBT flags) failed: %v", namespace, err)
+		return err
+	}
+
+	log.Infof("syncCBTWork: namespace %q CBT reconcile finished (enable=%t)", namespace, enable)
+	return nil
+}
+
+func loadAttachedPVNames(vaLister storagelistersv1.VolumeAttachmentLister) (map[string]struct{}, error) {
+	vas, err := vaLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	attached := make(map[string]struct{}, len(vas))
+	for _, va := range vas {
+		name := va.Spec.Source.PersistentVolumeName
+		if name == nil || *name == "" {
+			continue
+		}
+		attached[*name] = struct{}{}
+	}
+	return attached, nil
+}
+
+func buildPVCCandidates(ctx context.Context,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister,
+	namespace string) ([]pvcWithVolume, error) {
+	log := logger.GetLogger(ctx)
+
+	attachedPVs, err := loadAttachedPVNames(vaLister)
+	if err != nil {
+		log.Errorf("buildPVCCandidates: failed to list VolumeAttachment objects: %v", err)
+		return nil, err
+	}
+	log.Infof("buildPVCCandidates: namespace %q loaded %d attached PV names from VolumeAttachment cache",
+		namespace, len(attachedPVs))
+
+	pvcs, err := pvcLister.PersistentVolumeClaims(namespace).List(labels.Everything())
+	if err != nil {
+		log.Errorf("buildPVCCandidates: failed to list PVCs: %v", err)
+		return nil, err
+	}
+
+	candidates := make([]pvcWithVolume, 0, len(pvcs))
+	for _, pvc := range pvcs {
+		if !pvcEligibleForCBTChange(ctx, pvc, attachedPVs) {
+			continue
+		}
+		volumeID, ok := resolvePVCToVolumeID(ctx, pvLister, pvc)
+		if !ok {
+			log.Debugf("buildPVCCandidates: namespace %q PVC %s skipped: PV %s is not an eligible vSphere block volume",
+				namespace, pvc.Name, pvc.Spec.VolumeName)
+			continue
+		}
+		candidates = append(candidates, pvcWithVolume{pvc: pvc, volumeID: volumeID})
+	}
+	return candidates, nil
+}
+
+func resolvePVCToVolumeID(ctx context.Context,
+	pvLister corelisters.PersistentVolumeLister,
+	pvc *v1.PersistentVolumeClaim) (string, bool) {
+	log := logger.GetLogger(ctx)
+	pv, err := pvLister.Get(pvc.Spec.VolumeName)
+	if err != nil {
+		log.Errorf("resolvePVCToVolumeID: failed to get PV %s for PVC %s: %+v",
+			pvc.Spec.VolumeName, pvc.Name, err)
+		return "", false
+	}
+	if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != common.VSphereCSIDriverName {
+		return "", false
+	}
+	if pv.Spec.CSI.VolumeAttributes == nil ||
+		pv.Spec.CSI.VolumeAttributes[common.AttributeDiskType] != common.DiskTypeBlockVolume {
+		return "", false
+	}
+	if pv.Spec.CSI.VolumeHandle == "" {
+		return "", false
+	}
+	return pv.Spec.CSI.VolumeHandle, true
+}
+
+func filterCandidatesByCBTState(ctx context.Context, volManager volumes.Manager,
+	namespace string, candidates []pvcWithVolume, enable bool) ([]pvcWithVolume, error) {
+	log := logger.GetLogger(ctx)
+	if len(candidates) == 0 {
+		log.Debugf("filterCandidatesByCBTState: namespace %q has no candidates to filter by CBT state",
+			namespace)
+		return candidates, nil
+	}
+	candidateVolumeIDs := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		candidateVolumeIDs = append(candidateVolumeIDs, c.volumeID)
+	}
+	needsAction, err := queryVolumesNeedingFlip(ctx, volManager, candidateVolumeIDs, enable)
+	if err != nil {
+		log.Errorf("filterCandidatesByCBTState: namespace %q failed to query volumes needing CBT flip: %+v",
+			namespace, err)
+		return nil, err
+	}
+	filtered := candidates[:0]
+	for _, c := range candidates {
+		if _, ok := needsAction[c.volumeID]; ok {
+			filtered = append(filtered, c)
+		} else {
+			log.Debugf("filterCandidatesByCBTState: namespace %q volume %s CBT already in target state; skipping",
+				namespace, c.volumeID)
+		}
+	}
+	return filtered, nil
+}
+
+// applyCnsCbtFlags applies the CBT enable/disable flag to each candidate volume
+// sequentially.
+func applyCnsCbtFlags(ctx context.Context, volManager volumes.Manager,
+	namespace string, candidates []pvcWithVolume, enable bool) error {
+	log := logger.GetLogger(ctx)
+	if len(candidates) == 0 {
+		log.Debugf("applyCnsCbtFlags: namespace %q has no candidates to apply CBT flag", namespace)
+		return nil
+	}
+	for _, cand := range candidates {
+		if err := ctx.Err(); err != nil {
+			log.Infof("applyCnsCbtFlags: namespace %q CBT flag changes cancelled after partial progress: %v",
+				namespace, err)
+			return err
+		}
+		var opErr error
+		if enable {
+			opErr = common.SetVolumeCbtFlagsUtil(ctx, volManager, cand.volumeID)
+		} else {
+			opErr = common.ClearVolumeCbtFlagsUtil(ctx, volManager, cand.volumeID)
+		}
+		if opErr != nil {
+			log.Warnf("applyCnsCbtFlags: namespace %q failed to set CBT=%t for PVC %s (volume %s): %+v",
+				namespace, enable, cand.pvc.Name, cand.volumeID, opErr)
+			continue
+		}
+		log.Infof("applyCnsCbtFlags: namespace %q set CBT=%t for PVC %s (volume %s)",
+			namespace, enable, cand.pvc.Name, cand.volumeID)
+	}
+	return ctx.Err()
+}
+
+// queryVolumesNeedingFlip queries CNS for volumes in candidateVolumeIDs whose current CBT
+// state is opposite to the target. Batched at volumdIDLimitPerQuery so a single
+// CnsQueryFilter never exceeds the same input-size envelope used by full sync.
+func queryVolumesNeedingFlip(ctx context.Context, volManager volumes.Manager,
+	candidateVolumeIDs []string, enable bool) (map[string]struct{}, error) {
+	log := logger.GetLogger(ctx)
+	nonTargetCBTState := cnstypes.CnsVolumeCBTStatusDisabled
+	if !enable {
+		nonTargetCBTState = cnstypes.CnsVolumeCBTStatusEnabled
+	}
+	needsAction := make(map[string]struct{}, len(candidateVolumeIDs))
+	for start := 0; start < len(candidateVolumeIDs); start += volumdIDLimitPerQuery {
+		end := start + volumdIDLimitPerQuery
+		if end > len(candidateVolumeIDs) {
+			end = len(candidateVolumeIDs)
+		}
+		batch := make([]cnstypes.CnsVolumeId, 0, end-start)
+		for _, id := range candidateVolumeIDs[start:end] {
+			batch = append(batch, cnstypes.CnsVolumeId{Id: id})
+		}
+		queryFilter := cnstypes.CnsQueryFilter{VolumeIds: batch, ChangedBlockTracking: nonTargetCBTState}
+		queryResult, err := volManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{})
+		if err != nil {
+			return nil, err
+		}
+		if queryResult == nil {
+			continue
+		}
+		log.Debugf("queryVolumesNeedingFlip: QueryAllVolume batch [%d:%d) returned %d volumes needing CBT flip",
+			start, end, len(queryResult.Volumes))
+		for _, vol := range queryResult.Volumes {
+			needsAction[vol.VolumeId.Id] = struct{}{}
+		}
+	}
+	return needsAction, nil
+}
+
+// pvcEligibleForCBTChange returns false for PVCs that must be skipped:
+//   - not in Bound phase (no backing volume yet)
+//   - no backing volume name
+//   - currently attached to a PodVM via VolumeAttachment (CBT ops require the volume to be detached)
+//   - in use by a VM Service VM (annotation prefix "cns.vmware.com/usedby-vm-"); these attachments
+//     go through CnsNodeVMBatchAttachment and do not create VolumeAttachment objects, so they are
+//     not covered by the VolumeAttachment check above
+func pvcEligibleForCBTChange(ctx context.Context,
+	pvc *v1.PersistentVolumeClaim, attachedPVs map[string]struct{}) bool {
+	log := logger.GetLogger(ctx)
+	if pvc.Status.Phase != v1.ClaimBound {
+		return false
+	}
+	if pvc.Spec.VolumeName == "" {
+		return false
+	}
+	if _, attached := attachedPVs[pvc.Spec.VolumeName]; attached {
+		log.Debugf("pvcEligibleForCBTChange: PVC %s/%s is attached to PodVM; skipping",
+			pvc.Namespace, pvc.Name)
+		return false
+	}
+	for key := range pvc.Annotations {
+		if strings.HasPrefix(key, vmServiceVMAnnotationPrefix) {
+			log.Debugf("pvcEligibleForCBTChange: PVC %s/%s is in use by a VM Service VM; skipping",
+				pvc.Namespace, pvc.Name)
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/syncer/cbtsync_test.go
+++ b/pkg/syncer/cbtsync_test.go
@@ -1,0 +1,684 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// fakeVolMgr records SetVolumeControlFlags / ClearVolumeControlFlags and QueryAllVolume calls
+// and returns configurable errors. It embeds cnsvolume.MockManager to satisfy the rest of
+// the cnsvolume.Manager interface.
+type fakeVolMgr struct {
+	cnsvolume.MockManager
+
+	mu              sync.Mutex
+	setCalls        []string
+	clearCalls      []string
+	setErr          error
+	clearErr        error
+	queryResult     *cnstypes.CnsQueryResult
+	queryErr        error
+	queryBatchSizes []int
+	// queryFn, if set, takes precedence over queryResult/queryErr; lets a test produce
+	// a per-batch response to assert batching behavior.
+	queryFn func(filter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error)
+}
+
+func (f *fakeVolMgr) SetVolumeControlFlags(_ context.Context, volumeID string, _ []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setCalls = append(f.setCalls, volumeID)
+	return f.setErr
+}
+
+func (f *fakeVolMgr) ClearVolumeControlFlags(_ context.Context, volumeID string, _ []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clearCalls = append(f.clearCalls, volumeID)
+	return f.clearErr
+}
+
+func (f *fakeVolMgr) QueryAllVolume(_ context.Context, filter cnstypes.CnsQueryFilter,
+	_ cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queryBatchSizes = append(f.queryBatchSizes, len(filter.VolumeIds))
+	if f.queryFn != nil {
+		return f.queryFn(filter)
+	}
+	return f.queryResult, f.queryErr
+}
+
+func (f *fakeVolMgr) setCallsCopy() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.setCalls))
+	copy(out, f.setCalls)
+	return out
+}
+
+func (f *fakeVolMgr) clearCallsCopy() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.clearCalls))
+	copy(out, f.clearCalls)
+	return out
+}
+
+func (f *fakeVolMgr) queryBatchSizesCopy() []int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]int, len(f.queryBatchSizes))
+	copy(out, f.queryBatchSizes)
+	return out
+}
+
+var _ cnsvolume.Manager = (*fakeVolMgr)(nil)
+
+// newCBTBlockPV returns a vSphere CSI block-volume PersistentVolume.
+func newCBTBlockPV(name, volumeHandle string) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       common.VSphereCSIDriverName,
+					VolumeHandle: volumeHandle,
+					VolumeAttributes: map[string]string{
+						common.AttributeDiskType: common.DiskTypeBlockVolume,
+					},
+				},
+			},
+		},
+	}
+}
+
+// newPVC returns a Bound PVC referencing the given PV.
+func newPVC(namespace, name, pvName string, labels map[string]string,
+	annotations map[string]string) *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec:   v1.PersistentVolumeClaimSpec{VolumeName: pvName},
+		Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimBound},
+	}
+}
+
+// newPVCWithPhase returns a PVC in the requested phase.
+func newPVCWithPhase(namespace, name, pvName string,
+	phase v1.PersistentVolumeClaimPhase) *v1.PersistentVolumeClaim {
+	pvc := newPVC(namespace, name, pvName, nil, nil)
+	pvc.Status.Phase = phase
+	return pvc
+}
+
+// newVolumeAttachmentForPV returns a VolumeAttachment for the given PV name.
+func newVolumeAttachmentForPV(name, pvName string) *storagev1.VolumeAttachment {
+	pvNameRef := pvName
+	return &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: storagev1.VolumeAttachmentSpec{
+			Source: storagev1.VolumeAttachmentSource{PersistentVolumeName: &pvNameRef},
+		},
+	}
+}
+
+// cnsVolumeWithCBT builds a minimal CnsVolume with the given ID and CBT state.
+func cnsVolumeWithCBT(id string, status cnstypes.CnsVolumeCBTStatus) cnstypes.CnsVolume {
+	return cnstypes.CnsVolume{
+		VolumeId:             cnstypes.CnsVolumeId{Id: id},
+		ChangedBlockTracking: status,
+	}
+}
+
+// newTestListers builds in-memory PV / PVC / VolumeAttachment listers seeded with the given
+// objects so tests can stand in for the singleton InformerManager listers.
+func newTestListers(t *testing.T, objs ...client.Object) (corelisters.PersistentVolumeLister,
+	corelisters.PersistentVolumeClaimLister, storagelistersv1.VolumeAttachmentLister) {
+	t.Helper()
+	pvIdx := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	pvcIdx := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	vaIdx := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, o := range objs {
+		switch obj := o.(type) {
+		case *v1.PersistentVolume:
+			require.NoError(t, pvIdx.Add(obj))
+		case *v1.PersistentVolumeClaim:
+			require.NoError(t, pvcIdx.Add(obj))
+		case *storagev1.VolumeAttachment:
+			require.NoError(t, vaIdx.Add(obj))
+		}
+	}
+	return corelisters.NewPersistentVolumeLister(pvIdx),
+		corelisters.NewPersistentVolumeClaimLister(pvcIdx),
+		storagelistersv1.NewVolumeAttachmentLister(vaIdx)
+}
+
+func TestLoadAttachedPVNames(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+
+	t.Run("EmptyClusterReturnsEmptySet", func(t *testing.T) {
+		_, _, vaLister := newTestListers(t)
+		got, err := loadAttachedPVNames(vaLister)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("CollectsAllAttachedPVNames", func(t *testing.T) {
+		va1 := newVolumeAttachmentForPV("va-1", "pv-attached-1")
+		va2 := newVolumeAttachmentForPV("va-2", "pv-attached-2")
+		emptyName := ""
+		vaEmpty := &storagev1.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{Name: "va-empty"},
+			Spec: storagev1.VolumeAttachmentSpec{
+				Source: storagev1.VolumeAttachmentSource{PersistentVolumeName: &emptyName},
+			},
+		}
+		vaNil := &storagev1.VolumeAttachment{ObjectMeta: metav1.ObjectMeta{Name: "va-nil"}}
+
+		_, _, vaLister := newTestListers(t, va1, va2, vaEmpty, vaNil)
+		got, err := loadAttachedPVNames(vaLister)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]struct{}{
+			"pv-attached-1": {},
+			"pv-attached-2": {},
+		}, got)
+	})
+
+	_ = ctx
+}
+
+func TestPvcShouldBeConsideredForCBT(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+
+	attached := func(pvNames ...string) map[string]struct{} {
+		m := make(map[string]struct{}, len(pvNames))
+		for _, n := range pvNames {
+			m[n] = struct{}{}
+		}
+		return m
+	}
+
+	tests := []struct {
+		name        string
+		pvc         *v1.PersistentVolumeClaim
+		attachedPVs map[string]struct{}
+		want        bool
+	}{
+		{
+			name: "NotBound",
+			pvc:  newPVCWithPhase("ns", "p", "pv-x", v1.ClaimPending),
+			want: false,
+		},
+		{
+			name: "NoVolumeName",
+			pvc:  newPVC("ns", "p", "", nil, nil),
+			want: false,
+		},
+		{
+			name:        "AttachedPV",
+			pvc:         newPVC("ns", "p", "pv-x", nil, nil),
+			attachedPVs: attached("pv-x"),
+			want:        false,
+		},
+		{
+			name: "VMServiceAttachedAnnotation",
+			pvc: newPVC("ns", "p", "pv-x", nil,
+				map[string]string{"cns.vmware.com/usedby-vm-abc": "true"}),
+			attachedPVs: attached(),
+			want:        false,
+		},
+		{
+			name:        "Eligible",
+			pvc:         newPVC("ns", "p", "pv-x", nil, nil),
+			attachedPVs: attached(),
+			want:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, pvcEligibleForCBTChange(ctx, tt.pvc, tt.attachedPVs))
+		})
+	}
+}
+
+func TestResolvePVCToVolumeID(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+
+	t.Run("MissingPVReturnsFalse", func(t *testing.T) {
+		pvLister, _, _ := newTestListers(t)
+		pvc := newPVC("ns", "pvc-1", "pv-missing", nil, nil)
+		id, ok := resolvePVCToVolumeID(ctx, pvLister, pvc)
+		assert.False(t, ok)
+		assert.Empty(t, id)
+	})
+
+	t.Run("NonCSIPVReturnsFalse", func(t *testing.T) {
+		pv := &v1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "pv-1"}}
+		pvLister, _, _ := newTestListers(t, pv)
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		_, ok := resolvePVCToVolumeID(ctx, pvLister, pvc)
+		assert.False(t, ok)
+	})
+
+	t.Run("ForeignCSIDriverReturnsFalse", func(t *testing.T) {
+		pv := &v1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: "pv-1"},
+			Spec: v1.PersistentVolumeSpec{
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					CSI: &v1.CSIPersistentVolumeSource{Driver: "other.csi.driver"},
+				},
+			},
+		}
+		pvLister, _, _ := newTestListers(t, pv)
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		_, ok := resolvePVCToVolumeID(ctx, pvLister, pvc)
+		assert.False(t, ok)
+	})
+
+	t.Run("FileVolumeReturnsFalse", func(t *testing.T) {
+		pv := newCBTBlockPV("pv-1", "vol-1")
+		pv.Spec.CSI.VolumeAttributes[common.AttributeDiskType] = "vSphere CNS File Volume"
+		pvLister, _, _ := newTestListers(t, pv)
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		_, ok := resolvePVCToVolumeID(ctx, pvLister, pvc)
+		assert.False(t, ok)
+	})
+
+	t.Run("EmptyVolumeHandleReturnsFalse", func(t *testing.T) {
+		pv := newCBTBlockPV("pv-1", "")
+		pvLister, _, _ := newTestListers(t, pv)
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		_, ok := resolvePVCToVolumeID(ctx, pvLister, pvc)
+		assert.False(t, ok)
+	})
+
+	t.Run("ValidBlockVolumeReturnsHandle", func(t *testing.T) {
+		pv := newCBTBlockPV("pv-1", "vol-handle-1")
+		pvLister, _, _ := newTestListers(t, pv)
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		id, ok := resolvePVCToVolumeID(ctx, pvLister, pvc)
+		assert.True(t, ok)
+		assert.Equal(t, "vol-handle-1", id)
+	})
+}
+
+func TestBuildPVCCandidates(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+
+	t.Run("EmptyNamespaceReturnsEmpty", func(t *testing.T) {
+		pvLister, pvcLister, vaLister := newTestListers(t)
+		got, err := buildPVCCandidates(ctx, pvLister, pvcLister, vaLister, "ns")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("AttachedPVCSkipped", func(t *testing.T) {
+		pv := newCBTBlockPV("pv-1", "vol-1")
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		va := newVolumeAttachmentForPV("va-1", "pv-1")
+		pvLister, pvcLister, vaLister := newTestListers(t, pv, pvc, va)
+		got, err := buildPVCCandidates(ctx, pvLister, pvcLister, vaLister, "ns")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("EligiblePVCIncluded", func(t *testing.T) {
+		pv := newCBTBlockPV("pv-1", "vol-1")
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		pvLister, pvcLister, vaLister := newTestListers(t, pv, pvc)
+		got, err := buildPVCCandidates(ctx, pvLister, pvcLister, vaLister, "ns")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "vol-1", got[0].volumeID)
+	})
+
+	t.Run("NonBoundPVCsSkipped", func(t *testing.T) {
+		pv := newCBTBlockPV("pv-bound", "vol-bound")
+		pvcBound := newPVC("ns", "pvc-bound", "pv-bound", nil, nil)
+		pvcPending := newPVCWithPhase("ns", "pvc-pending", "", v1.ClaimPending)
+		pvLister, pvcLister, vaLister := newTestListers(t, pv, pvcBound, pvcPending)
+		got, err := buildPVCCandidates(ctx, pvLister, pvcLister, vaLister, "ns")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "vol-bound", got[0].volumeID)
+	})
+
+	t.Run("MixedEligibilityFiltersCorrectly", func(t *testing.T) {
+		pvGood := newCBTBlockPV("pv-good", "vol-good")
+		pvFile := newCBTBlockPV("pv-file", "vol-file")
+		pvFile.Spec.CSI.VolumeAttributes[common.AttributeDiskType] = "vSphere CNS File Volume"
+		pvAttached := newCBTBlockPV("pv-attached", "vol-attached")
+
+		pvcGood := newPVC("ns", "pvc-good", "pv-good", nil, nil)
+		pvcFile := newPVC("ns", "pvc-file", "pv-file", nil, nil)
+		pvcAttached := newPVC("ns", "pvc-attached", "pv-attached", nil, nil)
+		va := newVolumeAttachmentForPV("va-1", "pv-attached")
+
+		pvLister, pvcLister, vaLister := newTestListers(t, pvGood, pvFile, pvAttached,
+			pvcGood, pvcFile, pvcAttached, va)
+		got, err := buildPVCCandidates(ctx, pvLister, pvcLister, vaLister, "ns")
+		require.NoError(t, err)
+		require.Len(t, got, 1, "only pvcGood should survive all filters")
+		assert.Equal(t, "vol-good", got[0].volumeID)
+	})
+}
+
+func TestFilterCandidatesByCBTState(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+
+	t.Run("EmptyInputReturnsEmpty", func(t *testing.T) {
+		got, err := filterCandidatesByCBTState(ctx, &fakeVolMgr{}, "ns", nil, true)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("QueryErrorReturnsError", func(t *testing.T) {
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		vm := &fakeVolMgr{queryErr: errors.New("cns unavailable")}
+		in := []pvcWithVolume{{pvc: pvc, volumeID: "vol-1"}}
+		got, err := filterCandidatesByCBTState(ctx, vm, "ns", in, true)
+		require.Error(t, err, "query failure must be surfaced so the caller can requeue")
+		assert.Nil(t, got)
+	})
+
+	t.Run("AlreadyInTargetStateFiltered", func(t *testing.T) {
+		vm := &fakeVolMgr{queryResult: &cnstypes.CnsQueryResult{}}
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		in := []pvcWithVolume{{pvc: pvc, volumeID: "vol-1"}}
+		got, err := filterCandidatesByCBTState(ctx, vm, "ns", in, true)
+		require.NoError(t, err)
+		assert.Empty(t, got, "volume already in target state must be filtered out")
+	})
+
+	t.Run("NeedsFlipIsKept", func(t *testing.T) {
+		vm := &fakeVolMgr{
+			queryResult: &cnstypes.CnsQueryResult{
+				Volumes: []cnstypes.CnsVolume{cnsVolumeWithCBT("vol-1", cnstypes.CnsVolumeCBTStatusDisabled)},
+			},
+		}
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		in := []pvcWithVolume{{pvc: pvc, volumeID: "vol-1"}}
+		got, err := filterCandidatesByCBTState(ctx, vm, "ns", in, true)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "vol-1", got[0].volumeID)
+	})
+}
+
+// TestQueryVolumesNeedingFlip exercises the QueryAllVolume input batching.
+func TestQueryVolumesNeedingFlip(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+
+	t.Run("EmptyInputIssuesNoQueries", func(t *testing.T) {
+		vm := &fakeVolMgr{}
+		got, err := queryVolumesNeedingFlip(ctx, vm, nil, true)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		assert.Empty(t, vm.queryBatchSizesCopy())
+	})
+
+	t.Run("SingleBatchUnderThreshold", func(t *testing.T) {
+		ids := []string{"vol-1", "vol-2", "vol-3"}
+		vm := &fakeVolMgr{
+			queryFn: func(filter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+				vols := make([]cnstypes.CnsVolume, 0, len(filter.VolumeIds))
+				for _, v := range filter.VolumeIds {
+					vols = append(vols, cnsVolumeWithCBT(v.Id, cnstypes.CnsVolumeCBTStatusDisabled))
+				}
+				return &cnstypes.CnsQueryResult{Volumes: vols}, nil
+			},
+		}
+		got, err := queryVolumesNeedingFlip(ctx, vm, ids, true)
+		require.NoError(t, err)
+		assert.Len(t, got, 3)
+		assert.Equal(t, []int{3}, vm.queryBatchSizesCopy())
+	})
+
+	t.Run("MultipleBatchesAtBoundary", func(t *testing.T) {
+		const total = 2*volumdIDLimitPerQuery + volumdIDLimitPerQuery/2
+		ids := make([]string, total)
+		for i := range ids {
+			ids[i] = fmt.Sprintf("vol-%d", i)
+		}
+		vm := &fakeVolMgr{
+			queryFn: func(filter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+				vols := make([]cnstypes.CnsVolume, 0, len(filter.VolumeIds))
+				for _, v := range filter.VolumeIds {
+					vols = append(vols, cnsVolumeWithCBT(v.Id, cnstypes.CnsVolumeCBTStatusDisabled))
+				}
+				return &cnstypes.CnsQueryResult{Volumes: vols}, nil
+			},
+		}
+		got, err := queryVolumesNeedingFlip(ctx, vm, ids, true)
+		require.NoError(t, err)
+		assert.Len(t, got, total)
+		assert.Equal(t,
+			[]int{volumdIDLimitPerQuery, volumdIDLimitPerQuery, volumdIDLimitPerQuery / 2},
+			vm.queryBatchSizesCopy())
+	})
+
+	t.Run("FirstBatchErrorAborts", func(t *testing.T) {
+		const total = 2 * volumdIDLimitPerQuery
+		ids := make([]string, total)
+		for i := range ids {
+			ids[i] = fmt.Sprintf("vol-%d", i)
+		}
+		vm := &fakeVolMgr{queryErr: errors.New("cns boom")}
+		_, err := queryVolumesNeedingFlip(ctx, vm, ids, true)
+		require.Error(t, err)
+		assert.Equal(t, []int{volumdIDLimitPerQuery}, vm.queryBatchSizesCopy(),
+			"should stop at the first failing batch instead of plowing through")
+	})
+
+	t.Run("DisableUsesEnabledFilter", func(t *testing.T) {
+		vm := &fakeVolMgr{
+			queryFn: func(filter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+				assert.Equal(t, cnstypes.CnsVolumeCBTStatusEnabled, filter.ChangedBlockTracking,
+					"disable reconcile must query for currently-enabled volumes")
+				return &cnstypes.CnsQueryResult{}, nil
+			},
+		}
+		_, err := queryVolumesNeedingFlip(ctx, vm, []string{"vol-1"}, false)
+		require.NoError(t, err)
+	})
+}
+
+// TestPeriodicSkipsActiveReconcile verifies that syncCBTForNamespace skips work when
+// a background controller reconcile is in flight for the same namespace.
+func TestPeriodicSkipsActiveReconcile(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	ns := "skip-test-ns"
+
+	_, fakeCancel := context.WithCancel(ctx)
+	cbtWorkMu.Lock()
+	cbtWorkMap[ns] = &cbtWork{cancel: fakeCancel}
+	cbtWorkMu.Unlock()
+	defer func() {
+		cbtWorkMu.Lock()
+		delete(cbtWorkMap, ns)
+		cbtWorkMu.Unlock()
+		fakeCancel()
+	}()
+
+	vm := &fakeVolMgr{}
+	pvLister, pvcLister, vaLister := newTestListers(t)
+
+	err := syncCBTForNamespace(ctx, vm, pvLister, pvcLister, vaLister, ns, true)
+	require.NoError(t, err)
+	assert.Empty(t, vm.setCallsCopy(), "periodic sync must not call Set when reconcile is active")
+	assert.Empty(t, vm.clearCallsCopy(), "periodic sync must not call Clear when reconcile is active")
+}
+
+// TestReconcileCancelsInFlightWork verifies that ReconcileCBTForNamespace cancels the
+// context of any in-flight CBT work (periodic sync or a previous background reconcile)
+// for the same namespace before scheduling its own work.
+func TestReconcileCancelsInFlightWork(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	ns := "cancel-test-ns"
+
+	fakeCtx, fakeCancel := context.WithCancel(ctx)
+	cbtWorkMu.Lock()
+	cbtWorkMap[ns] = &cbtWork{cancel: fakeCancel}
+	cbtWorkMu.Unlock()
+	defer func() {
+		cbtWorkMu.Lock()
+		delete(cbtWorkMap, ns)
+		cbtWorkMu.Unlock()
+	}()
+
+	pv := newCBTBlockPV("pv-1", "vol-1")
+	pvc := newPVC(ns, "pvc-1", "pv-1", nil, nil)
+	vm := &fakeVolMgr{queryResult: &cnstypes.CnsQueryResult{}}
+	pvLister, pvcLister, vaLister := newTestListers(t, pv, pvc)
+
+	require.NoError(t, ReconcileCBTForNamespace(ctx, vm, pvLister, pvcLister, vaLister, ns, true))
+
+	assert.ErrorIs(t, fakeCtx.Err(), context.Canceled,
+		"ReconcileCBTForNamespace must cancel the in-flight CBT work context")
+
+	// Wait for the background goroutine to finish so it doesn't leak into the next test.
+	assert.Eventually(t, func() bool {
+		cbtWorkMu.Lock()
+		defer cbtWorkMu.Unlock()
+		return cbtWorkMap[ns] == nil
+	}, time.Second*5, time.Millisecond*10,
+		"background reconcile goroutine must clear cbtWorkMap entry on exit")
+}
+
+// TestReconcileClearsStateAfterCompletion verifies that the cbtWorkMap entry is removed
+// once the background reconcile goroutine launched by ReconcileCBTForNamespace finishes,
+// so future periodic syncs are no longer blocked.
+func TestReconcileClearsStateAfterCompletion(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	ns := "mark-test-ns"
+
+	cbtWorkMu.Lock()
+	delete(cbtWorkMap, ns)
+	cbtWorkMu.Unlock()
+
+	pv := newCBTBlockPV("pv-1", "vol-1")
+	pvc := newPVC(ns, "pvc-1", "pv-1", nil, nil)
+	vm := &fakeVolMgr{queryResult: &cnstypes.CnsQueryResult{}}
+	pvLister, pvcLister, vaLister := newTestListers(t, pv, pvc)
+
+	require.NoError(t, ReconcileCBTForNamespace(ctx, vm, pvLister, pvcLister, vaLister, ns, true))
+
+	assert.Eventually(t, func() bool {
+		cbtWorkMu.Lock()
+		defer cbtWorkMu.Unlock()
+		return cbtWorkMap[ns] == nil
+	}, time.Second*5, time.Millisecond*10,
+		"namespace entry must be deleted after the background reconcile goroutine returns")
+}
+
+// TestReconcileQueueFullReturnsError verifies that ReconcileCBTForNamespace returns an
+// error (so the controller can requeue) when the bounded background pool is fully busy.
+func TestReconcileQueueFullReturnsError(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+
+	queue := getCBTWorkQueue(ctx)
+	capacity := cap(queue)
+	require.Greater(t, capacity, 0, "queue must have non-zero capacity")
+
+	// Fill every slot so the next non-blocking enqueue cannot proceed.
+	for i := 0; i < capacity; i++ {
+		queue <- struct{}{}
+	}
+	defer func() {
+		for i := 0; i < capacity; i++ {
+			<-queue
+		}
+	}()
+
+	vm := &fakeVolMgr{}
+	pvLister, pvcLister, vaLister := newTestListers(t)
+	err := ReconcileCBTForNamespace(ctx, vm, pvLister, pvcLister, vaLister, "queue-full-ns", true)
+	require.Error(t, err, "queue-full reconcile must return error so the controller requeues")
+	assert.Contains(t, err.Error(), "queue is full")
+	assert.Empty(t, vm.setCallsCopy(),
+		"no CBT work should run when reconcile was rejected due to a full queue")
+}
+
+func TestApplyCnsCbtFlags(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+
+	t.Run("EmptyCandidatesIsNoop", func(t *testing.T) {
+		vm := &fakeVolMgr{}
+		err := applyCnsCbtFlags(ctx, vm, "ns", nil, true)
+		require.NoError(t, err)
+		assert.Empty(t, vm.setCallsCopy())
+		assert.Empty(t, vm.clearCallsCopy())
+	})
+
+	t.Run("EnableCallsSet", func(t *testing.T) {
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		vm := &fakeVolMgr{}
+		candidates := []pvcWithVolume{{pvc: pvc, volumeID: "vol-1"}}
+		err := applyCnsCbtFlags(ctx, vm, "ns", candidates, true)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"vol-1"}, vm.setCallsCopy())
+		assert.Empty(t, vm.clearCallsCopy())
+	})
+
+	t.Run("DisableCallsClear", func(t *testing.T) {
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		vm := &fakeVolMgr{}
+		candidates := []pvcWithVolume{{pvc: pvc, volumeID: "vol-1"}}
+		err := applyCnsCbtFlags(ctx, vm, "ns", candidates, false)
+		require.NoError(t, err)
+		assert.Empty(t, vm.setCallsCopy())
+		assert.Equal(t, []string{"vol-1"}, vm.clearCallsCopy())
+	})
+
+	t.Run("SetErrorIsLogged", func(t *testing.T) {
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		vm := &fakeVolMgr{setErr: errors.New("cns set failed")}
+		candidates := []pvcWithVolume{{pvc: pvc, volumeID: "vol-1"}}
+		err := applyCnsCbtFlags(ctx, vm, "ns", candidates, true)
+		require.NoError(t, err, "per-volume errors are best-effort and must not be returned")
+		assert.Equal(t, []string{"vol-1"}, vm.setCallsCopy())
+	})
+}

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -285,6 +285,13 @@ func (m *mockCOCommon) HandleLateEnablementOfCapability(ctx context.Context,
 	panic("implement me")
 }
 
+func (m *mockCOCommon) IsDPOServiceInstalled(ctx context.Context) (bool, error) {
+	return true, nil
+}
+
+func (m *mockCOCommon) HandleLateInstallationOfDPOService(ctx context.Context) {
+}
+
 func (m *mockCOCommon) IsFSSEnabled(ctx context.Context, featureName string) bool {
 	return true
 }

--- a/pkg/syncer/dpoperator/controller/add_cbtconfig.go
+++ b/pkg/syncer/dpoperator/controller/add_cbtconfig.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/dpoperator/controller/cbtconfig"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, cbtconfig.Add)
+}

--- a/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller.go
+++ b/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cbtconfig
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer"
+)
+
+const (
+	maxReconcileWorkerThreads  = 1
+	reconcileErrorRequeueAfter = 5 * time.Minute
+)
+
+// cbtStatusState decodes the CBT intent from a CBTConfigStatus.
+//
+// enabled carries the resolved enable/disable intent; it is only meaningful
+// when configured is true.
+// configured is true when the operator has written status.enabled (non-nil);
+// both true and false values are actionable. configured is false when the
+// operator has not yet reconciled the field, and the caller should skip acting.
+func cbtStatusState(st cbtconfigv1alpha1.CBTConfigStatus) (enabled, configured bool) {
+	if st.Enabled == nil {
+		return false, false
+	}
+	return *st.Enabled, true
+}
+
+// Add creates a new CBTConfig controller and adds it to the Manager.
+// pvLister, pvcLister and vaLister come from the singleton InformerManager shared with the
+// metadata syncer and k8sorchestrator, so no second copy of those informers is started here.
+func Add(mgr manager.Manager, volumeManager volume.Manager,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister) error {
+	rec := newReconciler(mgr, volumeManager, pvLister, pvcLister, vaLister)
+	return add(mgr, rec)
+}
+
+func newReconciler(mgr manager.Manager, volumeManager volume.Manager,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister) *ReconcileCBTConfig {
+	return &ReconcileCBTConfig{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		volumeManager: volumeManager,
+		pvLister:      pvLister,
+		pvcLister:     pvcLister,
+		vaLister:      vaLister,
+	}
+}
+
+func add(mgr manager.Manager, r *ReconcileCBTConfig) error {
+	_, log := logger.GetNewContextWithLogger()
+	c, err := controller.New("cbtconfig-controller", mgr,
+		controller.Options{Reconciler: r, MaxConcurrentReconciles: maxReconcileWorkerThreads})
+	if err != nil {
+		log.Errorf("failed to create new CBTConfig controller with error: %+v", err)
+		return err
+	}
+
+	pred := predicate.TypedFuncs[*cbtconfigv1alpha1.CBTConfig]{
+		// Reconcile whenever the operator has written status.enabled (non-nil).
+		// A disabled (false) value is also actionable — it means CBT must be cleared.
+		CreateFunc: func(e event.TypedCreateEvent[*cbtconfigv1alpha1.CBTConfig]) bool {
+			_, configured := cbtStatusState(e.Object.Status)
+			return configured
+		},
+		// Enqueue only when the effective enable/disable intent changes — either
+		// status.enabled transitions from nil to set, or its boolean value flips.
+		// This avoids reconciling on every unrelated status or metadata update.
+		UpdateFunc: func(e event.TypedUpdateEvent[*cbtconfigv1alpha1.CBTConfig]) bool {
+			oldEnabled, oldConfigured := cbtStatusState(e.ObjectOld.Status)
+			newEnabled, newConfigured := cbtStatusState(e.ObjectNew.Status)
+			return oldConfigured != newConfigured || oldEnabled != newEnabled
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*cbtconfigv1alpha1.CBTConfig]) bool {
+			return false
+		},
+	}
+
+	err = c.Watch(source.Kind(
+		mgr.GetCache(),
+		&cbtconfigv1alpha1.CBTConfig{},
+		&handler.TypedEnqueueRequestForObject[*cbtconfigv1alpha1.CBTConfig]{}, pred))
+	if err != nil {
+		log.Errorf("failed to watch for changes to CBTConfig resource with error: %+v", err)
+		return err
+	}
+	return nil
+}
+
+// ReconcileCBTConfig reconciles a CBTConfig object.
+type ReconcileCBTConfig struct {
+	client client.Client
+	scheme *runtime.Scheme
+	// pvLister, pvcLister and vaLister are backed by the singleton InformerManager; reads
+	// come from in-process informer caches without an apiserver round-trip per reconcile.
+	pvLister      corelisters.PersistentVolumeLister
+	pvcLister     corelisters.PersistentVolumeClaimLister
+	vaLister      storagelistersv1.VolumeAttachmentLister
+	volumeManager volume.Manager
+}
+
+var _ reconcile.Reconciler = &ReconcileCBTConfig{}
+
+// Reconcile reads that state of the cluster for a CBTConfig object and makes changes.
+func (r *ReconcileCBTConfig) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+	log.Debugf("Received Reconcile for CBTConfig request: %q", request.NamespacedName)
+
+	instance := &cbtconfigv1alpha1.CBTConfig{}
+	err := r.client.Get(ctx, request.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("CBTConfig resource not found. Ignoring since object must be deleted.")
+			return reconcile.Result{}, nil
+		}
+		log.Errorf("Error reading the CBTConfig with name: %q. Err: %+v", request.Name, err)
+		return reconcile.Result{}, err
+	}
+
+	if instance.DeletionTimestamp != nil {
+		log.Debugf("CBTConfig %q is being deleted; skipping reconcile", request.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
+	enable, configured := cbtStatusState(instance.Status)
+	if !configured {
+		log.Debugf("CBTConfig %q status.enabled not yet set; skipping reconcile", request.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+	if err := syncer.ReconcileCBTForNamespace(ctx, r.volumeManager,
+		r.pvLister, r.pvcLister, r.vaLister,
+		instance.Namespace, enable); err != nil {
+		log.Errorf("CBTConfig reconcile failed for namespace %q: %+v", instance.Namespace, err)
+		return reconcile.Result{RequeueAfter: reconcileErrorRequeueAfter}, nil
+	}
+	log.Debugf("Successfully reconciled CBTConfig %q (enable=%t)", request.NamespacedName, enable)
+	return reconcile.Result{}, nil
+}

--- a/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller_test.go
+++ b/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller_test.go
@@ -1,0 +1,449 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cbtconfig
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// fakeVolumeManager records SetVolumeControlFlags / ClearVolumeControlFlags calls and returns
+// configurable errors. It embeds volume.MockManager to satisfy the rest of the volume.Manager
+// interface (other methods will panic if accidentally invoked, which is desirable - any test
+// that calls them is exercising untested behavior).
+type fakeVolumeManager struct {
+	cnsvolume.MockManager
+
+	mu          sync.Mutex
+	setCalls    []string
+	clearCalls  []string
+	setErr      error
+	clearErr    error
+	queryResult *cnstypes.CnsQueryResult
+	queryErr    error
+	// queryFn, if set, takes precedence over queryResult/queryErr.
+	queryFn func(filter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error)
+}
+
+func (f *fakeVolumeManager) SetVolumeControlFlags(_ context.Context, volumeID string,
+	_ []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setCalls = append(f.setCalls, volumeID)
+	return f.setErr
+}
+
+func (f *fakeVolumeManager) ClearVolumeControlFlags(_ context.Context, volumeID string,
+	_ []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clearCalls = append(f.clearCalls, volumeID)
+	return f.clearErr
+}
+
+func (f *fakeVolumeManager) QueryAllVolume(_ context.Context, filter cnstypes.CnsQueryFilter,
+	_ cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.queryFn != nil {
+		return f.queryFn(filter)
+	}
+	return f.queryResult, f.queryErr
+}
+
+func (f *fakeVolumeManager) setCallsCopy() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.setCalls))
+	copy(out, f.setCalls)
+	return out
+}
+
+func (f *fakeVolumeManager) clearCallsCopy() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.clearCalls))
+	copy(out, f.clearCalls)
+	return out
+}
+
+var _ cnsvolume.Manager = (*fakeVolumeManager)(nil)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddToScheme(scheme))
+	require.NoError(t, storagev1.AddToScheme(scheme))
+	require.NoError(t, cbtconfigv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func newTestClientBuilder(t *testing.T) *fake.ClientBuilder {
+	t.Helper()
+	return fake.NewClientBuilder().WithScheme(newTestScheme(t))
+}
+
+func newCBTBlockPV(name, volumeHandle string) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       common.VSphereCSIDriverName,
+					VolumeHandle: volumeHandle,
+					VolumeAttributes: map[string]string{
+						common.AttributeDiskType: common.DiskTypeBlockVolume,
+					},
+				},
+			},
+		},
+	}
+}
+
+func newPVC(namespace, name, pvName string, labels map[string]string,
+	annotations map[string]string) *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec:   v1.PersistentVolumeClaimSpec{VolumeName: pvName},
+		Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimBound},
+	}
+}
+
+func newPVCWithPhase(namespace, name, pvName string,
+	phase v1.PersistentVolumeClaimPhase) *v1.PersistentVolumeClaim {
+	pvc := newPVC(namespace, name, pvName, nil, nil)
+	pvc.Status.Phase = phase
+	return pvc
+}
+
+func newVolumeAttachmentForPV(name, pvName string) *storagev1.VolumeAttachment {
+	pvNameRef := pvName
+	return &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: storagev1.VolumeAttachmentSpec{
+			Source: storagev1.VolumeAttachmentSource{PersistentVolumeName: &pvNameRef},
+		},
+	}
+}
+
+func newCBTConfig(namespace, name string, statusEnabled *bool) *cbtconfigv1alpha1.CBTConfig {
+	return &cbtconfigv1alpha1.CBTConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status:     cbtconfigv1alpha1.CBTConfigStatus{Enabled: statusEnabled},
+	}
+}
+
+func cnsVolumeWithCBT(id string, status cnstypes.CnsVolumeCBTStatus) cnstypes.CnsVolume {
+	return cnstypes.CnsVolume{
+		VolumeId:             cnstypes.CnsVolumeId{Id: id},
+		ChangedBlockTracking: status,
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// newTestListers builds in-memory PV / PVC / VolumeAttachment listers seeded with the given objects.
+func newTestListers(t *testing.T, objs ...client.Object) (corelisters.PersistentVolumeLister,
+	corelisters.PersistentVolumeClaimLister, storagelistersv1.VolumeAttachmentLister) {
+	t.Helper()
+	pvIdx := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	pvcIdx := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	vaIdx := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, o := range objs {
+		switch obj := o.(type) {
+		case *v1.PersistentVolume:
+			require.NoError(t, pvIdx.Add(obj))
+		case *v1.PersistentVolumeClaim:
+			require.NoError(t, pvcIdx.Add(obj))
+		case *storagev1.VolumeAttachment:
+			require.NoError(t, vaIdx.Add(obj))
+		}
+	}
+	return corelisters.NewPersistentVolumeLister(pvIdx),
+		corelisters.NewPersistentVolumeClaimLister(pvcIdx),
+		storagelistersv1.NewVolumeAttachmentLister(vaIdx)
+}
+
+// newTestReconciler builds a *ReconcileCBTConfig directly (bypassing newReconciler) so tests
+// don't have to satisfy the controller-runtime manager.Manager interface.
+func newTestReconciler(c client.Client, vm cnsvolume.Manager,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister) *ReconcileCBTConfig {
+	return &ReconcileCBTConfig{
+		client:        c,
+		scheme:        c.Scheme(),
+		volumeManager: vm,
+		pvLister:      pvLister,
+		pvcLister:     pvcLister,
+		vaLister:      vaLister,
+	}
+}
+
+// newSeededReconciler builds a reconciler whose r.client and listers are seeded with the same objs.
+func newSeededReconciler(t *testing.T, vm cnsvolume.Manager,
+	objs ...client.Object) (*ReconcileCBTConfig, client.Client) {
+	t.Helper()
+	c := newTestClientBuilder(t).WithObjects(objs...).Build()
+	pvLister, pvcLister, vaLister := newTestListers(t, objs...)
+	return newTestReconciler(c, vm, pvLister, pvcLister, vaLister), c
+}
+
+func TestCbtStatusState(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         cbtconfigv1alpha1.CBTConfigStatus
+		wantEnabled    bool
+		wantConfigured bool
+	}{
+		{name: "EnabledNil", status: cbtconfigv1alpha1.CBTConfigStatus{Enabled: nil},
+			wantEnabled: false, wantConfigured: false},
+		{name: "EnabledFalse", status: cbtconfigv1alpha1.CBTConfigStatus{Enabled: boolPtr(false)},
+			wantEnabled: false, wantConfigured: true},
+		{name: "EnabledTrue", status: cbtconfigv1alpha1.CBTConfigStatus{Enabled: boolPtr(true)},
+			wantEnabled: true, wantConfigured: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enabled, configured := cbtStatusState(tt.status)
+			assert.Equal(t, tt.wantEnabled, enabled, "enabled")
+			assert.Equal(t, tt.wantConfigured, configured, "configured")
+		})
+	}
+}
+
+// eventuallyEqual polls fn until it returns the expected slice or the timeout elapses,
+// then asserts equality. Background CBT work runs on a goroutine launched by
+// ReconcileCBTForNamespace, so observable side effects (Set/Clear calls on the fake
+// volume manager) are not visible the moment Reconcile returns.
+func eventuallyEqual(t *testing.T, fn func() []string, want []string, msg string) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		got := fn()
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	}, time.Second*5, time.Millisecond*10, msg)
+}
+
+// neverHasCalls polls fn for the given duration and asserts the slice stays empty.
+// Used by tests that expect the background goroutine to short-circuit before issuing
+// any Set/Clear call (e.g. when phase 2 fails or all volumes are already in state).
+func neverHasCalls(t *testing.T, fn func() []string, msg string) {
+	t.Helper()
+	assert.Never(t, func() bool {
+		return len(fn()) > 0
+	}, time.Millisecond*200, time.Millisecond*10, msg)
+}
+
+func TestReconcile(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+
+	disabledQueryResult := func(volumeIDs ...string) *cnstypes.CnsQueryResult {
+		vols := make([]cnstypes.CnsVolume, 0, len(volumeIDs))
+		for _, id := range volumeIDs {
+			vols = append(vols, cnsVolumeWithCBT(id, cnstypes.CnsVolumeCBTStatusDisabled))
+		}
+		return &cnstypes.CnsQueryResult{Volumes: vols}
+	}
+	enabledQueryResult := func(volumeIDs ...string) *cnstypes.CnsQueryResult {
+		vols := make([]cnstypes.CnsVolume, 0, len(volumeIDs))
+		for _, id := range volumeIDs {
+			vols = append(vols, cnsVolumeWithCBT(id, cnstypes.CnsVolumeCBTStatusEnabled))
+		}
+		return &cnstypes.CnsQueryResult{Volumes: vols}
+	}
+
+	t.Run("CBTConfigNotFoundReturnsNil", func(t *testing.T) {
+		r, _ := newSeededReconciler(t, &fakeVolumeManager{})
+		res, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "absent"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+	})
+
+	t.Run("CBTConfigBeingDeletedIsNoop", func(t *testing.T) {
+		now := metav1.Now()
+		cbt := newCBTConfig("ns", "cbt", boolPtr(true))
+		cbt.DeletionTimestamp = &now
+		cbt.Finalizers = []string{"keep-me"}
+		vm := &fakeVolumeManager{}
+		r, _ := newSeededReconciler(t, vm, cbt)
+		res, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "cbt"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+		assert.Empty(t, vm.setCallsCopy())
+		assert.Empty(t, vm.clearCallsCopy())
+	})
+
+	t.Run("EnableAppliesSetToUnattachedBlockPVCsOnly", func(t *testing.T) {
+		cbt := newCBTConfig("ns", "cbt", boolPtr(true))
+		pvAttached := newCBTBlockPV("pv-attached", "vol-attached")
+		pvUnattached := newCBTBlockPV("pv-unattached", "vol-unattached")
+		pvcAttached := newPVC("ns", "pvc-attached", "pv-attached", nil, nil)
+		pvcUnattached := newPVC("ns", "pvc-unattached", "pv-unattached", nil, nil)
+		va := newVolumeAttachmentForPV("va-1", "pv-attached")
+
+		vm := &fakeVolumeManager{queryResult: disabledQueryResult("vol-unattached")}
+		r, _ := newSeededReconciler(t, vm, cbt, pvAttached, pvUnattached,
+			pvcAttached, pvcUnattached, va)
+
+		res, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "cbt"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+		eventuallyEqual(t, vm.setCallsCopy, []string{"vol-unattached"},
+			"background goroutine must call Set on the unattached volume only")
+		neverHasCalls(t, vm.clearCallsCopy, "Clear must not be called on enable")
+	})
+
+	t.Run("DisableClearsCBTOnPreviouslyEnabledUnattachedPVCs", func(t *testing.T) {
+		cbt := newCBTConfig("ns", "cbt", boolPtr(false))
+		pv := newCBTBlockPV("pv-1", "vol-1")
+		pvc := newPVC("ns", "pvc-1", "pv-1", map[string]string{"cbt": "true"}, nil)
+
+		vm := &fakeVolumeManager{queryResult: enabledQueryResult("vol-1")}
+		r, _ := newSeededReconciler(t, vm, cbt, pv, pvc)
+
+		res, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "cbt"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+		eventuallyEqual(t, vm.clearCallsCopy, []string{"vol-1"},
+			"background goroutine must call Clear when disabling CBT")
+		neverHasCalls(t, vm.setCallsCopy, "Set must not be called on disable")
+	})
+
+	t.Run("EnableSkipsNonBoundPVCs", func(t *testing.T) {
+		cbt := newCBTConfig("ns", "cbt", boolPtr(true))
+		pvBound := newCBTBlockPV("pv-bound", "vol-bound")
+		pvLost := newCBTBlockPV("pv-lost", "vol-lost")
+		pvcBound := newPVC("ns", "pvc-bound", "pv-bound", nil, nil)
+		pvcPending := newPVCWithPhase("ns", "pvc-pending", "", v1.ClaimPending)
+		pvcLost := newPVCWithPhase("ns", "pvc-lost", "pv-lost", v1.ClaimLost)
+
+		vm := &fakeVolumeManager{queryResult: disabledQueryResult("vol-bound")}
+		r, _ := newSeededReconciler(t, vm, cbt, pvBound, pvLost, pvcBound, pvcPending, pvcLost)
+
+		res, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "cbt"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+		eventuallyEqual(t, vm.setCallsCopy, []string{"vol-bound"},
+			"only the Bound PVC's volume should have CBT enabled")
+	})
+
+	t.Run("EnableSkipsPVCsAlreadyInTargetCBTState", func(t *testing.T) {
+		cbt := newCBTConfig("ns", "cbt", boolPtr(true))
+		pv := newCBTBlockPV("pv-1", "vol-1")
+		pvc := newPVC("ns", "pvc-1", "pv-1", map[string]string{"cbt": "true"}, nil)
+		vm := &fakeVolumeManager{queryResult: &cnstypes.CnsQueryResult{}}
+		r, _ := newSeededReconciler(t, vm, cbt, pv, pvc)
+
+		res, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "cbt"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+		neverHasCalls(t, vm.setCallsCopy, "Set must not be called when CBT already enabled")
+		neverHasCalls(t, vm.clearCallsCopy, "Clear must not be called on enable")
+	})
+
+	// Phase 2 (CNS query) failures used to bubble back through ReconcileCBTForNamespace and
+	// requeue at the controller layer. Now that the work runs on a bounded background pool,
+	// query failures are logged and absorbed by the goroutine — re-convergence happens via
+	// the periodic sync. The controller's only requeue trigger is "queue full".
+	t.Run("QueryErrorIsAbsorbedByBackgroundGoroutine", func(t *testing.T) {
+		cbt := newCBTConfig("ns", "cbt", boolPtr(true))
+		pv := newCBTBlockPV("pv-1", "vol-1")
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		vm := &fakeVolumeManager{queryErr: errors.New("cns boom")}
+		r, _ := newSeededReconciler(t, vm, cbt, pv, pvc)
+
+		res, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "cbt"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res,
+			"phase failures are absorbed by the background goroutine; controller does not requeue")
+		neverHasCalls(t, vm.setCallsCopy, "Set must not be called when phase 2 fails")
+	})
+
+	t.Run("VolumeOpFailureIsLogged", func(t *testing.T) {
+		cbt := newCBTConfig("ns", "cbt", boolPtr(true))
+		pv := newCBTBlockPV("pv-1", "vol-1")
+		pvc := newPVC("ns", "pvc-1", "pv-1", nil, nil)
+		vm := &fakeVolumeManager{
+			setErr: errors.New("cns set failed"),
+			queryResult: &cnstypes.CnsQueryResult{
+				Volumes: []cnstypes.CnsVolume{cnsVolumeWithCBT("vol-1", cnstypes.CnsVolumeCBTStatusDisabled)},
+			},
+		}
+		r, _ := newSeededReconciler(t, vm, cbt, pv, pvc)
+
+		res, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "cbt"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res, "per-volume set failure is best-effort; no requeue expected")
+		eventuallyEqual(t, vm.setCallsCopy, []string{"vol-1"},
+			"background goroutine should still attempt the per-volume Set even on failure")
+	})
+}

--- a/pkg/syncer/dpoperator/controller/controller.go
+++ b/pkg/syncer/dpoperator/controller/controller.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+)
+
+// AddToManagerFunc registers a single DP operator controller with mgr. The PV / PVC /
+// VolumeAttachment listers come from the singleton InformerManager (shared with the metadata
+// syncer and k8sorchestrator) so child controllers do not start their own copies of those
+// informers via the controller-runtime cache.
+type AddToManagerFunc func(mgr manager.Manager, volumeManager volume.Manager,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister) error
+
+// AddToManagerFuncs is the list of registration funcs invoked by AddToManager.
+// The DP operator only runs on the Supervisor (Workload) cluster, so cluster flavor
+// is implied and not threaded through these registration funcs.
+var AddToManagerFuncs []AddToManagerFunc
+
+// AddToManager adds all Controllers to the Manager.
+func AddToManager(mgr manager.Manager, volumeManager volume.Manager,
+	pvLister corelisters.PersistentVolumeLister,
+	pvcLister corelisters.PersistentVolumeClaimLister,
+	vaLister storagelistersv1.VolumeAttachmentLister) error {
+	for _, f := range AddToManagerFuncs {
+		if err := f(mgr, volumeManager, pvLister, pvcLister, vaLister); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/syncer/dpoperator/manager.go
+++ b/pkg/syncer/dpoperator/manager.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dpoperator
+
+import (
+	"context"
+	"fmt"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/dpoperator/controller"
+)
+
+// NewManager creates and initializes a new controller manager for the DP operator.
+// The DP operator only runs on the Supervisor (Workload) cluster, so the cluster flavor
+// is implied and hard-coded internally rather than being passed in by the caller.
+func NewManager(
+	ctx context.Context,
+	configInfo *cnsconfig.ConfigurationInfo,
+) (ctrlmgr.Manager, error) {
+	log := logger.GetLogger(ctx)
+	log.Infof("Initializing DP Operator")
+	kubeConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	mgr, err := ctrlmgr.New(kubeConfig, ctrlmgr.Options{
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new Data Protection(DP) operator instance. Err: %+v", err)
+	}
+
+	log.Info("Registering Components for Data Protection(DP) operator")
+
+	if err := cbtconfigv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		return nil, fmt.Errorf("failed to set scheme for Data Protection(DP) operator for type %s. Err: %+v",
+			cbtconfigv1alpha1.GroupVersion.String(), err)
+	}
+
+	vcClient, err := cnsvsphere.GetVirtualCenterInstance(ctx, configInfo, false)
+	if err != nil {
+		return nil, err
+	}
+
+	volumeManager, err := volume.GetManager(ctx, vcClient, nil, false, false, false,
+		cnstypes.CnsClusterFlavorWorkload, configInfo.Cfg.Global.SupervisorID,
+		configInfo.Cfg.Global.ClusterDistribution)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create an instance of volume manager: %w", err)
+	}
+
+	// Reuse the singleton InformerManager so the DP operator's PV/PVC/VA reads share the
+	// same cluster-wide informer caches that the metadata syncer (and other syncer
+	// controllers) already run in this process. Listen() starts the factory and waits for
+	// the registered informers' caches to sync (idempotent across callers - the metadata
+	// syncer also calls Listen on the same singleton).
+	k8sClient, err := k8s.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client for dp operator: %w", err)
+	}
+	informerManager := k8s.NewInformer(ctx, k8sClient, true)
+	informerManager.InitVolumeAttachmentInformer()
+	informerManager.Listen()
+
+	// Get listers after Listen() so caches are populated by the time the controllers start
+	// reconciling.
+	pvLister := informerManager.GetPVLister()
+	pvcLister := informerManager.GetPVCLister()
+	vaLister := informerManager.GetVolumeAttachmentLister()
+
+	if err := controller.AddToManager(mgr, volumeManager, pvLister, pvcLister, vaLister); err != nil {
+		return nil, err
+	}
+
+	return mgr, nil
+}

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -723,6 +723,13 @@ func (m *mockCOCommonForFullSync) HandleLateEnablementOfCapability(
 	// No-op for mock
 }
 
+func (m *mockCOCommonForFullSync) IsDPOServiceInstalled(ctx context.Context) (bool, error) {
+	return true, nil
+}
+
+func (m *mockCOCommonForFullSync) HandleLateInstallationOfDPOService(ctx context.Context) {
+}
+
 // mockVolumeManagerForFullSync implements volumes.Manager for testing.
 // cnsVolumes holds a pre-built index of VolumeId.Id -> CnsVolume so that
 // QueryAllVolume and QueryVolumeAsync can return realistic results without

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -189,6 +189,32 @@ func getFullSyncIntervalInMin(ctx context.Context) int {
 	return fullSyncIntervalInMin
 }
 
+// getCBTSyncIntervalInMin returns the CBTSync interval in minutes.
+// If environment variable CBT_SYNC_INTERVAL_MINUTES is set and valid (positive integer),
+// return that value. Otherwise use defaultCBTSyncIntervalInMin.
+func getCBTSyncIntervalInMin(ctx context.Context) int {
+	log := logger.GetLogger(ctx)
+	intervalInMin := defaultCBTSyncIntervalInMin
+	if v := os.Getenv("CBT_SYNC_INTERVAL_MINUTES"); v != "" {
+		if value, err := strconv.Atoi(v); err == nil {
+			if value <= 0 {
+				log.Warnf("CBTSync: interval set in env variable CBT_SYNC_INTERVAL_MINUTES %s "+
+					"is equal or less than 0, will use the default interval", v)
+			} else if value > defaultCBTSyncIntervalInMin {
+				log.Warnf("CBTSync: interval set in env variable CBT_SYNC_INTERVAL_MINUTES %s "+
+					"is larger than max value can be set, will use the default interval", v)
+			} else {
+				intervalInMin = value
+				log.Infof("CBTSync: interval is set to %d minutes", intervalInMin)
+			}
+		} else {
+			log.Warnf("CBTSync: interval set in env variable CBT_SYNC_INTERVAL_MINUTES %s "+
+				"is invalid, will use the default interval", v)
+		}
+	}
+	return intervalInMin
+}
+
 // getVolumeHealthIntervalInMin returns the VolumeHealthInterval.
 // If environment variable VOLUME_HEALTH_STATUS_INTERVAL_MINUTES is set and valid,
 // return the interval value read from environment variable.
@@ -723,6 +749,14 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		return logger.LogNewErrorf(log, "failed to listen on pods. Error: %v", err)
 	}
 
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSI_Backup_API) {
+		// Initialize the VolumeAttachment informer and get the lister. This is needed
+		// for the cbtsync to watch on VolumeAttachment resources.
+		metadataSyncer.k8sInformerManager.InitVolumeAttachmentInformer()
+		metadataSyncer.vaLister = metadataSyncer.k8sInformerManager.GetVolumeAttachmentLister()
+	}
+
 	metadataSyncer.pvLister = metadataSyncer.k8sInformerManager.GetPVLister()
 	metadataSyncer.pvcLister = metadataSyncer.k8sInformerManager.GetPVCLister()
 	metadataSyncer.podLister = metadataSyncer.k8sInformerManager.GetPodLister()
@@ -829,6 +863,19 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 						csiFulSyncWg.Wait()
 					}
 				}
+			}
+		}()
+	}
+
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSI_Backup_API) {
+		cbtSyncTicker := time.NewTicker(time.Duration(getCBTSyncIntervalInMin(ctx)) * time.Minute)
+		defer cbtSyncTicker.Stop()
+		go func() {
+			for range cbtSyncTicker.C {
+				ctx, log = logger.GetNewContextWithLogger()
+				log.Infof("periodic CBTSync is triggered")
+				runPeriodicCBTSync(ctx, metadataSyncer)
 			}
 		}()
 	}

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -37,6 +38,9 @@ var Version string
 const (
 	// default interval for csi full sync, used unless overridden by user in csi-controller YAML
 	defaultFullSyncIntervalInMin = 30
+
+	// default interval for PVC label/CNS CBT flags reconciliation on Supervisor
+	defaultCBTSyncIntervalInMin = 30
 
 	// key for HealthStatus annotation on PVC
 	annVolumeHealth = "volumehealth.storage.kubernetes.io/health"
@@ -116,6 +120,7 @@ type metadataSyncInformer struct {
 	k8sInformerManager *k8s.InformerManager
 	pvLister           corelisters.PersistentVolumeLister
 	pvcLister          corelisters.PersistentVolumeClaimLister
+	vaLister           storagelistersv1.VolumeAttachmentLister
 	podLister          corelisters.PodLister
 	coCommonInterface  commonco.COCommonInterface
 	// fileVolumeClient is a controller-runtime client for reading FileVolume CRs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is part of CSI CBT enablement in WCP gated by FSS CSI_Backup_API.
It implements CBT enablement for PVC unattached.
a. add a reconciler to apply CBT flag change for PVC unattached when CBTConfig status/enabled changes
b. add a periodic sync to sync CBT flag with CBTConfig status/enabled

The CSI_Backup_API feature relies on DPO(Data Protection Operator) service. This change also handle late installation of DPO service by polling CBTConfig CR every 5 minutes. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Running regression tests
Passed https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1513/
Passed https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1138/

**Manual Test**:

1, reconciler (CBTConfig enabled=false)
[reconcileCBTConfigDisabled.txt](https://github.com/user-attachments/files/27548439/reconcileCBTConfigDisabled.txt)

2, reconciler (CBTConfig enabled=true)
[reconcileCBTConfigEnabled.txt](https://github.com/user-attachments/files/27548438/reconcileCBTConfigEnabled.txt)

3, periodic sync
[periodicsync.txt](https://github.com/user-attachments/files/27548363/periodicsync.txt)

4, DPO not installed
```DPO not installed
2026-05-09T08:32:03.308Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1292	DPO service is not installed on the cluster.	{"TraceId": "0963adc6-2874-41c1-abe4-4bc3677b8864"}
2026-05-09T08:32:03.308Z	INFO	k8sorchestrator/k8sorchestrator.go:1308	Waiting for DPO service installation (poll interval: 5m0s)	{"TraceId": "0963adc6-2874-41c1-abe4-4bc3677b8864"}
2026-05-09T08:37:03.313Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1292	DPO service is not installed on the cluster.	{"TraceId": "0963adc6-2874-41c1-abe4-4bc3677b8864"}
2026-05-09T08:37:03.313Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1327	DPO service not yet installed.	{"TraceId": "0963adc6-2874-41c1-abe4-4bc3677b8864"}
```

5,  DPO installed first time and verify the csi controller pod restarts within 5 minutes
```
2026-05-09T08:42:05.309Z	INFO	k8sorchestrator/k8sorchestrator.go:1298	DPO service is installed on the cluster.	{"TraceId": "34411988-55b5-4f7b-b2cf-f5ae08e9bf8b"}
```

6,  Verified 1000+ pvc reconcile

```
2026-05-10T13:18:24.349Z        INFO    syncer/cbtsync.go:319   reconciling CBT(enable=true) for namespace "test-vadp-supervisor-ns"    {"TraceId": "7a35dafe-8e26-4980-bbfc-546ede09044b"}
2026-05-10T13:18:24.350Z        INFO    syncer/cbtsync.go:380   namespace "test-vadp-supervisor-ns" loaded 1 attached PV names from VolumeAttachment cache      {"TraceId": "7a35dafe-8e26-4980-bbfc-546ede09044b"}
2026-05-10T13:18:24.353Z        INFO    syncer/cbtsync.go:169   finished periodic CBT reconciliation for VC lvn-dvm-10-162-160-90.dvm.lvn.broadcom.net  {"TraceId": "ae4e49d2-ecce-4884-9a49-7ac0afc657ae"}
2026-05-10T13:18:24.372Z        INFO    syncer/cbtsync.go:329   namespace "test-vadp-supervisor-ns" phase 1: 1005 candidate(s)  {"TraceId": "7a35dafe-8e26-4980-bbfc-546ede09044b"}
...
2026-05-10T13:18:59.023Z        INFO    syncer/cbtsync.go:339   namespace "test-vadp-supervisor-ns" phase 2: 1005 candidate(s) need CBT flip    {"TraceId": "7a35dafe-8e26-4980-bbfc-546ede09
044b"}
...
...
2026-05-10T13:21:17.033Z        INFO    syncer/cbtsync.go:349   namespace "test-vadp-supervisor-ns" CBT reconcile finished (enable=true)        {"TraceId": "7a35dafe-8e26-4980-bbfc-546ede09044b"}
```

7.  cancel current reconciling
[cancel.log](https://github.com/user-attachments/files/27744744/cancel.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
manage CBT state for PVC unattached
```
