### PR TITLE
wcp: route reserved FVS storage classes based on per-namespace network provider

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -68,6 +68,7 @@ import (
 	cnsvolumeinfov1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 const (
@@ -107,6 +108,16 @@ var (
 	// When false, ControllerModifyVolume returns Unimplemented and MODIFY_VOLUME is not advertised
 	// in ControllerGetCapabilities.
 	isVMPVCStoragePolicyMutabilityEnabled bool
+	// isPerNamespaceNetworkProvidersFSSEnabled is true when the supports_per_namespace_network_providers
+	// capability is enabled on the supervisor; when true, FVS routing reads the namespace-scoped
+	// NetworkSettings CR per CreateVolume call instead of consulting the cached global provider.
+	isPerNamespaceNetworkProvidersFSSEnabled bool
+	// cachedGlobalNetworkProvider holds the value of wcp-network-config.network_provider resolved
+	// once during controller.Init when isPerNamespaceNetworkProvidersFSSEnabled is false. It is
+	// only consulted on the FVS routing path for the reserved vsan-file-service-policy /
+	// vsan-file-service-policy-latebinding storage classes; legacy non-FVS paths do not use this
+	// value. Empty when the per-namespace capability is on (in which case the value is unused).
+	cachedGlobalNetworkProvider string
 )
 
 var getCandidateDatastores = cnsvsphere.GetCandidateDatastoresInCluster
@@ -216,6 +227,26 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
 			common.VsanFileVolumeService, "", "")
 	}
+	isPerNamespaceNetworkProvidersFSSEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.SupportsPerNamespaceNetworkProviders)
+	if !isPerNamespaceNetworkProvidersFSSEnabled {
+		// Resolve the global wcp-network-config network provider once at startup so reserved-FVS
+		// storage class requests don't pay a configmap read on every CreateVolume. The cache is
+		// only consulted on the FVS routing path; legacy file/block paths are unaffected.
+		// If the read fails we leave the cache empty and surface a clear error from
+		// shouldProvisionVsanFileVolumeViaFVS so non-FVS paths keep working.
+		if np, npErr := cnsoperatorutil.GetNetworkProvider(ctx); npErr != nil {
+			log.Warnf("failed to read network provider from wcp-network-config: %v; reserved FVS storage "+
+				"classes will be rejected until the controller is restarted with a readable wcp-network-config",
+				npErr)
+		} else {
+			cachedGlobalNetworkProvider = np
+			log.Infof("cached global network provider %q from wcp-network-config "+
+				"(supports_per_namespace_network_providers capability disabled)", cachedGlobalNetworkProvider)
+		}
+		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
+			cnstypes.CnsClusterFlavorWorkload, common.SupportsPerNamespaceNetworkProviders, "", "")
+	}
 	if !IsMultipleClustersPerVsphereZoneFSSEnabled {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
 			common.MultipleClustersPerVsphereZone, "", "")
@@ -311,13 +342,21 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		}
 		log.Info("Initialized CBTConfig Kubernetes client")
 	}
