### PR TITLE
Modifications in Syncer to report CNS about missing kubernetes PVs

### DIFF
--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -95,6 +95,13 @@ const (
 	// PrometheusUnregisterVolumeOpType represents UnregisterVolume operation.
 	PrometheusUnregisterVolumeOpType = "unregister-volume"
 
+	// PrometheusPVMissingLabelKey is the CNS metadata label key set on a CNS
+	// volume whose matching Kubernetes PV is not found during full sync.
+	PrometheusPVMissingLabelKey = "pv_missing"
+	// PrometheusPVMissingLabelValue is the value associated with
+	// PrometheusPVMissingLabelKey when the K8s PV is missing.
+	PrometheusPVMissingLabelValue = "true"
+
 	// PrometheusPassStatus represents a successful API run.
 	PrometheusPassStatus = "pass"
 	// PrometheusFailStatus represents an unsuccessful API run.
@@ -169,4 +176,17 @@ var (
 		Help:    "Histogram vector for individual request to vCenter",
 		Buckets: []float64{2, 5, 10, 15, 20, 25, 30, 60, 120, 180},
 	}, []string{"request", "client", "status"})
+
+	// CnsVolumePVMissingGaugeVec is a gauge metric that tracks, per vCenter,
+	// the number of CNS volumes whose matching Kubernetes PV was not found in
+	// the most recent full-sync cycle. It is reset to the new count at the end
+	// of each cycle, so it always reflects the current observation rather than
+	// a cumulative tally. A non-zero value indicates volumes that have been
+	// labeled with pv_missing=true on the CNS side and may need VI Admin
+	// inspection (typically the result of force-deleted PVs with Retain
+	// reclaim policy).
+	CnsVolumePVMissingGaugeVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "vsphere_cns_volume_pv_missing",
+		Help: "Number of CNS volumes whose corresponding Kubernetes PV was not found during the last full sync, per vCenter.",
+	}, []string{"vc"})
 )

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -467,19 +467,32 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 	createSpecArray, updateSpecArray := fullSyncGetVolumeSpecs(ctx, vcenter.Client.Version, k8sPVs,
 		volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, volumeClusterDistributionMap,
 		containerCluster, migrationFeatureStateForFullSync, vc)
-	volToBeDeleted, err := getVolumesToBeDeleted(ctx, queryAllResult.Volumes, k8sPVMap, metadataSyncer,
-		migrationFeatureStateForFullSync, vc)
+
+	// Per the cns-health-initiative design (docs/mermaid/cns-health-initiative/
+	// 03-syncer-no-unregister.mmd), CNS volumes whose matching K8s PV cannot
+	// be found are no longer unregistered (the legacy fullSyncDeleteVolumes
+	// flow that issued DeleteVolume(deleteDisk=false) has been removed).
+	// Instead we label them with `pv_missing=true` on their existing PV-type
+	// CnsKubernetesEntityMetadata, after a two-cycle grace period to absorb
+	// transient races between PV deletion and full-sync execution.
+	missingPVUpdateSpecs, missingPVCount, err := getMissingPVVolumeUpdateSpecs(ctx, queryAllResult.Volumes,
+		k8sPVMap, metadataSyncer, migrationFeatureStateForFullSync, containerCluster, vc)
 	if err != nil {
-		log.Errorf("FullSync for VC %s: failed to get list of volumes to be deleted with err %+v", vc, err)
+		log.Errorf("FullSync for VC %s: failed to compute pv_missing update specs with err %+v", vc, err)
 		return err
+	}
+	prometheus.CnsVolumePVMissingGaugeVec.WithLabelValues(vc).Set(float64(missingPVCount))
+	if len(missingPVUpdateSpecs) > 0 {
+		log.Infof("FullSync for VC %s: applying pv_missing label to %d volume(s)",
+			vc, len(missingPVUpdateSpecs))
+		updateSpecArray = append(updateSpecArray, missingPVUpdateSpecs...)
 	}
 
 	wg := sync.WaitGroup{}
-	wg.Add(3)
+	wg.Add(2)
 	// Perform operations.
 	go fullSyncCreateVolumes(ctx, createSpecArray, metadataSyncer, &wg, migrationFeatureStateForFullSync, volManager, vc)
 	go fullSyncUpdateVolumes(ctx, updateSpecArray, metadataSyncer, &wg, volManager, vc)
-	go fullSyncDeleteVolumes(ctx, volToBeDeleted, metadataSyncer, &wg, migrationFeatureStateForFullSync, volManager, vc)
 	wg.Wait()
 
 	cleanupCnsMaps(k8sPVMap, vc)
@@ -1124,112 +1137,6 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 
 }
 
