### PR TITLE
Add volume type annotation for supervisor volumes

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -416,6 +416,65 @@ const (
 	// and is used to specify the `CnsBackingType` during volume attachment.
 	AnnKeyBackingDiskType = "cns.vmware.com.protected/disk-backing"
 
+	// AnnPrefixVKSWorkloadType is the common prefix for all PVC annotations
+	// that classify a supervisor PVC according to its consumer workload type.
+	// Annotations under this prefix are managed by supervisor full-sync (see
+	// annotateSupervisorPVCsWithWorkloadType in pkg/syncer/fullsync.go) and
+	// must not be hand-edited — full-sync re-reconciles them every cycle.
+	//
+	// The classification is encoded as boolean tags rather than a single
+	// enumerated value because a PVC can in principle satisfy more than one
+	// signal (e.g., a guest-cluster Pod volume that also gained a VM owner
+	// reference). Boolean tags let the syncer record both signals without
+	// information loss; consumers can OR / AND them as needed.
+	AnnPrefixVKSWorkloadType = "csi.vsphere.volume.type/"
+
+	// AnnKeyVKSNode is set to "true" on a supervisor PVC when at least one
+	// of its OwnerReferences has Kind == "VirtualMachine" or "VSphereMachine".
+	// This identifies PVCs backing VKS guest-cluster Node disks (the node VM
+	// is the volume's owner; deletion of the node VM cascades to the PVC).
+	AnnKeyVKSNode = AnnPrefixVKSWorkloadType + "vks-node"
+
+	// AnnKeyVKSWorkload is set to "true" on a supervisor PVC when one of its
+	// labels carries the "<guest-cluster-name>/TKGService" marker. This
+	// identifies PVCs created on the supervisor on behalf of a workload Pod
+	// running inside a VKS (TKGService) guest cluster. Such PVCs do not have
+	// a VM owner reference; their lifetime is tied to the guest-cluster PVC,
+	// not to any particular Node VM.
+	AnnKeyVKSWorkload = AnnPrefixVKSWorkloadType + "vks-workload"
+
+	// AnnKeySupervisorWorkload is set to "true" on a supervisor PVC that
+	// matches neither AnnKeyVKSNode nor AnnKeyVKSWorkload — i.e., the PVC
+	// was created directly on the supervisor cluster (by a Pod VM, by an
+	// admin, by a third-party operator, etc.) rather than by a VKS guest
+	// cluster. The annotation is set explicitly rather than implied by
+	// absence so that "annotation missing" reliably means "fullsync has not
+	// yet evaluated this PVC" rather than "this is a supervisor workload".
+	AnnKeySupervisorWorkload = AnnPrefixVKSWorkloadType + "supervisor-workload"
+
+	// AnnValueTrue is the canonical value used for the boolean
+	// csi.vsphere.volume.type/* annotations.
+	AnnValueTrue = "true"
+
+	// OwnerKindVirtualMachine is the Kind value used in OwnerReferences for
+	// VM Operator (vmoperator.vmware.com) VirtualMachine objects. VKS node
+	// VMs are managed by VM Operator and use this Kind.
+	OwnerKindVirtualMachine = "VirtualMachine"
+
+	// OwnerKindVSphereMachine is the Kind value used in OwnerReferences for
+	// Cluster API VSphere provider (infrastructure.cluster.x-k8s.io)
+	// VSphereMachine objects. Some VKS configurations expose CAPV machines
+	// as the owner instead of (or in addition to) the VM Operator VM.
+	OwnerKindVSphereMachine = "VSphereMachine"
+
+	// TKGServiceLabelMarker is the substring matched inside PVC label keys
+	// to identify VKS guest-cluster (TKGService) Pod volumes. The fully
+	// qualified label key has the form "<guest-cluster-name>/TKGService"
+	// (the prefix encodes the guest-cluster identifier). This is the same
+	// marker already used elsewhere in the syncer to locate the guest
+	// cluster name (see RemoveCNSFinalizerFromPVCIfTKGClusterDeleted).
+	TKGServiceLabelMarker = "TKGService"
+
 	// PvcUIDLabelKey is a label which gets added to CnsNodeVMAttachment instances
 	// to indicate the PVC that it has attached.
 	PvcUIDLabelKey = "cns.vmware.com/pvc-uid"
@@ -523,6 +582,15 @@ const (
 	// SupportsPerNamespaceNetworkProviders is a WCP capability indicating that network provider
 	// is resolved per namespace (NetworkSettings CR) rather than from the global wcp-network-config.
 	SupportsPerNamespaceNetworkProviders = "supports_per_namespace_network_providers"
+
+	// SupervisorPVCWorkloadTypeAnnotation is the FSS that gates
+	// annotateSupervisorPVCsWithWorkloadType (see pkg/syncer/fullsync.go).
+	// When enabled, supervisor full-sync iterates every PVC in every
+	// namespace each cycle and reconciles the csi.vsphere.volume.type/*
+	// classification annotations onto them. The flag exists so the
+	// roll-out can be staged per cluster and so individual environments
+	// can disable the additional API traffic if needed.
+	SupervisorPVCWorkloadTypeAnnotation = "supervisor-pvc-workload-type-annotation"
 )
 
 var WCPFeatureStates = map[string]struct{}{

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -126,6 +126,19 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 		}
 	}
 
