### PR TITLE
Prepare CSI driver manifest files to publish 3.7.1 images

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -149,7 +149,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.7.1-rc.2
+          image: registry.k8s.io/csi-vsphere/syncer:v3.7.1
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -279,7 +279,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.7.1-rc.2
+          image: registry.k8s.io/csi-vsphere/driver:v3.7.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -340,7 +340,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.7.1-rc.2
+          image: registry.k8s.io/csi-vsphere/syncer:v3.7.1
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -475,7 +475,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.7.1-rc.2
+          image: registry.k8s.io/csi-vsphere/driver:v3.7.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -622,7 +622,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: vsphere-csi-node
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.7.1-rc.2
+          image: registry.k8s.io/csi-vsphere/driver:v3.7.1
           command:
             - "csi.exe"
           args:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Prepare CSI driver manifest files to publish 3.7.1 images


**Testing done**:
Signed-off by CSI FVT

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Prepare CSI driver manifest files to publish 3.7.1 images
```
