### PR TITLE
Manifests: register improved-volume-visibility FSS (supervisor 1.32–1.35, guest 1.34–1.36)

### DIFF
--- a/manifests/guestcluster/1.34/pvcsi.yaml
+++ b/manifests/guestcluster/1.34/pvcsi.yaml
@@ -745,6 +745,7 @@ data:
   "linked-clone-support": "true"
   "vsan-file-volume-service-support": "false"
   "CSI_Backup_API": "false"
+  "improved-volume-visibility": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.35/pvcsi.yaml
+++ b/manifests/guestcluster/1.35/pvcsi.yaml
@@ -746,6 +746,7 @@ data:
   "linked-clone-support": "true"
   "vsan-file-volume-service-support": "false"
   "CSI_Backup_API": "false"
+  "improved-volume-visibility": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.36/pvcsi.yaml
+++ b/manifests/guestcluster/1.36/pvcsi.yaml
@@ -746,6 +746,7 @@ data:
   "linked-clone-support": "true"
   "vsan-file-volume-service-support": "false"
   "CSI_Backup_API": "false"
+  "improved-volume-visibility": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -617,6 +617,7 @@ data:
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
   "high-pv-node-density": "false" # When enabled, increases the MAX_VOLUMES_PER_NODE from 59 to 255 for guest cluster nodes
+  "improved-volume-visibility": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -628,6 +628,7 @@ data:
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
   "high-pv-node-density": "false" # When enabled, increases the MAX_VOLUMES_PER_NODE from 59 to 255 for guest cluster nodes
+  "improved-volume-visibility": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -628,6 +628,7 @@ data:
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
   "high-pv-node-density": "false" # When enabled, increases the MAX_VOLUMES_PER_NODE from 59 to 255 for guest cluster nodes
+  "improved-volume-visibility": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -628,6 +628,7 @@ data:
   "workload-domain-isolation": "false"
   "sv-pvc-snapshot-protection-finalizer": "true"
   "high-pv-node-density": "false" # When enabled, increases the MAX_VOLUMES_PER_NODE from 59 to 255 for guest cluster nodes
+  "improved-volume-visibility": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds the improved-volume-visibility feature-state-switch key to the csi-feature-states ConfigMap in the four most recent supervisor manifests and to the internal-feature-states.csi.vsphere.vmware.com ConfigMap in the three most recent guest-cluster manifests. The key is defaulted to "false" everywhere, so this change is manifest-only and dormant on rollout — no behavior change until an operator flips it per cluster.



**Testing done**:
N/A


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Manifests: register improved-volume-visibility FSS (supervisor 1.32–1.35, guest 1.34–1.36)
```