+	// On Supervisor cluster, if SupervisorPVCWorkloadTypeAnnotation FSS is enabled,
+	// classify every PVC according to the consumer workload-type signals
+	// (VKS Node VM ownerRef, VKS guest cluster TKGService label, or none)
+	// and reconcile the matching csi.vsphere.volume.type/* annotations. The
+	// annotations are advisory metadata for VI admins, operators, and other
+	// tooling that needs to distinguish VKS-attributable PVCs from purely
+	// supervisor-side ones; they have no functional effect on CSI provisioning.
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.SupervisorPVCWorkloadTypeAnnotation) {
+			annotateSupervisorPVCsWithWorkloadType(ctx, metadataSyncer)
+		}
+	}
+
 	defer func() {
 		fullSyncStatus := prometheus.PrometheusPassStatus
 		if err != nil {
@@ -1854,6 +1867,189 @@ func RemoveCNSFinalizerFromSnapIfTKGClusterDeleted(ctx context.Context, snapshot
 			}
 		}
 	}
+}
+
+// classifySupervisorPVC examines the labels and ownerReferences of a
+// supervisor PVC and returns the set of csi.vsphere.volume.type/* annotation
+// keys that should be present on it. All returned keys map to AnnValueTrue;
+// the value is the same for every category so callers only need the keys.
+//
+// Classification rules (boolean tags, not mutually exclusive):
+//
+//   - AnnKeyVKSNode is included if any OwnerReference has
+//     Kind == OwnerKindVirtualMachine or Kind == OwnerKindVSphereMachine.
+//     This signals that the PVC is consumed as a Node-VM disk in a VKS
+//     guest cluster (lifetime tied to a specific Node VM).
+//
+//   - AnnKeyVKSWorkload is included if any label key contains
+//     TKGServiceLabelMarker. VKS guest-cluster Pod PVCs carry a label of
+//     the form "<gc-name>/TKGService" — the presence of that marker is
+//     authoritative even when the rest of the key has been redacted.
+//
+//   - AnnKeySupervisorWorkload is included only when neither of the above
+//     applies. The annotation is set explicitly rather than implied by
+//     absence so that "no csi.vsphere.volume.type/* annotation at all"
+//     reliably means "fullsync has not yet evaluated this PVC".
+//
+// A PVC that satisfies both Node and Workload signals (rare but possible
+// if, for example, a guest-cluster Pod volume gains a VM owner reference
+// through an out-of-band edit) is double-tagged with vks-node AND
+// vks-workload but is NOT tagged supervisor-workload.
+func classifySupervisorPVC(pvc *v1.PersistentVolumeClaim) map[string]string {
+	desired := make(map[string]string, 2)
+
+	hasVKSNode := false
+	for _, owner := range pvc.OwnerReferences {
+		if owner.Kind == common.OwnerKindVirtualMachine ||
+			owner.Kind == common.OwnerKindVSphereMachine {
+			hasVKSNode = true
+			break
+		}
+	}
+
+	hasVKSWorkload := false
+	for key := range pvc.Labels {
+		if strings.Contains(key, common.TKGServiceLabelMarker) {
+			hasVKSWorkload = true
+			break
+		}
+	}
+
+	if hasVKSNode {
+		desired[common.AnnKeyVKSNode] = common.AnnValueTrue
+	}
+	if hasVKSWorkload {
+		desired[common.AnnKeyVKSWorkload] = common.AnnValueTrue
+	}
+	if !hasVKSNode && !hasVKSWorkload {
+		desired[common.AnnKeySupervisorWorkload] = common.AnnValueTrue
+	}
+	return desired
+}
+
+// reconcilePVCWorkloadTypeAnnotations returns a Strategic-Merge-Patch byte
+// payload that, when applied to pvc, adds every annotation in desired and
+// removes every csi.vsphere.volume.type/* annotation that is NOT in desired.
+// Annotations outside the AnnPrefixVKSWorkloadType namespace are left
+// untouched. Returns (nil, false, nil) if no change is needed; the caller
+// can then skip the API patch entirely.
+//
+// The patch is built via strategic-merge so that:
+//   - other PVC fields (Spec, Status, other annotations) are never touched,
+//   - stale tags are explicitly deleted via the JSON "null" value (the SMP
+//     convention for removing a map entry).
+func reconcilePVCWorkloadTypeAnnotations(pvc *v1.PersistentVolumeClaim,
+	desired map[string]string) ([]byte, bool, error) {
+	annotationsPatch := map[string]interface{}{}
+
+	// 1) Add or update the desired tags.
+	for key, val := range desired {
+		if existing, ok := pvc.Annotations[key]; !ok || existing != val {
+			annotationsPatch[key] = val
+		}
+	}
+
+	// 2) Remove any pre-existing csi.vsphere.volume.type/* tag that is not
+	//    in the desired set. In Strategic Merge Patch, setting a map key
+	//    to JSON null deletes that key.
+	for key := range pvc.Annotations {
+		if !strings.HasPrefix(key, common.AnnPrefixVKSWorkloadType) {
+			continue
+		}
+		if _, keep := desired[key]; !keep {
+			annotationsPatch[key] = nil
+		}
+	}
+
+	if len(annotationsPatch) == 0 {
+		return nil, false, nil
+	}
+
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotationsPatch,
+		},
+	}
+	body, err := json.Marshal(patch)
+	if err != nil {
+		return nil, false, err
+	}
+	return body, true, nil
+}
+
+// annotateSupervisorPVCsWithWorkloadType iterates over every PVC in every
+// supervisor namespace and reconciles the csi.vsphere.volume.type/*
+// annotations that classify the PVC's consumer workload type (VKS Node VM,
+// VKS guest-cluster Pod, or supervisor-side workload). See classifySupervisorPVC
+// for the rule set.
+//
+// PVCs being deleted (DeletionTimestamp set) are skipped — there is no
+// value in updating a tombstone and doing so can race with the deletion
+// flow. Errors are logged per-PVC but do NOT abort the loop: classification
+// is idempotent and the next full-sync cycle will reattempt.
+//
+// This helper is gated behind the SupervisorPVCWorkloadTypeAnnotation FSS
+// and only runs in CnsClusterFlavorWorkload (supervisor) deployments.
+func annotateSupervisorPVCsWithWorkloadType(ctx context.Context,
+	metadataSyncer *metadataSyncInformer) {
+	log := logger.GetLogger(ctx)
+	log.Infof("annotateSupervisorPVCsWithWorkloadType: start")
+	startTime := time.Now()
+
+	k8sClient, err := k8s.NewClient(ctx)
+	if err != nil {
+		log.Errorf("annotateSupervisorPVCsWithWorkloadType: failed to get kubernetes client. Err: %v", err)
+		return
+	}
+
+	// Use the informer cache rather than a fresh API list — supervisors with
+	// thousands of namespaces would otherwise pay a multi-second round-trip
+	// on every full-sync cycle.
+	pvcs, err := metadataSyncer.pvcLister.PersistentVolumeClaims(v1.NamespaceAll).List(labels.Everything())
+	if err != nil {
+		log.Errorf("annotateSupervisorPVCsWithWorkloadType: failed to list supervisor PVCs. Err: %v", err)
+		return
+	}
+
+	var patched, skipped, failed int
+	for _, pvc := range pvcs {
+		if pvc.ObjectMeta.DeletionTimestamp != nil {
+			skipped++
+			continue
+		}
+		desired := classifySupervisorPVC(pvc)
+		patchBytes, needsPatch, err := reconcilePVCWorkloadTypeAnnotations(pvc, desired)
+		if err != nil {
+			log.Errorf("annotateSupervisorPVCsWithWorkloadType: failed to build patch for PVC %s/%s. Err: %v",
+				pvc.Namespace, pvc.Name, err)
+			failed++
+			continue
+		}
+		if !needsPatch {
+			skipped++
+			continue
+		}
+		_, err = k8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Patch(ctx,
+			pvc.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+		if err != nil {
+			// IsNotFound: the PVC was deleted between List and Patch. Treat
+			// as transient — the next full-sync cycle will re-evaluate the
+			// rest of the cluster.
+			if apierrors.IsNotFound(err) {
+				skipped++
+				continue
+			}
+			log.Warnf("annotateSupervisorPVCsWithWorkloadType: failed to patch PVC %s/%s. Err: %v",
+				pvc.Namespace, pvc.Name, err)
+			failed++
+			continue
+		}
+		log.Infof("annotateSupervisorPVCsWithWorkloadType: reconciled workload-type annotations on PVC %s/%s",
+			pvc.Namespace, pvc.Name)
+		patched++
+	}
+	log.Infof("annotateSupervisorPVCsWithWorkloadType: end. total=%d patched=%d skipped=%d failed=%d elapsed=%s",
+		len(pvcs), patched, skipped, failed, time.Since(startTime))
 }
 
 // cleanupUnusedPVCsAndSnapshotsFromGuestCluster iterates over all PVCs and VolumeSnapshots and

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -1541,3 +1541,209 @@ func TestSetChangeIDAnnotationOnSupervisorSnapshots(t *testing.T) {
 	setChangeIDAnnotationOnSupervisorSnapshots(ctx, mockMetadataSyncer, "test-vc")
 	// If we get here without panicking, test passes
 }
+
+// makePVCForClassification is a small builder for the
+// TestClassifySupervisorPVC table tests.
+func makePVCForClassification(labels map[string]string,
+	ownerKinds []string) *v1.PersistentVolumeClaim {
+	owners := make([]metav1.OwnerReference, 0, len(ownerKinds))
+	for _, k := range ownerKinds {
+		owners = append(owners, metav1.OwnerReference{Kind: k, Name: "owner-" + k})
+	}
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-pvc",
+			Namespace:       "test-ns",
+			Labels:          labels,
+			OwnerReferences: owners,
+		},
+	}
+}
+
+// TestClassifySupervisorPVC verifies the rule table for
+// classifySupervisorPVC: VirtualMachine / VSphereMachine ownerRefs imply
+// vks-node, a TKGService marker in any label key implies vks-workload,
+// and the absence of both implies supervisor-workload. The classification
+// is boolean-tag-based — vks-node and vks-workload can co-occur, but
+// supervisor-workload is mutually exclusive with both.
+func TestClassifySupervisorPVC(t *testing.T) {
+	tests := []struct {
+		name      string
+		labels    map[string]string
+		owners    []string
+		wantKeys  []string
+		notWanted []string
+	}{
+		{
+			name:      "vks node via VirtualMachine ownerRef",
+			owners:    []string{"VirtualMachine"},
+			wantKeys:  []string{common.AnnKeyVKSNode},
+			notWanted: []string{common.AnnKeyVKSWorkload, common.AnnKeySupervisorWorkload},
+		},
+		{
+			name:      "vks node via VSphereMachine ownerRef",
+			owners:    []string{"VSphereMachine"},
+			wantKeys:  []string{common.AnnKeyVKSNode},
+			notWanted: []string{common.AnnKeyVKSWorkload, common.AnnKeySupervisorWorkload},
+		},
+		{
+			name:      "vks workload via TKGService label",
+			labels:    map[string]string{"my-tkc/TKGService": "abc123"},
+			wantKeys:  []string{common.AnnKeyVKSWorkload},
+			notWanted: []string{common.AnnKeyVKSNode, common.AnnKeySupervisorWorkload},
+		},
+		{
+			name: "vks workload via TKGService marker anywhere in key",
+			// The current syncer uses strings.Contains(key, "TKGService")
+			// rather than a prefix/suffix match — we intentionally preserve
+			// that semantics so prior PVCs with non-standard label keys
+			// stay matched.
+			labels:    map[string]string{"random/key.with.TKGService.embedded": "x"},
+			wantKeys:  []string{common.AnnKeyVKSWorkload},
+			notWanted: []string{common.AnnKeyVKSNode, common.AnnKeySupervisorWorkload},
+		},
+		{
+			name:      "no signals -> supervisor-workload",
+			wantKeys:  []string{common.AnnKeySupervisorWorkload},
+			notWanted: []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload},
+		},
+		{
+			name:      "both signals -> double-tagged, supervisor-workload NOT set",
+			labels:    map[string]string{"my-tkc/TKGService": "abc123"},
+			owners:    []string{"VirtualMachine"},
+			wantKeys:  []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload},
+			notWanted: []string{common.AnnKeySupervisorWorkload},
+		},
+		{
+			name:      "unrelated owner kind is ignored",
+			owners:    []string{"StatefulSet"},
+			wantKeys:  []string{common.AnnKeySupervisorWorkload},
+			notWanted: []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pvc := makePVCForClassification(tt.labels, tt.owners)
+			got := classifySupervisorPVC(pvc)
+			for _, k := range tt.wantKeys {
+				v, ok := got[k]
+				assert.True(t, ok, "missing expected key %s in classification (got=%v)", k, got)
+				assert.Equal(t, common.AnnValueTrue, v, "expected value %q for key %s", common.AnnValueTrue, k)
+			}
+			for _, k := range tt.notWanted {
+				_, ok := got[k]
+				assert.False(t, ok, "unexpected key %s in classification (got=%v)", k, got)
+			}
+		})
+	}
+}
+
+// TestReconcilePVCWorkloadTypeAnnotations exercises the diff-and-patch
+// path: it should emit a Strategic Merge Patch that adds the desired
+// annotations, removes stale csi.vsphere.volume.type/* annotations, leaves
+// other annotations untouched, and returns no-patch-needed when the PVC
+// already matches the desired set.
+func TestReconcilePVCWorkloadTypeAnnotations(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingAnn    map[string]string
+		desired        map[string]string
+		wantNeedsPatch bool
+		// substrings the generated patch JSON must contain (for additions)
+		mustContain []string
+		// substrings the generated patch JSON must contain at value=null
+		// (for deletions of stale tags)
+		mustContainDeletion []string
+		// substrings the generated patch JSON must NOT contain (e.g.,
+		// annotations outside the AnnPrefixVKSWorkloadType namespace
+		// must never be mentioned)
+		mustNotContain []string
+	}{
+		{
+			name:           "fresh PVC, no annotations, gets vks-node",
+			existingAnn:    nil,
+			desired:        map[string]string{common.AnnKeyVKSNode: common.AnnValueTrue},
+			wantNeedsPatch: true,
+			mustContain:    []string{common.AnnKeyVKSNode, common.AnnValueTrue},
+		},
+		{
+			name: "already-correct annotations -> no patch",
+			existingAnn: map[string]string{
+				common.AnnKeyVKSWorkload: common.AnnValueTrue,
+			},
+			desired:        map[string]string{common.AnnKeyVKSWorkload: common.AnnValueTrue},
+			wantNeedsPatch: false,
+		},
+		{
+			name: "stale tag must be deleted (set to null) when classification changes",
+			existingAnn: map[string]string{
+				common.AnnKeySupervisorWorkload: common.AnnValueTrue,
+			},
+			desired:             map[string]string{common.AnnKeyVKSNode: common.AnnValueTrue},
+			wantNeedsPatch:      true,
+			mustContain:         []string{common.AnnKeyVKSNode},
+			mustContainDeletion: []string{common.AnnKeySupervisorWorkload},
+		},
+		{
+			name: "unrelated annotation outside the namespace must not appear in patch",
+			existingAnn: map[string]string{
+				"csi.vsphere.volume/fast-provisioning": "true",
+				"some.other.namespace/label":           "value",
+			},
+			desired:        map[string]string{common.AnnKeyVKSNode: common.AnnValueTrue},
+			wantNeedsPatch: true,
+			mustContain:    []string{common.AnnKeyVKSNode},
+			mustNotContain: []string{
+				"csi.vsphere.volume/fast-provisioning",
+				"some.other.namespace/label",
+			},
+		},
+		{
+			name: "double-tag transition: vks-node already set, add vks-workload",
+			existingAnn: map[string]string{
+				common.AnnKeyVKSNode: common.AnnValueTrue,
+			},
+			desired: map[string]string{
+				common.AnnKeyVKSNode:     common.AnnValueTrue,
+				common.AnnKeyVKSWorkload: common.AnnValueTrue,
+			},
+			wantNeedsPatch: true,
+			mustContain:    []string{common.AnnKeyVKSWorkload},
+			// vks-node is already correct, so it must NOT be in the patch
+			// — strategic merge would no-op on it but the smaller payload
+			// is the correct shape.
+			mustNotContain: []string{`"` + common.AnnKeyVKSNode + `":"true"`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "pvc",
+					Namespace:   "ns",
+					Annotations: tt.existingAnn,
+				},
+			}
+			patchBytes, needsPatch, err := reconcilePVCWorkloadTypeAnnotations(pvc, tt.desired)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantNeedsPatch, needsPatch, "needsPatch mismatch")
+			if !tt.wantNeedsPatch {
+				assert.Nil(t, patchBytes)
+				return
+			}
+			body := string(patchBytes)
+			for _, s := range tt.mustContain {
+				assert.Contains(t, body, s, "patch must contain %q\npatch=%s", s, body)
+			}
+			for _, s := range tt.mustContainDeletion {
+				// SMP deletes a map key by setting it to JSON null.
+				assert.Contains(t, body, `"`+s+`":null`,
+					"stale tag %q must be set to null for deletion\npatch=%s", s, body)
+			}
+			for _, s := range tt.mustNotContain {
+				assert.NotContains(t, body, s,
+					"patch must NOT contain %q\npatch=%s", s, body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Annotate supervisor PVCs with consumer-workload type during full-sync
What
Adds a new supervisor full-sync pass that classifies every supervisor PVC by its consumer workload and stamps a small set of boolean annotations under csi.vsphere.volume.type/*. The classification is derived purely from PVC metadata (OwnerReferences + Labels) and is reconciled idempotently every full-sync cycle.

Today a supervisor namespace hosts PVCs from three very different consumers — VKS Node VMs, VKS workload Pods, and the supervisor itself — and there is no first-class way for a Tenant Admin to tell them apart. They have to read OwnerReferences, decode label keys, or cross-reference guest-cluster manifests, which is fragile and not friendly to dashboards or quotas.

With these annotations:

One label-selector → the right view. kubectl get pvc -A -l-equivalent (via field selectors / annotation filters) and the VCFA UI can finally render a "type" column without bespoke parsing.
Capacity reporting per workload class. Tenant Admins can answer "how much storage is used by guest-cluster nodes vs. their workloads vs. supervisor-side Pods?" — directly from PVC metadata, without joining against VM Operator or Cluster API objects.
Quota and policy decisions. Storage quota dashboards, chargeback exports, and admission policies (e.g., "no Retain reclaim policy on Node-VM PVCs") can key off a stable, documented annotation instead of inferring intent from internal CRDs.
Lifecycle troubleshooting. When a VKS guest cluster is deleted or stuck, operators can immediately enumerate the affected supervisor PVCs (vks-node + vks-workload) and isolate them from supervisor-native ones (supervisor-workload).
Stable contract for tooling. The csi.vsphere.volume.type/ namespace is owned by the syncer; FSS-gated rollout means the annotation appears once enabled and stays consistent across upgrades, giving VCFA UI / API a contract it can rely on.
The change is metadata-only, has no effect on provisioning or attach paths, and is reconciled on every full-sync cycle so newly created PVCs are tagged within one interval and reclassifications (e.g., a PV regaining a VM owner) are picked up automatically.

Sample screenshot about how VCFA would show the volume type:
(See workload column below)
<img width="775" height="591" alt="Screenshot 2026-05-21 at 3 42 09 PM" src="https://github.com/user-attachments/assets/b289052f-06bb-42a2-b43d-43c3af4a59d6" />

**Testing done**:
```
VKS Node Volume:

kubectl get pvc -n test-gc-e2e-demo-ns   e928a136-82dc-432b-9504-c6ff88129e8e-c00c6d65-7ffe-47d5-bf39-c4773bd12e55 -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com/usedby-vm-9f9f754e-c899-4e1a-97f6-21f019e9869c: ""
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume-requested-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-workload: "true".  <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Wed May 20 23:19:08 UTC
        2026
    creationTimestamp: "2026-05-20T23:17:03Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    labels:
      test-cluster-e2e-script/TKGService: e928a136-82dc-432b-9504-c6ff88129e8e
    name: e928a136-82dc-432b-9504-c6ff88129e8e-c00c6d65-7ffe-47d5-bf39-c4773bd12e55
    namespace: test-gc-e2e-demo-ns
    resourceVersion: "10419483"
    uid: 1699e21c-63e8-436e-a1ba-6ec9d14b7fe1
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 2Gi
    storageClassName: gc-storage-profile
    volumeMode: Filesystem
    volumeName: pvc-1699e21c-63e8-436e-a1ba-6ec9d14b7fe1
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 2Gi
    phase: Bound


Supervisor Workload Volumes(PodVM/VM Service vm)
kubectl get pvc -n test-gc-e2e-demo-ns   www-web-0 -o yaml
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/supervisor-workload: "true".  <<<<<<<<<<<<<<<<<
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: lvn-dvm-10-192-50-91.dvm.lvn.broadcom.net
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Wed May 20 23:35:09 UTC
        2026
    creationTimestamp: "2026-05-20T23:33:48Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      app: nginx
    name: www-web-0
    namespace: test-gc-e2e-demo-ns
    resourceVersion: "10419515"
    uid: af6621cb-3f40-4a3d-8f94-9058eebf826f
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 2Gi
    storageClassName: gc-storage-profile-latebinding
    volumeMode: Filesystem
    volumeName: pvc-af6621cb-3f40-4a3d-8f94-9058eebf826f
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 2Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add volume type annotation for supervisor volumes
```
