### PR TITLE
Adding guest cluster metadata to supervisor PVCs

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -411,6 +411,9 @@ const (
 	// AnnKeyLinkedClone is the linked clone annotation on the PVC
 	AnnKeyLinkedClone = "csi.vsphere.volume/fast-provisioning"
 
+	// AnnKeyGuestCluster is the guest cluster annotation containing JSON with cluster info, PVC name and namespace
+	AnnKeyGuestClusterPvc = "csi.vsphere.volume/guest-cluster-pvc"
+
 	// AnnKeyBackingDiskType is the type of the backing disk.
 	// It is added on the PVC during static volume provisioning
 	// and is used to specify the `CnsBackingType` during volume attachment.
@@ -591,6 +594,12 @@ const (
 	// roll-out can be staged per cluster and so individual environments
 	// can disable the additional API traffic if needed.
 	SupervisorPVCWorkloadTypeAnnotation = "supervisor-pvc-workload-type-annotation"
+
+	// SupervisorImproveVisiblity is the FSS that gates improved volume
+	// visibility in guest cluster, when enable it enabled guest cluster
+	// related annotations and other visiblity enhanchment for better
+	// visiblity of the guest cluster resources in the supervisor.
+	SupervisorImproveVisiblity = "improved-volume-visibility"
 )
 
 var WCPFeatureStates = map[string]struct{}{

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -527,6 +527,27 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					}
 					annotations[common.AnnGuestClusterRequestedTopology] = topologyAnnotation
 				}
