### PR TITLE
Fix total quota validation for StatefulSets in Supervisor Cluster

### DIFF
--- a/tests/e2e/improved_csi_idempotency.go
+++ b/tests/e2e/improved_csi_idempotency.go
@@ -973,13 +973,13 @@ func extendVolumeWithServiceDown(serviceName string, namespace string, client cl
 
 		//New size is 6Gi, diskSizeInMb is 2Gi so multiplying by 3 to make the expected quota consumption value
 		quotavalidationStatus := validate_totalStoragequota(ctx, []string{newDiskSizeinMbstr},
-			totalQuotaUsedBefore, totalquotaAfterExpansion)
+			totalQuotaUsedBefore, totalquotaAfterExpansion, false)
 		gomega.Expect(quotavalidationStatus).NotTo(gomega.BeFalse())
 		quotavalidationStatus = validate_totalStoragequota(ctx, []string{newDiskSizeinMbstr},
-			storagePolicyQuotaBefore, storagepolicyquotaAfterExpansion)
+			storagePolicyQuotaBefore, storagepolicyquotaAfterExpansion, true)
 		gomega.Expect(quotavalidationStatus).NotTo(gomega.BeFalse())
 		quotavalidationStatus = validate_totalStoragequota(ctx, []string{newDiskSizeinMbstr},
-			storagePolicyUsageBefore, storagepolicyUsageAfterExpansion)
+			storagePolicyUsageBefore, storagepolicyUsageAfterExpansion, true)
 		gomega.Expect(quotavalidationStatus).NotTo(gomega.BeFalse())
 	}
 }

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -7377,7 +7377,7 @@ func getStoragePolicyUsageForSpecificResourceType(ctx context.Context, restClien
 }
 
 func validate_totalStoragequota(ctx context.Context, diskSizes []string, totalUsedQuotaBefore *resource.Quantity,
-	totalUsedQuotaAfter *resource.Quantity) bool {
+	totalUsedQuotaAfter *resource.Quantity, exactMatch bool) bool {
 	var validTotalQuota bool
 	validTotalQuota = false
 	var totalDiskStorage int64
@@ -7422,8 +7422,17 @@ func validate_totalStoragequota(ctx context.Context, diskSizes []string, totalUs
 		quotaBefore+totalDiskStorage, quotaAfter))
 	ginkgo.By(fmt.Sprintf("totalDiskStorage:  %v", totalDiskStorage))
 
-	if quotaBefore+totalDiskStorage == quotaAfter {
-		validTotalQuota = true
+	if exactMatch {
+		if quotaBefore+totalDiskStorage == quotaAfter {
+			validTotalQuota = true
+		}
+	} else {
+		if quotaAfter >= quotaBefore+totalDiskStorage {
+			validTotalQuota = true
+		}
+	}
+
+	if validTotalQuota {
 		ginkgo.By(fmt.Sprintf("quotaBefore+diskSize:  %v, quotaAfter : %v",
 			quotaBefore+totalDiskStorage, quotaAfter))
 		ginkgo.By(fmt.Sprintf("validTotalQuota on storagePolicy:  %v", validTotalQuota))
@@ -7682,11 +7691,11 @@ func validateQuotaUsageAfterResourceCreation(ctx context.Context, restConfig *re
 			storagePolicyName, namespace, resourceUsage, resourceExtensionName, islatebinding)
 
 	sp_quota_validation := validate_totalStoragequota(ctx, size, storagePolicyQuotaBefore,
-		storagePolicyQuotaAfter)
+		storagePolicyQuotaAfter, true)
 	framework.Logf("Storage-policy-Quota CR validation status :%v", sp_quota_validation)
 
 	sp_usage_validation := validate_totalStoragequota(ctx, size, storagePolicyUsageBefore,
-		storagePolicyUsageAfter)
+		storagePolicyUsageAfter, true)
 	framework.Logf("Storage-policy-usage CR validation status :%v", sp_usage_validation)
 
 	return sp_quota_validation, sp_usage_validation
@@ -8246,7 +8255,7 @@ func validateTotalQuota(ctx context.Context, restConfig *rest.Config, storagePol
 			storagePolicyName, namespace, "", "", islatebinding)
 
 	quotavalidationStatus := validate_totalStoragequota(ctx, size, totalQuotaUsedBefore,
-		totalQuotaUsedAfter)
+		totalQuotaUsedAfter, false)
 	framework.Logf("totalStoragequota validation status :%v", quotavalidationStatus)
 
 	return totalQuotaUsedAfter, quotavalidationStatus


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Added `exactMatch` flag to `validate_totalStoragequota` to allow `>=` checks
- Updated `validateTotalQuota` to use `exactMatch=false` to account for unpredictable ephemeral storage consumption by StatefulSet pods
- Updated `validateQuotaUsageAfterResourceCreation` to use `exactMatch=true` for strict PVC quota validation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Due to pod storage poliy quota, the total quota is shown more

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
