### PR TITLE
Fix VM Operator PersistentVolumeClaim scheme registration error

### DIFF
--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -29,6 +29,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -78,7 +80,15 @@ func getGlobalScheme(ctx context.Context) *runtime.Scheme {
 		log.Info("Initializing global scheme for CNS Operator")
 		globalScheme = runtime.NewScheme()
 
-		// Add all schemes sequentially to avoid race conditions
+		// Add core Kubernetes types first (required for PVC and other core resources)
+		if err := corev1.AddToScheme(globalScheme); err != nil {
+			log.Errorf("failed to add corev1 to global scheme: %+v", err)
+		}
+		if err := storagev1.AddToScheme(globalScheme); err != nil {
+			log.Errorf("failed to add storagev1 to global scheme: %+v", err)
+		}
+
+		// Add all other schemes sequentially to avoid race conditions
 		if err := cnsoperatorv1alpha1.AddToScheme(globalScheme); err != nil {
 			log.Errorf("failed to add cnsoperatorv1alpha1 to global scheme: %+v", err)
 		}

--- a/pkg/syncer/cnsoperator/manager/init_test.go
+++ b/pkg/syncer/cnsoperator/manager/init_test.go
@@ -33,6 +33,10 @@ import (
 // the scheme confirms each underlying AddToScheme ran successfully without
 // pulling every API package into this test (which would bloat the test binary).
 var expectedRegisteredKinds = []schema.GroupVersionKind{
+	// corev1
+	{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
+	// storagev1
+	{Group: "storage.k8s.io", Version: "v1", Kind: "StorageClass"},
 	// cnsoperatorv1alpha1
 	{Group: "cns.vmware.com", Version: "v1alpha1", Kind: "CnsVolumeMetadata"},
 	// csinodetopologyv1alpha1


### PR DESCRIPTION
Resolves the runtime error "no kind is registered for the type v1.PersistentVolumeClaim in scheme pkg/runtime/scheme.go:111" that occurs when VM Operator controllers try to work with PVC objects but the core Kubernetes types aren't registered in the runtime scheme.

Changes:
- Add corev1.AddToScheme() to register core Kubernetes types including PersistentVolumeClaim
- Add storagev1.AddToScheme() to register storage types including StorageClass
- Update scheme initialization to register core types before custom types
- Add corresponding test expectations for PVC and StorageClass in init_test.go
- Maintain thread-safe initialization using sync.Once pattern

This fix ensures VM Operator can properly deserialize/serialize PVC objects when processing virtual machine volume attachments, preventing failures during pod startup and disk promotion operations.

Root cause: The global scheme was only registering custom API types but missing the fundamental Kubernetes core and storage API types that VM Operator needs when interacting with PersistentVolumeClaim resources.

Bug Number: https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3708996

Testing Done: Triggered failed workload(passing with this change) as well as precheckins for wcp

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1177/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1544/
