### PR TITLE
Allow removal of finalizer from CnsNodeVmAttachment CR only if it doesn't contain used-by annotation

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -62,6 +62,7 @@ import (
 const (
 	workerThreadsEnvVar     = "WORKER_THREADS_NODEVM_ATTACH"
 	defaultMaxWorkerThreads = 20
+	attachedVmPrefix        = "cns.vmware.com/usedby-vm-"
 )
 
 // backOffDuration is a map of cnsnodevmattachment name's to the time after
@@ -824,11 +825,38 @@ func addFinalizerToPVC(ctx context.Context, client client.Client,
 	return faulttype, err
 }
 
+// pvcHasUsedByAnnotaion goes through all annotations on the PVC to find out if the PVC is used by any VM or not.
+func pvcHasUsedByAnnotaion(ctx context.Context, pvc *v1.PersistentVolumeClaim) bool {
+	log := logger.GetLogger(ctx)
+
+	if pvc.Annotations == nil {
+		log.Infof("No annotation found on PVC %s", pvc.Name)
+		return false
+	}
+
+	for key := range pvc.Annotations {
+		if strings.HasPrefix(key, attachedVmPrefix) {
+			log.Infof("Annotation with prefix %s found on PVC %s", attachedVmPrefix, pvc.Name)
+			return true
+		}
+	}
+
+	log.Infof("PVC %s does not contain any annotations with prefix %s", pvc.Name, attachedVmPrefix)
+	return false
+}
+
 // removeFinalizerFromPVC will remove the CNS Finalizer, cns.vmware.com/pvc-protection,
 // from a given PersistentVolumeClaim.
 func removeFinalizerFromPVC(ctx context.Context, client client.Client,
 	pvc *v1.PersistentVolumeClaim) (string, error) {
 	log := logger.GetLogger(ctx)
+
+	// Before proceeding with finalizer removal, check if PVC has any used-by annotations
+	if pvcHasUsedByAnnotaion(ctx, pvc) {
+		log.Infof("PVC %s still has used-by annotations, skipping finalizer removal", pvc.Name)
+		return "", nil
+	}
+
 	finalizerFound := false
 	for i, finalizer := range pvc.Finalizers {
 		if finalizer == cnsoptypes.CNSPvcFinalizer {

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
@@ -844,3 +844,159 @@ func (m *trackingMockVolumeManager) ClearVolumeControlFlags(ctx context.Context,
 	m.clearCalled = true
 	return nil
 }
+
+// TestRemoveFinalizerFromPVCWithUsedByAnnotations tests that the removeFinalizerFromPVC function
+// properly skips finalizer removal when used-by annotations are present on the PVC.
+func TestRemoveFinalizerFromPVCWithUsedByAnnotations(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	err := v1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		pvcAnnotations    map[string]string
+		shouldSkipRemoval bool
+	}{
+		{
+			name: "PVC with used-by annotation should skip finalizer removal",
+			pvcAnnotations: map[string]string{
+				"cns.vmware.com/usedby-vm-12345": "",
+				"other-annotation":               "value",
+			},
+			shouldSkipRemoval: true,
+		},
+		{
+			name: "PVC with multiple used-by annotations should skip finalizer removal",
+			pvcAnnotations: map[string]string{
+				"cns.vmware.com/usedby-vm-12345": "",
+				"cns.vmware.com/usedby-vm-67890": "",
+			},
+			shouldSkipRemoval: true,
+		},
+		{
+			name: "PVC without used-by annotations should allow finalizer removal",
+			pvcAnnotations: map[string]string{
+				"other-annotation": "value",
+			},
+			shouldSkipRemoval: false,
+		},
+		{
+			name:              "PVC with no annotations should allow finalizer removal",
+			pvcAnnotations:    nil,
+			shouldSkipRemoval: false,
+		},
+		{
+			name: "PVC with similar but non-matching annotations should allow finalizer removal",
+			pvcAnnotations: map[string]string{
+				"cns.vmware.com/other-annotation": "value",
+				"usedby-vm-12345":                 "value",
+			},
+			shouldSkipRemoval: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pvc",
+					Namespace:   "test-ns",
+					Annotations: tt.pvcAnnotations,
+					Finalizers:  []string{cnsoptypes.CNSPvcFinalizer},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(pvc).
+				Build()
+
+			// Call removeFinalizerFromPVC
+			faultType, err := removeFinalizerFromPVC(ctx, fakeClient, pvc)
+
+			// Should never return an error
+			assert.NoError(t, err)
+			assert.Empty(t, faultType)
+
+			// Verify the PVC state
+			updatedPVC := &v1.PersistentVolumeClaim{}
+			err = fakeClient.Get(ctx, client.ObjectKey{
+				Name:      pvc.Name,
+				Namespace: pvc.Namespace,
+			}, updatedPVC)
+			assert.NoError(t, err)
+
+			if tt.shouldSkipRemoval {
+				// Should still have the finalizer when skipping removal
+				assert.Contains(t, updatedPVC.Finalizers, cnsoptypes.CNSPvcFinalizer,
+					"Expected finalizer to be preserved when used-by annotations are present")
+			} else {
+				// For cases where finalizer should be removed, log the attempt
+				t.Logf("Finalizer removal attempted for PVC without used-by annotations")
+			}
+		})
+	}
+}
+
+// TestPvcHasUsedByAnnotaion tests the helper function that checks for used-by annotations.
+func TestPvcHasUsedByAnnotaion(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name: "PVC with used-by annotation",
+			annotations: map[string]string{
+				"cns.vmware.com/usedby-vm-12345": "",
+			},
+			expected: true,
+		},
+		{
+			name: "PVC with multiple used-by annotations",
+			annotations: map[string]string{
+				"cns.vmware.com/usedby-vm-12345": "",
+				"cns.vmware.com/usedby-vm-67890": "",
+			},
+			expected: true,
+		},
+		{
+			name: "PVC without used-by annotations",
+			annotations: map[string]string{
+				"other-annotation": "value",
+			},
+			expected: false,
+		},
+		{
+			name:        "PVC with no annotations",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name: "PVC with similar but non-matching annotations",
+			annotations: map[string]string{
+				"cns.vmware.com/other-annotation": "value",
+				"usedby-vm-12345":                 "value",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pvc",
+					Namespace:   "test-ns",
+					Annotations: tt.annotations,
+				},
+			}
+
+			result := pvcHasUsedByAnnotaion(ctx, pvc)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a case and a narrow window where finalizer from a PVC might be removed by legacy CnsNodeVMAttachment:

 Volume vol-1 is attached to VM-1 before upgrade to 9.1 via the legacy CnsNodeVMAttachment CR.
After upgrade to 9.1, it is attempted to be attached to VM-2 via batchattach then it fails as expected.
(note that VM op ensures that the same PVC does not appear in legacy as well as batch attachment of the same VM but it can appear in legacy and batch attachment of different VMs).

If user chooses to detach vol-1 from VM-2, batch attach has a check which ensures that finalizer is not removed from vol-1. See this: https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go#L977-L990

But if user chooses to detach vol-1 from VM-1, then there is no such protection in the legacy CnsNodeVMAttachment flow.
The finalizer will be added back by batch attach workflow during attach of the volume but there is a narrow window where PVC may be left unprotected.

See the following example:

Let's say for some reason the legacy CnsNodeVMAttachment succeeds to detach the volume from VM-1 but fails during finalizer removal from PVC and waits for next rsconcile to go do it.

In the meantime batch attach attaches the volume to VM-2 and adds used-by annotation to it along with finalizer.

Now the legacy CnsNodeVMAttachment reconcile kicks in again (as it failed earlier), finds vol-1 is already detached from VM-1 and removes finalizer from the PVC.

To fix this, we need a check in CnsNodeVMAttachment code which ensures that the finalizer is removed from PVC only if used-by annotation is not there on it.

**Testing done**:

Disabled SharedDiskFss temporarily and atatch PVC-1 to VM-1 via legacy CnsNodeVMAttachment.

Then proceeded to attach it via batchattach.

Deleted the CnsNodeVMAttachment CR to simulate detach. Observed that finalizer was not removed fromt he PVC. 

Log evidence:
"{"level":"info","time":"2026-05-20T04:04:26.461554639Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:856","msg":"PVC pvc-1 still has used-by annotations, skipping finalizer removal","TraceId":"ccea7a7a-f3e0-481b-8521-e1c50f017843"}"

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1532/
VKS precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1156/
