### PR TITLE
wcpguest: allow FVS file volumes to be provisioned in any zone via PVC annotation

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -465,7 +465,54 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				annotations := make(map[string]string)
 				key := fmt.Sprintf("%s/%s", c.tanzukubernetesClusterName, c.guestClusterDist)
 				labels[key] = c.tanzukubernetesClusterUID
-				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
+
+				// FVS DevOps zone override: when a guest PVC for the new vSAN File Service has
+				// csi.vsphere.volume-requested-topology set by DevOps, propagate it to the
+				// supervisor PVC and override req.AccessibilityRequirements.Preferred. If the
+				// annotation is absent/empty, fvsTopologyOverridden stays false and the existing
+				// TKGsHA topology block below runs unchanged, honoring
+				// req.AccessibilityRequirements.Preferred as today. Gated on
+				// IsVsanFileVolumeServiceEnabled FSS so behavior is unchanged when FSS is off.
+				// Limited to file volumes whose storage class is an FVS SC; block volumes and
+				// legacy file volumes are unaffected.
+				fvsTopologyOverridden := false
+				if IsVsanFileVolumeServiceEnabled && isFileVolumeRequest && !isLinkedCloneRequest {
+					if pvcName == "" || pvcNamespace == "" {
+						msg := fmt.Sprintf("missing guest PVC name/namespace parameters; "+
+							"cannot evaluate FVS topology override for supervisor PVC %s",
+							supervisorPVCName)
+						log.Error(msg)
+						return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+					}
+					guestPVC, err := c.guestClient.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(
+						ctx, pvcName, metav1.GetOptions{})
+					if err != nil {
+						msg := fmt.Sprintf("failed to get guest PVC %s/%s for FVS topology override: %v",
+							pvcNamespace, pvcName, err)
+						log.Error(msg)
+						return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+					}
+					if common.IsFVSPersistentVolumeClaim(guestPVC) {
+						if v, ok := guestPVC.Annotations[common.AnnGuestClusterRequestedTopology]; ok &&
+							strings.TrimSpace(v) != "" {
+							normalized, err := validateGuestClusterRequestedTopologyAnnotation(v)
+							if err != nil {
+								msg := fmt.Sprintf("invalid %s annotation on guest PVC %s/%s: %v",
+									common.AnnGuestClusterRequestedTopology, pvcNamespace, pvcName, err)
+								log.Error(msg)
+								return nil, csifault.CSIInvalidArgumentFault,
+									status.Error(codes.InvalidArgument, msg)
+							}
+							annotations[common.AnnGuestClusterRequestedTopology] = normalized
+							fvsTopologyOverridden = true
+							log.Infof("FVS: overriding requested topology for supervisor PVC %s "+
+								"with DevOps annotation %q", supervisorPVCName, normalized)
+						}
+					}
+				}
+
+				if !fvsTopologyOverridden &&
+					commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 					req.AccessibilityRequirements != nil &&
 					!isLinkedCloneRequest && // the cns-csi mutation webhook in supervisor will automatically set it.
 					(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||

--- a/pkg/csi/service/wcpguest/controller_fvs_create_test.go
+++ b/pkg/csi/service/wcpguest/controller_fvs_create_test.go
@@ -1,0 +1,542 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wcpguest
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+)
+
+// fvsCreateGuestPVCName/Namespace are the metadata the external-provisioner
+// sidecar would inject via "--extra-create-metadata" parameters
+// (csi.storage.k8s.io/pvc/name and csi.storage.k8s.io/pvc/namespace).
+const (
+	fvsCreateGuestPVCName      = "pvc-12345"
+	fvsCreateGuestPVCNamespace = "guest-app-ns"
+	fvsCreateSupervisorPVCName = "-12345"
+	fvsCreateSupervisorNS      = "test-namespace-fvs-create"
+	fvsCreateNonFVSStorageSC   = "non-fvs-sc"
+)
+
+// newFVSCreateController builds a controller for the FVS create-volume tests
+// with isolated supervisor and guest fake clients and the package CO interface
+// initialized with a known FSS map.
+//
+// The default in unittestcommon.GetFakeContainerOrchestratorInterface enables
+// "tkgs-ha" and "workload-domain-isolation"; we leave those alone so the
+// existing TKGsHA topology block runs in the no-override fall-through tests.
+func newFVSCreateController(t *testing.T, guestObjs ...*v1.PersistentVolumeClaim) *controller {
+	t.Helper()
+	supervisorClient := testclient.NewClientset()
+	guestClient := testclient.NewClientset()
+	for _, p := range guestObjs {
+		_, err := guestClient.CoreV1().PersistentVolumeClaims(p.Namespace).Create(
+			context.Background(), p, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to seed guest PVC %s/%s: %v", p.Namespace, p.Name, err)
+		}
+	}
+	c := &controller{
+		supervisorClient:    supervisorClient,
+		guestClient:         guestClient,
+		supervisorNamespace: fvsCreateSupervisorNS,
+	}
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("failed to build fake CO: %v", err)
+	}
+	commonco.ContainerOrchestratorUtility = co
+	return c
+}
+
+// makeGuestPVC builds a guest cluster PVC with the supplied storage class and
+// optional csi.vsphere.volume-requested-topology annotation. An empty SC name
+// leaves Spec.StorageClassName nil.
+func makeGuestPVC(name, namespace, sc, requestedTopologyAnnotation string) *v1.PersistentVolumeClaim {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+		},
+	}
+	if sc != "" {
+		scCopy := sc
+		pvc.Spec.StorageClassName = &scCopy
+	}
+	if requestedTopologyAnnotation != "" {
+		pvc.Annotations = map[string]string{
+			common.AnnGuestClusterRequestedTopology: requestedTopologyAnnotation,
+		}
+	}
+	return pvc
+}
+
+// fvsCreateRequest constructs a CreateVolumeRequest with PVC metadata params
+// (supplied by external-provisioner --extra-create-metadata) and an optional
+// AccessibilityRequirements topology.
+func fvsCreateRequest(accessMode csi.VolumeCapability_AccessMode_Mode,
+	preferredZone string) *csi.CreateVolumeRequest {
+	params := map[string]string{
+		common.AttributeSupervisorStorageClass: testStorageClass,
+		common.AttributePvcName:                fvsCreateGuestPVCName,
+		common.AttributePvcNamespace:           fvsCreateGuestPVCNamespace,
+	}
+	req := &csi.CreateVolumeRequest{
+		Name: testVolumeName,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters: params,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{AccessMode: &csi.VolumeCapability_AccessMode{Mode: accessMode}},
+		},
+	}
+	if preferredZone != "" {
+		segment := map[string]string{"topology.kubernetes.io/zone": preferredZone}
+		req.AccessibilityRequirements = &csi.TopologyRequirement{
+			Requisite: []*csi.Topology{{Segments: segment}},
+			Preferred: []*csi.Topology{{Segments: segment}},
+		}
+	}
+	return req
+}
+
+// runCreateVolumeAndBindSupervisorPVC invokes CreateVolume in a goroutine and
+// flips the supervisor PVC to Bound so the call returns. It also sets the
+// csi.vsphere.volume-accessible-topology annotation on the supervisor PVC so
+// the response-side topology generation in CreateVolume can succeed (the
+// supervisor reconciler would set this in production). Returns the bound
+// supervisor PVC (with annotations as set by CreateVolume) and the response.
+func runCreateVolumeAndBindSupervisorPVC(t *testing.T, c *controller,
+	req *csi.CreateVolumeRequest) (*v1.PersistentVolumeClaim, *csi.CreateVolumeResponse, error) {
+	t.Helper()
+	respCh := make(chan *csi.CreateVolumeResponse, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		resp, err := c.CreateVolume(context.Background(), req)
+		respCh <- resp
+		errCh <- err
+	}()
+
+	var pvc *v1.PersistentVolumeClaim
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("supervisor PVC %s was not created within timeout", fvsCreateSupervisorPVCName)
+		default:
+		}
+		got, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+			context.Background(), fvsCreateSupervisorPVCName, metav1.GetOptions{})
+		if err == nil {
+			pvc = got
+			break
+		}
+		// CreateVolume may have failed before creating the PVC; fall through.
+		select {
+		case respErr := <-errCh:
+			resp := <-respCh
+			return nil, resp, respErr
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	if pvc.Annotations == nil {
+		pvc.Annotations = map[string]string{}
+	}
+	pvc.Annotations[common.AnnVolumeAccessibleTopology] =
+		`[{"topology.kubernetes.io/zone":"zone-1"}]`
+	pvc.Status.Phase = v1.ClaimBound
+	if _, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Update(
+		context.Background(), pvc, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to mark supervisor PVC bound: %v", err)
+	}
+
+	resp := <-respCh
+	err := <-errCh
+	if err != nil {
+		return nil, resp, err
+	}
+	pvc, getErr := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+		context.Background(), fvsCreateSupervisorPVCName, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("failed to read back supervisor PVC: %v", getErr)
+	}
+	return pvc, resp, nil
+}
+
+// expectSupervisorAnnotation asserts the supervisor PVC's
+// csi.vsphere.volume-requested-topology annotation matches `want` exactly.
+// If `want` is empty, asserts the annotation is unset.
+func expectSupervisorAnnotation(t *testing.T, pvc *v1.PersistentVolumeClaim, want string) {
+	t.Helper()
+	got, ok := pvc.Annotations[common.AnnGuestClusterRequestedTopology]
+	if want == "" {
+		if ok {
+			t.Fatalf("expected supervisor PVC annotation %s to be unset, got %q",
+				common.AnnGuestClusterRequestedTopology, got)
+		}
+		return
+	}
+	if !ok {
+		t.Fatalf("expected supervisor PVC annotation %s = %q, but it is unset",
+			common.AnnGuestClusterRequestedTopology, want)
+	}
+	if got != want {
+		t.Fatalf("supervisor PVC annotation %s mismatch:\n  got:  %s\n  want: %s",
+			common.AnnGuestClusterRequestedTopology, got, want)
+	}
+}
+
+// --- helper validation tests ---------------------------------------------
+
+func TestValidateGuestClusterRequestedTopologyAnnotation(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOut   string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "single zone canonical",
+			input:   `[{"topology.kubernetes.io/zone":"zone-1"}]`,
+			wantOut: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
+		},
+		{
+			name: "multi zone with whitespace",
+			input: `  [ {"topology.kubernetes.io/zone":"zone-1"} , ` +
+				`{"topology.kubernetes.io/zone":"zone-2"}, ` +
+				`{"topology.kubernetes.io/zone":"zone-3"} ]  `,
+			wantOut: `[{"topology.kubernetes.io/zone":"zone-1"},` +
+				`{"topology.kubernetes.io/zone":"zone-2"},` +
+				`{"topology.kubernetes.io/zone":"zone-3"}]`,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			wantErr:   true,
+			errSubstr: "empty",
+		},
+		{
+			name:      "whitespace only",
+			input:     "   \t\n",
+			wantErr:   true,
+			errSubstr: "empty",
+		},
+		{
+			name:      "malformed json",
+			input:     `[{"topology.kubernetes.io/zone":"zone-1"`,
+			wantErr:   true,
+			errSubstr: "failed to parse",
+		},
+		{
+			name:      "empty array",
+			input:     `[]`,
+			wantErr:   true,
+			errSubstr: "at least one",
+		},
+		{
+			name:      "empty inner map",
+			input:     `[{}]`,
+			wantErr:   true,
+			errSubstr: "empty topology segment",
+		},
+		{
+			name:      "empty value",
+			input:     `[{"topology.kubernetes.io/zone":""}]`,
+			wantErr:   true,
+			errSubstr: "empty topology value",
+		},
+		{
+			name:      "empty key",
+			input:     `[{"":"zone-1"}]`,
+			wantErr:   true,
+			errSubstr: "empty topology key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateGuestClusterRequestedTopologyAnnotation(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got nil; out=%q", tt.input, got)
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("error %q does not contain expected substring %q",
+						err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for input %q: %v", tt.input, err)
+			}
+			if got != tt.wantOut {
+				t.Fatalf("normalized output mismatch:\n  got:  %s\n  want: %s",
+					got, tt.wantOut)
+			}
+		})
+	}
+}
+
+// --- CreateVolume FVS override tests --------------------------------------
+
+// TestCreateVolume_FVS_RequestedTopologyAnnotation_SingleZone: guest PVC has
+// canonical single-zone JSON annotation; supervisor PVC must carry the same
+// canonical JSON.
+func TestCreateVolume_FVS_RequestedTopologyAnnotation_SingleZone(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	annotationValue := `[{"topology.kubernetes.io/zone":"zone-1"}]`
+	guestPVC := makeGuestPVC(fvsCreateGuestPVCName, fvsCreateGuestPVCNamespace,
+		common.StorageClassVsanFileServicePolicy, annotationValue)
+	c := newFVSCreateController(t, guestPVC)
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c,
+		fvsCreateRequest(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, ""))
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	expectSupervisorAnnotation(t, pvc, annotationValue)
+}
+
+// TestCreateVolume_FVS_RequestedTopologyAnnotation_MultiZone: multi-zone
+// annotation with extra whitespace; supervisor PVC must carry whitespace-
+// normalized canonical JSON.
+func TestCreateVolume_FVS_RequestedTopologyAnnotation_MultiZone(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	rawAnnotation := `[{"topology.kubernetes.io/zone":"zone-1"}, ` +
+		`{"topology.kubernetes.io/zone":"zone-2"}, ` +
+		`{"topology.kubernetes.io/zone":"zone-3"}, ` +
+		`{"topology.kubernetes.io/zone":"zone-4"}, ` +
+		`{"topology.kubernetes.io/zone":"zone-5"}]`
+	canonical := `[{"topology.kubernetes.io/zone":"zone-1"},` +
+		`{"topology.kubernetes.io/zone":"zone-2"},` +
+		`{"topology.kubernetes.io/zone":"zone-3"},` +
+		`{"topology.kubernetes.io/zone":"zone-4"},` +
+		`{"topology.kubernetes.io/zone":"zone-5"}]`
+	guestPVC := makeGuestPVC(fvsCreateGuestPVCName, fvsCreateGuestPVCNamespace,
+		common.StorageClassVsanFileServicePolicyLateBinding, rawAnnotation)
+	c := newFVSCreateController(t, guestPVC)
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c,
+		fvsCreateRequest(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, ""))
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	expectSupervisorAnnotation(t, pvc, canonical)
+}
+
+// TestCreateVolume_FVS_RequestedTopologyAnnotation_OverridesRequest: when both
+// the request topology and the guest PVC annotation are set, the annotation
+// wins.
+func TestCreateVolume_FVS_RequestedTopologyAnnotation_OverridesRequest(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	annotationValue := `[{"topology.kubernetes.io/zone":"zone-1"}]`
+	guestPVC := makeGuestPVC(fvsCreateGuestPVCName, fvsCreateGuestPVCNamespace,
+		common.StorageClassVsanFileServicePolicy, annotationValue)
+	c := newFVSCreateController(t, guestPVC)
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c,
+		fvsCreateRequest(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, "zone-3"))
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	expectSupervisorAnnotation(t, pvc, annotationValue)
+}
+
+// TestCreateVolume_FVS_NoAnnotation_FallsBackToRequest: FVS guest PVC without
+// the override annotation falls back to the existing TKGsHA path which uses
+// req.AccessibilityRequirements.Preferred.
+func TestCreateVolume_FVS_NoAnnotation_FallsBackToRequest(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	guestPVC := makeGuestPVC(fvsCreateGuestPVCName, fvsCreateGuestPVCNamespace,
+		common.StorageClassVsanFileServicePolicy, "")
+	c := newFVSCreateController(t, guestPVC)
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c,
+		fvsCreateRequest(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, "zone-3"))
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	expectSupervisorAnnotation(t, pvc,
+		`[{"topology.kubernetes.io/zone":"zone-3"}]`)
+}
+
+// TestCreateVolume_FVS_EmptyAnnotation_FallsBackToRequest: empty-string
+// annotation behaves the same as missing annotation.
+func TestCreateVolume_FVS_EmptyAnnotation_FallsBackToRequest(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	guestPVC := makeGuestPVC(fvsCreateGuestPVCName, fvsCreateGuestPVCNamespace,
+		common.StorageClassVsanFileServicePolicy, "")
+	guestPVC.Annotations = map[string]string{
+		common.AnnGuestClusterRequestedTopology: "",
+	}
+	c := newFVSCreateController(t, guestPVC)
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c,
+		fvsCreateRequest(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, "zone-3"))
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	expectSupervisorAnnotation(t, pvc,
+		`[{"topology.kubernetes.io/zone":"zone-3"}]`)
+}
+
+// TestCreateVolume_FVS_FSSDisabled_NoOverride: when IsVsanFileVolumeServiceEnabled
+// is false, the override is skipped even if the annotation is set on the FVS
+// guest PVC. The supervisor PVC reflects the request-topology fallback (via the
+// existing TKGsHA + WorkloadDomainIsolation path for file volumes).
+func TestCreateVolume_FVS_FSSDisabled_NoOverride(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, false)
+	annotationValue := `[{"topology.kubernetes.io/zone":"zone-1"}]`
+	guestPVC := makeGuestPVC(fvsCreateGuestPVCName, fvsCreateGuestPVCNamespace,
+		common.StorageClassVsanFileServicePolicy, annotationValue)
+	c := newFVSCreateController(t, guestPVC)
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c,
+		fvsCreateRequest(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, "zone-3"))
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	expectSupervisorAnnotation(t, pvc,
+		`[{"topology.kubernetes.io/zone":"zone-3"}]`)
+}
+
+// TestCreateVolume_NonFVSStorageClass_NoOverride: file volume but guest PVC
+// has a non-FVS storage class. Override is skipped via IsFVSPersistentVolumeClaim;
+// existing path runs.
+func TestCreateVolume_NonFVSStorageClass_NoOverride(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	annotationValue := `[{"topology.kubernetes.io/zone":"zone-1"}]`
+	guestPVC := makeGuestPVC(fvsCreateGuestPVCName, fvsCreateGuestPVCNamespace,
+		fvsCreateNonFVSStorageSC, annotationValue)
+	c := newFVSCreateController(t, guestPVC)
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c,
+		fvsCreateRequest(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, "zone-3"))
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	expectSupervisorAnnotation(t, pvc,
+		`[{"topology.kubernetes.io/zone":"zone-3"}]`)
+}
+
+// TestCreateVolume_BlockVolume_NoOverride: block volume request with the
+// annotation set on the guest PVC; the override gate requires
+// isFileVolumeRequest, so the annotation is NOT propagated. Supervisor PVC
+// gets the request-topology via the existing TKGsHA path.
+func TestCreateVolume_BlockVolume_NoOverride(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	annotationValue := `[{"topology.kubernetes.io/zone":"zone-1"}]`
+	guestPVC := makeGuestPVC(fvsCreateGuestPVCName, fvsCreateGuestPVCNamespace,
+		common.StorageClassVsanFileServicePolicy, annotationValue)
+	guestPVC.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+	c := newFVSCreateController(t, guestPVC)
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c,
+		fvsCreateRequest(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER, "zone-3"))
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	expectSupervisorAnnotation(t, pvc,
+		`[{"topology.kubernetes.io/zone":"zone-3"}]`)
+}
+
+// TestCreateVolume_FVS_InvalidAnnotation_Errors: malformed JSON / empty array
+// / empty key or value in the annotation must surface as InvalidArgument
+// without creating the supervisor PVC.
+func TestCreateVolume_FVS_InvalidAnnotation_Errors(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation string
+	}{
+		{"malformed json", `[{"topology.kubernetes.io/zone":"zone-1"`},
+		{"empty array", `[]`},
+		{"empty inner map", `[{}]`},
+		{"empty value", `[{"topology.kubernetes.io/zone":""}]`},
+		{"empty key", `[{"":"zone-1"}]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setVsanFileVolumeServiceEnabledForTest(t, true)
+			guestPVC := makeGuestPVC(fvsCreateGuestPVCName, fvsCreateGuestPVCNamespace,
+				common.StorageClassVsanFileServicePolicy, tc.annotation)
+			c := newFVSCreateController(t, guestPVC)
+
+			req := fvsCreateRequest(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, "")
+			_, err := c.CreateVolume(context.Background(), req)
+			if err == nil {
+				t.Fatalf("expected InvalidArgument error for annotation %q, got nil", tc.annotation)
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+			}
+			if st.Code() != codes.InvalidArgument {
+				t.Fatalf("expected codes.InvalidArgument, got %s: %v", st.Code(), err)
+			}
+			// Supervisor PVC must not have been created.
+			_, getErr := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+				context.Background(), fvsCreateSupervisorPVCName, metav1.GetOptions{})
+			if getErr == nil {
+				t.Fatalf("supervisor PVC %s should not exist after invalid override",
+					fvsCreateSupervisorPVCName)
+			}
+		})
+	}
+}
+
+// TestCreateVolume_FVS_MissingPVCMetadata_Errors: when the
+// csi.storage.k8s.io/pvc/name parameter is missing (e.g. external-provisioner
+// not deployed with --extra-create-metadata), the FVS override path returns
+// Internal error (strict — design choice).
+func TestCreateVolume_FVS_MissingPVCMetadata_Errors(t *testing.T) {
+	setVsanFileVolumeServiceEnabledForTest(t, true)
+	c := newFVSCreateController(t)
+
+	req := fvsCreateRequest(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, "")
+	delete(req.Parameters, common.AttributePvcName)
+
+	_, err := c.CreateVolume(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected Internal error when guest PVC name parameter is missing, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.Internal {
+		t.Fatalf("expected codes.Internal, got %s: %v", st.Code(), err)
+	}
+}

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -293,6 +293,56 @@ func generateGuestClusterRequestedTopologyJSON(topologies []*csi.Topology) (stri
 	return "[" + strings.Join(segmentsArray, ",") + "]", nil
 }
 
+// validateGuestClusterRequestedTopologyAnnotation validates a DevOps-supplied
+// csi.vsphere.volume-requested-topology annotation value on a guest-cluster
+// PVC and returns its canonical (whitespace-normalized) JSON representation
+// to set on the supervisor PVC.
+//
+// The accepted shape is the same JSON segment-map array used end-to-end with
+// the supervisor, e.g.:
+//
+//	[{"topology.kubernetes.io/zone":"zone-1"},{"topology.kubernetes.io/zone":"zone-2"}]
+//
+// The helper rejects empty input, malformed JSON, an empty array, empty inner
+// maps, and entries with empty keys or values. It does not enforce a specific
+// topology key; the supervisor's existing validation/reconciliation is the
+// source of truth on accepted keys.
+func validateGuestClusterRequestedTopologyAnnotation(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("annotation value is empty")
+	}
+	segments := make([]map[string]string, 0)
+	if err := json.Unmarshal([]byte(trimmed), &segments); err != nil {
+		return "", fmt.Errorf("failed to parse annotation value %q as JSON array of "+
+			"topology segment maps: %v", trimmed, err)
+	}
+	if len(segments) == 0 {
+		return "", fmt.Errorf("annotation value %q must contain at least one topology segment", trimmed)
+	}
+	for i, seg := range segments {
+		if len(seg) == 0 {
+			return "", fmt.Errorf("annotation value %q contains an empty topology segment at index %d",
+				trimmed, i)
+		}
+		for k, v := range seg {
+			if strings.TrimSpace(k) == "" {
+				return "", fmt.Errorf("annotation value %q contains an empty topology key at index %d",
+					trimmed, i)
+			}
+			if strings.TrimSpace(v) == "" {
+				return "", fmt.Errorf("annotation value %q contains an empty topology value for key %q "+
+					"at index %d", trimmed, k, i)
+			}
+		}
+	}
+	normalized, err := json.Marshal(segments)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal normalized topology segments: %v", err)
+	}
+	return string(normalized), nil
+}
+
 // generateVolumeAccessibleTopologyFromPVCAnnotation returns accessible topologies generated using
 // PVC annotation "csi.vsphere.volume-accessible-topology".
 func generateVolumeAccessibleTopologyFromPVCAnnotation(claim *v1.PersistentVolumeClaim) (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

By default, file volumes in a VKS cluster can only be provisioned in zones where VKS nodes are deployed (Immediate binding) or where the scheduled pod's node resides (WaitForFirstConsumer binding). There is no way for DevOps to target a zone that is not assigned to the namespace or has no deployed nodes.

How does DevOps consume a PVC that is provisioned in zones external to the namespace, or in zones where no VKS nodes are currently present?

For file volumes, this workflow is supported because the volume is accessed through a network file mount and does not require node-level volume attachment. As long as network connectivity to the file service endpoint exists, workloads can mount and access the volume regardless of the zone in which the backing storage was provisioned.

To support pod scheduling for these PVCs, the corresponding PV will include node affinity rules covering all zones associated with the VKS namespace. This ensures that workloads running on any VKS node within the namespace can consume the file volume without being restricted to the external provisioning zone.


This change enables DevOps to set the existing
csi.vsphere.volume-requested-topology annotation directly on a guest cluster PVC to provision a vSAN File Service (FVS) file volume in any zone, including zones external to the namespace or with no VKS nodes. The annotation value is a JSON segment-map array identical to the format the supervisor already uses, for example:

  '[{"topology.kubernetes.io/zone":"zone-1"},{"topology.kubernetes.io/zone":"zone-2"}]'

The guest CSI CreateVolume reads this annotation and propagates it to the supervisor PVC, overriding the topology calculated from req.AccessibilityRequirements.Preferred (which is bound to the zones Kubernetes knows about for the workload).

The feature is gated by IsVsanFileVolumeServiceEnabled (vsan-file-volume-service-support FSS) and applies only to PVCs using the new FVS marker storage classes (vsan-file-service-policy or vsan-file-service-policy-latebinding). Block volumes, legacy file volumes, and any path where the FSS is disabled are unaffected. When the annotation is absent or empty, the existing TKGsHA topology behavior is preserved unchanged.

Changes:
- controller_helper.go: add validateGuestClusterRequestedTopologyAnnotation to parse, validate, and whitespace-normalize the annotation value.
- controller.go: add FVS zone override block in CreateVolume before the existing TKGsHA topology block; guard existing block with !fvsTopologyOverridden.
- controller_fvs_create_test.go: unit tests covering single/multi-zone override, annotation-beats-request topology, FSS-disabled fallback, non-FVS storage class passthrough, block volume unaffected, invalid annotation errors, and missing PVC metadata error.


**Testing done**:

WCP supervisor: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1518/

VKS - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1150/ 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
wcpguest: allow FVS file volumes to be provisioned in any zone via PVC annotation
```
