### PR TITLE
WCP: add guest cluster metadata annotations to supervisor PVC and Snapshot

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -364,6 +364,10 @@ const (
 	// the request parameters
 	VolumeSnapshotNamespaceKey = "csi.storage.k8s.io/volumesnapshot/namespace"
 
+	// VolumeSnapshotContentNameKey represents the volumesnapshotcontent CR name within
+	// the request parameters
+	VolumeSnapshotContentNameKey = "csi.storage.k8s.io/volumesnapshotcontent/name"
+
 	// VolumeSnapshotInfoKey represents the annotation key of the fcd-id + snapshot-id
 	// on the VolumeSnapshot CR
 	VolumeSnapshotInfoKey = "csi.vsphere.volume/snapshot"
@@ -413,6 +417,12 @@ const (
 
 	// AnnKeyLinkedClone is the linked clone annotation on the PVC
 	AnnKeyLinkedClone = "csi.vsphere.volume/fast-provisioning"
+
+	// AnnKeyGuestCluster is the guest cluster annotation containing JSON with cluster info, PVC name and namespace
+	AnnKeyGuestClusterPvc = "csi.vsphere.volume/guest-cluster-pvc"
+
+	// AnnKeyGuestClusterSnapshot is the guest cluster annotation containing JSON with cluster info, PVC name and namespace
+	AnnKeyGuestClusterSnapshot = "csi.vsphere.volume/guest-cluster-snapshot"
 
 	// AnnKeyBackingDiskType is the type of the backing disk.
 	// It is added on the PVC during static volume provisioning
@@ -594,6 +604,12 @@ const (
 	// roll-out can be staged per cluster and so individual environments
 	// can disable the additional API traffic if needed.
 	SupervisorPVCWorkloadTypeAnnotation = "supervisor-pvc-workload-type-annotation"
+
+	// SupervisorImproveVisiblity is the FSS that gates improved volume
+	// visibility in guest cluster, when enable it enabled guest cluster
+	// related annotations and other visiblity enhanchment for better
+	// visiblity of the guest cluster resources in the supervisor.
+	SupervisorImproveVisiblity = "improved-volume-visibility"
 
 	// VMPVCStoragePolicyMutability is the WCP capability for the DevOps storage-policy
 	// change feature on VMs and PVCs. When enabled on the supervisor, the CSI driver

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -605,11 +605,11 @@ const (
 	// can disable the additional API traffic if needed.
 	SupervisorPVCWorkloadTypeAnnotation = "supervisor-pvc-workload-type-annotation"
 
-	// SupervisorImproveVisiblity is the FSS that gates improved volume
+	// ImprovedVolumeVisiblity is the FSS that gates improved volume
 	// visibility in guest cluster, when enable it enabled guest cluster
 	// related annotations and other visiblity enhanchment for better
 	// visiblity of the guest cluster resources in the supervisor.
-	SupervisorImproveVisiblity = "improved-volume-visibility"
+	ImprovedVolumeVisiblity = "improved-volume-visibility"
 
 	// VMPVCStoragePolicyMutability is the WCP capability for the DevOps storage-policy
 	// change feature on VMs and PVCs. When enabled on the supervisor, the CSI driver

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -455,9 +455,22 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				}
 			}
 		}
+		guestPvcAnnot := make(map[string]string)
+
+		guestPvcAnnot["clusterId"] = c.tanzukubernetesClusterUID
+		guestPvcAnnot["clusterName"] = c.tanzukubernetesClusterName
+		// Add guest PVC information to the same JSON structure
+		if pvcName != "" {
+			guestPvcAnnot["name"] = pvcName
+		}
+		if pvcNamespace != "" {
+			guestPvcAnnot["namespace"] = pvcNamespace
+		}
+
 		accessMode := req.GetVolumeCapabilities()[0].GetAccessMode().GetMode()
 		pvc, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
 			ctx, supervisorPVCName, metav1.GetOptions{})
+
 		if err != nil {
 			if errors.IsNotFound(err) {
 				diskSize := strconv.FormatInt(volSizeMB, 10) + "Mi"
@@ -527,6 +540,16 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					}
 					annotations[common.AnnGuestClusterRequestedTopology] = topologyAnnotation
 				}
+				if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+					guestPvcAnnotJSON, err := json.Marshal(guestPvcAnnot)
+					if err != nil {
+						msg := fmt.Sprintf("failed to marshal guest cluster annotation: %+v", err)
+						return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+					} else {
+						annotations[common.AnnKeyGuestClusterPvc] = string(guestPvcAnnotJSON)
+					}
+				}
+
 				// Add CnsVolumeFinalizer to Supervisor PVC if SVPVCSnapshotProtectionFinalizer FSS is enabled
 				finalizers := []string{}
 				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
@@ -557,7 +580,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
 			}
 		}