-	if isVsanFileVolumeServiceFSSEnabled {
+
+	// Dynamic client is needed by both FVS (FileVolume CR operations) and the per-namespace
+	// network provider path (NetworkSettings CR lookups for FVS routing).
+	if isVsanFileVolumeServiceFSSEnabled || isPerNamespaceNetworkProvidersFSSEnabled {
 		c.dynamicClient, err = dynamic.NewForConfig(cfg)
 		if err != nil {
 			log.Errorf("failed to create dynamic Kubernetes client. err=%v", err)
 			return err
 		}
 		log.Info("Initialized dynamic Kubernetes client")
+	}
+	// FileVolume typed client and namespace informer are only used for FVS FileVolume CR
+	// provisioning; they are not needed when only the per-namespace network provider
+	// capability is enabled.
+	if isVsanFileVolumeServiceFSSEnabled {
 		fvsScheme := runtime.NewScheme()
 		if err = fvsapis.AddToScheme(fvsScheme); err != nil {
 			log.Errorf("failed to add FileVolume API types to scheme. err=%v", err)
@@ -1853,7 +1892,8 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					"file volume feature is disabled on the cluster")
 			}
 			scName := req.Parameters[common.AttributeStorageClassName]
-			useFVS, err := shouldProvisionVsanFileVolumeViaFVS(ctx, scName)
+			pvcNamespace := req.Parameters[common.AttributePvcNamespace]
+			useFVS, err := shouldProvisionVsanFileVolumeViaFVS(ctx, c.dynamicClient, pvcNamespace, scName)
 			if err != nil {
 				return nil, csifault.CSIInvalidArgumentFault, err
 			}

--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fvv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/filevolume/v1alpha1"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
@@ -691,14 +692,22 @@ func (c *controller) expandFileVolumeViaFVS(ctx context.Context, req *csi.Contro
 }
 
 // shouldProvisionVsanFileVolumeViaFVS encapsulates routing to the FVS CR workflow.
-func shouldProvisionVsanFileVolumeViaFVS(ctx context.Context, storageClassName string) (bool, error) {
+//
+// The reserved vsan-file-service-policy / vsan-file-service-policy-latebinding storage classes
+// require the NSX_VPC network provider. The provider is resolved either per-namespace (from the
+// PVC namespace's NetworkSettings CR) when supports_per_namespace_network_providers is on, or from
+// the cached global wcp-network-config value resolved once at controller.Init when the per-
+// namespace capability is off. Non-reserved storage classes return useFVS=false without consulting
+// the network provider.
+func shouldProvisionVsanFileVolumeViaFVS(ctx context.Context, dc dynamic.Interface,
+	pvcNamespace, storageClassName string) (bool, error) {
 	if !isVsanFileVolumeServiceFSSEnabled {
 		return false, nil
 	}
 	if !isVsanFileServicePolicyStorageClass(storageClassName) {
 		return false, nil
 	}
-	np, err := cnsoperatorutil.GetNetworkProvider(ctx)
+	np, err := resolveNetworkProviderForFVS(ctx, dc, pvcNamespace)
 	if err != nil {
 		return false, err
 	}
@@ -708,6 +717,33 @@ func shouldProvisionVsanFileVolumeViaFVS(ctx context.Context, storageClassName s
 			storageClassName, np)
 	}
 	return true, nil
+}
+
+// resolveNetworkProviderForFVS reads the per-namespace NetworkSettings CR when
+// supports_per_namespace_network_providers is on, otherwise returns the global provider value
+// cached during controller.Init (no per-call wcp-network-config read).
+func resolveNetworkProviderForFVS(ctx context.Context, dc dynamic.Interface,
+	pvcNamespace string) (string, error) {
+	if isPerNamespaceNetworkProvidersFSSEnabled {
+		if dc == nil {
+			return "", status.Errorf(codes.FailedPrecondition,
+				"dynamic client unavailable; required when %s is enabled",
+				common.SupportsPerNamespaceNetworkProviders)
+		}
+		np, err := cnsoperatorutil.GetNetworkProviderFromNetworkSettings(ctx, dc, pvcNamespace)
+		if err != nil {
+			return "", status.Errorf(codes.FailedPrecondition,
+				"failed to resolve network provider from NetworkSettings in namespace %q: %v",
+				pvcNamespace, err)
+		}
+		return np, nil
+	}
+	if cachedGlobalNetworkProvider == "" {
+		return "", status.Errorf(codes.FailedPrecondition,
+			"global network provider was not resolved at controller startup; "+
+				"restart the CSI controller with a readable wcp-network-config to use reserved FVS storage classes")
+	}
+	return cachedGlobalNetworkProvider, nil
 }
 
 // shouldDeleteFileVolumeViaFVS encapsulates routing to the FVS CR workflow on DeleteVolume,

--- a/pkg/csi/service/wcp/fvs_filevolume_test.go
+++ b/pkg/csi/service/wcp/fvs_filevolume_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -436,52 +438,269 @@ func TestCreateFileVolumeViaFVS_ValidationAndPVC(t *testing.T) {
 	})
 }
 
