### PR TITLE
Fix VM Operator PersistentVolumeClaim scheme registration error

### DIFF
--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -25,15 +25,16 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
 	cnsoperatorconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/config"
@@ -76,9 +77,14 @@ func getGlobalScheme(ctx context.Context) *runtime.Scheme {
 	log := logger.GetLogger(ctx)
 	schemeOnce.Do(func() {
 		log.Info("Initializing global scheme for CNS Operator")
-		globalScheme = runtime.NewScheme()
 
-		// Add all schemes sequentially to avoid race conditions
+		// Start with the complete client-go scheme that includes all core Kubernetes types
+		globalScheme = runtime.NewScheme()
+		if err := clientgoscheme.AddToScheme(globalScheme); err != nil {
+			log.Errorf("failed to add clientgoscheme to global scheme: %+v", err)
+		}
+
+		// Add all other schemes sequentially to avoid race conditions
 		if err := cnsoperatorv1alpha1.AddToScheme(globalScheme); err != nil {
 			log.Errorf("failed to add cnsoperatorv1alpha1 to global scheme: %+v", err)
 		}

--- a/pkg/syncer/cnsoperator/manager/init_test.go
+++ b/pkg/syncer/cnsoperator/manager/init_test.go
@@ -33,6 +33,9 @@ import (
 // the scheme confirms each underlying AddToScheme ran successfully without
 // pulling every API package into this test (which would bloat the test binary).
 var expectedRegisteredKinds = []schema.GroupVersionKind{
+	// clientgoscheme includes core Kubernetes types
+	{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
+	{Group: "storage.k8s.io", Version: "v1", Kind: "StorageClass"},
 	// cnsoperatorv1alpha1
 	{Group: "cns.vmware.com", Version: "v1alpha1", Kind: "CnsVolumeMetadata"},
 	// csinodetopologyv1alpha1
@@ -41,8 +44,9 @@ var expectedRegisteredKinds = []schema.GroupVersionKind{
 	{Group: "cns.vmware.com", Version: "v1alpha1", Kind: "CnsFileVolumeClient"},
 	// wcpcapapis
 	{Group: "iaas.vmware.com", Version: "v1alpha1", Kind: "Capabilities"},
-	// vmoperatortypes (vm-operator v1alpha5)
+	// vmoperatortypes (vm-operator v1alpha5) - includes both VirtualMachine and VirtualMachineSnapshot
 	{Group: "vmoperator.vmware.com", Version: "v1alpha5", Kind: "VirtualMachine"},
+	{Group: "vmoperator.vmware.com", Version: "v1alpha5", Kind: "VirtualMachineSnapshot"},
 }
 
 // resetGlobalScheme resets the package-level globalScheme / schemeOnce so each


### PR DESCRIPTION
Resolves the runtime error "no kind is registered for the type v1.PersistentVolumeClaim in scheme pkg/runtime/scheme.go:111" that occurs when VM Operator controllers try to work with PVC objects but the core Kubernetes types aren't registered in the runtime scheme.

Changes:
- Use clientgoscheme.AddToScheme() to establish complete core Kubernetes type coverage
- Update scheme initialization to register core types before custom types
- Add corresponding test expectations for PVC and StorageClass in init_test.go
- Maintain thread-safe initialization using sync.Once pattern

This fix ensures VM Operator can properly deserialize/serialize PVC objects when processing virtual machine volume attachments, preventing failures during pod startup and disk promotion operations.

Root cause: The global scheme was only registering custom API types but missing the fundamental Kubernetes core and storage API types that VM Operator needs when interacting with PersistentVolumeClaim resources.

Bug Number: https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3708996

Testing Done: Triggered failed workload(passing with this change) as well as precheckins for wcp
With latest commit
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1185/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1556/