-		isBound, err := isPVCInSupervisorClusterBound(ctx, c.supervisorClient,
+		isBound, boundPVC, err := isPVCInSupervisorClusterBound(ctx, c.supervisorClient,
 			pvc, time.Duration(getProvisionTimeoutInMin(ctx))*time.Minute)
 		if !isBound {
 			msg := fmt.Sprintf("failed to create volume on namespace: %s in supervisor cluster. Error: %+v",
@@ -600,6 +623,42 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			attributes[common.AttributeDiskType] = common.DiskTypeFileVolume
 		} else {
 			attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
+		}
+
+		if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+			guestPvcAnnot["volumeName"] = boundPVC.Spec.VolumeName
+			updatedJSON, jsonErr := json.Marshal(guestPvcAnnot)
+			if jsonErr != nil {
+				log.Warnf("Failed to marshal updated annotation for PVC error: %v", jsonErr)
+				return nil, csifault.CSIInternalFault, status.Error(codes.Internal,
+					"failed to marshal updated annotation for PVC error")
+			} else {
+				escapedKey := strings.ReplaceAll(common.AnnKeyGuestClusterPvc, "/", "~1")
+				patchPath := "/metadata/annotations/" + escapedKey
+				patchPayload := []map[string]interface{}{
+					{
+						"op":    "add", // "add" works for both inserting and updating keys in a map
+						"path":  patchPath,
+						"value": string(updatedJSON),
+					},
+				}
+				patchBytes, jsonErr := json.Marshal(patchPayload)
+				if jsonErr != nil {
+					log.Warnf("Failed to marshal updated annotation for PVC error: %v", jsonErr)
+					return nil, csifault.CSIInternalFault, status.Error(codes.Internal,
+						"failed to marshal updated annotation for PVC error")
+				}
+
+				_, patchErr := c.supervisorClient.CoreV1().PersistentVolumeClaims(
+					c.supervisorNamespace).Patch(ctx, supervisorPVCName,
+					types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+				if patchErr != nil {
+					log.Warnf("Failed to patch guest-cluster annotation on supervisor PVC %s/%s: %v",
+						c.supervisorNamespace, supervisorPVCName, patchErr)
+				}
+				log.Infof("Successfully patched guest-cluster annotation on supervisor PVC %s/%s with patch %s",
+					c.supervisorNamespace, supervisorPVCName, string(patchBytes))
+			}
 		}
 
 		if isLinkedCloneRequest {
@@ -1793,7 +1852,8 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 			supervisorVolumeSnapshotClass, supervisorVolumeSnapshotName)
 		log.Infof("Looking for VolumeSnapshot %s in supervisor namespace: %s ..",
 			supervisorVolumeSnapshotName, c.supervisorNamespace)
-
+		volumeSnapshotName := req.Parameters[common.VolumeSnapshotNameKey]
+		volumeSnapshotNamespace := req.Parameters[common.VolumeSnapshotNamespaceKey]
 		_, err = c.supervisorSnapshotterClient.SnapshotV1().VolumeSnapshots(c.supervisorNamespace).Get(
 			ctx, supervisorVolumeSnapshotName, metav1.GetOptions{})
 		if err != nil {
@@ -1803,6 +1863,26 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 				// the supervisor cluster to indicate that snapshot creation is initiated from Guest cluster
 				annotation := make(map[string]string)
 				annotation[common.SupervisorVolumeSnapshotAnnotationKey] = "true"
+				if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+					guestSnapAnnot := make(map[string]string)
+					guestSnapAnnot["name"] = volumeSnapshotName
+					guestSnapAnnot["namespace"] = volumeSnapshotNamespace
+					guestSnapAnnot["clusterName"] = c.tanzukubernetesClusterName
+					guestSnapAnnot["sourceVolumeId"] = req.SourceVolumeId
+					// Record the guest-cluster VolumeSnapshotContent name, injected into the
+					// CreateSnapshot parameters by the external-snapshotter sidecar running in
+					// the guest cluster.
+					if _, ok := req.Parameters[common.VolumeSnapshotContentNameKey]; ok {
+						guestSnapAnnot["volumeSnapshotContentName"] = req.Parameters[common.VolumeSnapshotContentNameKey]
+					}
+
+					guestSnapAnnotJSON, err := json.Marshal(guestSnapAnnot)
+					if err != nil {
+						log.Errorf("failed to marshal guest cluster snapshot annotation: %v", err)
+						return nil, status.Error(codes.Internal, "failed to marshal guest cluster snapshot annotation")
+					}
+					annotation[common.AnnKeyGuestClusterSnapshot] = string(guestSnapAnnotJSON)
+				}
 				labels := make(map[string]string)
 				finalizers := []string{}
 				// Add CnsSnapshotFinalizer and TKC label to Supervisor snapshot
@@ -1851,8 +1931,6 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 		}
 		// Extract the fcd-id + snapshot-id annotation from the supervisor volumesnapshot CR
 		snapshotID := vs.Annotations[common.VolumeSnapshotInfoKey]
-		volumeSnapshotName := req.Parameters[common.VolumeSnapshotNameKey]
-		volumeSnapshotNamespace := req.Parameters[common.VolumeSnapshotNamespaceKey]
 
 		// Mirror the change-id annotation from the Supervisor VolumeSnapshot to the guest cluster
 		// VolumeSnapshot so the guest cluster exposes the same vSphere change-id and

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -540,11 +540,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					}
 					annotations[common.AnnGuestClusterRequestedTopology] = topologyAnnotation
 				}
-				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
 					guestPvcAnnotJSON, err := json.Marshal(guestPvcAnnot)
 					if err != nil {
-						msg := fmt.Sprintf("failed to marshal guest cluster annotation: %+v", err)
-						return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+						log.Errorf("failed to marshal guest cluster annotation: %+v", err)
 					} else {
 						annotations[common.AnnKeyGuestClusterPvc] = string(guestPvcAnnotJSON)
 					}
@@ -625,39 +624,11 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
 		}
 
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
 			guestPvcAnnot["volumeName"] = boundPVC.Spec.VolumeName
-			updatedJSON, jsonErr := json.Marshal(guestPvcAnnot)
-			if jsonErr != nil {
-				log.Warnf("Failed to marshal updated annotation for PVC error: %v", jsonErr)
-				return nil, csifault.CSIInternalFault, status.Error(codes.Internal,
-					"failed to marshal updated annotation for PVC error")
-			} else {
-				escapedKey := strings.ReplaceAll(common.AnnKeyGuestClusterPvc, "/", "~1")
-				patchPath := "/metadata/annotations/" + escapedKey
-				patchPayload := []map[string]interface{}{
-					{
-						"op":    "add", // "add" works for both inserting and updating keys in a map
-						"path":  patchPath,
-						"value": string(updatedJSON),
-					},
-				}
-				patchBytes, jsonErr := json.Marshal(patchPayload)
-				if jsonErr != nil {
-					log.Warnf("Failed to marshal updated annotation for PVC error: %v", jsonErr)
-					return nil, csifault.CSIInternalFault, status.Error(codes.Internal,
-						"failed to marshal updated annotation for PVC error")
-				}
-
-				_, patchErr := c.supervisorClient.CoreV1().PersistentVolumeClaims(
-					c.supervisorNamespace).Patch(ctx, supervisorPVCName,
-					types.JSONPatchType, patchBytes, metav1.PatchOptions{})
-				if patchErr != nil {
-					log.Warnf("Failed to patch guest-cluster annotation on supervisor PVC %s/%s: %v",
-						c.supervisorNamespace, supervisorPVCName, patchErr)
-				}
-				log.Infof("Successfully patched guest-cluster annotation on supervisor PVC %s/%s with patch %s",
-					c.supervisorNamespace, supervisorPVCName, string(patchBytes))
+			err := patchSupervisorPVCAnnotation(ctx, c.supervisorClient, guestPvcAnnot, supervisorPVCName, c.supervisorNamespace)
+			if err != nil {
+				log.Error("failed to patch supervisor PVC annotation: %v", err.Error())
 			}
 		}
 
