### PR TITLE
Always bind K8sCloudOperatorService to localhost

### DIFF
--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -84,7 +84,7 @@ func InitK8sCloudOperatorService(ctx context.Context) error {
 	k8sCloudOperatorServicePort := common.GetK8sCloudOperatorServicePort(ctx)
 	log.Debugf("K8s Cloud Operator Service will be running on port %d", k8sCloudOperatorServicePort)
 	port := flag.Int("port", k8sCloudOperatorServicePort, "The k8s cloud operator service port")
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
+	lis, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", *port))
 	if err != nil {
 		log.Errorf("failed to listen. Err: %v", err)
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The vsphere-csi-driver syncer exposes a gRPC K8sCloudOperator service on port 29000 (all interfaces) with no authentication or TLS. The service provides four RPCs that execute with the syncer's cluster-admin ServiceAccount, enabling unauthenticated callers on the node network to read Node annotations cross-namespace, enumerate all PVCs cluster-wide, and patch PVC annotations in arbitrary namespaces.

This fix ensures that the port 29000 is open only on local host.

**Testing done**:
WCP precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1555/
VKS precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1211/