+// withFVSPackageState saves and restores the package-level FSS booleans + cached global provider
+// so subtests can exercise shouldProvisionVsanFileVolumeViaFVS / resolveNetworkProviderForFVS in
+// isolation without leaking state across tests.
+func withFVSPackageState(t *testing.T) {
+	t.Helper()
+	oldFVS := isVsanFileVolumeServiceFSSEnabled
+	oldPerNS := isPerNamespaceNetworkProvidersFSSEnabled
+	oldCache := cachedGlobalNetworkProvider
+	t.Cleanup(func() {
+		isVsanFileVolumeServiceFSSEnabled = oldFVS
+		isPerNamespaceNetworkProvidersFSSEnabled = oldPerNS
+		cachedGlobalNetworkProvider = oldCache
+	})
+}
+
 func TestShouldProvisionVsanFileVolumeViaFVS(t *testing.T) {
 	ctx := context.Background()
 
-	ok, err := shouldProvisionVsanFileVolumeViaFVS(ctx, "other-sc")
-	require.NoError(t, err)
-	require.False(t, ok)
-
-	t.Run("non-VPC network provider returns FailedPrecondition", func(t *testing.T) {
-		orig := cnsoperatorutil.GetNetworkProviderFunc
-		defer func() { cnsoperatorutil.GetNetworkProviderFunc = orig }()
-		cnsoperatorutil.GetNetworkProviderFunc = func(ctx context.Context) (string, error) {
-			return "NSX_T", nil
-		}
-		oldFSS := isVsanFileVolumeServiceFSSEnabled
-		defer func() { isVsanFileVolumeServiceFSSEnabled = oldFSS }()
+	t.Run("non-reserved SC returns useFVS=false without provider lookup", func(t *testing.T) {
+		withFVSPackageState(t)
 		isVsanFileVolumeServiceFSSEnabled = true
-		_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, common.StorageClassVsanFileServicePolicy)
-		require.Error(t, err)
-	})
-
-	t.Run("VPC provider FSS disabled", func(t *testing.T) {
-		orig := cnsoperatorutil.GetNetworkProviderFunc
-		defer func() { cnsoperatorutil.GetNetworkProviderFunc = orig }()
-		cnsoperatorutil.GetNetworkProviderFunc = func(ctx context.Context) (string, error) {
-			return cnsoperatorutil.VPCNetworkProvider, nil
-		}
-		oldFSS := isVsanFileVolumeServiceFSSEnabled
-		defer func() { isVsanFileVolumeServiceFSSEnabled = oldFSS }()
-		isVsanFileVolumeServiceFSSEnabled = false
-		ok, err := shouldProvisionVsanFileVolumeViaFVS(ctx, common.StorageClassVsanFileServicePolicy)
+		isPerNamespaceNetworkProvidersFSSEnabled = false
+		// Cache is intentionally left empty: helper must not consult the cache when SC is non-reserved.
+		cachedGlobalNetworkProvider = ""
+		ok, err := shouldProvisionVsanFileVolumeViaFVS(ctx, nil, "ns", "other-sc")
 		require.NoError(t, err)
 		require.False(t, ok)
 	})
 
-	t.Run("VPC provider FSS enabled", func(t *testing.T) {
-		orig := cnsoperatorutil.GetNetworkProviderFunc
-		defer func() { cnsoperatorutil.GetNetworkProviderFunc = orig }()
-		cnsoperatorutil.GetNetworkProviderFunc = func(ctx context.Context) (string, error) {
-			return cnsoperatorutil.VPCNetworkProvider, nil
-		}
-		oldFSS := isVsanFileVolumeServiceFSSEnabled
-		defer func() { isVsanFileVolumeServiceFSSEnabled = oldFSS }()
+	t.Run("FVS FSS disabled returns useFVS=false for reserved SC (controller guard takes over)",
+		func(t *testing.T) {
+			withFVSPackageState(t)
+			isVsanFileVolumeServiceFSSEnabled = false
+			ok, err := shouldProvisionVsanFileVolumeViaFVS(ctx, nil, "ns",
+				common.StorageClassVsanFileServicePolicy)
+			require.NoError(t, err)
+			require.False(t, ok)
+		})
+
+	t.Run("per-namespace OFF + cache=NSX_VPC + reserved SC routes to FVS", func(t *testing.T) {
+		withFVSPackageState(t)
 		isVsanFileVolumeServiceFSSEnabled = true
-		ok, err := shouldProvisionVsanFileVolumeViaFVS(ctx, common.StorageClassVsanFileServicePolicy)
+		isPerNamespaceNetworkProvidersFSSEnabled = false
+		cachedGlobalNetworkProvider = cnsoperatorutil.VPCNetworkProvider
+		ok, err := shouldProvisionVsanFileVolumeViaFVS(ctx, nil, "ns",
+			common.StorageClassVsanFileServicePolicy)
 		require.NoError(t, err)
 		require.True(t, ok)
+	})
+
+	t.Run("per-namespace OFF + cache=NSXT_CONTAINER_PLUGIN + reserved SC -> FailedPrecondition",
+		func(t *testing.T) {
+			withFVSPackageState(t)
+			isVsanFileVolumeServiceFSSEnabled = true
+			isPerNamespaceNetworkProvidersFSSEnabled = false
+			cachedGlobalNetworkProvider = cnsoperatorutil.NSXTNetworkProvider
+			_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, nil, "ns",
+				common.StorageClassVsanFileServicePolicy)
+			require.Error(t, err)
+			require.Equal(t, codes.FailedPrecondition, status.Code(err))
+			require.Contains(t, err.Error(), "requires NSX_VPC")
+		})
+
+	t.Run("per-namespace OFF + cache=VSPHERE_NETWORK + reserved SC -> FailedPrecondition",
+		func(t *testing.T) {
+			withFVSPackageState(t)
+			isVsanFileVolumeServiceFSSEnabled = true
+			isPerNamespaceNetworkProvidersFSSEnabled = false
+			cachedGlobalNetworkProvider = cnsoperatorutil.VDSNetworkProvider
+			_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, nil, "ns",
+				common.StorageClassVsanFileServicePolicyLateBinding)
+			require.Error(t, err)
+			require.Equal(t, codes.FailedPrecondition, status.Code(err))
+			require.Contains(t, err.Error(), "requires NSX_VPC")
+		})
+
+	t.Run("per-namespace OFF + cache empty + reserved SC -> FailedPrecondition", func(t *testing.T) {
+		withFVSPackageState(t)
+		isVsanFileVolumeServiceFSSEnabled = true
+		isPerNamespaceNetworkProvidersFSSEnabled = false
+		cachedGlobalNetworkProvider = ""
+		_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, nil, "ns",
+			common.StorageClassVsanFileServicePolicy)
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		require.Contains(t, err.Error(), "global network provider was not resolved")
+	})
+}
+
+// networkSettingsGVRForTest mirrors the GVR exported privately in cnsoperatorutil; we redeclare
+// it locally so the test doesn't introduce a public API just for tests.
+var networkSettingsGVRForTest = schema.GroupVersionResource{
+	Group:    "netoperator.vmware.com",
+	Version:  "v1alpha1",
+	Resource: "networksettings",
+}
+
+// newFakeDynamicClientForNetworkSettings builds a fake dynamic client that knows how to list
+// NetworkSettings CRs (the fake tracker requires the list-kind to be registered explicitly).
+func newFakeDynamicClientForNetworkSettings(t *testing.T) *fake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(networkSettingsGVRForTest.GroupVersion())
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		networkSettingsGVRForTest: "NetworkSettingsList",
+	}
+	return fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+}
+
+// seedNetworkSettings creates a NetworkSettings CR via the dynamic client (matches the
+// production code path used by getNetworkProviderFromNetworkSettings). Pass provider="" to omit
+// the provider field, mirroring a misconfigured CR.
+func seedNetworkSettings(t *testing.T, dc *fake.FakeDynamicClient, name, namespace, provider string) {
+	t.Helper()
+	obj := map[string]interface{}{
+		"apiVersion": "netoperator.vmware.com/v1alpha1",
+		"kind":       "NetworkSettings",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+	if provider != "" {
+		obj["provider"] = provider
+	}
+	cr := &unstructured.Unstructured{Object: obj}
+	_, err := dc.Resource(networkSettingsGVRForTest).Namespace(namespace).Create(
+		context.Background(), cr, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func TestShouldProvisionVsanFileVolumeViaFVS_PerNamespace(t *testing.T) {
+	ctx := context.Background()
+	const ns = "tenant-ns"
+
+	t.Run("per-namespace ON + provider=vpc routes to FVS", func(t *testing.T) {
+		withFVSPackageState(t)
+		isVsanFileVolumeServiceFSSEnabled = true
+		isPerNamespaceNetworkProvidersFSSEnabled = true
+		dc := newFakeDynamicClientForNetworkSettings(t)
+		seedNetworkSettings(t, dc, "ns-1", ns, "vpc")
+		ok, err := shouldProvisionVsanFileVolumeViaFVS(ctx, dc, ns,
+			common.StorageClassVsanFileServicePolicy)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("per-namespace ON + provider=nsx-tier1 -> FailedPrecondition", func(t *testing.T) {
+		withFVSPackageState(t)
+		isVsanFileVolumeServiceFSSEnabled = true
+		isPerNamespaceNetworkProvidersFSSEnabled = true
+		dc := newFakeDynamicClientForNetworkSettings(t)
+		seedNetworkSettings(t, dc, "ns-1", ns, "nsx-tier1")
+		_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, dc, ns,
+			common.StorageClassVsanFileServicePolicy)
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		require.Contains(t, err.Error(), "requires NSX_VPC")
+	})
+
+	t.Run("per-namespace ON + provider=vsphere-distributed -> FailedPrecondition", func(t *testing.T) {
+		withFVSPackageState(t)
+		isVsanFileVolumeServiceFSSEnabled = true
+		isPerNamespaceNetworkProvidersFSSEnabled = true
+		dc := newFakeDynamicClientForNetworkSettings(t)
+		seedNetworkSettings(t, dc, "ns-1", ns, "vsphere-distributed")
+		_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, dc, ns,
+			common.StorageClassVsanFileServicePolicyLateBinding)
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		require.Contains(t, err.Error(), "requires NSX_VPC")
+	})
+
+	t.Run("per-namespace ON + NetworkSettings absent -> FailedPrecondition", func(t *testing.T) {
+		withFVSPackageState(t)
+		isVsanFileVolumeServiceFSSEnabled = true
+		isPerNamespaceNetworkProvidersFSSEnabled = true
+		dc := newFakeDynamicClientForNetworkSettings(t)
+		_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, dc, ns,
+			common.StorageClassVsanFileServicePolicy)
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err),
+			"ErrNetworkSettingsUnavailable must be re-wrapped as FailedPrecondition, got code: %v", status.Code(err))
+		require.Contains(t, err.Error(), "failed to resolve network provider from NetworkSettings")
+	})
+
+	t.Run("per-namespace ON + provider field empty -> FailedPrecondition", func(t *testing.T) {
+		withFVSPackageState(t)
+		isVsanFileVolumeServiceFSSEnabled = true
+		isPerNamespaceNetworkProvidersFSSEnabled = true
+		dc := newFakeDynamicClientForNetworkSettings(t)
+		seedNetworkSettings(t, dc, "ns-1", ns, "")
+		_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, dc, ns,
+			common.StorageClassVsanFileServicePolicy)
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err),
+			"empty-provider NetworkSettings must be re-wrapped as FailedPrecondition, got code: %v", status.Code(err))
+		require.Contains(t, err.Error(), "failed to resolve network provider from NetworkSettings")
+	})
+
+	t.Run("per-namespace ON + dynamic client nil -> FailedPrecondition", func(t *testing.T) {
+		withFVSPackageState(t)
+		isVsanFileVolumeServiceFSSEnabled = true
+		isPerNamespaceNetworkProvidersFSSEnabled = true
+		_, err := shouldProvisionVsanFileVolumeViaFVS(ctx, nil, ns,
+			common.StorageClassVsanFileServicePolicy)
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		require.Contains(t, err.Error(), "dynamic client unavailable")
+	})
+}
+
+func TestResolveNetworkProviderForFVS(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("per-namespace OFF returns cached global provider without dc lookup", func(t *testing.T) {
+		withFVSPackageState(t)
+		isPerNamespaceNetworkProvidersFSSEnabled = false
+		cachedGlobalNetworkProvider = cnsoperatorutil.VPCNetworkProvider
+		got, err := resolveNetworkProviderForFVS(ctx, nil, "ignored")
+		require.NoError(t, err)
+		require.Equal(t, cnsoperatorutil.VPCNetworkProvider, got)
+	})
+
+	t.Run("per-namespace OFF + empty cache returns FailedPrecondition", func(t *testing.T) {
+		withFVSPackageState(t)
+		isPerNamespaceNetworkProvidersFSSEnabled = false
+		cachedGlobalNetworkProvider = ""
+		_, err := resolveNetworkProviderForFVS(ctx, nil, "ignored")
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	})
+
+	t.Run("per-namespace ON reads from NetworkSettings CR", func(t *testing.T) {
+		withFVSPackageState(t)
+		isPerNamespaceNetworkProvidersFSSEnabled = true
+		cachedGlobalNetworkProvider = "should-not-be-used"
+		dc := newFakeDynamicClientForNetworkSettings(t)
+		seedNetworkSettings(t, dc, "ns-1", "tenant", "vpc")
+		got, err := resolveNetworkProviderForFVS(ctx, dc, "tenant")
+		require.NoError(t, err)
+		require.Equal(t, cnsoperatorutil.VPCNetworkProvider, got)
+	})
+
+	t.Run("per-namespace ON + nil dc returns FailedPrecondition", func(t *testing.T) {
+		withFVSPackageState(t)
+		isPerNamespaceNetworkProvidersFSSEnabled = true
+		_, err := resolveNetworkProviderForFVS(ctx, nil, "tenant")
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	})
+
+	t.Run("per-namespace ON + NetworkSettings lookup error is wrapped as FailedPrecondition", func(t *testing.T) {
+		// Validates the review comment: plain errors from getNetworkProviderFromNetworkSettings
+		// (e.g. ErrNetworkSettingsUnavailable) must be re-wrapped so callers see
+		// codes.FailedPrecondition rather than codes.Unknown.
+		withFVSPackageState(t)
+		isPerNamespaceNetworkProvidersFSSEnabled = true
+		dc := newFakeDynamicClientForNetworkSettings(t) // no CR seeded -> ErrNetworkSettingsUnavailable
+		_, err := resolveNetworkProviderForFVS(ctx, dc, "tenant")
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err),
+			"plain error from getNetworkProviderFromNetworkSettings must be wrapped as FailedPrecondition")
 	})
 }
 