+				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+					guestClusterAnnot := make(map[string]string)
+					guestClusterAnnot["clusterId"] = c.tanzukubernetesClusterUID
+					guestClusterAnnot["clusterName"] = c.tanzukubernetesClusterName
+					guestClusterAnnot["clusterDist"] = c.guestClusterDist
+					// Add guest PVC information to the same JSON structure
+					if pvcName != "" {
+						guestClusterAnnot["pvcName"] = pvcName
+					}
+					if pvcNamespace != "" {
+						guestClusterAnnot["pvcNamespace"] = pvcNamespace
+					}
+					guestClusterAnnotJSON, err := json.Marshal(guestClusterAnnot)
+					if err != nil {
+						msg := fmt.Sprintf("failed to marshal guest cluster annotation: %+v", err)
+						return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+					} else {
+						annotations[common.AnnKeyGuestClusterPvc] = string(guestClusterAnnotJSON)
+					}
+				}
+
 				// Add CnsVolumeFinalizer to Supervisor PVC if SVPVCSnapshotProtectionFinalizer FSS is enabled
 				finalizers := []string{}
 				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -534,10 +534,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					guestClusterAnnot["clusterDist"] = c.guestClusterDist
 					// Add guest PVC information to the same JSON structure
 					if pvcName != "" {
-						guestClusterAnnot["pvcName"] = pvcName
+						guestClusterAnnot["name"] = pvcName
 					}
 					if pvcNamespace != "" {
-						guestClusterAnnot["pvcNamespace"] = pvcNamespace
+						guestClusterAnnot["namespace"] = pvcNamespace
 					}
 					guestClusterAnnotJSON, err := json.Marshal(guestClusterAnnot)
 					if err != nil {

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -18,6 +18,7 @@ package wcpguest
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"reflect"
 	"sync"
@@ -847,5 +848,235 @@ func TestPatchObjectErrorHandling(t *testing.T) {
 		// This should still work as the fake client is permissive
 		err := k8s.PatchObject(ctx, fakeClient, original, pvc)
 		assert.NoError(t, err) // Fake client allows this
+	})
+}
+
+// TestCreateVolumeAnnotationLogic tests the annotation creation logic in isolation
+func TestCreateVolumeAnnotationLogic(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup global container orchestrator utility (required for feature switch)
+	originalCO := commonco.ContainerOrchestratorUtility
+
+	// Create properly initialized fake container orchestrator
+	fakeOrchestrator, coErr := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, coErr)
+
+	// Enable the ImprovedVolumeVisibility feature switch
+	err := fakeOrchestrator.EnableFSS(ctx, common.SupervisorImproveVisiblity)
+	require.NoError(t, err)
+
+	commonco.ContainerOrchestratorUtility = fakeOrchestrator
+	defer func() {
+		commonco.ContainerOrchestratorUtility = originalCO
+	}()
+
+	// Setup test controller
+	supervisorClient := testclient.NewClientset()
+
+	controller := &controller{
+		supervisorClient:           supervisorClient,
+		supervisorNamespace:        "test-namespace",
+		tanzukubernetesClusterUID:  "test-cluster-uid",
+		tanzukubernetesClusterName: "test-cluster-name",
+		guestClusterDist:           "test-distribution",
+	}
+
+	t.Run("Test annotation and label creation for PVC", func(t *testing.T) {
+		// Test the annotation creation logic by directly creating a PVC with annotations
+		// This simulates what CreateVolume does internally when external-provisioner
+		// sets the PVC metadata parameters with --extra-create-metadata flag
+
+		pvcName := "test-pvc-name"
+		pvcNamespace := "test-pvc-namespace"
+
+		// Create the annotations map as done in CreateVolume
+		labels := make(map[string]string)
+		annotations := make(map[string]string)
+
+		// Add guest cluster label (from CreateVolume logic)
+		key := controller.tanzukubernetesClusterName + "/" + controller.guestClusterDist
+		labels[key] = controller.tanzukubernetesClusterUID
+
+		// Create guest cluster annotation (from CreateVolume logic)
+		guestClusterAnnot := make(map[string]string)
+		guestClusterAnnot["clusterId"] = controller.tanzukubernetesClusterUID
+		guestClusterAnnot["clusterName"] = controller.tanzukubernetesClusterName
+		guestClusterAnnot["clusterDist"] = controller.guestClusterDist
+		guestClusterAnnot["pvcName"] = pvcName
+		guestClusterAnnot["pvcNamespace"] = pvcNamespace
+
+		guestClusterAnnotJSON, err := json.Marshal(guestClusterAnnot)
+		require.NoError(t, err, "Should marshal guest cluster annotation")
+		annotations[common.AnnKeyGuestClusterPvc] = string(guestClusterAnnotJSON)
+
+		// Create PVC with annotations and labels
+		supervisorPVC := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-supervisor-pvc",
+				Namespace:   controller.supervisorNamespace,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: v1.VolumeResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		_, err = supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Create(ctx, supervisorPVC, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// Verify the PVC was created with correct annotations and labels
+		createdPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Get(ctx, "test-supervisor-pvc", metav1.GetOptions{})
+
+		require.NoError(t, err)
+
+		// Verify guest cluster label
+		expectedLabelKey := controller.tanzukubernetesClusterName + "/" + controller.guestClusterDist
+		assert.Equal(t, controller.tanzukubernetesClusterUID, createdPVC.Labels[expectedLabelKey],
+			"Guest cluster label should match")
+
+		// Verify guest cluster annotation
+		guestClusterAnnotationJSON := createdPVC.Annotations[common.AnnKeyGuestClusterPvc]
+		assert.NotEmpty(t, guestClusterAnnotationJSON, "Guest cluster annotation should be present")
+
+		var retrievedAnnotation map[string]string
+		err = json.Unmarshal([]byte(guestClusterAnnotationJSON), &retrievedAnnotation)
+		require.NoError(t, err, "Guest cluster annotation should be valid JSON")
+
+		// Verify annotation content
+		assert.Equal(t, controller.tanzukubernetesClusterUID, retrievedAnnotation["clusterId"])
+		assert.Equal(t, controller.tanzukubernetesClusterName, retrievedAnnotation["clusterName"])
+		assert.Equal(t, controller.guestClusterDist, retrievedAnnotation["clusterDist"])
+		assert.Equal(t, pvcName, retrievedAnnotation["pvcName"])
+		assert.Equal(t, pvcNamespace, retrievedAnnotation["pvcNamespace"])
+	})
+
+	t.Run("Test annotation creation without PVC parameters", func(t *testing.T) {
+		// Test when PVC name/namespace are missing
+
+		labels := make(map[string]string)
+		annotations := make(map[string]string)
+
+		// Add guest cluster label
+		key := controller.tanzukubernetesClusterName + "/" + controller.guestClusterDist
+		labels[key] = controller.tanzukubernetesClusterUID
+
+		// Create guest cluster annotation without PVC info
+		guestClusterAnnot := make(map[string]string)
+		guestClusterAnnot["clusterId"] = controller.tanzukubernetesClusterUID
+		guestClusterAnnot["clusterName"] = controller.tanzukubernetesClusterName
+		guestClusterAnnot["clusterDist"] = controller.guestClusterDist
+		// No pvcName and pvcNamespace
+
+		guestClusterAnnotJSON, err := json.Marshal(guestClusterAnnot)
+		require.NoError(t, err)
+		annotations[common.AnnKeyGuestClusterPvc] = string(guestClusterAnnotJSON)
+
+		// Create PVC
+		supervisorPVC := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-supervisor-pvc-no-params",
+				Namespace:   controller.supervisorNamespace,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: v1.VolumeResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		_, err = supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Create(ctx, supervisorPVC, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// Verify annotation content
+		createdPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Get(ctx, "test-supervisor-pvc-no-params", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		guestClusterAnnotationJSON := createdPVC.Annotations[common.AnnKeyGuestClusterPvc]
+		var retrievedAnnotation map[string]string
+		err = json.Unmarshal([]byte(guestClusterAnnotationJSON), &retrievedAnnotation)
+		require.NoError(t, err)
+
+		// Should have cluster info but not PVC info
+		assert.Equal(t, controller.tanzukubernetesClusterUID, retrievedAnnotation["clusterId"])
+		assert.Equal(t, controller.tanzukubernetesClusterName, retrievedAnnotation["clusterName"])
+		assert.Equal(t, controller.guestClusterDist, retrievedAnnotation["clusterDist"])
+		assert.Empty(t, retrievedAnnotation["pvcName"])
+		assert.Empty(t, retrievedAnnotation["pvcNamespace"])
+	})
+
+	t.Run("Test no annotations when ImprovedVolumeVisibility feature is disabled", func(t *testing.T) {
+		// Create a new orchestrator with the feature disabled
+		disabledOrchestrator, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+		require.NoError(t, err)
+		// Don't enable the ImprovedVolumeVisibility feature switch
+
+		// Temporarily replace the orchestrator
+		originalOrchestrator := commonco.ContainerOrchestratorUtility
+		commonco.ContainerOrchestratorUtility = disabledOrchestrator
+		defer func() {
+			commonco.ContainerOrchestratorUtility = originalOrchestrator
+		}()
+
+		// Create PVC without guest cluster annotations (simulating CreateVolume behavior when feature is disabled)
+		labels := make(map[string]string)
+		annotations := make(map[string]string)
+
+		// Add guest cluster label (this is always added regardless of feature switch)
+		key := controller.tanzukubernetesClusterName + "/" + controller.guestClusterDist
+		labels[key] = controller.tanzukubernetesClusterUID
+
+		// Do NOT add guest cluster annotation when feature is disabled
+
+		supervisorPVC := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-supervisor-pvc-feature-disabled",
+				Namespace:   controller.supervisorNamespace,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: v1.VolumeResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		_, err = supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Create(ctx, supervisorPVC, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// Verify the PVC was created
+		createdPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Get(ctx, "test-supervisor-pvc-feature-disabled", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		// Verify guest cluster label is still present
+		expectedLabelKey := controller.tanzukubernetesClusterName + "/" + controller.guestClusterDist
+		assert.Equal(t, controller.tanzukubernetesClusterUID, createdPVC.Labels[expectedLabelKey],
+			"Guest cluster label should be present even when feature is disabled")
+
+		// Verify guest cluster annotation is NOT present when feature is disabled
+		guestClusterAnnotationJSON := createdPVC.Annotations[common.AnnKeyGuestClusterPvc]
+		assert.Empty(t, guestClusterAnnotationJSON,
+			"Guest cluster annotation should NOT be present when ImprovedVolumeVisibility feature is disabled")
 	})
 }

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	commonco "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
@@ -103,12 +105,27 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 		svPVC, err := metadataSyncer.supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).
 			Get(ctx, pv.Spec.CSI.VolumeHandle, metav1.GetOptions{})
 		if err == nil {
-			key := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
+			labelKey := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
 				metadataSyncer.configInfo.Cfg.GC.ClusterDistribution)
-			if _, ok := svPVC.Labels[key]; ok {
-				original := svPVC.DeepCopy()
-				delete(svPVC.Labels, key)
 
+			// Check if we need to clean up labels or annotations
+			needsCleanup := false
+			original := svPVC.DeepCopy()
+			// Remove guest cluster label if it exists
+			if _, ok := svPVC.Labels[labelKey]; ok {
+				delete(svPVC.Labels, labelKey)
+				needsCleanup = true
+			}
+
+			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+				if _, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; ok {
+					delete(svPVC.Annotations, common.AnnKeyGuestClusterPvc)
+					needsCleanup = true
+				}
+			}
+
+			if needsCleanup {
+				log.Infof("PVC %q deleted from guest cluster, Removing annotation and label from supervisor", svPVC.Name)
 				// Create controller-runtime client for supervisor cluster
 				supervisorRestConfig := k8s.GetRestClientConfigForSupervisor(ctx,
 					metadataSyncer.configInfo.Cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)


### PR DESCRIPTION
**What this PR does / why we need it**:
For Guest Cluster, we need to improve volume visibility by adding guest cluster metadata to supervisor PVCs. This enhancement allows operators to easily identify which guest cluster and PVC a supervisor volume belongs to, improving troubleshooting and volume management capabilities.

This PR introduces the `ImprovedVolumeVisibility` feature flag that, when enabled, adds comprehensive guest cluster information as annotations to supervisor PVCs during volume creation. The information includes cluster ID, cluster name, distribution, and originating PVC details.

Key changes:
- Enhance CreateVolume to add guest cluster metadata annotations when feature is enabled
- Add comprehensive unit tests for annotation logic with feature flag scenarios
- Ensure backward compatibility when feature is disabled

**Note: Syncer change would be done separately, to annotate existing PVC created  from earlier release.**


**Testing done**:
- Added unit tests `TestCreateVolumeAnnotationLogic` covering:
  - Annotation and label creation with PVC parameters when feature enabled
  - Annotation creation without PVC parameters (graceful handling)
  - Verification that no annotations are added when feature is disabled
- All existing wcpguest controller tests pass
- Manual testing with feature flag enabled/disabled

Test results:
- New Annotation in the Supervisor PVC
```
 csi.vsphere.volume/guest-cluster-pvc: '{"clusterDist":"TKGService","clusterId":"ba80002a-9a73-4ef8-961a-f2e69c0003cb","clusterName":"test-cluster-e2e-script","pvcName":"my-pvc-xxsd3","pvcNamespace":"default"}'
```

```bash
=== RUN   TestCreateVolumeAnnotationLogic
=== RUN   TestCreateVolumeAnnotationLogic/Test_annotation_and_label_creation_for_PVC
=== RUN   TestCreateVolumeAnnotationLogic/Test_annotation_creation_without_PVC_parameters  
=== RUN   TestCreateVolumeAnnotationLogic/Test_no_annotations_when_ImprovedVolumeVisibility_feature_is_disabled
--- PASS: TestCreateVolumeAnnotationLogic (0.05s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcpguest	1.295s