-// fullSyncDeleteVolumes deletes volumes with given array of volumeId.
-// Before deleting a volume, all current K8s volumes are retrieved.
-// If the volume is successfully deleted, it is removed from cnsDeletionMap.
-func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.CnsVolumeId,
-	metadataSyncer *metadataSyncInformer, wg *sync.WaitGroup,
-	migrationFeatureStateForFullSync bool, volManager volumes.Manager, vc string) {
-	defer wg.Done()
-	log := logger.GetLogger(ctx)
-	deleteDisk := false
-	currentK8sPVMap := make(map[string]bool)
-	volumeOperationsLock[vc].Lock()
-	defer volumeOperationsLock[vc].Unlock()
-	// Get all K8s PVs.
-	currentK8sPV, err := getPVsInBoundAvailableOrReleasedForVc(ctx, metadataSyncer, vc)
-	if err != nil {
-		log.Errorf("FullSync for VC %s: fullSyncDeleteVolumes failed to get PVs from kubernetes. Err: %v", vc, err)
-		return
-	}
-
-	// Create map for easy lookup.
-	for _, pv := range currentK8sPV {
-		if pv.Spec.CSI != nil {
-			currentK8sPVMap[pv.Spec.CSI.VolumeHandle] = true
-		} else if migrationFeatureStateForFullSync && pv.Spec.VsphereVolume != nil {
-			migrationVolumeSpec := &migration.VolumeSpec{
-				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
-				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
-			if err != nil {
-				log.Errorf("FullSync for VC %s: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
-					vc, migrationVolumeSpec, err)
-				return
-			}
-			currentK8sPVMap[volumeHandle] = true
-		}
-	}
-	var queryVolumeIds []cnstypes.CnsVolumeId
-	for _, volID := range volumeIDDeleteArray {
-		// Delete volume if not present in currentK8sPVMap.
-		if _, existsInK8s := currentK8sPVMap[volID.Id]; !existsInK8s {
-			queryVolumeIds = append(queryVolumeIds, cnstypes.CnsVolumeId{Id: volID.Id})
-		}
-	}
-	// This check is needed to prevent querying all CNS volumes when
-	// queryFilter.VolumeIds does not have any volumes. volumes in the
-	// queryFilter.VolumeIds should be one which is not present in the k8s,
-	// but needs to be verified that it is not in use by any other k8s cluster.
-	if len(queryVolumeIds) == 0 {
-		log.Infof("FullSync for VC %s: fullSyncDeleteVolumes could not find any volume "+
-			"which is not present in k8s and needs to be checked for volume deletion.", vc)
-		return
-	}
-	allQueryResults, err := fullSyncGetQueryResults(ctx, queryVolumeIds, "", volManager, metadataSyncer)
-	if err != nil {
-		log.Errorf("FullSync for VC %s: fullSyncGetQueryResults failed to query volume metadata from vc. Err: %v", vc, err)
-		return
-	}
-	// Verify if Volume is not in use by any other Cluster before removing CNS tag
-	for _, queryResult := range allQueryResults {
-		for _, volume := range queryResult.Volumes {
-			inUsebyOtherK8SCluster := false
-			for _, metadata := range volume.Metadata.EntityMetadata {
-				if metadata.(*cnstypes.CnsKubernetesEntityMetadata).ClusterID != clusterIDforVolumeMetadata {
-					inUsebyOtherK8SCluster = true
-					log.Debugf("FullSync for VC %s: fullSyncDeleteVolumes: Volume: %q is "+
-						"in use by other cluster.", vc, volume.VolumeId.Id)
-					break
-				}
-			}
-			if !inUsebyOtherK8SCluster {
-				log.Infof("FullSync for VC %s: fullSyncDeleteVolumes: Calling DeleteVolume for volume %v with delete disk %v",
-					vc, volume.VolumeId.Id, deleteDisk)
-				_, err := volManager.DeleteVolume(ctx, volume.VolumeId.Id, deleteDisk)
-				if err != nil {
-					log.Warnf("FullSync for VC %s: fullSyncDeleteVolumes: Failed to delete volume %s with error %+v",
-						vc, volume.VolumeId.Id, err)
-					continue
-				}
-
-				if len(metadataSyncer.configInfo.Cfg.VirtualCenter) > 1 {
-					// Delete CNSVolumeInfo CR for the volume ID.
-					err = volumeInfoService.DeleteVolumeInfo(ctx, volume.VolumeId.Id)
-					if err != nil {
-						log.Errorf("failed to remove volumeID %q for vCenter %q from CNSVolumeInfo CR. Error: %+v",
-							volume.VolumeId.Id, vc, err)
-					}
-				}
-
-				if migrationFeatureStateForFullSync {
-					err = volumeMigrationService.DeleteVolumeInfo(ctx, volume.VolumeId.Id)
-					// For non-migrated volumes DeleteVolumeInfo will not return
-					// error. So, the volume id will be deleted from cnsDeletionMap.
-					if err != nil {
-						log.Warnf("FullSync for VC %s: fullSyncDeleteVolumes: Failed to delete volume mapping CR for %s. Err: %+v",
-							vc, volume.VolumeId.Id, err)
-						continue
-					}
-				}
-			}
-			// Delete volume from cnsDeletionMap which is successfully deleted from
-			// CNS.
-			delete(cnsDeletionMap[vc], volume.VolumeId.Id)
-		}
-	}
-}
-
 // fullSyncUpdateVolumes update metadata for volumes with given array of
 // createSpec.
 func fullSyncUpdateVolumes(ctx context.Context, updateSpecArray []cnstypes.CnsVolumeMetadataUpdateSpec,
@@ -1545,14 +1452,40 @@ func fullSyncGetVolumeSpecs(ctx context.Context, vCenterVersion string, pvList [
 	return createSpecArray, updateSpecArray
 }
 
-// getVolumesToBeDeleted return list of volumeIds that need to be deleted.
-// A volumeId is added to this list only if it was present in cnsDeletionMap
-// across two cycles of full sync.
-func getVolumesToBeDeleted(ctx context.Context, cnsVolumeList []cnstypes.CnsVolume, k8sPVMap map[string]string,
-	metadataSyncer *metadataSyncInformer, migrationFeatureStateForFullSync bool,
-	vc string) ([]cnstypes.CnsVolumeId, error) {
+// getMissingPVVolumeUpdateSpecs scans the CNS volume list for volumes whose
+// corresponding Kubernetes PV cannot be found in k8sPVMap and returns the set
+// of CnsVolumeMetadataUpdateSpec needed to set the `pv_missing=true` label on
+// the existing PV-type CnsKubernetesEntityMetadata of each such volume.
+//
+// A two-cycle grace period is observed: a volume only becomes a candidate for
+// labeling on the second consecutive full-sync where its PV is absent. The
+// per-vCenter cnsDeletionMap (kept under its legacy name to avoid touching
+// unrelated state) is reused as the grace tracker — entries are added on the
+// first miss and act as the "seen before" flag on the second miss.
+//
+// Volumes are skipped if:
+//   - the PVC for the volume is still cached (transient race),
+//   - the volume is an in-use inline-migrated volume (when CSI migration is on),
+//   - the volume's PV-type entity is already labeled `pv_missing=true`,
+//   - the volume has no PV-type entity scoped to this cluster (legacy/foreign).
+//
+// This function replaces the legacy getVolumesToBeDeleted + fullSyncDeleteVolumes
+// pair, which used to call DeleteVolume(deleteDisk=false) to unregister the
+// CNS volume — stranding the underlying FCD invisibly. With the new flow the
+// volume stays registered and remains visible in the vCenter Container Volumes
+// view so a VI admin can inspect and remediate, while observability is exposed
+// through the prometheus.CnsVolumePVMissingGaugeVec metric.
+//
+// The returned count is the number of volumes for which an UpdateSpec was
+// generated and corresponds to what the caller should publish to the
+// pv_missing gauge for this VC.
+func getMissingPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstypes.CnsVolume,
+	k8sPVMap map[string]string, metadataSyncer *metadataSyncInformer,
+	migrationFeatureStateForFullSync bool, containerCluster cnstypes.CnsContainerCluster,
+	vc string) ([]cnstypes.CnsVolumeMetadataUpdateSpec, int, error) {
 	log := logger.GetLogger(ctx)
-	var volToBeDeleted []cnstypes.CnsVolumeId
+	var updateSpecArray []cnstypes.CnsVolumeMetadataUpdateSpec
+
 	// inlineVolumeMap holds the volume path information for migrated volumes
 	// which are used by Pods.
 	inlineVolumeMap := make(map[string]string)
@@ -1561,44 +1494,131 @@ func getVolumesToBeDeleted(ctx context.Context, cnsVolumeList []cnstypes.CnsVolu
 		inlineVolumeMap, err = fullSyncGetInlineMigratedVolumesInfo(ctx, metadataSyncer, migrationFeatureStateForFullSync)
 		if err != nil {
 			log.Errorf("FullSync for VC %s: Failed to get inline migrated volumes. Err: %v", vc, err)
-			return volToBeDeleted, err
+			return nil, 0, err
 		}
 	}
+
 	for _, vol := range cnsVolumeList {
-		if _, existsInK8s := k8sPVMap[vol.VolumeId.Id]; !existsInK8s {
-			if _, existsInCnsDeletionMap := cnsDeletionMap[vc][vol.VolumeId.Id]; existsInCnsDeletionMap {
-				// Volume does not exist in K8s across two fullsync cycles, because
-				// it was present in cnsDeletionMap across two full sync cycles.
-				// Add it to delete list.
-				log.Debugf("FullSync for VC %s: Volume with id %s added to delete list", vc, vol.VolumeId.Id)
-				volToBeDeleted = append(volToBeDeleted, vol.VolumeId)
-			} else {
-				if nsNameStr, ok := metadataSyncer.coCommonInterface.GetPVCNamespacedNameByUID(vol.VolumeId.Id); ok {
-					log.Infof(
-						"Skipping volume %q during full sync: corresponding PVC found in cache at %s, not adding to deletion map",
-						vol.VolumeId.Id,
-						nsNameStr,
-					)
-					continue
-				}
-				// Add to cnsDeletionMap.
-				if migrationFeatureStateForFullSync {
-					// If migration is ON, verify if the volume is present in inlineVolumeMap.
-					if _, existsInInlineVolumeMap := inlineVolumeMap[vol.VolumeId.Id]; !existsInInlineVolumeMap {
-						log.Infof("FullSync for VC %s: Volume with id %q added to cnsDeletionMap", vc, vol.VolumeId.Id)
-						cnsDeletionMap[vc][vol.VolumeId.Id] = true
-					} else {
-						log.Debugf("FullSync for VC %s: Inline migrated volume with id %s is in use. Skipping for deletion",
-							vc, vol.VolumeId.Id)
-					}
-				} else {
-					log.Debugf("FullSync for VC %s: Volume with id %s added to cnsDeletionMap", vc, vol.VolumeId.Id)
-					cnsDeletionMap[vc][vol.VolumeId.Id] = true
-				}
+		if _, existsInK8s := k8sPVMap[vol.VolumeId.Id]; existsInK8s {
+			continue
+		}
+
+		// PVC is still cached: the PV likely has not surfaced in the lister
+		// yet. Defer to the next full-sync cycle rather than racing the API
+		// server's eventual-consistency.
+		if nsNameStr, ok := metadataSyncer.coCommonInterface.GetPVCNamespacedNameByUID(vol.VolumeId.Id); ok {
+			log.Infof(
+				"FullSync for VC %s: Skipping pv_missing labeling for volume %q: PVC found in cache at %s",
+				vc, vol.VolumeId.Id, nsNameStr,
+			)
+			continue
+		}
+
+		// Migrated inline-volumes that are still referenced by a running Pod
+		// must not be labeled as PV-missing; the in-tree volume path is the
+		// authoritative reference, not a PV object.
+		if migrationFeatureStateForFullSync {
+			if _, inUse := inlineVolumeMap[vol.VolumeId.Id]; inUse {
+				log.Debugf("FullSync for VC %s: Skipping pv_missing labeling for in-use inline-migrated volume %q",
+					vc, vol.VolumeId.Id)
+				continue
 			}
 		}
+
+		// Grace period: first time we observe the volume without its PV we
+		// only record it; only on the next cycle do we act on it.
+		if _, seenBefore := cnsDeletionMap[vc][vol.VolumeId.Id]; !seenBefore {
+			cnsDeletionMap[vc][vol.VolumeId.Id] = true
+			log.Infof("FullSync for VC %s: Volume %q has no matching K8s PV; "+
+				"deferring pv_missing label to next cycle (grace period)",
+				vc, vol.VolumeId.Id)
+			continue
+		}
+
+		updateSpec, ok := buildPVMissingUpdateSpec(ctx, vol, containerCluster, vc)
+		if !ok {
+			// Either the volume has no in-cluster PV-type entity or it is
+			// already labeled. Keep it in the grace tracker so subsequent
+			// cycles continue to no-op cheaply.
+			continue
+		}
+		updateSpecArray = append(updateSpecArray, updateSpec)
 	}
-	return volToBeDeleted, nil
+	return updateSpecArray, len(updateSpecArray), nil
+}
+
+// buildPVMissingUpdateSpec returns an UpdateSpec that sets pv_missing=true on
+// the CNS volume's PV-type CnsKubernetesEntityMetadata, preserving any
+// pre-existing labels on those entries.
+//
+// If the volume has one or more in-cluster PV-type entities, each is reissued
+// with the pv_missing label appended.
+//
+// If no in-cluster PV-type entity is present (legacy volumes, or volumes
+// whose CNS metadata never carried a PV entity), a synthetic PV-type entity
+// is generated using the CNS volume's `Name` as the entity name so the label
+// has somewhere to live. Volumes that lack a usable name AND have no
+// in-cluster PV entity are skipped — there is no safe key to attach the
+// label under.
+//
+// Returns (spec, false) if there is nothing to update (every PV entity is
+// already labeled, or no candidate entity could be synthesized).
+func buildPVMissingUpdateSpec(ctx context.Context, vol cnstypes.CnsVolume,
+	containerCluster cnstypes.CnsContainerCluster, vc string) (cnstypes.CnsVolumeMetadataUpdateSpec, bool) {
+	log := logger.GetLogger(ctx)
+	var entityMetadata []cnstypes.BaseCnsEntityMetadata
+	foundInClusterPV := false
+	for _, em := range vol.Metadata.EntityMetadata {
+		k8sEm, ok := em.(*cnstypes.CnsKubernetesEntityMetadata)
+		if !ok {
+			continue
+		}
+		if k8sEm.ClusterID != clusterIDforVolumeMetadata {
+			// Entity belongs to a different K8s cluster — leave it alone.
+			continue
+		}
+		if k8sEm.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) {
+			continue
+		}
+		foundInClusterPV = true
+		labels := cnsvsphere.GetLabelsMapFromKeyValue(k8sEm.Labels)
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		if labels[prometheus.PrometheusPVMissingLabelKey] == prometheus.PrometheusPVMissingLabelValue {
+			// Already labeled in CNS; nothing to do for this entity.
+			continue
+		}
+		labels[prometheus.PrometheusPVMissingLabelKey] = prometheus.PrometheusPVMissingLabelValue
+		entityMetadata = append(entityMetadata,
+			cnsvsphere.GetCnsKubernetesEntityMetaData(k8sEm.EntityName, labels, false,
+				k8sEm.EntityType, k8sEm.Namespace, k8sEm.ClusterID, k8sEm.ReferredEntity))
+	}
+
+	if !foundInClusterPV && vol.Name != "" {
+		// Synthesize a PV-type entity so the pv_missing label has a home on
+		// volumes whose CNS metadata never carried a PV entry.
+		labels := map[string]string{
+			prometheus.PrometheusPVMissingLabelKey: prometheus.PrometheusPVMissingLabelValue,
+		}
+		entityMetadata = append(entityMetadata,
+			cnsvsphere.GetCnsKubernetesEntityMetaData(vol.Name, labels, false,
+				string(cnstypes.CnsKubernetesEntityTypePV), "", clusterIDforVolumeMetadata, nil))
+	}
+
+	if len(entityMetadata) == 0 {
+		return cnstypes.CnsVolumeMetadataUpdateSpec{}, false
+	}
+	log.Infof("FullSync for VC %s: Adding pv_missing label to volume %q "+
+		"(no matching K8s PV after grace period)", vc, vol.VolumeId.Id)
+	return cnstypes.CnsVolumeMetadataUpdateSpec{
+		VolumeId: cnstypes.CnsVolumeId{Id: vol.VolumeId.Id},
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster:      containerCluster,
+			ContainerClusterArray: []cnstypes.CnsContainerCluster{containerCluster},
+			EntityMetadata:        entityMetadata,
+		},
+	}, true
 }
 
 // buildPVCMapPodMap build two maps to help find
@@ -1696,11 +1716,18 @@ func isUpdateRequired(ctx context.Context, vCenterVersion string, k8sMetadataLis
 }
 
 // cleanupCnsMaps performs cleanup on cnsCreationMap and cnsDeletionMap.
-// Removes volume entries from cnsCreationMap that do not exist in K8s
-// and volume entries from cnsDeletionMap that exist in K8s.
-// An entry could have been added to cnsCreationMap (or cnsDeletionMap),
-// because full sync was triggered in between the delete (or create)
-// operation of a volume.
+//
+//   - cnsCreationMap: tracks volumes seen in K8s but not yet in CNS. Entries
+//     whose volume is no longer in K8s are removed (the create candidacy
+//     lapsed before the second cycle could act).
+//   - cnsDeletionMap: now serves as the pv_missing grace tracker (see
+//     getMissingPVVolumeUpdateSpecs). Entries whose volume reappeared in K8s
+//     are removed so the volume is no longer considered "PV missing" and the
+//     grace period resets for any future absence.
+//
+// The map names are retained for historical/test compatibility; their meaning
+// for cnsDeletionMap has shifted from "to be deleted" to "missing PV, awaiting
+// label".
 func cleanupCnsMaps(k8sPVs map[string]string, vc string) {
 	// Cleanup cnsCreationMap.
 	cnsCreationMapForVc := cnsCreationMap[vc]
@@ -1709,11 +1736,11 @@ func cleanupCnsMaps(k8sPVs map[string]string, vc string) {
 			delete(cnsCreationMap[vc], volID)
 		}
 	}
-	// Cleanup cnsDeletionMap.
+	// Cleanup cnsDeletionMap (pv_missing grace tracker).
 	cnsDeletionMapForVc := cnsDeletionMap[vc]
 	for volID := range cnsDeletionMapForVc {
 		if _, existsInK8s := k8sPVs[volID]; existsInK8s {
-			// Delete volume from cnsDeletionMap which is present in kubernetes.
+			// PV reappeared — clear the grace flag.
 			delete(cnsDeletionMap[vc], volID)
 		}
 	}

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -2055,3 +2055,264 @@ func TestReconcileKeepAfterDeleteVmFlags(t *testing.T) {
 	assert.Equal(t, []string{"vol-2"}, protectCalls,
 		"Only vol-2 should have ProtectVolumeFromVMDeletion called")
 }
+
+// pvMissingTestSetup configures the package-level state required by
+// getMissingPVVolumeUpdateSpecs: the per-VC cnsDeletionMap entry (grace
+// tracker) and clusterIDforVolumeMetadata. It returns a metadataSyncInformer
+// carrying a mockCOCommonForFullSync so the function's PVC-namespace cache
+// lookup returns false (i.e. "no cached PVC"), matching the production code
+// path we want to exercise.
+func pvMissingTestSetup(t *testing.T, vc, clusterID string) *metadataSyncInformer {
+	t.Helper()
+	cnsDeletionMap = map[string]map[string]bool{vc: {}}
+	clusterIDforVolumeMetadata = clusterID
+	return &metadataSyncInformer{
+		coCommonInterface: &mockCOCommonForFullSync{},
+	}
+}
+
+// makeCNSVolume builds a CnsVolume with optional PV-type entity metadata.
+func makeCNSVolume(id, name, clusterID string, pvEntities ...*cnstypes.CnsKubernetesEntityMetadata) cnstypes.CnsVolume {
+	var ems []cnstypes.BaseCnsEntityMetadata
+	for _, em := range pvEntities {
+		ems = append(ems, em)
+	}
+	return cnstypes.CnsVolume{
+		VolumeId: cnstypes.CnsVolumeId{Id: id},
+		Name:     name,
+		Metadata: cnstypes.CnsVolumeMetadata{EntityMetadata: ems},
+	}
+}
+
+// hasPVMissingTrueLabel returns true if any PV-type entity in the spec carries
+// pv_missing=true (Delete=false).
+func hasPVMissingTrueLabel(spec cnstypes.CnsVolumeMetadataUpdateSpec) bool {
+	for _, baseEm := range spec.Metadata.EntityMetadata {
+		em, ok := baseEm.(*cnstypes.CnsKubernetesEntityMetadata)
+		if !ok || em.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) || em.Delete {
+			continue
+		}
+		for _, kv := range em.Labels {
+			if kv.Key == "pv_missing" && kv.Value == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestGetMissingPVVolumeUpdateSpecs_GracePeriod verifies that on the first
+// full-sync cycle where a CNS volume has no matching K8s PV, the volume is
+// only recorded in the grace tracker (cnsDeletionMap) and NO update spec is
+// produced. On the second cycle, an update spec with pv_missing=true is
+// generated.
+func TestGetMissingPVVolumeUpdateSpecs_GracePeriod(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vc := "test-vc"
+	clusterID := "test-cluster"
+	ms := pvMissingTestSetup(t, vc, clusterID)
+
+	pvEntity := &cnstypes.CnsKubernetesEntityMetadata{
+		CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+			EntityName: "pv-orphan",
+			ClusterID:  clusterID,
+		},
+		EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+	}
+	vol := makeCNSVolume("vol-1", "pv-orphan", clusterID, pvEntity)
+	cc := cnstypes.CnsContainerCluster{ClusterId: clusterID}
+
+	// Cycle 1: empty k8sPVMap. Expect 0 update specs (grace recorded).
+	specs, count, err := getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		map[string]string{}, ms, false, cc, vc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.Len(t, specs, 0)
+	assert.True(t, cnsDeletionMap[vc]["vol-1"],
+		"volume should be in grace tracker after cycle 1")
+
+	// Cycle 2: still missing → expect 1 spec with pv_missing=true.
+	specs, count, err = getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		map[string]string{}, ms, false, cc, vc)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Len(t, specs, 1)
+	assert.Equal(t, "vol-1", specs[0].VolumeId.Id)
+	assert.True(t, hasPVMissingTrueLabel(specs[0]),
+		"pv_missing=true label should be present on PV-type entity")
+}
+
+// TestGetMissingPVVolumeUpdateSpecs_PVExists verifies that volumes whose PV
+// IS present in K8s are not touched and not added to the grace tracker.
+func TestGetMissingPVVolumeUpdateSpecs_PVExists(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vc := "test-vc"
+	clusterID := "test-cluster"
+	ms := pvMissingTestSetup(t, vc, clusterID)
+
+	vol := makeCNSVolume("vol-1", "pv-good", clusterID,
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+				EntityName: "pv-good",
+				ClusterID:  clusterID,
+			},
+			EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		})
+	cc := cnstypes.CnsContainerCluster{ClusterId: clusterID}
+
+	k8sPVMap := map[string]string{"vol-1": ""}
+	specs, count, err := getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		k8sPVMap, ms, false, cc, vc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.Len(t, specs, 0)
+	assert.False(t, cnsDeletionMap[vc]["vol-1"],
+		"volume with present PV should not be in grace tracker")
+}
+
+// TestGetMissingPVVolumeUpdateSpecs_PreservesExistingLabels verifies that the
+// pv_missing label is appended on top of any pre-existing labels on the PV-
+// type entity, rather than replacing them.
+func TestGetMissingPVVolumeUpdateSpecs_PreservesExistingLabels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vc := "test-vc"
+	clusterID := "test-cluster"
+	ms := pvMissingTestSetup(t, vc, clusterID)
+
+	vol := makeCNSVolume("vol-1", "pv-orphan", clusterID,
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+				EntityName: "pv-orphan",
+				ClusterID:  clusterID,
+				Labels: []types.KeyValue{
+					{Key: "app", Value: "nginx"},
+					{Key: "tier", Value: "frontend"},
+				},
+			},
+			EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		})
+	cc := cnstypes.CnsContainerCluster{ClusterId: clusterID}
+
+	// Pre-seed the grace tracker to short-circuit the cycle-1 deferral.
+	cnsDeletionMap[vc]["vol-1"] = true
+
+	specs, _, err := getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		map[string]string{}, ms, false, cc, vc)
+	assert.NoError(t, err)
+	assert.Len(t, specs, 1)
+
+	labels := map[string]string{}
+	for _, baseEm := range specs[0].Metadata.EntityMetadata {
+		em := baseEm.(*cnstypes.CnsKubernetesEntityMetadata)
+		for _, kv := range em.Labels {
+			labels[kv.Key] = kv.Value
+		}
+	}
+	assert.Equal(t, "true", labels["pv_missing"], "pv_missing label must be set")
+	assert.Equal(t, "nginx", labels["app"], "pre-existing app label must be preserved")
+	assert.Equal(t, "frontend", labels["tier"], "pre-existing tier label must be preserved")
+}
+
+// TestGetMissingPVVolumeUpdateSpecs_AlreadyLabeled verifies idempotency: a
+// volume that is already labeled pv_missing=true on its PV entity does not
+// produce a second update spec, even after the grace period is satisfied.
+func TestGetMissingPVVolumeUpdateSpecs_AlreadyLabeled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vc := "test-vc"
+	clusterID := "test-cluster"
+	ms := pvMissingTestSetup(t, vc, clusterID)
+
+	vol := makeCNSVolume("vol-1", "pv-orphan", clusterID,
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+				EntityName: "pv-orphan",
+				ClusterID:  clusterID,
+				Labels: []types.KeyValue{
+					{Key: "pv_missing", Value: "true"},
+				},
+			},
+			EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		})
+	cc := cnstypes.CnsContainerCluster{ClusterId: clusterID}
+
+	// Pre-seed grace tracker so we skip straight to the labeling decision.
+	cnsDeletionMap[vc]["vol-1"] = true
+
+	specs, count, err := getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		map[string]string{}, ms, false, cc, vc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "should not re-label an already-labeled volume")
+	assert.Len(t, specs, 0)
+}
+
+// TestGetMissingPVVolumeUpdateSpecs_SynthesizesPVEntity verifies that volumes
+// with no in-cluster PV-type entity still get labeled via a synthetic PV
+// entity derived from CnsVolume.Name (legacy volumes whose CNS metadata
+// never carried a PV entry).
+func TestGetMissingPVVolumeUpdateSpecs_SynthesizesPVEntity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vc := "test-vc"
+	clusterID := "test-cluster"
+	ms := pvMissingTestSetup(t, vc, clusterID)
+
+	// Note: no entityMetadata at all.
+	vol := makeCNSVolume("vol-1", "legacy-pv-name", clusterID)
+	cc := cnstypes.CnsContainerCluster{ClusterId: clusterID}
+
+	cnsDeletionMap[vc]["vol-1"] = true
+
+	specs, _, err := getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		map[string]string{}, ms, false, cc, vc)
+	assert.NoError(t, err)
+	assert.Len(t, specs, 1)
+	assert.True(t, hasPVMissingTrueLabel(specs[0]))
+	// The synthesized entity must reuse vol.Name as the EntityName so the
+	// label is attached to a stable key.
+	found := false
+	for _, baseEm := range specs[0].Metadata.EntityMetadata {
+		em := baseEm.(*cnstypes.CnsKubernetesEntityMetadata)
+		if em.EntityName == "legacy-pv-name" &&
+			em.EntityType == string(cnstypes.CnsKubernetesEntityTypePV) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "synthesized PV entity must use vol.Name as EntityName")
+}
+
+// TestGetMissingPVVolumeUpdateSpecs_ForeignClusterIgnored verifies that
+// PV-type entity metadata that belongs to a different K8s cluster (different
+// ClusterID) is left alone — we do not relabel volumes co-owned by another
+// cluster's PVs.
+func TestGetMissingPVVolumeUpdateSpecs_ForeignClusterIgnored(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vc := "test-vc"
+	clusterID := "test-cluster"
+	ms := pvMissingTestSetup(t, vc, clusterID)
+
+	// Vol has a PV entity for a DIFFERENT cluster.
+	vol := makeCNSVolume("vol-1", "", clusterID,
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+				EntityName: "pv-on-other-cluster",
+				ClusterID:  "some-other-cluster",
+			},
+			EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		})
+	cc := cnstypes.CnsContainerCluster{ClusterId: clusterID}
+
+	cnsDeletionMap[vc]["vol-1"] = true
+
+	specs, count, err := getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		map[string]string{}, ms, false, cc, vc)
+	assert.NoError(t, err)
+	// vol.Name is empty AND there's no in-cluster PV entity → nothing to label.
+	assert.Equal(t, 0, count)
+	assert.Len(t, specs, 0)
+}

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -40,6 +40,7 @@ import (
 	cnsvolumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -655,8 +656,10 @@ func runTestFullSyncWorkflows(t *testing.T) {
 	}
 	cnsDeletionMap = make(map[string]map[string]bool)
 	cnsDeletionMap[csiConfig.Global.VCenterIP] = make(map[string]bool)
-	// PV does not exist in K8S, but volume exist in CNS cache.
-	// FullSync should delete this volume from CNS cache after two cycles.
+	// PV does not exist in K8S, but volume exists in CNS cache.
+	// Per the cns-health-initiative design, fullsync no longer unregisters
+	// such volumes; instead it labels them with pv_missing=true on their
+	// PV-type CnsKubernetesEntityMetadata after a two-cycle grace period.
 	waitForListerSync()
 	err = CsiFullSync(ctx, metadataSyncer, csiConfig.Global.VCenterIP)
 	if err != nil {
@@ -667,14 +670,39 @@ func runTestFullSyncWorkflows(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify if volume has been deleted from cache.
+	// Verify the volume is still registered in CNS and now carries the
+	// pv_missing=true label on a PV-type entity.
 	queryResult, err = virtualCenter.CnsClient.QueryVolume(ctx, &queryFilter)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(queryResult.Volumes) != 0 {
-		t.Fatalf("Full sync failed to remove volume")
+	if len(queryResult.Volumes) != 1 {
+		t.Fatalf("Full sync should have retained the volume; got %d volume(s)", len(queryResult.Volumes))
+	}
+	foundPVMissing := false
+	for _, baseEm := range queryResult.Volumes[0].Metadata.EntityMetadata {
+		em, ok := baseEm.(*cnstypes.CnsKubernetesEntityMetadata)
+		if !ok {
+			continue
+		}
+		if em.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) {
+			continue
+		}
+		for _, kv := range em.Labels {
+			if kv.Key == prometheus.PrometheusPVMissingLabelKey &&
+				kv.Value == prometheus.PrometheusPVMissingLabelValue {
+				foundPVMissing = true
+				break
+			}
+		}
+		if foundPVMissing {
+			break
+		}
+	}
+	if !foundPVMissing {
+		t.Fatalf("Full sync did not apply pv_missing=true label after two cycles; queryResult: %+v",
+			spew.Sdump(queryResult))
 	}
 
 	// PV and PVC exist in K8S, but does not exist in CNS cache.

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -70,10 +70,14 @@ const (
 )
 
 var (
-	// cnsDeletionMap tracks volumes that exist in CNS but not in K8s
-	// If a volume exists in this map across two fullsync cycles,
-	// the volume is deleted from CNS
-	// A separate map is maintained for each VC.
+	// cnsDeletionMap tracks volumes that exist in CNS but not in K8s.
+	// It serves as the pv_missing grace tracker: if a volume exists in this
+	// map across two fullsync cycles, it is labeled with `pv_missing=true` on
+	// its existing CNS PV-type entity metadata (it is NOT deleted/unregistered
+	// from CNS — that legacy behaviour was removed per the cns-health-
+	// initiative design). A separate map is maintained for each VC.
+	// The historical name is preserved to minimize churn in the syncer code
+	// and tests.
 	cnsDeletionMap map[string]map[string]bool
 
 	// cnsCreationMap tracks volumes that exist in K8s but not in CNS

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -540,6 +540,12 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, pvSpec.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		// Static PV deletion no longer drives CNS unregister via full-sync
+		// (cns-health-initiative). Explicitly unregister the CNS volume
+		// while keeping the FCD so PV-2 below can re-register against it.
+		ginkgo.By("Explicitly unregistering CNS volume (deleteDisk=false) so the same FCD can back PV-2")
+		err = e2eVSphere.cnsDeleteVolume(ctx, pv.Spec.CSI.VolumeHandle, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -554,8 +560,13 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, pvSpec.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		// Final cleanup: unregister and delete the underlying FCD as well.
+		ginkgo.By("Explicitly deleting CNS volume + FCD for PV-2 (cns-health-initiative cleanup)")
+		err = e2eVSphere.cnsDeleteVolume(ctx, pv2.Spec.CSI.VolumeHandle, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv2.Spec.CSI.VolumeHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		deleteFCDRequired = false
 		pv = nil
 	})
 

--- a/tests/e2e/fullsync_pv_missing.go
+++ b/tests/e2e/fullsync_pv_missing.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+// Tests for the pv_missing labeling contract introduced by the
+// cns-health-initiative change in pkg/syncer/fullsync.go.
+//
+// Per the new design, full-sync no longer unregisters CNS volumes whose
+// matching K8s PV is missing. Instead it:
+//
+//   - observes the volume across two consecutive full-sync cycles (grace
+//     period to absorb transient races),
+//   - applies the metadata label `pv_missing=true` on the volume's PV-type
+//     CnsKubernetesEntityMetadata,
+//   - leaves the volume registered so VI admins can inspect via the
+//     vCenter Container Volumes view, and
+//   - exposes the count via the Prometheus gauge `vsphere_cns_volume_pv_missing`.
+//
+// These tests verify that contract end-to-end. They do not replace the
+// existing fullsync_test_for_block_volume.go suite; they complement it with
+// positive coverage of the new behaviour and its idempotency.
+var _ bool = ginkgo.Describe("[csi-block-vanilla][csi-supervisor] full-sync pv_missing labeling", func() {
+	f := framework.NewDefaultFramework("e2e-pv-missing")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		client                     clientset.Interface
+		namespace                  string
+		fullSyncWaitTime           int
+		storagePolicyName          string
+		scParameters               map[string]string
+		isVsanHealthServiceStopped bool
+	)
+
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = getNamespaceToRunTests(f)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		nodeList, err := fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+		bootstrap()
+		scParameters = make(map[string]string)
+		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
+		if os.Getenv(envFullSyncWaitTime) != "" {
+			fullSyncWaitTime, err = strconv.Atoi(os.Getenv(envFullSyncWaitTime))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			if fullSyncWaitTime < 120 || fullSyncWaitTime > defaultFullSyncWaitTime {
+				framework.Failf("The FullSync Wait time %v is not set correctly", fullSyncWaitTime)
+			}
+		} else {
+			fullSyncWaitTime = defaultFullSyncWaitTime
+		}
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if isVsanHealthServiceStopped {
+			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+		}
+	})
+
+	// pvMissingCreatePVCAndPV provisions a single PVC backed by a CSI PV using
+	// the same storage-class setup as fullsync_test_for_block_volume.go and
+	// returns the StorageClass, PVC, PV, and volume handle. The caller owns
+	// cleanup.
+	pvMissingCreatePVCAndPV := func(ctx context.Context) (*storagev1.StorageClass, *v1.PersistentVolumeClaim,
+		*v1.PersistentVolume, string) {
+		var sc *storagev1.StorageClass
+		var pvc *v1.PersistentVolumeClaim
+		var err error
+		if vanillaCluster {
+			sc, pvc, err = createPVCAndStorageClass(ctx, client, namespace, nil, nil, "", nil, "", false, "")
+		} else if supervisorCluster {
+			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+			scParameters[scParamStoragePolicyID] = profileID
+			restClientConfig := getRestConfigClient()
+			setStoragePolicyQuota(ctx, restClientConfig, storagePolicyName, namespace, rqLimit)
+			sc, pvc, err = createPVCAndStorageClass(ctx, client, namespace, nil,
+				scParameters, "", nil, "", true, "", storagePolicyName)
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pvs, err := fpv.WaitForPVClaimBoundPhase(ctx, client,
+			[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
+		pv := pvs[0]
+		return sc, pvc, pv, pv.Spec.CSI.VolumeHandle
+	}
+
+	// Test 1: applied (CNS volume gets labeled pv_missing=true after PV
+	// deletion + 2 full-sync cycles + grace period). This is the primary
+	// positive assertion of the new contract.
+	ginkgo.It("[pv-missing-applied] CNS volume is retained and labeled pv_missing=true "+
+		"after the K8s PV is deleted", ginkgo.Label(p0, block, vanilla, wcp, core, vc70), func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sc, pvc, pv, fcdID := pvMissingCreatePVCAndPV(ctx)
+		defer func() {
+			if !supervisorCluster {
+				_ = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			}
+		}()
+
+		ginkgo.By("Stopping vsan-health on the vCenter host to batch PVC+PV deletion outside of CNS")
+		isVsanHealthServiceStopped = true
+		err := invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
+
+		ginkgo.By(fmt.Sprintf("Deleting PVC %s/%s and PV %s while vsan-health is stopped", namespace, pvc.Name, pv.Name))
+		err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Starting vsan-health on the vCenter host")
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds (2x fullSyncWaitTime) to span the grace period",
+			2*fullSyncWaitTime))
+		time.Sleep(time.Duration(2*fullSyncWaitTime) * time.Second)
+
+		ginkgo.By(fmt.Sprintf("Verify pv_missing=true label is applied on CNS volume %s", fcdID))
+		err = e2eVSphere.waitForPVMissingLabel(ctx, fcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify the CNS volume is still registered (not unregistered)")
+		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(fcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(queryResult.Volumes).To(gomega.HaveLen(1),
+			"CNS volume must remain registered after missing-PV labeling")
+
+		ginkgo.By("Cleanup: explicitly unregister + delete FCD via cnsDeleteVolume")
+		err = e2eVSphere.cnsDeleteVolume(ctx, fcdID, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	// Test 2: cleared (pv_missing label is removed when a matching K8s PV
+	// is re-created). The label must not be sticky — operational remediation
+	// of the missing-PV condition has to clear the signal naturally.
+	ginkgo.It("[pv-missing-cleared] pv_missing label is cleared when a matching K8s PV reappears",
+		ginkgo.Label(p1, block, vanilla, wcp, core, vc70), func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sc, pvc, pv, fcdID := pvMissingCreatePVCAndPV(ctx)
+			defer func() {
+				if !supervisorCluster {
+					_ = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+				}
+			}()
+
+			ginkgo.By("Stopping vsan-health and deleting PVC+PV to trigger the missing-PV state")
+			isVsanHealthServiceStopped = true
+			err := invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
+			err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+
+			ginkgo.By("Span the grace period so pv_missing=true is applied")
+			time.Sleep(time.Duration(2*fullSyncWaitTime) * time.Second)
+			err = e2eVSphere.waitForPVMissingLabel(ctx, fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Re-create a static PV pointing at the same VolumeHandle so K8s
+			// once again has a PV for this volume. Full-sync's existing update
+			// path should overwrite the PV-entity metadata and drop pv_missing.
+			ginkgo.By(fmt.Sprintf("Re-creating a static PV pointing at the same VolumeHandle %s", fcdID))
+			staticPVLabels := map[string]string{"fcd-id": fcdID}
+			newPV := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels, ext4FSType)
+			newPV, err = client.CoreV1().PersistentVolumes().Create(ctx, newPV, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow full-sync to overwrite labels", fullSyncWaitTime))
+			time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+
+			ginkgo.By("Verify pv_missing label is no longer present on CNS volume")
+			labeled, err := e2eVSphere.hasPVMissingLabel(fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(labeled).To(gomega.BeFalse(),
+				"pv_missing label must be cleared once a matching K8s PV exists")
+
+			ginkgo.By("Cleanup: delete the static PV and the underlying CNS volume + FCD")
+			err = client.CoreV1().PersistentVolumes().Delete(ctx, newPV.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.cnsDeleteVolume(ctx, fcdID, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+	// Test 3: grace period (after a single full-sync cycle the label must
+	// NOT be present; only after the second cycle does labeling occur).
+	// This protects against regressions where the grace period is removed
+	// or shortened — without it, transient API races between PV deletion
+	// and full-sync would flap the label.
+	ginkgo.It("[pv-missing-grace] pv_missing label is applied only after the two-cycle grace period",
+		ginkgo.Label(p1, block, vanilla, core, vc70), func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sc, pvc, pv, fcdID := pvMissingCreatePVCAndPV(ctx)
+			defer func() {
+				if !supervisorCluster {
+					_ = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+				}
+			}()
+
+			ginkgo.By(fmt.Sprintf("Deleting PVC %s/%s and PV %s with CNS healthy (no service stop)",
+				namespace, pvc.Name, pv.Name))
+			err := client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("Sleeping for one fullSyncWaitTime (%v sec) — first cycle only records the volume",
+				fullSyncWaitTime))
+			time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+
+			ginkgo.By("After the first full-sync cycle the volume must NOT yet carry pv_missing=true")
+			labeled, err := e2eVSphere.hasPVMissingLabel(fcdID)
+			// hasPVMissingLabel returns false when the volume has been removed
+			// from CNS (a regression — old unregister flow). We assert both
+			// "volume present" and "label absent" together.
+			queryResult, qerr := e2eVSphere.queryCNSVolumeWithResult(fcdID)
+			gomega.Expect(qerr).NotTo(gomega.HaveOccurred())
+			gomega.Expect(queryResult.Volumes).To(gomega.HaveLen(1),
+				"CNS volume must remain registered through the grace period")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(labeled).To(gomega.BeFalse(),
+				"pv_missing=true must NOT be applied on the first full-sync cycle (grace period)")
+
+			ginkgo.By(fmt.Sprintf("Sleeping for another fullSyncWaitTime (%v sec) — second cycle applies the label",
+				fullSyncWaitTime))
+			time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+
+			ginkgo.By("After the second full-sync cycle the volume MUST carry pv_missing=true")
+			err = e2eVSphere.waitForPVMissingLabel(ctx, fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Cleanup")
+			err = e2eVSphere.cnsDeleteVolume(ctx, fcdID, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+	// Test 4: idempotency (running multiple full-sync cycles against an
+	// already-labeled volume must not produce duplicate labels or change
+	// the existing label's value). Protects against bug classes where the
+	// labeling code path keeps appending KeyValue entries.
+	ginkgo.It("[pv-missing-idempotent] pv_missing label is applied at most once across multiple cycles",
+		ginkgo.Label(p2, block, vanilla, core, vc70), func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sc, pvc, pv, fcdID := pvMissingCreatePVCAndPV(ctx)
+			defer func() {
+				if !supervisorCluster {
+					_ = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+				}
+			}()
+
+			ginkgo.By(fmt.Sprintf("Deleting PVC %s/%s and PV %s", namespace, pvc.Name, pv.Name))
+			err := client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Span grace period + 2 additional full-sync cycles (4x total) to test idempotency")
+			time.Sleep(time.Duration(4*fullSyncWaitTime) * time.Second)
+
+			ginkgo.By("Verify pv_missing=true exactly once on the PV-type CnsKubernetesEntityMetadata")
+			queryResult, err := e2eVSphere.queryCNSVolumeWithResult(fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(queryResult.Volumes).To(gomega.HaveLen(1))
+
+			pvMissingCount := 0
+			for _, baseEm := range queryResult.Volumes[0].Metadata.EntityMetadata {
+				em, ok := baseEm.(*cnstypes.CnsKubernetesEntityMetadata)
+				if !ok || em.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) {
+					continue
+				}
+				for _, kv := range em.Labels {
+					if kv.Key == "pv_missing" && kv.Value == "true" {
+						pvMissingCount++
+					}
+				}
+			}
+			gomega.Expect(pvMissingCount).To(gomega.Equal(1),
+				"pv_missing=true must appear exactly once across the PV-type entity's Labels even after multiple cycles")
+
+			ginkgo.By("Cleanup")
+			err = e2eVSphere.cnsDeleteVolume(ctx, fcdID, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+})

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -48,9 +48,14 @@ import (
 //         present.
 // Test 2) Verify labels are created in CNS after updating pvc and/or pv with
 //         new labels.
-// Test 3) Verify CNS volume is deleted after full sync when pv entry is delete.
+// Test 3) Verify CNS volume is labeled pv_missing=true after full sync when
+//         the corresponding K8s PV is deleted (cns-health-initiative change:
+//         volumes are no longer unregistered from CNS when their PV goes
+//         missing — they are labeled instead so VI admins can remediate).
 //
-// Cleanup: Delete PVC and StorageClass and verify volume is deleted from CNS.
+// Cleanup: Delete PVC and StorageClass. Volumes whose K8s PV is missing must
+// be explicitly cleaned up via cnsDeleteVolume(deleteDisk=true); they are no
+// longer auto-removed by full-sync.
 
 var _ bool = ginkgo.Describe("full-sync-test", func() {
 	f := framework.NewDefaultFramework("e2e-full-sync-test")
@@ -206,14 +211,20 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		// Static PV deletion no longer triggers CNS unregister via full-sync
+		// (cns-health-initiative). Drive the cleanup explicitly so the test
+		// is hermetic and the FCD is not leaked.
+		ginkgo.By(fmt.Sprintf("Explicitly deleting CNS volume %s (deleteDisk=true)", fcdID))
+		err = e2eVSphere.cnsDeleteVolume(ctx, fcdID, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		ginkgo.By(fmt.Sprintf("Waiting for volume %s to be deleted", fcdID))
 		err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(),
+		ginkgo.By(fmt.Sprintf("Sweeping FCD: %s (tolerating not-found)", fcdID))
+		_ = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(),
 			[]string{disklibUnlinkErr}, []string{objOrItemNotFoundErr})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})
 
@@ -306,98 +317,126 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 	})
 
+	// Per the cns-health-initiative change (see pkg/syncer/fullsync.go),
+	// full-sync no longer unregisters CNS volumes whose K8s PV has been
+	// deleted; it labels them pv_missing=true on the existing PV-type
+	// CnsKubernetesEntityMetadata after a two-cycle grace period. This test
+	// verifies the new contract.
 	ginkgo.It("[ef-vanilla-block][pq-n1-vanilla-block][pq-n2-vanilla-block][ef-wcp][csi-supervisor]"+
 		"[csi-block-vanilla][csi-block-vanilla-serialized] Verify CNS "+
-		"volume is deleted after full sync when pv entry is delete", ginkgo.Label(p0, block, vanilla, wcp, core,
-		vc70), func() {
-		ginkgo.By("Invoking test to verify CNS volume creation")
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		var sc *storagev1.StorageClass
-		var pvc *v1.PersistentVolumeClaim
-		var err error
-		// Decide which test setup is available to run.
-		if vanillaCluster {
-			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
-			sc, pvc, err = createPVCAndStorageClass(ctx, client, namespace, nil, nil, "", nil, "", false, "")
-		} else if supervisorCluster {
-			ginkgo.By("CNS_TEST: Running for WCP setup")
-			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
-			scParameters[scParamStoragePolicyID] = profileID
-			restClientConfig := getRestConfigClient()
-			setStoragePolicyQuota(ctx, restClientConfig, storagePolicyName, namespace, rqLimit)
-			sc, pvc, err = createPVCAndStorageClass(ctx, client, namespace, nil,
-				scParameters, "", nil, "", true, "", storagePolicyName)
-		}
-
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		defer func() {
-			if !supervisorCluster {
-				err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		"volume is labeled pv_missing=true after full sync when pv entry is deleted",
+		ginkgo.Label(p0, block, vanilla, wcp, core, vc70), func() {
+			ginkgo.By("Invoking test to verify CNS volume creation")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var sc *storagev1.StorageClass
+			var pvc *v1.PersistentVolumeClaim
+			var err error
+			// Decide which test setup is available to run.
+			if vanillaCluster {
+				ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+				sc, pvc, err = createPVCAndStorageClass(ctx, client, namespace, nil, nil, "", nil, "", false, "")
+			} else if supervisorCluster {
+				ginkgo.By("CNS_TEST: Running for WCP setup")
+				profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+				scParameters[scParamStoragePolicyID] = profileID
+				restClientConfig := getRestConfigClient()
+				setStoragePolicyQuota(ctx, restClientConfig, storagePolicyName, namespace, rqLimit)
+				sc, pvc, err = createPVCAndStorageClass(ctx, client, namespace, nil,
+					scParameters, "", nil, "", true, "", storagePolicyName)
 			}
-		}()
 
-		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
-		pvs, err := fpv.WaitForPVClaimBoundPhase(ctx, client,
-			[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
-		pv := pvs[0]
-		fcdID = pv.Spec.CSI.VolumeHandle
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer func() {
+				if !supervisorCluster {
+					err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}()
 
-		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(fcdID)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(len(queryResult.Volumes) > 0)
+			ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
+			pvs, err := fpv.WaitForPVClaimBoundPhase(ctx, client,
+				[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pvs).NotTo(gomega.BeEmpty())
+			pv := pvs[0]
+			fcdID = pv.Spec.CSI.VolumeHandle
 
-		if len(queryResult.Volumes) > 0 {
-			// Find datastore from the retrieved datastoreURL.
-			finder := find.NewFinder(e2eVSphere.Client.Client, false)
+			queryResult, err := e2eVSphere.queryCNSVolumeWithResult(fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(queryResult.Volumes) > 0)
 
-			for _, dc := range datacenters {
-				datacenter, err = finder.Datacenter(ctx, dc)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				finder.SetDatacenter(datacenter)
-				datastore, err = getDatastoreByURL(ctx, queryResult.Volumes[0].DatastoreUrl, datacenter)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				if datastore != nil {
-					break
+			if len(queryResult.Volumes) > 0 {
+				// Find datastore from the retrieved datastoreURL.
+				finder := find.NewFinder(e2eVSphere.Client.Client, false)
+
+				for _, dc := range datacenters {
+					datacenter, err = finder.Datacenter(ctx, dc)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					finder.SetDatacenter(datacenter)
+					datastore, err = getDatastoreByURL(ctx, queryResult.Volumes[0].DatastoreUrl, datacenter)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if datastore != nil {
+						break
+					}
 				}
 			}
-		}
-		gomega.Expect(datastore).NotTo(gomega.BeNil())
-		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		isVsanHealthServiceStopped = true
-		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
-			vsanHealthServiceWaitTime))
-		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
+			gomega.Expect(datastore).NotTo(gomega.BeNil())
+			ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
+			isVsanHealthServiceStopped = true
+			err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
+				vsanHealthServiceWaitTime))
+			time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 
-		ginkgo.By(fmt.Sprintf("Deleting PVC %s in namespace %s", pvc.Name, namespace))
-		err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("Deleting PVC %s in namespace %s", pvc.Name, namespace))
+			err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Deleting the PV %s", pv.Name))
-		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("Deleting the PV %s", pv.Name))
+			err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
-		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
+			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow full sync finish", fullSyncWaitTime))
-		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+			// Wait long enough to clear the full-sync grace period (the first
+			// missed cycle only records the volume in the tracker; the second
+			// cycle applies the label). 2x fullSyncWaitTime is the documented
+			// envelope for the grace window across all clusters.
+			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds (2x fullSyncWaitTime) to span the pv_missing grace period",
+				2*fullSyncWaitTime))
+			time.Sleep(time.Duration(2*fullSyncWaitTime) * time.Second)
 
-		ginkgo.By(fmt.Sprintf("Waiting for volume %s to be deleted", fcdID))
-		err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("Waiting for pv_missing=true label to appear on volume %s", fcdID))
+			err = e2eVSphere.waitForPVMissingLabel(ctx, fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(),
-			[]string{disklibUnlinkErr}, []string{objOrItemNotFoundErr})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// Volume must still exist in CNS — the label is on the volume, not
+			// a tombstone. Confirm by direct query.
+			queryResult, err = e2eVSphere.queryCNSVolumeWithResult(fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(queryResult.Volumes).To(gomega.HaveLen(1),
+				"CNS volume must remain registered after missing-PV labeling (unregister flow has been removed)")
 
-	})
+			// Test owns cleanup — full-sync will no longer GC orphaned volumes.
+			ginkgo.By(fmt.Sprintf("Explicitly deleting CNS volume %s (deleteDisk=true) since fullsync "+
+				"no longer unregisters volumes with missing PVs", fcdID))
+			err = e2eVSphere.cnsDeleteVolume(ctx, fcdID, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("Waiting for volume %s to be removed from CNS", fcdID))
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// FCD already destroyed via cnsDeleteVolume(deleteDisk=true); this
+			// is a defensive sweep tolerating not-found.
+			ginkgo.By(fmt.Sprintf("Sweeping FCD: %s (tolerating not-found)", fcdID))
+			_ = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(),
+				[]string{disklibUnlinkErr}, []string{objOrItemNotFoundErr})
+
+		})
 
 	// Fullsync test with multiple PVCs.
 	// 1. create a storage class with reclaim policy as "Retain".
@@ -683,14 +722,19 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		// Static PV deletion no longer triggers CNS unregister via full-sync
+		// (cns-health-initiative). Drive cleanup explicitly.
+		ginkgo.By(fmt.Sprintf("Explicitly deleting CNS volume %s (deleteDisk=true)", fcdID))
+		err = e2eVSphere.cnsDeleteVolume(ctx, fcdID, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		ginkgo.By(fmt.Sprintf("Waiting for volume %s to be deleted", fcdID))
 		err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(),
+		ginkgo.By(fmt.Sprintf("Sweeping FCD: %s (tolerating not-found)", fcdID))
+		_ = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(),
 			[]string{disklibUnlinkErr}, []string{objOrItemNotFoundErr})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})
 
@@ -771,14 +815,19 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		// Static PV deletion no longer triggers CNS unregister via full-sync
+		// (cns-health-initiative). Drive cleanup explicitly.
+		ginkgo.By(fmt.Sprintf("Explicitly deleting CNS volume %s (deleteDisk=true)", fcdID))
+		err = e2eVSphere.cnsDeleteVolume(ctx, fcdID, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		ginkgo.By(fmt.Sprintf("Waiting for volume %s to be deleted", fcdID))
 		err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(),
+		ginkgo.By(fmt.Sprintf("Sweeping FCD: %s (tolerating not-found)", fcdID))
+		_ = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(),
 			[]string{disklibUnlinkErr}, []string{objOrItemNotFoundErr})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
 	/*

--- a/tests/e2e/fullsync_test_for_file_volume.go
+++ b/tests/e2e/fullsync_test_for_file_volume.go
@@ -41,7 +41,10 @@ import (
 // Test 1) Verify CNS volume is created after full sync when pv entry is present.
 // Test 2) Verify labels are created in CNS after updating pvc and/or pv with
 //         new labels.
-// Test 3) Verify CNS volume is deleted after full sync when pv entry is delete.
+// Test 3) Verify CNS volume is labeled pv_missing=true after full sync when
+//         the corresponding K8s PV is deleted (cns-health-initiative change).
+//         NOTE: This scenario is not implemented in this file; see
+//         fullsync_test_for_block_volume.go for the implemented variant.
 //
 // Cleanup
 // - Delete PVC and StorageClass and verify volume is deleted from CNS.

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -641,6 +641,13 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 			if !isPvDeleted {
 				err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// PV is statically-provisioned with no PVC binding by the
+				// time this defer fires; the controller-side DeleteVolume
+				// RPC will not be invoked, and per the cns-health-initiative
+				// change full-sync only labels the volume pv_missing=true
+				// instead of unregistering it. Drive the cleanup explicitly.
+				err = e2eVSphere.cnsDeleteVolume(ctx, fcdID, true)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}

--- a/tests/e2e/vcp_to_csi_full_sync.go
+++ b/tests/e2e/vcp_to_csi_full_sync.go
@@ -155,19 +155,30 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration full sync tests", gi
 				if defaultDatastore == nil {
 					defaultDatastore = getDefaultDatastore(ctx)
 				}
+				// Retain-policy + PV.Delete means the CNS volume's K8s PV is now
+				// missing. Per the cns-health-initiative change in
+				// pkg/syncer/fullsync.go, full-sync no longer unregisters such
+				// volumes; it labels them pv_missing=true and leaves them in
+				// CNS for VI-admin remediation. To keep this cleanup hermetic
+				// (no leaked FCDs across tests), we drive the unregister and
+				// FCD removal explicitly via cnsDeleteVolume.
 				if pv.Spec.CSI != nil {
+					err = e2eVSphere.cnsDeleteVolume(ctx, pv.Spec.CSI.VolumeHandle, true)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					err = e2eVSphere.deleteFCD(ctx, pv.Spec.CSI.VolumeHandle, defaultDatastore.Reference())
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					// FCD already removed by cnsDeleteVolume(deleteDisk=true);
+					// defensive sweep tolerates not-found.
+					_ = e2eVSphere.deleteFCD(ctx, pv.Spec.CSI.VolumeHandle, defaultDatastore.Reference())
 				} else {
 					if kcmMigEnabled {
 						found, crd := getCnsVSphereVolumeMigrationCrd(ctx, pv.Spec.VsphereVolume.VolumePath)
 						gomega.Expect(found).To(gomega.BeTrue())
+						err = e2eVSphere.cnsDeleteVolume(ctx, crd.Spec.VolumeID, true)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						err = e2eVSphere.waitForCNSVolumeToBeDeleted(crd.Spec.VolumeID)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						err = e2eVSphere.deleteFCD(ctx, crd.Spec.VolumeID, defaultDatastore.Reference())
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						_ = e2eVSphere.deleteFCD(ctx, crd.Spec.VolumeID, defaultDatastore.Reference())
 					}
 					err = deleteVmdk(ctx, esxHost, pv.Spec.VsphereVolume.VolumePath)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -269,15 +280,17 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration full sync tests", gi
 	// 9. Sleep double the Full Sync interval.
 	// 10. Verify PVC name is removed from CNS entry for PV1.
 	// 11. Verify CNS entry for PVC1 is removed.
-	// 12. Delete PV1 and vmdk1.
+	// 12. Delete PV1 and vmdk1 (use cnsDeleteVolume; PV1 absent from K8s
+	//     would otherwise be labeled pv_missing=true by full-sync per the
+	//     cns-health-initiative change, not unregistered).
 	// 13. Verify CNS entry for PV1 is removed.
 	// 14. Verify cnsvspherevolumemigrations crds are removed for PVC1 and PV1.
 	// 15. Delete the SC1.
 	// 16. Disable CSIMigration and CSIMigrationvSphere feature gates on
 	//     kube-controller-manager (& restart).
 	//
-	// Verify volume entries are deleted in CNS when PVC and PC with reclaim
-	// policy Retain are deleted in K8s (when CNS was down).
+	// Verify behavior in CNS when PVC and PV with reclaim policy Retain are
+	// deleted in K8s (when CNS was down).
 	// Steps:
 	// 1. Enable CSIMigration and CSIMigrationvSphere feature gates on
 	//    kube-controller-manager (& restart).
@@ -289,9 +302,11 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration full sync tests", gi
 	// 7. Delete PVC1.
 	// 8. Delete PV1.
 	// 9. Start vsan-health on VC.
-	// 10. Sleep double the Full Sync interval.
-	// 11. Verify CNS entry for PVC1 and PV1 is removed.
-	// 12. Delete vmdk1.
+	// 10. Sleep 2x Full Sync interval (to span the pv_missing grace period).
+	// 11. Verify CNS volume for PV1 is labeled pv_missing=true (NOT removed —
+	//     cns-health-initiative replaced the unregister flow with labeling).
+	// 12. Explicitly cnsDeleteVolume(deleteDisk=true) to clean up; full-sync
+	//     no longer GCs orphaned volumes.
 	// 13. Verify cnsvspherevolumemigrations crds are removed for PVC1 and PV1.
 	// 14. Delete the SC1.
 	// 15. Disable CSIMigration and CSIMigrationvSphere feature gates on
@@ -532,6 +547,15 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration full sync tests", gi
 			vcpPvcsPostMig[5].Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		// Capture the FCD of the Retain PV we're about to delete. With the
+		// cns-health-initiative change, this volume will be labeled
+		// pv_missing=true by full-sync rather than unregistered, so we track
+		// it separately from the deletion-via-controller bucket.
+		retainPVVPath := vcpPvsPostMig[6].Spec.VsphereVolume.VolumePath
+		foundRetainCRD, retainPVCRD := getCnsVSphereVolumeMigrationCrd(ctx, retainPVVPath)
+		gomega.Expect(foundRetainCRD).To(gomega.BeTrue())
+		pvMissingFcdID := retainPVCRD.Spec.VolumeID
+
 		ginkgo.By("Delete one PV with Retain policy for which PVC was also deleted above")
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, vcpPvsPostMig[6].Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -546,10 +570,15 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration full sync tests", gi
 		ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow full sync finish", fullSyncWaitTime))
-		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+		// Wait long enough to span the pv_missing grace period (the first
+		// missed full-sync cycle only records the volume; the second cycle
+		// applies the label). The deletion-via-controller path needs only
+		// one full-sync interval, but we wait for the longer envelope.
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds (2x fullSyncWaitTime) to span the pv_missing grace period",
+			2*fullSyncWaitTime))
+		time.Sleep(time.Duration(2*fullSyncWaitTime) * time.Second)
 
-		ginkgo.By("Verify the deleted PVCs and PVs are no longer present in CNS cache")
+		ginkgo.By("Verify the PVCs (deleted via controller path with ReclaimPolicy=Delete) are no longer in CNS")
 		for _, crd := range crdsToVerifyDeletion {
 			err = waitForCnsVSphereVolumeMigrationCrdToBeDeleted(ctx, crd)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -558,6 +587,29 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration full sync tests", gi
 			err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
+
+		// The Retain PV deleted directly (vcpPvsPostMig[6]) hits the
+		// missing-PV path. Per the cns-health-initiative change in
+		// pkg/syncer/fullsync.go this is now labeled pv_missing=true rather
+		// than unregistered. Verify the new contract and then explicitly
+		// clean up since fullsync no longer GCs the volume.
+		ginkgo.By(fmt.Sprintf("Verify Retain PV's CNS volume %s is labeled pv_missing=true", pvMissingFcdID))
+		err = e2eVSphere.waitForPVMissingLabel(ctx, pvMissingFcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		queryRes, err := e2eVSphere.queryCNSVolumeWithResult(pvMissingFcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(queryRes.Volumes).To(gomega.HaveLen(1),
+			"Retain PV's CNS volume must remain registered after missing-PV labeling")
+
+		ginkgo.By(fmt.Sprintf("Explicitly deleting CNS volume %s (deleteDisk=true) since fullsync "+
+			"no longer unregisters volumes with missing PVs", pvMissingFcdID))
+		err = e2eVSphere.cnsDeleteVolume(ctx, pvMissingFcdID, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = e2eVSphere.waitForCNSVolumeToBeDeleted(pvMissingFcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitForCnsVSphereVolumeMigrationCrdToBeDeleted(ctx, retainPVCRD)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		_, err = fpv.WaitForPVClaimBoundPhase(ctx, client, []*v1.PersistentVolumeClaim{pvc2}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -595,6 +595,110 @@ func (vs *vSphere) deleteFCD(ctx context.Context, fcdID string, dsRef vim25types
 	return nil
 }
 
+// cnsDeleteVolume invokes the CNS DeleteVolume API directly (bypassing the
+// CSI driver) and waits for the task to complete.
+//
+// This is used by tests whose volume cleanup historically relied on full-sync
+// to unregister CNS volumes for missing/orphaned PVs. The cns-health-initiative
+// change (syncer/fullsync: replace missing-PV unregister with pv_missing
+// labeling) means full-sync no longer GCs such volumes; tests must now drive
+// CNS-side cleanup explicitly.
+//
+// When deleteDisk is true, the underlying FCD is also deleted; when false,
+// only the CNS metadata is removed (the FCD remains and can be reclaimed by
+// a subsequent vs.deleteFCD call).
+func (vs *vSphere) cnsDeleteVolume(ctx context.Context, volumeID string, deleteDisk bool) error {
+	req := cnstypes.CnsDeleteVolume{
+		This:       cnsVolumeManagerInstance,
+		VolumeIds:  []cnstypes.CnsVolumeId{{Id: volumeID}},
+		DeleteDisk: deleteDisk,
+	}
+	res, err := cnsmethods.CnsDeleteVolume(ctx, vs.CnsClient.Client, &req)
+	if err != nil {
+		return err
+	}
+	task := object.NewTask(vs.Client.Client, res.Returnval)
+	taskInfo, err := cns.GetTaskInfo(ctx, task)
+	if err != nil {
+		return err
+	}
+	_, err = cns.GetTaskResult(ctx, taskInfo)
+	return err
+}
+
+// waitForPVMissingLabel polls QueryCNSVolumeWithResult and returns nil once
+// the CNS volume identified by volumeID has the `pv_missing=true` label
+// applied to at least one PV-type CnsKubernetesEntityMetadata, indicating
+// that fullsync has observed the K8s PV as missing across the grace period.
+//
+// Times out after pollTimeout. Use this in place of waitForCNSVolumeToBeDeleted
+// for tests whose original intent was to verify the (now-removed) missing-PV
+// unregister path.
+func (vs *vSphere) waitForPVMissingLabel(ctx context.Context, volumeID string) error {
+	const pvMissingLabelKey = "pv_missing"
+	const pvMissingLabelValue = "true"
+	waitErr := wait.PollUntilContextTimeout(ctx, poll, pollTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			result, err := vs.queryCNSVolumeWithResult(volumeID)
+			if err != nil {
+				return false, err
+			}
+			if len(result.Volumes) == 0 {
+				// Volume vanished from CNS; this is not the contract we are
+				// asserting and almost certainly means a different cleanup
+				// path got there first. Surface as failure so the caller can
+				// react.
+				return false, fmt.Errorf("volume %s no longer exists in CNS while waiting for pv_missing label", volumeID)
+			}
+			for _, baseEm := range result.Volumes[0].Metadata.EntityMetadata {
+				em, ok := baseEm.(*cnstypes.CnsKubernetesEntityMetadata)
+				if !ok {
+					continue
+				}
+				if em.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) {
+					continue
+				}
+				for _, kv := range em.Labels {
+					if kv.Key == pvMissingLabelKey && kv.Value == pvMissingLabelValue {
+						return true, nil
+					}
+				}
+			}
+			return false, nil
+		})
+	return waitErr
+}
+
+// hasPVMissingLabel returns true if the most recent CNS query result for
+// volumeID shows pv_missing=true on a PV-type entity. Unlike
+// waitForPVMissingLabel it does not poll; useful for negative assertions.
+func (vs *vSphere) hasPVMissingLabel(volumeID string) (bool, error) {
+	const pvMissingLabelKey = "pv_missing"
+	const pvMissingLabelValue = "true"
+	result, err := vs.queryCNSVolumeWithResult(volumeID)
+	if err != nil {
+		return false, err
+	}
+	if len(result.Volumes) == 0 {
+		return false, nil
+	}
+	for _, baseEm := range result.Volumes[0].Metadata.EntityMetadata {
+		em, ok := baseEm.(*cnstypes.CnsKubernetesEntityMetadata)
+		if !ok {
+			continue
+		}
+		if em.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) {
+			continue
+		}
+		for _, kv := range em.Labels {
+			if kv.Key == pvMissingLabelKey && kv.Value == pvMissingLabelValue {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 // relocateFCD relocates an FCD disk
 func (vs *vSphere) relocateFCD(ctx context.Context, fcdID string,
 	dsRefSrc vim25types.ManagedObjectReference, dsRefDest vim25types.ManagedObjectReference) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does**:
Syncer/fullsync: replace missing-PV unregister flow with pv_missing labeling

Stop calling DeleteVolume(deleteDisk=false) from full-sync for CNS volumes whose corresponding Kubernetes PV is not found. Instead, after a two-cycle grace period, set the metadata label pv_missing=true on the volume's PV-type CnsKubernetesEntityMetadata and expose the count via a new Prometheus gauge vsphere_cns_volume_pv_missing{vc=...}. Pre-existing labels on the PV entity are preserved; labeling is idempotent across cycles; labels are naturally cleared if the PV reappears (the existing K8s-driven UpdateVolumeMetadata path overwrites the entity).


**Why we need it**:
The legacy flow was actively harmful in a recurring real-world scenario:

It silently stranded vSphere FCDs. When full-sync couldn't find a PV (typically because a backup vendor's restore workflow force-deletes the PV while the storage class has reclaimPolicy: Retain, or an operator/admin accidentally removed the PV), the syncer would call DeleteVolume(deleteDisk=false). This unregisters the CNS managed volume but leaves the underlying First-Class Disk on the datastore. The disk:
disappears from vCenter → Container Volumes,
keeps consuming datastore capacity,
has no association back to the K8s workload it came from,
cannot be reclaimed by any automated CSI flow because CSI no longer knows it exists.
VI admins had no signal. There was no metric, event, or audit trail tying a stranded FCD back to the PV-deletion that caused it. Operators discovered the stranding only when datastores filled up.



**Testing done**:
Vanilla e2e pipeline results:
<br> PR 4036<br>
Ran 64 of 2361 Specs
SUCCESS! -- 64 Passed | 0 Failed | 0 Pending | 2297 Skipped | 0 Flaked

VKS e2e pipeline results:
<br> PR 4036<br>
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked

WCP e2e pipeline results:
<br> PR 4036<br>
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 1 Pending | 1079 Skipped | 0 Flaked

<img width="1315" height="200" alt="Screenshot 2026-05-13 at 1 02 59 PM" src="https://github.com/user-attachments/assets/d260d553-2920-467b-b422-29c203e74232" />


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Modifications in Syncer to report CNS about missing kubernetes PVs
```