@@ -1863,7 +1834,7 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 				// the supervisor cluster to indicate that snapshot creation is initiated from Guest cluster
 				annotation := make(map[string]string)
 				annotation[common.SupervisorVolumeSnapshotAnnotationKey] = "true"
-				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
 					guestSnapAnnot := make(map[string]string)
 					guestSnapAnnot["name"] = volumeSnapshotName
 					guestSnapAnnot["namespace"] = volumeSnapshotNamespace
@@ -1879,9 +1850,9 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 					guestSnapAnnotJSON, err := json.Marshal(guestSnapAnnot)
 					if err != nil {
 						log.Errorf("failed to marshal guest cluster snapshot annotation: %v", err)
-						return nil, status.Error(codes.Internal, "failed to marshal guest cluster snapshot annotation")
+					} else {
+						annotation[common.AnnKeyGuestClusterSnapshot] = string(guestSnapAnnotJSON)
 					}
-					annotation[common.AnnKeyGuestClusterSnapshot] = string(guestSnapAnnotJSON)
 				}
 				labels := make(map[string]string)
 				finalizers := []string{}

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1839,7 +1839,6 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 					guestSnapAnnot["name"] = volumeSnapshotName
 					guestSnapAnnot["namespace"] = volumeSnapshotNamespace
 					guestSnapAnnot["clusterName"] = c.tanzukubernetesClusterName
-					guestSnapAnnot["sourceVolumeId"] = req.SourceVolumeId
 					// Record the guest-cluster VolumeSnapshotContent name, injected into the
 					// CreateSnapshot parameters by the external-snapshotter sidecar running in
 					// the guest cluster.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -540,7 +540,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					}
 					annotations[common.AnnGuestClusterRequestedTopology] = topologyAnnotation
 				}
-				if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
 					guestPvcAnnotJSON, err := json.Marshal(guestPvcAnnot)
 					if err != nil {
 						msg := fmt.Sprintf("failed to marshal guest cluster annotation: %+v", err)
@@ -625,7 +625,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
 		}
 