@@ -1198,15 +1417,14 @@ func TestReservedFVSStorageClassGuard(t *testing.T) {
 	require.True(t, isVsanFileServicePolicyStorageClass(common.StorageClassVsanFileServicePolicyLateBinding))
 	require.False(t, isVsanFileServicePolicyStorageClass("ordinary-sc"))
 
-	oldFSS := isVsanFileVolumeServiceFSSEnabled
-	defer func() { isVsanFileVolumeServiceFSSEnabled = oldFSS }()
+	withFVSPackageState(t)
 	isVsanFileVolumeServiceFSSEnabled = false
 
 	for _, sc := range []string{
 		common.StorageClassVsanFileServicePolicy,
 		common.StorageClassVsanFileServicePolicyLateBinding,
 	} {
-		useFVS, err := shouldProvisionVsanFileVolumeViaFVS(ctx, sc)
+		useFVS, err := shouldProvisionVsanFileVolumeViaFVS(ctx, nil, "ns", sc)
 		require.NoError(t, err, "sc=%s", sc)
 		require.False(t, useFVS, "sc=%s: with FSS disabled the guard must reject by hitting the reserved-SC branch", sc)
 		require.True(t, isVsanFileServicePolicyStorageClass(sc),

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -188,6 +188,15 @@ func GetTKGVMIPFromNetworkSettings(ctx context.Context, vmOperatorClient client.
 	return GetTKGVMIP(ctx, vmOperatorClient, dc, vmNamespace, vmName, networkProviderType, true)
 }
 
+// GetNetworkProviderFromNetworkSettings returns the per-namespace NetworkSettings provider
+// (mapped to NSXTNetworkProvider / VDSNetworkProvider / VPCNetworkProvider). Callers must only use
+// this when SupportsPerNamespaceNetworkProviders is enabled. Returns ErrNetworkSettingsUnavailable
+// when the namespace has no NetworkSettings or provider is empty.
+func GetNetworkProviderFromNetworkSettings(ctx context.Context, dc dynamic.Interface,
+	namespace string) (string, error) {
+	return getNetworkProviderFromNetworkSettings(ctx, dc, namespace)
+}
+
 func getNetworkProviderFromNetworkSettings(ctx context.Context, dc dynamic.Interface,
 	namespace string) (string, error) {
 	list, err := dc.Resource(networkSettingsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For vsan-file-service-policy and vsan-file-service-policy-latebinding, resolve the network provider per-namespace when the supports_per_namespace_network_providers capability is enabled: read the NetworkSettings CR in the PVC's namespace and allow FVS provisioning only when provider is "vpc"; return FailedPrecondition for nsx-tier1, vsphere-distributed, or a missing/empty CR.

When the per-namespace capability is off, fall back to the global wcp-network-config provider cached once at controller.Init (no per-CreateVolume configmap read). Non-NSX_VPC providers with a reserved storage class still fail with FailedPrecondition. Non-reserved storage classes are unaffected.

Register a HandleLateEnablementOfCapability watcher in the WCP controller for supports_per_namespace_network_providers so the controller restarts and rebuilds the cache when the capability is later enabled.

Broaden the dynamicClient init condition to cover the per-namespace path; export GetNetworkProviderFromNetworkSettings in cnsoperator/util so the wcp controller can reuse the NetworkSettings lookup without duplicating the vsphere-distributed/nsx-tier1/vpc mapping logic.

Add unit tests: capability-off subtests using cachedGlobalNetworkProvider (NSX_VPC pass, NSXT_CONTAINER_PLUGIN reject, VSPHERE_NETWORK reject, empty-cache reject), capability-on subtests using a fake dynamic client seeded with NetworkSettings CRs (vpc/nsx-tier1/vsphere-distributed/ absent/empty/nil-dc), and TestResolveNetworkProviderForFVS covering both branches of the resolver helper.


**Testing done**:
pre-checkin
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1573/

```
Ran 16 of 2357 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2341 Skipped | 0 Flaked
```

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1214/

```
Ran 6 of 2357 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2351 Skipped | 0 Flaked
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
wcp: route reserved FVS storage classes based on per-namespace network provider
```