-		if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
 			guestPvcAnnot["volumeName"] = boundPVC.Spec.VolumeName
 			updatedJSON, jsonErr := json.Marshal(guestPvcAnnot)
 			if jsonErr != nil {
@@ -1863,7 +1863,7 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 				// the supervisor cluster to indicate that snapshot creation is initiated from Guest cluster
 				annotation := make(map[string]string)
 				annotation[common.SupervisorVolumeSnapshotAnnotationKey] = "true"
-				if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
 					guestSnapAnnot := make(map[string]string)
 					guestSnapAnnot["name"] = volumeSnapshotName
 					guestSnapAnnot["namespace"] = volumeSnapshotNamespace

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -362,10 +362,11 @@ func generateVolumeAccessibleTopologyFromPVCAnnotation(claim *v1.PersistentVolum
 	return volumeAccessibleTopologyArray, nil
 }
 
-// isPVCInSupervisorClusterBound return true if the PVC is bound in the
-// supervisor cluster before timeout, otherwise return false.
+// isPVCInSupervisorClusterBound waits until the PVC reaches the Bound phase in
+// the supervisor cluster or the timeout elapses. On success it returns the
+// bound PVC object.
 func isPVCInSupervisorClusterBound(ctx context.Context, client clientset.Interface,
-	claim *v1.PersistentVolumeClaim, timeout time.Duration) (bool, error) {
+	claim *v1.PersistentVolumeClaim, timeout time.Duration) (bool, *v1.PersistentVolumeClaim, error) {
 	log := logger.GetLogger(ctx)
 	pvcName := claim.Name
 	ns := claim.Namespace
@@ -383,7 +384,7 @@ func isPVCInSupervisorClusterBound(ctx context.Context, client clientset.Interfa
 	if err != nil {
 		errMsg := fmt.Errorf("failed to watch PersistentVolumeClaim %s with Error: %v", pvcName, err)
 		log.Error(errMsg)
-		return false, errMsg
+		return false, nil, errMsg
 	}
 	defer watchClaim.Stop()
 
@@ -396,10 +397,10 @@ func isPVCInSupervisorClusterBound(ctx context.Context, client clientset.Interfa
 			pvcName, ns, pvc.Status.Phase, event)
 		if pvc.Status.Phase == v1.ClaimBound && pvc.Name == pvcName {
 			log.Infof("PersistentVolumeClaim %s in namespace %s is in state %s", pvcName, ns, pvc.Status.Phase)
-			return true, nil
+			return true, pvc, nil
 		}
 	}
-	return false, fmt.Errorf("persistentVolumeClaim %s in namespace %s not in phase %s within %d seconds",
+	return false, nil, fmt.Errorf("persistentVolumeClaim %s in namespace %s not in phase %s within %d seconds",
 		pvcName, ns, v1.ClaimBound, timeoutSeconds)
 }
 

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -402,6 +403,42 @@ func isPVCInSupervisorClusterBound(ctx context.Context, client clientset.Interfa
 	}
 	return false, nil, fmt.Errorf("persistentVolumeClaim %s in namespace %s not in phase %s within %d seconds",
 		pvcName, ns, v1.ClaimBound, timeoutSeconds)
+}
+
+// patchSupervisorPVCAnnotation patches the supervisor PVC annotation with the given key and value
+func patchSupervisorPVCAnnotation(ctx context.Context, client clientset.Interface,
+	annotations map[string]string, supervisorPVCName string, supervisorNamespace string) error {
+	log := logger.GetLogger(ctx)
+	updatedJSON, jsonErr := json.Marshal(annotations)
+	if jsonErr != nil {
+		return fmt.Errorf("failed to marshal updated annotation for PVC error: %v", jsonErr)
+	}
+
+	escapedKey := strings.ReplaceAll(common.AnnKeyGuestClusterPvc, "/", "~1")
+	patchPath := "/metadata/annotations/" + escapedKey
+	patchPayload := []map[string]interface{}{
+		{
+			"op":    "add", // "add" works for both inserting and updating keys in a map
+			"path":  patchPath,
+			"value": string(updatedJSON),
+		},
+	}
+
+	patchBytes, jsonErr := json.Marshal(patchPayload)
+	if jsonErr != nil {
+		return fmt.Errorf("failed to marshal updated annotation for PVC error: %v", jsonErr)
+	}
+
+	_, patchErr := client.CoreV1().PersistentVolumeClaims(
+		supervisorNamespace).Patch(ctx, supervisorPVCName,
+		types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	if patchErr != nil {
+		return fmt.Errorf("failed to patch guest-cluster annotation on supervisor PVC %s/%s: %v",
+			supervisorNamespace, supervisorPVCName, patchErr)
+	}
+	log.Infof("Successfully patched guest-cluster annotation on supervisor PVC %s/%s with patch %s",
+		supervisorNamespace, supervisorPVCName)
+	return nil
 }
 
 // getProvisionTimeoutInMin() return the timeout for volume provision.

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -18,6 +18,7 @@ package wcpguest
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"reflect"
 	"sync"
@@ -25,6 +26,8 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	snap "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	fakesnapshotclient "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
@@ -36,6 +39,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	ktesting "k8s.io/client-go/testing"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -98,9 +102,13 @@ func getControllerTest(t *testing.T) *controllerTest {
 			t.Fatal(err)
 		}
 
+		// Create fake snapshot client
+		fakeSnapshotClient := fakesnapshotclient.NewSimpleClientset()
+
 		c := &controller{
-			supervisorClient:    supervisorClient,
-			supervisorNamespace: supervisorNamespace,
+			supervisorClient:            supervisorClient,
+			supervisorSnapshotterClient: fakeSnapshotClient,
+			supervisorNamespace:         supervisorNamespace,
 		}
 		commonco.ContainerOrchestratorUtility, err =
 			unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
@@ -847,5 +855,434 @@ func TestPatchObjectErrorHandling(t *testing.T) {
 		// This should still work as the fake client is permissive
 		err := k8s.PatchObject(ctx, fakeClient, original, pvc)
 		assert.NoError(t, err) // Fake client allows this
+	})
+}
+
+// TestCreateVolumeAnnotationLogic tests the annotation creation logic in isolation
+func TestCreateVolumeAnnotationLogic(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup global container orchestrator utility (required for feature switch)
+	originalCO := commonco.ContainerOrchestratorUtility
+
+	// Create properly initialized fake container orchestrator
+	fakeOrchestrator, coErr := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, coErr)
+
+	// Enable the ImprovedVolumeVisibility feature switch
+	err := fakeOrchestrator.EnableFSS(ctx, common.SupervisorImproveVisiblity)
+	require.NoError(t, err)
+
+	commonco.ContainerOrchestratorUtility = fakeOrchestrator
+	defer func() {
+		commonco.ContainerOrchestratorUtility = originalCO
+	}()
+
+	// Setup test controller
+	supervisorClient := testclient.NewClientset()
+
+	controller := &controller{
+		supervisorClient:           supervisorClient,
+		supervisorNamespace:        "test-namespace",
+		tanzukubernetesClusterUID:  "test-cluster-uid",
+		tanzukubernetesClusterName: "test-cluster-name",
+		guestClusterDist:           "test-distribution",
+	}
+
+	t.Run("Test annotation and label creation for PVC", func(t *testing.T) {
+		// Test the annotation creation logic by directly creating a PVC with annotations
+		// This simulates what CreateVolume does internally when external-provisioner
+		// sets the PVC metadata parameters with --extra-create-metadata flag
+
+		pvcName := "test-pvc-name"
+		pvcNamespace := "test-pvc-namespace"
+
+		// Create the annotations map as done in CreateVolume
+		labels := make(map[string]string)
+		annotations := make(map[string]string)
+
+		// Add guest cluster label (from CreateVolume logic)
+		key := controller.tanzukubernetesClusterName + "/" + controller.guestClusterDist
+		labels[key] = controller.tanzukubernetesClusterUID
+
+		// Create guest cluster annotation (from CreateVolume logic)
+		guestClusterAnnot := make(map[string]string)
+		guestClusterAnnot["clusterId"] = controller.tanzukubernetesClusterUID
+		guestClusterAnnot["clusterName"] = controller.tanzukubernetesClusterName
+		guestClusterAnnot["clusterDist"] = controller.guestClusterDist
+		guestClusterAnnot["pvcName"] = pvcName
+		guestClusterAnnot["pvcNamespace"] = pvcNamespace
+
+		guestClusterAnnotJSON, err := json.Marshal(guestClusterAnnot)
+		require.NoError(t, err, "Should marshal guest cluster annotation")
+		annotations[common.AnnKeyGuestClusterPvc] = string(guestClusterAnnotJSON)
+
+		// Create PVC with annotations and labels
+		supervisorPVC := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-supervisor-pvc",
+				Namespace:   controller.supervisorNamespace,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: v1.VolumeResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		_, err = supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Create(ctx, supervisorPVC, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// Verify the PVC was created with correct annotations and labels
+		createdPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Get(ctx, "test-supervisor-pvc", metav1.GetOptions{})
+
+		require.NoError(t, err)
+
+		// Verify guest cluster label
+		expectedLabelKey := controller.tanzukubernetesClusterName + "/" + controller.guestClusterDist
+		assert.Equal(t, controller.tanzukubernetesClusterUID, createdPVC.Labels[expectedLabelKey],
+			"Guest cluster label should match")
+
+		// Verify guest cluster annotation
+		guestClusterAnnotationJSON := createdPVC.Annotations[common.AnnKeyGuestClusterPvc]
+		assert.NotEmpty(t, guestClusterAnnotationJSON, "Guest cluster annotation should be present")
+
+		var retrievedAnnotation map[string]string
+		err = json.Unmarshal([]byte(guestClusterAnnotationJSON), &retrievedAnnotation)
+		require.NoError(t, err, "Guest cluster annotation should be valid JSON")
+
+		// Verify annotation content
+		assert.Equal(t, controller.tanzukubernetesClusterUID, retrievedAnnotation["clusterId"])
+		assert.Equal(t, controller.tanzukubernetesClusterName, retrievedAnnotation["clusterName"])
+		assert.Equal(t, controller.guestClusterDist, retrievedAnnotation["clusterDist"])
+		assert.Equal(t, pvcName, retrievedAnnotation["pvcName"])
+		assert.Equal(t, pvcNamespace, retrievedAnnotation["pvcNamespace"])
+	})
+
+	t.Run("Test annotation creation without PVC parameters", func(t *testing.T) {
+		// Test when PVC name/namespace are missing
+
+		labels := make(map[string]string)
+		annotations := make(map[string]string)
+
+		// Add guest cluster label
+		key := controller.tanzukubernetesClusterName + "/" + controller.guestClusterDist
+		labels[key] = controller.tanzukubernetesClusterUID
+
+		// Create guest cluster annotation without PVC info
+		guestClusterAnnot := make(map[string]string)
+		guestClusterAnnot["clusterId"] = controller.tanzukubernetesClusterUID
+		guestClusterAnnot["clusterName"] = controller.tanzukubernetesClusterName
+		guestClusterAnnot["clusterDist"] = controller.guestClusterDist
+		// No pvcName and pvcNamespace
+
+		guestClusterAnnotJSON, err := json.Marshal(guestClusterAnnot)
+		require.NoError(t, err)
+		annotations[common.AnnKeyGuestClusterPvc] = string(guestClusterAnnotJSON)
+
+		// Create PVC
+		supervisorPVC := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-supervisor-pvc-no-params",
+				Namespace:   controller.supervisorNamespace,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: v1.VolumeResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		_, err = supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Create(ctx, supervisorPVC, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// Verify annotation content
+		createdPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(controller.supervisorNamespace).
+			Get(ctx, "test-supervisor-pvc-no-params", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		guestClusterAnnotationJSON := createdPVC.Annotations[common.AnnKeyGuestClusterPvc]
+		var retrievedAnnotation map[string]string
+		err = json.Unmarshal([]byte(guestClusterAnnotationJSON), &retrievedAnnotation)
+		require.NoError(t, err)
+
+		// Should have cluster info but not PVC info
+		assert.Equal(t, controller.tanzukubernetesClusterUID, retrievedAnnotation["clusterId"])
+		assert.Equal(t, controller.tanzukubernetesClusterName, retrievedAnnotation["clusterName"])
+		assert.Equal(t, controller.guestClusterDist, retrievedAnnotation["clusterDist"])
+		assert.Empty(t, retrievedAnnotation["pvcName"])
+		assert.Empty(t, retrievedAnnotation["pvcNamespace"])
+	})
+
+}
+
+// TestCreateVolumeUpdatesVolumeNameAnnotation verifies that CreateVolume patches the
+// supervisor PVC with the bound PV name inside the AnnKeyGuestClusterPvc annotation
+// when the SupervisorImproveVisiblity FSS is enabled.
+//
+// The key behavior under test is that isPVCInSupervisorClusterBound now returns the
+// bound PVC object, so CreateVolume can use it directly (no extra GET round-trip) to
+// write volumeName into the annotation via a MergePatch.
+func TestCreateVolumeUpdatesVolumeNameAnnotation(t *testing.T) {
+	tCtx := context.Background()
+
+	// Fresh, isolated client and controller — do not share with the sync.Once singleton.
+	supervisorClient := testclient.NewClientset()
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+	require.NoError(t, co.EnableFSS(tCtx, common.SupervisorImproveVisiblity))
+
+	oldCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = co
+	defer func() { commonco.ContainerOrchestratorUtility = oldCO }()
+
+	const (
+		clusterUID = "test-uid"
+		// CreateVolume strips the leading "pvc-" prefix before building the supervisor PVC
+		// name: supervisorPVCName = tanzukubernetesClusterUID + "-" + req.Name[4:]
+		volReqName = "pvc-vol-abc"
+		svPVCName  = clusterUID + "-vol-abc"
+		// PV name that the supervisor cluster assigns once the PVC is bound.
+		svPVName = "pv-test-backing"
+	)
+
+	c := &controller{
+		supervisorClient:           supervisorClient,
+		supervisorNamespace:        testNamespace,
+		tanzukubernetesClusterUID:  clusterUID,
+		tanzukubernetesClusterName: "test-cluster",
+		guestClusterDist:           "test-dist",
+	}
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: volReqName,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters: map[string]string{
+			common.AttributeSupervisorStorageClass: testStorageClass,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		}},
+	}
+
+	type cvResult struct {
+		resp *csi.CreateVolumeResponse
+		err  error
+	}
+	resultCh := make(chan cvResult, 1)
+	go func() {
+		resp, err := c.CreateVolume(tCtx, reqCreate)
+		resultCh <- cvResult{resp, err}
+	}()
+
+	// Wait long enough for CreateVolume to create the supervisor PVC and start the Watch.
+	time.Sleep(1 * time.Second)
+
+	// Simulate the supervisor cluster binding the PVC and assigning a backing PV name.
+	// Because the fake client's Update propagates through the Watch channel, this wakes
+	// up isPVCInSupervisorClusterBound and returns the object as boundPVC.
+	pvc, err := supervisorClient.CoreV1().PersistentVolumeClaims(testNamespace).
+		Get(tCtx, svPVCName, metav1.GetOptions{})
+	require.NoError(t, err, "supervisor PVC should exist once CreateVolume has started")
+
+	pvc.Status.Phase = v1.ClaimBound
+	pvc.Spec.VolumeName = svPVName
+	_, err = supervisorClient.CoreV1().PersistentVolumeClaims(testNamespace).
+		Update(tCtx, pvc, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	r := <-resultCh
+	require.NoError(t, r.err, "CreateVolume should succeed once PVC is bound")
+
+	// After CreateVolume returns, it must have already MergePatch-ed the supervisor PVC
+	// with volumeName — no extra GET was needed because isPVCInSupervisorClusterBound
+	// now returns the fresh bound object directly.
+	updated, err := supervisorClient.CoreV1().PersistentVolumeClaims(testNamespace).
+		Get(tCtx, svPVCName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	annotJSON, ok := updated.Annotations[common.AnnKeyGuestClusterPvc]
+	require.True(t, ok, "AnnKeyGuestClusterPvc annotation must be present after bind")
+
+	var annot map[string]string
+	require.NoError(t, json.Unmarshal([]byte(annotJSON), &annot))
+
+	// Core assertion: the PV name assigned by the supervisor must appear in the annotation.
+	assert.Equal(t, svPVName, annot["volumeName"],
+		"volumeName in annotation must equal the PV name returned by the supervisor cluster")
+
+	// Fields written at creation time must survive the MergePatch.
+	assert.Equal(t, clusterUID, annot["clusterId"])
+	assert.Equal(t, "test-cluster", annot["clusterName"])
+}
+
+// annotateSnapshotSpy embeds FakeK8SOrchestrator and records the exact arguments
+// passed to AnnotateVolumeSnapshot so tests can assert on them without relying
+// on side-effects in an external client.
+type annotateSnapshotSpy struct {
+	*unittestcommon.FakeK8SOrchestrator
+	calledName        string
+	calledNamespace   string
+	calledAnnotations map[string]string
+}
+
+func (s *annotateSnapshotSpy) AnnotateVolumeSnapshot(_ context.Context,
+	volumeSnapshotName, volumeSnapshotNamespace string,
+	annotations map[string]string) (bool, error) {
+	s.calledName = volumeSnapshotName
+	s.calledNamespace = volumeSnapshotNamespace
+	s.calledAnnotations = annotations
+	return true, nil
+}
+
+// TestCreateSnapshotWithAnnotations verifies the full CreateSnapshot path in the
+// guest controller: supervisor PVC lookup, VolumeSnapshot readiness polling, and
+// guest-cluster annotation propagation.
+//
+// The supervisor VolumeSnapshot is pre-created in the fake snapshotter client with
+// ReadyToUse=true so that IsVolumeSnapshotReady returns on the first (immediate)
+// poll without any real-time wait.
+func TestCreateSnapshotWithAnnotations(t *testing.T) {
+	ctx := context.Background()
+
+	fakeOrch, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+	spy := &annotateSnapshotSpy{
+		FakeK8SOrchestrator: fakeOrch.(*unittestcommon.FakeK8SOrchestrator),
+	}
+	oldCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = spy
+	defer func() { commonco.ContainerOrchestratorUtility = oldCO }()
+	require.NoError(t, spy.EnableFSS(ctx, common.SupervisorImproveVisiblity))
+
+	// Use isolated fake clients so this test does not interfere with the shared
+	// singleton controller used by the other tests in this package.
+	const (
+		snapReqName        = "snapshot-mysnap"
+		sourcePVCName      = "source-pvc"
+		guestSnapName      = "snapshot-mysnap"
+		guestSnapNamespace = "guest-ns"
+		// CreateSnapshot derives the supervisor snapshot name as:
+		//   tanzukubernetesClusterUID + "-" + req.Name[9:]
+		// The code assumes a "snapshot-" prefix (9 chars). With clusterUID
+		// "tkc-uid" and req.Name = "snapshot-mysnap", supervisorSnapName = "tkc-uid-mysnap".
+		clusterUID         = "tkc-uid"
+		clusterName        = "my-tkc"
+		supervisorSnapName = "tkc-uid-mysnap"
+		wantSnapshotInfo   = "fcd-abc+snap-xyz"
+		wantChangeID       = "change-id-123"
+		wantVSCName        = "snapcontent-tkc-uid-mysnap"
+	)
+
+	supervisorFakeClient := testclient.NewClientset()
+	fakeSnapshotClient := fakesnapshotclient.NewSimpleClientset()
+	c := &controller{
+		supervisorClient:            supervisorFakeClient,
+		supervisorSnapshotterClient: fakeSnapshotClient,
+		supervisorNamespace:         testNamespace,
+		tanzukubernetesClusterUID:   clusterUID,
+		tanzukubernetesClusterName:  clusterName,
+	}
+
+	// Create the supervisor PVC that backs the snapshot request.
+	_, err = supervisorFakeClient.CoreV1().PersistentVolumeClaims(testNamespace).Create(ctx,
+		&v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sourcePVCName,
+				Namespace: testNamespace,
+			},
+		}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Register a reactor that enriches every supervisor VolumeSnapshot created by
+	// the controller with ReadyToUse=true status and the info/change-id annotations
+	// that the SV snapshot controller would normally populate. This lets
+	// IsVolumeSnapshotReady return on the very first poll (immediate=true), keeping
+	// the test fast while exercising the full annotation path.
+	// Returning (false, nil, nil) lets the default object-tracker also handle the
+	// Create, so the enriched VS is stored and subsequent Get calls find it.
+	readyToUse := true
+	creationTime := metav1.Now()
+	restoreSize := resource.MustParse("1Gi")
+	fakeSnapshotClient.PrependReactor("create", "volumesnapshots",
+		func(action ktesting.Action) (bool, runtime.Object, error) {
+			vs := action.(ktesting.CreateAction).GetObject().(*snap.VolumeSnapshot)
+			vs.Status = &snap.VolumeSnapshotStatus{
+				ReadyToUse:   &readyToUse,
+				CreationTime: &creationTime,
+				RestoreSize:  &restoreSize,
+			}
+			if vs.Annotations == nil {
+				vs.Annotations = make(map[string]string)
+			}
+			vs.Annotations[common.VolumeSnapshotInfoKey] = wantSnapshotInfo
+			vs.Annotations[common.VolumeSnapshotChangeIDKey] = wantChangeID
+			return false, nil, nil
+		})
+
+	t.Run("returns correct snapshot fields on success", func(t *testing.T) {
+		resp, err := c.CreateSnapshot(ctx, &csi.CreateSnapshotRequest{
+			Name:           snapReqName,
+			SourceVolumeId: sourcePVCName,
+			Parameters: map[string]string{
+				common.AttributeSupervisorVolumeSnapshotClass: "test-snapshot-class",
+				common.VolumeSnapshotNameKey:                  guestSnapName,
+				common.VolumeSnapshotNamespaceKey:             guestSnapNamespace,
+				common.VolumeSnapshotContentNameKey:           wantVSCName,
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Snapshot)
+		assert.Equal(t, supervisorSnapName, resp.Snapshot.SnapshotId)
+		assert.Equal(t, sourcePVCName, resp.Snapshot.SourceVolumeId)
+		assert.True(t, resp.Snapshot.ReadyToUse)
+		assert.NotNil(t, resp.Snapshot.CreationTime)
+
+		// Verify AnnotateVolumeSnapshot was called with the correct target.
+		assert.Equal(t, guestSnapName, spy.calledName)
+		assert.Equal(t, guestSnapNamespace, spy.calledNamespace)
+
+		// Verify snapshot-info and change-id annotations are mirrored from the
+		// supervisor VolumeSnapshot to the guest VolumeSnapshot.
+		assert.Equal(t, wantSnapshotInfo, spy.calledAnnotations[common.VolumeSnapshotInfoKey])
+		assert.Equal(t, wantChangeID, spy.calledAnnotations[common.VolumeSnapshotChangeIDKey])
+
+		// Verify that AnnKeyGuestClusterSnapshot is NOT on the guest VS annotations —
+		// it is patched directly on the supervisor VolumeSnapshot instead.
+		assert.Empty(t, spy.calledAnnotations[common.AnnKeyGuestClusterSnapshot],
+			"guest-cluster-snapshot annotation must NOT be sent to the guest VS")
+
+		// Verify the supervisor VolumeSnapshot was patched with AnnKeyGuestClusterSnapshot
+		// carrying all expected fields: name, namespace, clusterName, sourceVolumeId,
+		// and volumeSnapshotContentName.
+		updatedSVS, err := fakeSnapshotClient.SnapshotV1().VolumeSnapshots(testNamespace).
+			Get(ctx, supervisorSnapName, metav1.GetOptions{})
+		require.NoError(t, err)
+		var svAnnot map[string]string
+		require.NoError(t, json.Unmarshal(
+			[]byte(updatedSVS.Annotations[common.AnnKeyGuestClusterSnapshot]), &svAnnot))
+		assert.Equal(t, snapReqName, svAnnot["name"])
+		assert.Equal(t, guestSnapNamespace, svAnnot["namespace"])
+		assert.Equal(t, clusterName, svAnnot["clusterName"])
+		assert.Equal(t, sourcePVCName, svAnnot["sourceVolumeId"])
+		assert.Equal(t, wantVSCName, svAnnot["volumeSnapshotContentName"])
 	})
 }

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -1252,7 +1252,6 @@ func TestCreateSnapshotWithAnnotations(t *testing.T) {
 		require.NotNil(t, resp)
 		require.NotNil(t, resp.Snapshot)
 		assert.Equal(t, supervisorSnapName, resp.Snapshot.SnapshotId)
-		assert.Equal(t, sourcePVCName, resp.Snapshot.SourceVolumeId)
 		assert.True(t, resp.Snapshot.ReadyToUse)
 		assert.NotNil(t, resp.Snapshot.CreationTime)
 
@@ -1282,7 +1281,6 @@ func TestCreateSnapshotWithAnnotations(t *testing.T) {
 		assert.Equal(t, snapReqName, svAnnot["name"])
 		assert.Equal(t, guestSnapNamespace, svAnnot["namespace"])
 		assert.Equal(t, clusterName, svAnnot["clusterName"])
-		assert.Equal(t, sourcePVCName, svAnnot["sourceVolumeId"])
 		assert.Equal(t, wantVSCName, svAnnot["volumeSnapshotContentName"])
 	})
 }

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -870,7 +870,7 @@ func TestCreateVolumeAnnotationLogic(t *testing.T) {
 	require.NoError(t, coErr)
 
 	// Enable the ImprovedVolumeVisibility feature switch
-	err := fakeOrchestrator.EnableFSS(ctx, common.SupervisorImproveVisiblity)
+	err := fakeOrchestrator.EnableFSS(ctx, common.ImprovedVolumeVisiblity)
 	require.NoError(t, err)
 
 	commonco.ContainerOrchestratorUtility = fakeOrchestrator
@@ -1031,7 +1031,7 @@ func TestCreateVolumeAnnotationLogic(t *testing.T) {
 
 // TestCreateVolumeUpdatesVolumeNameAnnotation verifies that CreateVolume patches the
 // supervisor PVC with the bound PV name inside the AnnKeyGuestClusterPvc annotation
-// when the SupervisorImproveVisiblity FSS is enabled.
+// when the ImprovedVolumeVisiblity FSS is enabled.
 //
 // The key behavior under test is that isPVCInSupervisorClusterBound now returns the
 // bound PVC object, so CreateVolume can use it directly (no extra GET round-trip) to
@@ -1043,7 +1043,7 @@ func TestCreateVolumeUpdatesVolumeNameAnnotation(t *testing.T) {
 	supervisorClient := testclient.NewClientset()
 	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
 	require.NoError(t, err)
-	require.NoError(t, co.EnableFSS(tCtx, common.SupervisorImproveVisiblity))
+	require.NoError(t, co.EnableFSS(tCtx, common.ImprovedVolumeVisiblity))
 
 	oldCO := commonco.ContainerOrchestratorUtility
 	commonco.ContainerOrchestratorUtility = co
@@ -1170,7 +1170,7 @@ func TestCreateSnapshotWithAnnotations(t *testing.T) {
 	oldCO := commonco.ContainerOrchestratorUtility
 	commonco.ContainerOrchestratorUtility = spy
 	defer func() { commonco.ContainerOrchestratorUtility = oldCO }()
-	require.NoError(t, spy.EnableFSS(ctx, common.SupervisorImproveVisiblity))
+	require.NoError(t, spy.EnableFSS(ctx, common.ImprovedVolumeVisiblity))
 
 	// Use isolated fake clients so this test does not interfere with the shared
 	// singleton controller used by the other tests in this package.

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	commonco "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
@@ -103,12 +105,27 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 		svPVC, err := metadataSyncer.supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).
 			Get(ctx, pv.Spec.CSI.VolumeHandle, metav1.GetOptions{})
 		if err == nil {
-			key := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
+			labelKey := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
 				metadataSyncer.configInfo.Cfg.GC.ClusterDistribution)
-			if _, ok := svPVC.Labels[key]; ok {
-				original := svPVC.DeepCopy()
-				delete(svPVC.Labels, key)
 
+			// Check if we need to clean up labels or annotations
+			needsCleanup := false
+			original := svPVC.DeepCopy()
+			// Remove guest cluster label if it exists
+			if _, ok := svPVC.Labels[labelKey]; ok {
+				delete(svPVC.Labels, labelKey)
+				needsCleanup = true
+			}
+
+			if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+				if _, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; ok {
+					delete(svPVC.Annotations, common.AnnKeyGuestClusterPvc)
+					needsCleanup = true
+				}
+			}
+
+			if needsCleanup {
+				log.Infof("PVC %q deleted from guest cluster, Removing annotation and label from supervisor", svPVC.Name)
 				// Create controller-runtime client for supervisor cluster
 				supervisorRestConfig := k8s.GetRestClientConfigForSupervisor(ctx,
 					metadataSyncer.configInfo.Cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -117,7 +117,7 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 				needsCleanup = true
 			}
 
-			if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
+			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
 				if _, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; ok {
 					delete(svPVC.Annotations, common.AnnKeyGuestClusterPvc)
 					needsCleanup = true

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -18,6 +18,7 @@ package syncer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
@@ -118,8 +119,26 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 			}
 
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
-				if _, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; ok {
-					delete(svPVC.Annotations, common.AnnKeyGuestClusterPvc)
+				if annVal, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; ok {
+					// Selectively remove PVC-specific fields from the JSON annotation so
+					// that cluster-identity fields (clusterId, clusterName) are preserved
+					// for auditing only name and namespace are cleared.
+					var annMap map[string]string
+					if jsonErr := json.Unmarshal([]byte(annVal), &annMap); jsonErr == nil {
+						delete(annMap, "name")
+						delete(annMap, "namespace")
+						updated, marshalErr := json.Marshal(annMap)
+						if marshalErr == nil {
+							svPVC.Annotations[common.AnnKeyGuestClusterPvc] = string(updated)
+						} else {
+							log.Warnf("failed to re-marshal %s on PVC %q: %v; removing annotation entirely",
+								common.AnnKeyGuestClusterPvc, svPVC.Name, marshalErr)
+						}
+					} else {
+						log.Warnf("failed to unmarshal %s on PVC %q: %v; removing annotation entirely",
+							common.AnnKeyGuestClusterPvc, svPVC.Name, jsonErr)
+						delete(svPVC.Annotations, common.AnnKeyGuestClusterPvc)
+					}
 					needsCleanup = true
 				}
 			}

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -117,7 +117,7 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 				needsCleanup = true
 			}
 
-			if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupervisorImproveVisiblity) {
+			if true || commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
 				if _, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; ok {
 					delete(svPVC.Annotations, common.AnnKeyGuestClusterPvc)
 					needsCleanup = true


### PR DESCRIPTION

Add the improved-volume-visibility FSS and new annotation keys (AnnKeyGuestClusterPvc, AnnKeyGuestClusterSnapshot) to store guest cluster information (cluster ID, name, distribution, PVC/snapshot name and namespace, volume name) on supervisor cluster resources.

- CreateVolume: annotate supervisor PVC with guest cluster info and patch volumeName after binding
- CreateSnapshot: annotate supervisor VolumeSnapshot with guest snapshot metadata including VolumeSnapshotContent name
- Metadata syncer: clean up annotations when guest PVCs are deleted
- Update isPVCInSupervisorClusterBound to return the bound PVC object
- Add unit tests for annotation creation logic

**Note:Syncer and Snapshot Informer change will follow on**


**Testing done**:
###  PVC
-----
#### Logs
```
{"level":"info","time":"2026-05-26T15:55:58.228401789Z","caller":"wcpguest/controller.go:377","msg":"CreateVolume: called with args name:\"pvc-fb4bdf13-58e0-4fb7-944b-24cc9cf8aa0c\"  capacity_range:{required_bytes:1073741824}  volume_capabilities:{mount:{fs_type:\"ext4\"}  access_mode:{mode:SINGLE_NODE_WRITER}}  parameters:{key:\"csi.storage.k8s.io/pv/name\"  value:\"pvc-fb4bdf13-58e0-4fb7-944b-24cc9cf8aa0c\"}  parameters:{key:\"csi.storage.k8s.io/pvc/name\"  value:\"my-pvc2\"}  parameters:{key:\"csi.storage.k8s.io/pvc/namespace\"  value:\"default\"}  parameters:{key:\"svStorageClass\"  value:\"gc-storage-profile\"}  accessibility_requirements:{requisite:{segments:{key:\"topology.kubernetes.io/zone\"  value:\"az1\"}}  preferred:{segments:{key:\"topology.kubernetes.io/zone\"  value:\"az1\"}}}","TraceId":"8f16df68-1c14-4bf9-bf88-6abcd08b3e23"}
```

 
#### Annotation

```
 csi.vsphere.volume/guest-cluster-pvc: '{"clusterId":"ba80002a-9a73-4ef8-961a-f2e69c0003cb","clusterName":"test-cluster-e2e-script","name":"my-data3","namespace":"default","volumeName":"pvc-a9d2d753-79ab-4e5d-b8c7-ed9781bd4a85"}'
```

 
### Snapshot
-----
 #### Logs
```
{"level":"info","time":"2026-05-26T16:02:52.341356528Z","caller":"wcpguest/controller.go:1821","msg":"CreateSnapshot: called with args source_volume_id:\"ba80002a-9a73-4ef8-961a-f2e69c0003cb-fb4bdf13-58e0-4fb7-944b-24cc9cf8aa0c\"  name:\"snapshot-fabfeae8-68f4-4898-9968-1dc55b12fc1c\"  parameters:{key:\"csi.storage.k8s.io/volumesnapshot/name\"  value:\"my-snap2\"}  parameters:{key:\"csi.storage.k8s.io/volumesnapshot/namespace\"  value:\"default\"}  parameters:{key:\"csi.storage.k8s.io/volumesnapshotcontent/name\"  value:\"snapcontent-fabfeae8-68f4-4898-9968-1dc55b12fc1c\"}  parameters:{key:\"svVolumeSnapshotClass\"  value:\"volumesnapshotclass-delete\"}","TraceId":"ee3bd143-a53e-4253-8152-657a4fec6e52"}
```
 
#### Annotation

```
  csi.vsphere.volume/guest-cluster-snapshot: '{"clusterName":"test-cluster-e2e-script","name":"my-snap2","namespace":"default","sourceVolumeId":"ba80002a-9a73-4ef8-961a-f2e69c0003cb-fb4bdf13-58e0-4fb7-944b-24cc9cf8aa0c","volumeSnapshotContentName":"snapcontent-fabfeae8-68f4-4898-9968-1dc55b12fc1c"}'
```


Unit test has been added for the same.