### PR TITLE
Manage keepAfterDeleteVm flag for VM-owned PVCs at registration and runtime

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -32,6 +32,8 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	vim25types "github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vslm"
+	vslmmethods "github.com/vmware/govmomi/vslm/methods"
+	vslmtypes "github.com/vmware/govmomi/vslm/types"
 	"google.golang.org/grpc/codes"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -133,6 +135,10 @@ type Manager interface {
 	RetrieveVStorageObject(ctx context.Context, volumeID string) (*vim25types.VStorageObject, error)
 	// ProtectVolumeFromVMDeletion sets keepAfterDeleteVm control flag on migrated volume
 	ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error
+	// UnprotectVolumeFromVMDeletion clears the keepAfterDeleteVm control flag for
+	// the given volumeID using the VSLM endpoint. Unlike ClearVolumeControlFlags
+	// (CNS API, vSphere 9.2+), this works on older vSphere too.
+	UnprotectVolumeFromVMDeletion(ctx context.Context, volumeID string) error
 	// SetVolumeControlFlags sets control flags for a given volume.
 	SetVolumeControlFlags(ctx context.Context, volumeID string, controlFlags []string) error
 	// ClearVolumeControlFlags clears control flags for a given volume.
@@ -3680,6 +3686,39 @@ func (m *defaultManager) ProtectVolumeFromVMDeletion(ctx context.Context, volume
 		log.Infof("Successfully re-registered volume to set control flag to " +
 			"protect volume from vm deletion")
 	}
+	return nil
+}
+
+// UnprotectVolumeFromVMDeletion clears the keepAfterDeleteVm control flag for
+// the given volumeID using the VSLM endpoint. Unlike ClearVolumeControlFlags
+// (CNS API, vSphere 9.2+), VSLM is broadly available on older vSphere too.
+//
+// This is the inverse of ProtectVolumeFromVMDeletion's pre-8.0u3 path. We call
+// methods.VslmClearVStorageObjectControlFlags directly (rather than the
+// govmomi GlobalObjectManager.ClearControlFlags wrapper) because the wrapper
+// does not accept a control-flags slice and would clear ALL flags on the FCD,
+// including enableChangedBlockTracking when CBT is on.
+func (m *defaultManager) UnprotectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	log := logger.GetLogger(ctx)
+	if err := validateManager(ctx, m); err != nil {
+		log.Errorf("failed to validate volume manager with err: %+v", err)
+		return err
+	}
+	if err := m.virtualCenter.ConnectVslm(ctx); err != nil {
+		log.Errorf("ConnectVslm failed with err: %+v", err)
+		return err
+	}
+	globalObjectManager := vslm.NewGlobalObjectManager(m.virtualCenter.VslmClient)
+	req := vslmtypes.VslmClearVStorageObjectControlFlags{
+		This:         globalObjectManager.Reference(),
+		Id:           vim25types.ID{Id: volumeID},
+		ControlFlags: []string{string(vim25types.VslmVStorageObjectControlFlagKeepAfterDeleteVm)},
+	}
+	if _, err := vslmmethods.VslmClearVStorageObjectControlFlags(ctx, m.virtualCenter.VslmClient, &req); err != nil {
+		log.Errorf("failed to clear keepAfterDeleteVm for volumeID %q with err: %v", volumeID, err)
+		return err
+	}
+	log.Infof("Successfully cleared keepAfterDeleteVm control flag for volumeID: %q", volumeID)
 	return nil
 }
 

--- a/pkg/common/cns-lib/volume/manager_mock.go
+++ b/pkg/common/cns-lib/volume/manager_mock.go
@@ -141,6 +141,11 @@ func (m MockManager) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID s
 	panic("implement me")
 }
 
+func (m MockManager) UnprotectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m MockManager) SetVolumeControlFlags(ctx context.Context, volumeID string, controlFlags []string) error {
 	//TODO implement me
 	panic("implement me")

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -196,6 +196,10 @@ func (m *MockVolumeManager) RetrieveVStorageObject(ctx context.Context,
 func (m *MockVolumeManager) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
 	return nil
 }
+
+func (m *MockVolumeManager) UnprotectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	return nil
+}
 func (m *MockVolumeManager) SetVolumeControlFlags(ctx context.Context, volumeID string, controlFlags []string) error {
 	return nil
 }

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -643,6 +643,11 @@ const (
 	MobilityOperatorVMInfraResource = "virtualmachineinframigrations"
 	// MobilityOperatorVolumeResource is the plural name of the VolumeMigration CR.
 	MobilityOperatorVolumeResource = "volumemigrations"
+
+	// AnnVMDeleteProtectionCleared is set on a PVC after the keepAfterDeleteVm
+	// control flag has been cleared due to VM ownerRef presence. This prevents
+	// redundant VSLM calls on syncer restarts or during periodic resyncs.
+	AnnVMDeleteProtectionCleared = "cns.vmware.com/vm-delete-protection-cleared"
 )
 
 var WCPFeatureStates = map[string]struct{}{

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -915,6 +915,10 @@ func (m *cbtFlagsMockVolumeManager) RetrieveVStorageObject(context.Context,
 func (m *cbtFlagsMockVolumeManager) ProtectVolumeFromVMDeletion(context.Context, string) error {
 	return nil
 }
+
+func (m *cbtFlagsMockVolumeManager) UnprotectVolumeFromVMDeletion(context.Context, string) error {
+	return nil
+}
 func (m *cbtFlagsMockVolumeManager) CreateSnapshot(context.Context, string, string,
 	interface{}) (*cnsvolume.CnsSnapshotInfo, error) {
 	return nil, nil

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -105,6 +105,10 @@ func (m *mockVolumeManager) RetrieveVStorageObject(ctx context.Context,
 func (m *mockVolumeManager) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
 	return nil
 }
+
+func (m *mockVolumeManager) UnprotectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	return nil
+}
 func (m *mockVolumeManager) SetVolumeControlFlags(ctx context.Context, volumeID string, controlFlags []string) error {
 	return nil
 }

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -595,6 +595,17 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 			instance.Name, instance.Spec.VolumeMode)
 	}
 
+	// When a PVC is created by VM Operator with DataSourceRef set to a VirtualMachine,
+	// and the matching VM volume entry has removable=false, clear the keepAfterDeleteVm
+	// control flag that CNS auto-sets on a newly registered FCD. This ensures the
+	// FCD lifecycle is governed by the PVC, not by the consuming VM. The clear is
+	// performed via the VSLM endpoint, which is broadly available on older vSphere too.
+	if err = clearKeepAfterDeleteVmIfNonRemovable(ctx, r.client, r.volumeManager,
+		pvc, instance.Namespace, volumeID); err != nil {
+		setInstanceError(ctx, r, instance, err.Error())
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
 	// Do this check before creating a PV. Otherwise, PVC will be bound to PV after PV
 	// is created even if validation fails
 	if pvc != nil {

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -3275,9 +3276,9 @@ func TestReconcileDelete(t *testing.T) {
 //   - the matching volume entry on the VM has removable=false.
 
 // vmImportTestSetup constructs a fake controller-runtime client with the
-// vm-operator scheme registered, optionally seeded with the supplied VM, plus
+// vm-operator scheme registered, optionally seeded with the supplied VM and PVC, plus
 // a mockVolumeManager whose UnprotectVolumeFromVMDeletion hook records calls.
-func vmImportTestSetup(t *testing.T, vm *vmoperatortypes.VirtualMachine,
+func vmImportTestSetup(t *testing.T, vm *vmoperatortypes.VirtualMachine, pvc *corev1.PersistentVolumeClaim,
 	clearErr error) (ctrlclient.Client, *mockVolumeManager, *[]string) {
 	t.Helper()
 	scheme := runtime.NewScheme()
@@ -3287,6 +3288,9 @@ func vmImportTestSetup(t *testing.T, vm *vmoperatortypes.VirtualMachine,
 	builder := fake.NewClientBuilder().WithScheme(scheme)
 	if vm != nil {
 		builder = builder.WithObjects(vm)
+	}
+	if pvc != nil {
+		builder = builder.WithObjects(pvc)
 	}
 	c := builder.Build()
 
@@ -3342,10 +3346,10 @@ func TestClearKeepAfterDeleteVm_RemovableFalse_ClearCalled(t *testing.T) {
 	vmName := "test-vm"
 	removable := false
 	vm := vmWithVolume(vmName, ns, pvcName, &removable)
-	c, mockVM, calls := vmImportTestSetup(t, vm, nil)
+	pvc := vmImportPVC(pvcName, ns, vmName)
+	c, mockVM, calls := vmImportTestSetup(t, vm, pvc, nil)
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
-		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"vol-1"}, *calls,
@@ -3359,7 +3363,7 @@ func TestClearKeepAfterDeleteVm_RemovableTrue_NoOp(t *testing.T) {
 	vmName := "test-vm"
 	removable := true
 	vm := vmWithVolume(vmName, ns, pvcName, &removable)
-	c, mockVM, calls := vmImportTestSetup(t, vm, nil)
+	c, mockVM, calls := vmImportTestSetup(t, vm, nil, nil)
 
 	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
@@ -3374,7 +3378,7 @@ func TestClearKeepAfterDeleteVm_RemovableNil_NoOp(t *testing.T) {
 	pvcName := "test-pvc"
 	vmName := "test-vm"
 	vm := vmWithVolume(vmName, ns, pvcName, nil)
-	c, mockVM, calls := vmImportTestSetup(t, vm, nil)
+	c, mockVM, calls := vmImportTestSetup(t, vm, nil, nil)
 
 	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
@@ -3387,7 +3391,7 @@ func TestClearKeepAfterDeleteVm_NoDataSourceRef_NoOp(t *testing.T) {
 	ctx := context.Background()
 	ns := "test-ns"
 	pvcName := "test-pvc"
-	c, mockVM, calls := vmImportTestSetup(t, nil, nil)
+	c, mockVM, calls := vmImportTestSetup(t, nil, nil, nil)
 
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
@@ -3402,7 +3406,7 @@ func TestClearKeepAfterDeleteVm_NoDataSourceRef_NoOp(t *testing.T) {
 
 func TestClearKeepAfterDeleteVm_NilPVC_NoOp(t *testing.T) {
 	ctx := context.Background()
-	c, mockVM, calls := vmImportTestSetup(t, nil, nil)
+	c, mockVM, calls := vmImportTestSetup(t, nil, nil, nil)
 
 	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, nil, "test-ns", "vol-1")
 	assert.NoError(t, err)
@@ -3414,7 +3418,7 @@ func TestClearKeepAfterDeleteVm_NonVMDataSourceRef_NoOp(t *testing.T) {
 	ctx := context.Background()
 	ns := "test-ns"
 	pvcName := "test-pvc"
-	c, mockVM, calls := vmImportTestSetup(t, nil, nil)
+	c, mockVM, calls := vmImportTestSetup(t, nil, nil, nil)
 
 	otherGroup := "snapshot.storage.k8s.io"
 	pvc := &corev1.PersistentVolumeClaim{
@@ -3439,7 +3443,7 @@ func TestClearKeepAfterDeleteVm_VMNotFound_ReturnsError(t *testing.T) {
 	ns := "test-ns"
 	pvcName := "test-pvc"
 	vmName := "missing-vm"
-	c, mockVM, calls := vmImportTestSetup(t, nil, nil)
+	c, mockVM, calls := vmImportTestSetup(t, nil, nil, nil)
 
 	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
@@ -3455,7 +3459,7 @@ func TestClearKeepAfterDeleteVm_ClearAPIError_ReturnsError(t *testing.T) {
 	vmName := "test-vm"
 	removable := false
 	vm := vmWithVolume(vmName, ns, pvcName, &removable)
-	c, mockVM, calls := vmImportTestSetup(t, vm, fmt.Errorf("boom"))
+	c, mockVM, calls := vmImportTestSetup(t, vm, nil, fmt.Errorf("boom"))
 
 	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
@@ -3473,11 +3477,64 @@ func TestClearKeepAfterDeleteVm_PVCClaimNameMismatch_NoOp(t *testing.T) {
 	// (e.g. multi-volume VM). The helper must only react to the matching entry.
 	removable := false
 	vm := vmWithVolume(vmName, ns, "other-pvc", &removable)
-	c, mockVM, calls := vmImportTestSetup(t, vm, nil)
+	c, mockVM, calls := vmImportTestSetup(t, vm, nil, nil)
 
 	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
 	assert.NoError(t, err)
 
 	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called when no VM volume matches the PVC")
+}
+
+func TestClearKeepAfterDeleteVm_AnnotationUpdateFailure_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	vmName := "test-vm"
+	removable := false
+	vm := vmWithVolume(vmName, ns, pvcName, &removable)
+
+	// Create scheme with required types
+	scheme := runtime.NewScheme()
+	assert.NoError(t, clientgoscheme.AddToScheme(scheme))
+	assert.NoError(t, vmoperatortypes.AddToScheme(scheme))
+
+	pvc := vmImportPVC(pvcName, ns, vmName)
+
+	// Create a fake client with an interceptor that fails on PVC Update
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(vm, pvc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(
+				ctx context.Context,
+				client ctrlclient.WithWatch,
+				obj ctrlclient.Object,
+				opts ...ctrlclient.UpdateOption,
+			) error {
+				if _, ok := obj.(*corev1.PersistentVolumeClaim); ok {
+					return fmt.Errorf("simulated update failure")
+				}
+				return client.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	calls := &[]string{}
+	mockVM := &mockVolumeManager{
+		unprotectVolumeFromVMDeletionFunc: func(_ context.Context, volumeID string) error {
+			*calls = append(*calls, volumeID)
+			return nil
+		},
+	}
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
+
+	// The error should be returned so the reconciler can retry
+	assert.Error(t, err, "annotation update failure must return an error")
+	assert.Contains(t, err.Error(), "simulated update failure")
+
+	// VSLM call should have been made before the annotation update failed
+	assert.Equal(t, []string{"vol-1"}, *calls,
+		"UnprotectVolumeFromVMDeletion should be called before annotation update")
 }

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
 	vim25types "github.com/vmware/govmomi/vim25/types"
@@ -46,6 +47,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
@@ -66,6 +68,7 @@ type mockVolumeManager struct {
 		ctxParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error)
 	unregisterVolume func(ctx context.Context, volumeID string,
 		unregisterDisk bool) (string, error)
+	unprotectVolumeFromVMDeletionFunc func(ctx context.Context, volumeID string) error
 }
 
 func (m *mockVolumeManager) UnregisterVolume(ctx context.Context, volumeID string,
@@ -171,6 +174,13 @@ func (m *mockVolumeManager) RetrieveVStorageObject(ctx context.Context,
 func (m *mockVolumeManager) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
 	//TODO implement me
 	panic("implement me")
+}
+
+func (m *mockVolumeManager) UnprotectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	if m.unprotectVolumeFromVMDeletionFunc != nil {
+		return m.unprotectVolumeFromVMDeletionFunc(ctx, volumeID)
+	}
+	return nil
 }
 
 func (m *mockVolumeManager) SetVolumeControlFlags(ctx context.Context, volumeID string, controlFlags []string) error {
@@ -3254,4 +3264,220 @@ func TestReconcileDelete(t *testing.T) {
 		_, err = k8sclient.CoreV1().PersistentVolumes().Get(ctx, "test-pv-unbound", metav1.GetOptions{})
 		assert.True(t, apierrors.IsNotFound(err), "Expected PV to be deleted (NotFound error)")
 	})
+}
+
+// clearKeepAfterDeleteVmIfNonRemovable tests
+//
+// These tests cover the helper that, after FCD registration, clears the
+// keepAfterDeleteVm control flag on the FCD via the VSLM endpoint
+// (UnprotectVolumeFromVMDeletion) when:
+//   - the PVC has a DataSourceRef pointing at vmoperator.vmware.com/VirtualMachine, AND
+//   - the matching volume entry on the VM has removable=false.
+
+// vmImportTestSetup constructs a fake controller-runtime client with the
+// vm-operator scheme registered, optionally seeded with the supplied VM, plus
+// a mockVolumeManager whose UnprotectVolumeFromVMDeletion hook records calls.
+func vmImportTestSetup(t *testing.T, vm *vmoperatortypes.VirtualMachine,
+	clearErr error) (ctrlclient.Client, *mockVolumeManager, *[]string) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	assert.NoError(t, clientgoscheme.AddToScheme(scheme))
+	assert.NoError(t, vmoperatortypes.AddToScheme(scheme))
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if vm != nil {
+		builder = builder.WithObjects(vm)
+	}
+	c := builder.Build()
+
+	calls := &[]string{}
+	mockVM := &mockVolumeManager{
+		unprotectVolumeFromVMDeletionFunc: func(_ context.Context, volumeID string) error {
+			*calls = append(*calls, volumeID)
+			return clearErr
+		},
+	}
+	return c, mockVM, calls
+}
+
+func vmWithVolume(vmName, namespace, claimName string, removable *bool) *vmoperatortypes.VirtualMachine {
+	return &vmoperatortypes.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: namespace},
+		Spec: vmoperatortypes.VirtualMachineSpec{
+			Volumes: []vmoperatortypes.VirtualMachineVolume{
+				{
+					Name: claimName,
+					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: claimName,
+							},
+						},
+					},
+					Removable: removable,
+				},
+			},
+		},
+	}
+}
+
+func vmImportPVC(pvcName, namespace, vmName string) *corev1.PersistentVolumeClaim {
+	apiGroup := "vmoperator.vmware.com"
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: namespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     "VirtualMachine",
+				Name:     vmName,
+			},
+		},
+	}
+}
+
+func TestClearKeepAfterDeleteVm_RemovableFalse_ClearCalled(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	vmName := "test-vm"
+	removable := false
+	vm := vmWithVolume(vmName, ns, pvcName, &removable)
+	c, mockVM, calls := vmImportTestSetup(t, vm, nil)
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"vol-1"}, *calls,
+		"UnprotectVolumeFromVMDeletion must be called exactly once for the registered volume")
+}
+
+func TestClearKeepAfterDeleteVm_RemovableTrue_NoOp(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	vmName := "test-vm"
+	removable := true
+	vm := vmWithVolume(vmName, ns, pvcName, &removable)
+	c, mockVM, calls := vmImportTestSetup(t, vm, nil)
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
+	assert.NoError(t, err)
+
+	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called when removable=true")
+}
+
+func TestClearKeepAfterDeleteVm_RemovableNil_NoOp(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	vmName := "test-vm"
+	vm := vmWithVolume(vmName, ns, pvcName, nil)
+	c, mockVM, calls := vmImportTestSetup(t, vm, nil)
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
+	assert.NoError(t, err)
+
+	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called when removable is nil (default true)")
+}
+
+func TestClearKeepAfterDeleteVm_NoDataSourceRef_NoOp(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	c, mockVM, calls := vmImportTestSetup(t, nil, nil)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+		Spec:       corev1.PersistentVolumeClaimSpec{DataSourceRef: nil},
+	}
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
+	assert.NoError(t, err)
+
+	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called without DataSourceRef")
+}
+
+func TestClearKeepAfterDeleteVm_NilPVC_NoOp(t *testing.T) {
+	ctx := context.Background()
+	c, mockVM, calls := vmImportTestSetup(t, nil, nil)
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, nil, "test-ns", "vol-1")
+	assert.NoError(t, err)
+
+	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called when pvc is nil")
+}
+
+func TestClearKeepAfterDeleteVm_NonVMDataSourceRef_NoOp(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	c, mockVM, calls := vmImportTestSetup(t, nil, nil)
+
+	otherGroup := "snapshot.storage.k8s.io"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &otherGroup,
+				Kind:     "VolumeSnapshot",
+				Name:     "snap-1",
+			},
+		},
+	}
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
+	assert.NoError(t, err)
+
+	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called for non-VirtualMachine DataSourceRef")
+}
+
+func TestClearKeepAfterDeleteVm_VMNotFound_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	vmName := "missing-vm"
+	c, mockVM, calls := vmImportTestSetup(t, nil, nil)
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
+	assert.Error(t, err, "missing VM CR must surface as an error so the reconciler requeues")
+
+	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called when VM lookup fails")
+}
+
+func TestClearKeepAfterDeleteVm_ClearAPIError_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	vmName := "test-vm"
+	removable := false
+	vm := vmWithVolume(vmName, ns, pvcName, &removable)
+	c, mockVM, calls := vmImportTestSetup(t, vm, fmt.Errorf("boom"))
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
+	assert.Error(t, err, "underlying VSLM error must surface so the reconciler requeues")
+
+	assert.Len(t, *calls, 1, "UnprotectVolumeFromVMDeletion must have been attempted exactly once")
+}
+
+func TestClearKeepAfterDeleteVm_PVCClaimNameMismatch_NoOp(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	vmName := "test-vm"
+	// VM has a non-removable volume but for a different PVC; our PVC is not on the VM
+	// (e.g. multi-volume VM). The helper must only react to the matching entry.
+	removable := false
+	vm := vmWithVolume(vmName, ns, "other-pvc", &removable)
+	c, mockVM, calls := vmImportTestSetup(t, vm, nil)
+
+	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
+	assert.NoError(t, err)
+
+	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called when no VM volume matches the PVC")
 }

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -36,6 +37,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
 	cnsstoragepolicyquotasv1alpha3 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha3"
+	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -104,6 +106,82 @@ func isDatastoreAccessibleToAZClusters(ctx context.Context, vc *vsphere.VirtualC
 		}
 	}
 	return false
+}
+
+// clearKeepAfterDeleteVmIfNonRemovable clears the keepAfterDeleteVm control flag
+// on the just-registered FCD when the PVC was created by VM Operator with a
+// VirtualMachine DataSourceRef and the matching volume entry on the VM has
+// removable=false. CNS automatically sets keepAfterDeleteVm on every newly
+// registered FCD; for non-removable VM-imported PVCs we want the FCD lifecycle
+// to be governed by the PVC, not by the consuming VM, so we clear the flag
+// after registration.
+//
+// The clear is performed via the VSLM endpoint (UnprotectVolumeFromVMDeletion),
+// which is broadly available on older vSphere as well; no FSS gate is required.
+//
+// Returns nil (no-op) when:
+//   - pvc is nil or has no DataSourceRef,
+//   - DataSourceRef does not point at vmoperator.vmware.com/VirtualMachine,
+//   - the matching VM volume entry has removable=true or removable=nil (default).
+//
+// Returns a non-nil error when the VirtualMachine CR cannot be fetched or when
+// the underlying VSLM clear call fails. Both cases are safe to retry on the
+// next reconcile (CreateVolume and VSLM clear are both idempotent).
+func clearKeepAfterDeleteVmIfNonRemovable(ctx context.Context, c ctrlruntimeclient.Client,
+	volumeManager volumes.Manager, pvc *v1.PersistentVolumeClaim, namespace, volumeID string) error {
+	log := logger.GetLogger(ctx)
+
+	if pvc == nil || pvc.Spec.DataSourceRef == nil ||
+		pvc.Spec.DataSourceRef.APIGroup == nil ||
+		*pvc.Spec.DataSourceRef.APIGroup != "vmoperator.vmware.com" ||
+		pvc.Spec.DataSourceRef.Kind != "VirtualMachine" {
+		return nil
+	}
+
+	vm := &vmoperatortypes.VirtualMachine{}
+	if err := c.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Namespace: namespace,
+		Name:      pvc.Spec.DataSourceRef.Name,
+	}, vm); err != nil {
+		return fmt.Errorf("failed to get VirtualMachine %s/%s referenced by PVC DataSourceRef: %v",
+			namespace, pvc.Spec.DataSourceRef.Name, err)
+	}
+
+	nonRemovable := false
+	for _, vmVol := range vm.Spec.Volumes {
+		if vmVol.PersistentVolumeClaim != nil &&
+			vmVol.PersistentVolumeClaim.ClaimName == pvc.Name &&
+			vmVol.Removable != nil && !*vmVol.Removable {
+			nonRemovable = true
+			break
+		}
+	}
+
+	if !nonRemovable {
+		return nil
+	}
+
+	log.Infof("Clearing keepAfterDeleteVm for volumeID %s (PVC %s/%s mounted as non-removable on VM %s)",
+		volumeID, pvc.Namespace, pvc.Name, vm.Name)
+	if err := volumeManager.UnprotectVolumeFromVMDeletion(ctx, volumeID); err != nil {
+		return fmt.Errorf("failed to clear keepAfterDeleteVm for volumeID %s: %v", volumeID, err)
+	}
+
+	// Set annotation to indicate keepAfterDeleteVm has been cleared.
+	// This prevents redundant VSLM calls on syncer restarts or informer resyncs.
+	pvcCopy := pvc.DeepCopy()
+	if pvcCopy.Annotations == nil {
+		pvcCopy.Annotations = make(map[string]string)
+	}
+	pvcCopy.Annotations[common.AnnVMDeleteProtectionCleared] = "true"
+	if err := c.Update(ctx, pvcCopy); err != nil {
+		log.Warnf("Failed to set %s annotation on PVC %s/%s: %v",
+			common.AnnVMDeleteProtectionCleared, pvc.Namespace, pvc.Name, err)
+	} else {
+		log.Infof("Set %s annotation on PVC %s/%s",
+			common.AnnVMDeleteProtectionCleared, pvc.Namespace, pvc.Name)
+	}
+	return nil
 }
 
 // constructCreateSpecForInstance creates CNS CreateVolume spec.

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -175,12 +175,11 @@ func clearKeepAfterDeleteVmIfNonRemovable(ctx context.Context, c ctrlruntimeclie
 	}
 	pvcCopy.Annotations[common.AnnVMDeleteProtectionCleared] = "true"
 	if err := c.Update(ctx, pvcCopy); err != nil {
-		log.Warnf("Failed to set %s annotation on PVC %s/%s: %v",
+		return fmt.Errorf("failed to set %s annotation on PVC %s/%s: %v",
 			common.AnnVMDeleteProtectionCleared, pvc.Namespace, pvc.Name, err)
-	} else {
-		log.Infof("Set %s annotation on PVC %s/%s",
-			common.AnnVMDeleteProtectionCleared, pvc.Namespace, pvc.Name)
 	}
+	log.Infof("Set %s annotation on PVC %s/%s",
+		common.AnnVMDeleteProtectionCleared, pvc.Namespace, pvc.Name)
 	return nil
 }
 

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -55,6 +55,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 	cnsvolumeinfov1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo/v1alpha1"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
@@ -137,6 +138,13 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.SupervisorPVCWorkloadTypeAnnotation) {
 			annotateSupervisorPVCsWithWorkloadType(ctx, metadataSyncer)
 		}
+	}
+
+	// On Supervisor cluster, reconcile keepAfterDeleteVm flags for PVCs with VM
+	// ownerRefs that may have been missed by pvcAdded (upgrade, informer gaps,
+	// transient failures). The annotation check ensures idempotency.
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		reconcileKeepAfterDeleteVmFlags(ctx, metadataSyncer)
 	}
 
 	defer func() {
@@ -2357,4 +2365,77 @@ func setChangeIDAnnotationOnSupervisorSnapshots(ctx context.Context, metadataSyn
 		"setChangeIDAnnotationOnSupervisorSnapshots: Completed. Annotated %d VolumeSnapshots with change-id",
 		totalAnnotatedCount)
 	log.Debugf("setChangeIDAnnotationOnSupervisorSnapshots: End for VC: %s", vc)
+}
+
+// reconcileKeepAfterDeleteVmFlags performs bidirectional reconciliation of the
+// keepAfterDeleteVm control flag for PVCs on Supervisor cluster:
+//
+//  1. Clear flag: PVCs with VM ownerRef but missing annotation → clear flag + set annotation
+//     (handles missed pvcAdded events during upgrade, informer gaps, transient failures)
+//
+//  2. Restore flag: PVCs with annotation but no VM ownerRef → restore flag + remove annotation
+//     (handles missed pvcUpdated events when VM ownerRef was removed)
+//
+// This function only runs on Supervisor cluster (CnsClusterFlavorWorkload).
+func reconcileKeepAfterDeleteVmFlags(ctx context.Context, metadataSyncer *metadataSyncInformer) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("reconcileKeepAfterDeleteVmFlags: Start")
+
+	// List all PVCs
+	allPVCs, err := metadataSyncer.pvcLister.List(labels.Everything())
+	if err != nil {
+		log.Errorf("reconcileKeepAfterDeleteVmFlags: Failed to list PVCs: %v", err)
+		return
+	}
+
+	clearedCount := 0
+	restoredCount := 0
+	for _, pvc := range allPVCs {
+		// Skip if PVC is not bound
+		if pvc.Status.Phase != v1.ClaimBound {
+			continue
+		}
+
+		// Get PV to retrieve volumeID (needed for both directions)
+		pv, err := metadataSyncer.pvLister.Get(pvc.Spec.VolumeName)
+		if err != nil {
+			log.Warnf("reconcileKeepAfterDeleteVmFlags: Failed to get PV %s for PVC %s/%s: %v",
+				pvc.Spec.VolumeName, pvc.Namespace, pvc.Name, err)
+			continue
+		}
+
+		// Only process vSphere CSI volumes
+		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != csitypes.Name {
+			continue
+		}
+
+		volumeID := pv.Spec.CSI.VolumeHandle
+		hasAnnotation := pvc.Annotations != nil && pvc.Annotations[common.AnnVMDeleteProtectionCleared] == "true"
+		hasVMOwner := hasVMOwnerRef(pvc)
+
+		// Case 1: PVC has VM ownerRef but no annotation → clear flag + set annotation
+		if hasVMOwner && !hasAnnotation {
+			if clearKeepAfterDeleteVmForExistingPVC(ctx, pvc, volumeID,
+				metadataSyncer.volumeManager, metadataSyncer.supervisorClient) {
+				clearedCount++
+			}
+			continue
+		}
+
+		// Case 2: PVC has annotation but no VM ownerRef → restore flag + remove annotation
+		if hasAnnotation && !hasVMOwner {
+			if restoreKeepAfterDeleteVmForDetachedPVC(ctx, pvc, volumeID,
+				metadataSyncer.volumeManager, metadataSyncer.supervisorClient) {
+				restoredCount++
+			}
+		}
+	}
+
+	if clearedCount > 0 {
+		log.Infof("reconcileKeepAfterDeleteVmFlags: Cleared keepAfterDeleteVm flag for %d PVCs", clearedCount)
+	}
+	if restoredCount > 0 {
+		log.Infof("reconcileKeepAfterDeleteVmFlags: Restored keepAfterDeleteVm flag for %d PVCs", restoredCount)
+	}
+	log.Debugf("reconcileKeepAfterDeleteVmFlags: End")
 }

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -918,6 +918,10 @@ func (m *mockVolumeManagerForFullSync) ProtectVolumeFromVMDeletion(ctx context.C
 	return nil
 }
 
+func (m *mockVolumeManagerForFullSync) UnprotectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	return nil
+}
+
 func (m *mockVolumeManagerForFullSync) SetVolumeControlFlags(
 	ctx context.Context, volumeID string, controlFlags []string,
 ) error {

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -40,6 +40,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
@@ -739,6 +740,10 @@ type mockVolumeManagerForFullSync struct {
 	mu             sync.Mutex
 	// cnsVolumes is the full set of CNS volumes, keyed by VolumeId.Id
 	cnsVolumeIndex map[string]cnstypes.CnsVolume
+	// unprotectVolumeFromVMDeletionFunc allows tests to customize the behavior
+	unprotectVolumeFromVMDeletionFunc func(ctx context.Context, volumeID string) error
+	// protectVolumeFromVMDeletionFunc allows tests to customize the behavior
+	protectVolumeFromVMDeletionFunc func(ctx context.Context, volumeID string) error
 }
 
 func (m *mockVolumeManagerForFullSync) CreateVolume(
@@ -915,10 +920,16 @@ func (m *mockVolumeManagerForFullSync) MonitorCreateVolumeTask(
 }
 
 func (m *mockVolumeManagerForFullSync) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	if m.protectVolumeFromVMDeletionFunc != nil {
+		return m.protectVolumeFromVMDeletionFunc(ctx, volumeID)
+	}
 	return nil
 }
 
 func (m *mockVolumeManagerForFullSync) UnprotectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	if m.unprotectVolumeFromVMDeletionFunc != nil {
+		return m.unprotectVolumeFromVMDeletionFunc(ctx, volumeID)
+	}
 	return nil
 }
 
@@ -1859,4 +1870,188 @@ func TestReconcilePVCWorkloadTypeAnnotations(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReconcileKeepAfterDeleteVmFlags tests that fullsync performs bidirectional
+// reconciliation of keepAfterDeleteVm flags:
+// - Clears flag for PVCs with VM ownerRef but no annotation
+// - Restores flag for PVCs with annotation but no VM ownerRef
+func TestReconcileKeepAfterDeleteVmFlags(t *testing.T) {
+	ctx := context.Background()
+
+	// Case 1: PVC with VM ownerRef but no annotation (needs flag cleared)
+	pvcNeedsClear := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-needs-clear",
+			Namespace: "test-ns",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "vmoperator.vmware.com/v1alpha2",
+					Kind:       "VirtualMachine",
+					Name:       "test-vm",
+				},
+			},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-1",
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+		},
+	}
+
+	// Case 2: PVC with annotation but no VM ownerRef (needs flag restored)
+	pvcNeedsRestore := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-needs-restore",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				common.AnnVMDeleteProtectionCleared: "true",
+			},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-2",
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+		},
+	}
+
+	// Case 3: PVC with VM ownerRef AND annotation (already processed - skip)
+	pvcAlreadyProcessed := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-already-processed",
+			Namespace: "test-ns",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "vmoperator.vmware.com/v1alpha2",
+					Kind:       "VirtualMachine",
+					Name:       "test-vm-2",
+				},
+			},
+			Annotations: map[string]string{
+				common.AnnVMDeleteProtectionCleared: "true",
+			},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-3",
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+		},
+	}
+
+	// Case 4: PVC without VM ownerRef and no annotation (no action needed)
+	pvcNoAction := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-no-action",
+			Namespace: "test-ns",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-4",
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+		},
+	}
+
+	// Create corresponding PVs
+	pv1 := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-1"},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       csitypes.Name,
+					VolumeHandle: "vol-1",
+				},
+			},
+		},
+	}
+	pv2 := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-2"},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       csitypes.Name,
+					VolumeHandle: "vol-2",
+				},
+			},
+		},
+	}
+	pv3 := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-3"},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       csitypes.Name,
+					VolumeHandle: "vol-3",
+				},
+			},
+		},
+	}
+	pv4 := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-4"},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       csitypes.Name,
+					VolumeHandle: "vol-4",
+				},
+			},
+		},
+	}
+
+	// Create fake k8s client with PVCs and PVs
+	k8sClient := k8sfake.NewSimpleClientset(
+		pvcNeedsClear, pvcNeedsRestore, pvcAlreadyProcessed, pvcNoAction,
+		pv1, pv2, pv3, pv4,
+	)
+
+	// Create fake informer manager with listers using a fresh factory to avoid singleton caching
+	factory := informers.NewSharedInformerFactory(k8sClient, 0)
+	informerManager := k8s.NewInformerFromFactory(ctx, k8sClient, factory)
+	// Register listeners so Listen() waits for the cache to sync
+	err := informerManager.AddPVCListener(
+		ctx, func(interface{}) {}, func(interface{}, interface{}) {}, func(interface{}) {},
+	)
+	assert.NoError(t, err, "Failed to add PVC listener")
+	err = informerManager.AddPVListener(
+		ctx, func(interface{}) {}, func(interface{}, interface{}) {}, func(interface{}) {},
+	)
+	assert.NoError(t, err, "Failed to add PV listener")
+	informerManager.Listen()
+
+	// Track VSLM calls
+	protectCalls := []string{}
+	unprotectCalls := []string{}
+	mockVolMgr := &mockVolumeManagerForFullSync{
+		protectVolumeFromVMDeletionFunc: func(_ context.Context, volumeID string) error {
+			protectCalls = append(protectCalls, volumeID)
+			return nil
+		},
+		unprotectVolumeFromVMDeletionFunc: func(_ context.Context, volumeID string) error {
+			unprotectCalls = append(unprotectCalls, volumeID)
+			return nil
+		},
+	}
+
+	// Create metadataSyncer
+	ms := &metadataSyncInformer{
+		clusterFlavor:    cnstypes.CnsClusterFlavorWorkload,
+		volumeManager:    mockVolMgr,
+		pvLister:         informerManager.GetPVLister(),
+		pvcLister:        informerManager.GetPVCLister(),
+		supervisorClient: k8sClient,
+	}
+
+	// Run the reconciliation
+	reconcileKeepAfterDeleteVmFlags(ctx, ms)
+
+	// Verify that PVC with VM ownerRef and no annotation had flag cleared
+	assert.Equal(t, []string{"vol-1"}, unprotectCalls,
+		"Only vol-1 should have UnprotectVolumeFromVMDeletion called")
+
+	// Verify that PVC with annotation but no VM ownerRef had flag restored
+	assert.Equal(t, []string{"vol-2"}, protectCalls,
+		"Only vol-2 should have ProtectVolumeFromVMDeletion called")
 }

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -528,6 +528,12 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			return logger.LogNewErrorf(log, "failed to create CnsOperator client for WCP mode. Err: %v", err)
 		}
 
+		// Initialize supervisor client for PVC annotation updates (e.g., VM delete protection).
+		metadataSyncer.supervisorClient, err = k8s.NewSupervisorClient(ctx, k8sConfig)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to create supervisorClient for WCP mode. Err: %v", err)
+		}
+
 		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSISVFeatureStateReplication) {
 			svParams, ok := COInitParams.(k8sorchestrator.K8sSupervisorInitParams)
 			if !ok {
@@ -718,18 +724,23 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 
 	// Set up kubernetes resource listeners for metadata syncer.
 	metadataSyncer.k8sInformerManager = k8s.NewInformer(ctx, k8sClient, true)
-	err = metadataSyncer.k8sInformerManager.AddPVCListener(
-		ctx,
-		nil, // Add.
-		func(oldObj interface{}, newObj interface{}) { // Update.
-			pvcUpdated(oldObj, newObj, metadataSyncer)
-		},
-		func(obj interface{}) { // Delete.
-			pvcDeleted(obj, metadataSyncer)
-		})
-	if err != nil {
-		return logger.LogNewErrorf(log, "failed to listen on PVCs. Error: %v", err)
+
+	// Initialize listers BEFORE registering listeners. This ensures that when
+	// pvcAdded is called, it can look up PVs via pvLister without nil panics.
+	metadataSyncer.pvLister = metadataSyncer.k8sInformerManager.GetPVLister()
+	metadataSyncer.pvcLister = metadataSyncer.k8sInformerManager.GetPVCLister()
+	metadataSyncer.podLister = metadataSyncer.k8sInformerManager.GetPodLister()
+
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSI_Backup_API) {
+		// Initialize the VolumeAttachment informer and get the lister. This is needed
+		// for the cbtsync to watch on VolumeAttachment resources.
+		metadataSyncer.k8sInformerManager.InitVolumeAttachmentInformer()
+		metadataSyncer.vaLister = metadataSyncer.k8sInformerManager.GetVolumeAttachmentLister()
 	}
+
+	// Register PV listener first, then PVC listener. This ordering ensures that
+	// when pvcAdded runs during informer sync, the PV cache is already populated.
 	err = metadataSyncer.k8sInformerManager.AddPVListener(
 		ctx,
 		func(obj interface{}) {
@@ -743,6 +754,20 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		})
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to listen on PVs. Error: %v", err)
+	}
+	err = metadataSyncer.k8sInformerManager.AddPVCListener(
+		ctx,
+		func(obj interface{}) { // Add.
+			pvcAdded(obj, metadataSyncer)
+		},
+		func(oldObj interface{}, newObj interface{}) { // Update.
+			pvcUpdated(oldObj, newObj, metadataSyncer)
+		},
+		func(obj interface{}) { // Delete.
+			pvcDeleted(obj, metadataSyncer)
+		})
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to listen on PVCs. Error: %v", err)
 	}
 	err = metadataSyncer.k8sInformerManager.AddPodListener(
 		ctx,
@@ -759,17 +784,6 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		return logger.LogNewErrorf(log, "failed to listen on pods. Error: %v", err)
 	}
 
-	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
-		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSI_Backup_API) {
-		// Initialize the VolumeAttachment informer and get the lister. This is needed
-		// for the cbtsync to watch on VolumeAttachment resources.
-		metadataSyncer.k8sInformerManager.InitVolumeAttachmentInformer()
-		metadataSyncer.vaLister = metadataSyncer.k8sInformerManager.GetVolumeAttachmentLister()
-	}
-
-	metadataSyncer.pvLister = metadataSyncer.k8sInformerManager.GetPVLister()
-	metadataSyncer.pvcLister = metadataSyncer.k8sInformerManager.GetPVCLister()
-	metadataSyncer.podLister = metadataSyncer.k8sInformerManager.GetPodLister()
 	stopCh := metadataSyncer.k8sInformerManager.Listen()
 	if stopCh == nil {
 		return logger.LogNewError(log, "Failed to sync informer caches")
@@ -2631,6 +2645,59 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 	return nil
 }
 
+// pvcAdded handles PVC add events. On Supervisor cluster, this clears the
+// keepAfterDeleteVm control flag for existing PVCs that have VM ownerRefs
+// but haven't been processed yet (e.g., on CSI driver upgrade/restart).
+func pvcAdded(obj interface{}, metadataSyncer *metadataSyncInformer) {
+	// Only process on Supervisor cluster
+	if metadataSyncer == nil || metadataSyncer.clusterFlavor != cnstypes.CnsClusterFlavorWorkload {
+		return
+	}
+
+	pvc, ok := obj.(*v1.PersistentVolumeClaim)
+	if pvc == nil || !ok {
+		return
+	}
+
+	// Skip if already processed (annotation present) - check this first to avoid
+	// unnecessary PV lookups and other checks on every syncer restart/resync.
+	if pvc.Annotations != nil && pvc.Annotations[common.AnnVMDeleteProtectionCleared] == "true" {
+		return
+	}
+
+	ctx, log := logger.GetNewContextWithLogger()
+
+	// Only process bound PVCs
+	if pvc.Status.Phase != v1.ClaimBound {
+		log.Debugf("PVCAdded: PVC %s/%s not in Bound phase; skipping", pvc.Namespace, pvc.Name)
+		return
+	}
+
+	// Ensure pvLister is initialized before using it
+	if metadataSyncer.pvLister == nil {
+		log.Debugf("PVCAdded: pvLister not initialized yet; skipping PVC %s/%s", pvc.Namespace, pvc.Name)
+		return
+	}
+
+	// Get PV object attached to PVC
+	pv, err := metadataSyncer.pvLister.Get(pvc.Spec.VolumeName)
+	if pv == nil || err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Errorf("PVCAdded: Error getting PV for PVC %s/%s: %v", pvc.Namespace, pvc.Name, err)
+		}
+		return
+	}
+
+	// Only process vSphere CSI volumes
+	if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != csitypes.Name {
+		return
+	}
+
+	// Clear keepAfterDeleteVm for existing PVCs with VM ownerRef
+	clearKeepAfterDeleteVmForExistingPVC(ctx, pvc, pv.Spec.CSI.VolumeHandle,
+		metadataSyncer.volumeManager, metadataSyncer.supervisorClient)
+}
+
 // pvcUpdated updates persistent volume claim metadata on VC when pvc labels
 // on K8S cluster have been updated.
 func pvcUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer) {
@@ -2727,6 +2794,16 @@ func pvcUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer
 			log.Debugf("PVCUpdated: Not a vSphere CSI Volume")
 			return
 		}
+
+		// On Supervisor, manage the keepAfterDeleteVm control flag based on
+		// VirtualMachine ownerRef changes. When a VM ownerRef is added, clear
+		// the flag (volume lifecycle tied to VM). When removed (and PVC not
+		// being deleted), restore the flag so the FCD persists independently.
+		if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+			handleVMOwnerRefChange(ctx, oldPvc, newPvc, pv.Spec.CSI.VolumeHandle,
+				metadataSyncer.volumeManager, metadataSyncer.supervisorClient)
+		}
+
 		// For volumes provisioned by CSI driver, verify if old and new labels are not equal.
 		if oldPvc.Status.Phase == v1.ClaimBound && reflect.DeepEqual(newPvc.Labels, oldPvc.Labels) {
 			log.Debugf("PVCUpdated: Old PVC and New PVC labels equal")

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -1175,3 +1175,46 @@ func clearKeepAfterDeleteVmForExistingPVC(ctx context.Context, pvc *v1.Persisten
 
 	return true
 }
+
+// restoreKeepAfterDeleteVmForDetachedPVC restores the keepAfterDeleteVm flag for
+// a PVC that has the protection-cleared annotation but no longer has a VM ownerRef.
+// This handles failed pvcUpdated events during upgrade/restart.
+// Returns true if the flag was restored, false otherwise.
+func restoreKeepAfterDeleteVmForDetachedPVC(ctx context.Context, pvc *v1.PersistentVolumeClaim,
+	volumeID string, volumeManager volumes.Manager, k8sClient clientset.Interface) bool {
+	log := logger.GetLogger(ctx)
+
+	// Skip if PVC has VM ownerRef (protection should remain cleared)
+	if hasVMOwnerRef(pvc) {
+		return false
+	}
+
+	// Skip if annotation not present (nothing to restore)
+	if pvc.Annotations == nil || pvc.Annotations[common.AnnVMDeleteProtectionCleared] != "true" {
+		return false
+	}
+
+	// Skip if PVC is being deleted
+	if !pvc.DeletionTimestamp.IsZero() {
+		log.Debugf("PVC %s/%s has deletion timestamp; skipping keepAfterDeleteVm restore",
+			pvc.Namespace, pvc.Name)
+		return false
+	}
+
+	log.Infof("PVC %s/%s has protection-cleared annotation but no VM ownerRef; "+
+		"restoring keepAfterDeleteVm for volume %s", pvc.Namespace, pvc.Name, volumeID)
+
+	if err := volumeManager.ProtectVolumeFromVMDeletion(ctx, volumeID); err != nil {
+		log.Errorf("Failed to restore keepAfterDeleteVm for volume %s (PVC %s/%s): %v",
+			volumeID, pvc.Namespace, pvc.Name, err)
+		return false
+	}
+
+	// Remove annotation since protection is restored
+	if err := removeVMDeleteProtectionClearedAnnotation(ctx, k8sClient, pvc); err != nil {
+		log.Errorf("Failed to remove protection-cleared annotation from PVC %s/%s: %v",
+			pvc.Namespace, pvc.Name, err)
+	}
+
+	return true
+}

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -995,4 +996,182 @@ func generateVolumeAccessibleTopologyFromPVCAnnotation(claim *v1.PersistentVolum
 			claim.Name, claim.Namespace, err)
 	}
 	return volumeAccessibleTopologyArray, nil
+}
+
+// vmOperatorAPIGroup is the API group for vmoperator VirtualMachine resources.
+const vmOperatorAPIGroup = "vmoperator.vmware.com"
+
+// hasVMOwnerRef checks if a PVC has an ownerReference pointing to a VirtualMachine.
+// Returns true if any ownerReference has Kind=VirtualMachine and APIVersion
+// contains the vmoperator.vmware.com API group.
+func hasVMOwnerRef(pvc *v1.PersistentVolumeClaim) bool {
+	if pvc == nil {
+		return false
+	}
+	for _, ownerRef := range pvc.OwnerReferences {
+		if ownerRef.Kind == "VirtualMachine" &&
+			len(ownerRef.APIVersion) > len(vmOperatorAPIGroup) &&
+			ownerRef.APIVersion[:len(vmOperatorAPIGroup)] == vmOperatorAPIGroup {
+			return true
+		}
+	}
+	return false
+}
+
+// handleVMOwnerRefChange detects changes in VM ownerRef between old and new PVC
+// and calls the appropriate volume manager method to set or clear the
+// keepAfterDeleteVm control flag. When clearing the flag, it also sets an
+// annotation on the PVC to prevent repeated VSLM calls on syncer restarts.
+//
+// When a VM ownerRef is added → clear keepAfterDeleteVm (volume tied to VM lifecycle)
+// When a VM ownerRef is removed (and PVC not being deleted) → set keepAfterDeleteVm
+func handleVMOwnerRefChange(ctx context.Context, oldPvc, newPvc *v1.PersistentVolumeClaim,
+	volumeID string, volumeManager volumes.Manager, k8sClient clientset.Interface) {
+	log := logger.GetLogger(ctx)
+
+	oldHasVMOwner := hasVMOwnerRef(oldPvc)
+	newHasVMOwner := hasVMOwnerRef(newPvc)
+
+	if oldHasVMOwner == newHasVMOwner {
+		return
+	}
+
+	if newHasVMOwner {
+		log.Infof("VM ownerRef added to PVC %s/%s; clearing keepAfterDeleteVm for volume %s",
+			newPvc.Namespace, newPvc.Name, volumeID)
+		if err := volumeManager.UnprotectVolumeFromVMDeletion(ctx, volumeID); err != nil {
+			log.Errorf("Failed to clear keepAfterDeleteVm for volume %s (PVC %s/%s): %v",
+				volumeID, newPvc.Namespace, newPvc.Name, err)
+			return
+		}
+		// Set annotation to prevent repeated VSLM calls on syncer restarts
+		if err := setVMDeleteProtectionClearedAnnotation(ctx, k8sClient, newPvc); err != nil {
+			log.Errorf("Failed to set protection-cleared annotation on PVC %s/%s: %v",
+				newPvc.Namespace, newPvc.Name, err)
+		}
+		return
+	}
+
+	if !newPvc.DeletionTimestamp.IsZero() {
+		log.Debugf("VM ownerRef removed from PVC %s/%s but PVC has deletion timestamp; "+
+			"skipping keepAfterDeleteVm restore for volume %s",
+			newPvc.Namespace, newPvc.Name, volumeID)
+		return
+	}
+
+	log.Infof("VM ownerRef removed from PVC %s/%s; setting keepAfterDeleteVm for volume %s",
+		newPvc.Namespace, newPvc.Name, volumeID)
+	if err := volumeManager.ProtectVolumeFromVMDeletion(ctx, volumeID); err != nil {
+		log.Errorf("Failed to set keepAfterDeleteVm for volume %s (PVC %s/%s): %v",
+			volumeID, newPvc.Namespace, newPvc.Name, err)
+		return
+	}
+	// Remove the annotation since protection is restored
+	if err := removeVMDeleteProtectionClearedAnnotation(ctx, k8sClient, newPvc); err != nil {
+		log.Errorf("Failed to remove protection-cleared annotation from PVC %s/%s: %v",
+			newPvc.Namespace, newPvc.Name, err)
+	}
+}
+
+// setVMDeleteProtectionClearedAnnotation sets the annotation indicating that
+// keepAfterDeleteVm has been cleared due to VM ownerRef presence.
+func setVMDeleteProtectionClearedAnnotation(ctx context.Context, k8sClient clientset.Interface,
+	pvc *v1.PersistentVolumeClaim) error {
+	log := logger.GetLogger(ctx)
+	if k8sClient == nil {
+		return fmt.Errorf("k8sClient is nil")
+	}
+
+	// Fetch fresh PVC to avoid conflicts
+	freshPVC, err := k8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get PVC %s/%s: %v", pvc.Namespace, pvc.Name, err)
+	}
+
+	// Check if annotation is already set
+	if freshPVC.Annotations != nil && freshPVC.Annotations[common.AnnVMDeleteProtectionCleared] == "true" {
+		return nil
+	}
+
+	metav1.SetMetaDataAnnotation(&freshPVC.ObjectMeta, common.AnnVMDeleteProtectionCleared, "true")
+	_, err = k8sClient.CoreV1().PersistentVolumeClaims(freshPVC.Namespace).Update(ctx, freshPVC, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update PVC %s/%s: %v", freshPVC.Namespace, freshPVC.Name, err)
+	}
+	log.Infof("Set %s annotation on PVC %s/%s", common.AnnVMDeleteProtectionCleared, pvc.Namespace, pvc.Name)
+	return nil
+}
+
+// removeVMDeleteProtectionClearedAnnotation removes the annotation when
+// keepAfterDeleteVm protection is restored (VM ownerRef removed).
+func removeVMDeleteProtectionClearedAnnotation(ctx context.Context, k8sClient clientset.Interface,
+	pvc *v1.PersistentVolumeClaim) error {
+	log := logger.GetLogger(ctx)
+	if k8sClient == nil {
+		return fmt.Errorf("k8sClient is nil")
+	}
+
+	// Fetch fresh PVC to avoid conflicts
+	freshPVC, err := k8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get PVC %s/%s: %v", pvc.Namespace, pvc.Name, err)
+	}
+
+	// Check if annotation exists
+	if freshPVC.Annotations == nil || freshPVC.Annotations[common.AnnVMDeleteProtectionCleared] == "" {
+		return nil
+	}
+
+	delete(freshPVC.Annotations, common.AnnVMDeleteProtectionCleared)
+	_, err = k8sClient.CoreV1().PersistentVolumeClaims(freshPVC.Namespace).Update(ctx, freshPVC, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update PVC %s/%s: %v", freshPVC.Namespace, freshPVC.Name, err)
+	}
+	log.Infof("Removed %s annotation from PVC %s/%s", common.AnnVMDeleteProtectionCleared, pvc.Namespace, pvc.Name)
+	return nil
+}
+
+// clearKeepAfterDeleteVmForExistingPVC clears the keepAfterDeleteVm flag for
+// a PVC that has a VM ownerRef but hasn't been processed yet (e.g., on CSI
+// driver upgrade). This is called from pvcAdded to handle existing PVCs.
+// Returns true if the flag was cleared, false otherwise.
+func clearKeepAfterDeleteVmForExistingPVC(ctx context.Context, pvc *v1.PersistentVolumeClaim,
+	volumeID string, volumeManager volumes.Manager, k8sClient clientset.Interface) bool {
+	log := logger.GetLogger(ctx)
+
+	// Skip if PVC doesn't have VM ownerRef
+	if !hasVMOwnerRef(pvc) {
+		return false
+	}
+
+	// Skip if already processed (annotation present)
+	if pvc.Annotations != nil && pvc.Annotations[common.AnnVMDeleteProtectionCleared] == "true" {
+		log.Debugf("PVC %s/%s already has protection-cleared annotation; skipping",
+			pvc.Namespace, pvc.Name)
+		return false
+	}
+
+	// Skip if PVC is being deleted
+	if !pvc.DeletionTimestamp.IsZero() {
+		log.Debugf("PVC %s/%s has deletion timestamp; skipping keepAfterDeleteVm clear",
+			pvc.Namespace, pvc.Name)
+		return false
+	}
+
+	log.Infof("Existing PVC %s/%s has VM ownerRef; clearing keepAfterDeleteVm for volume %s",
+		pvc.Namespace, pvc.Name, volumeID)
+
+	if err := volumeManager.UnprotectVolumeFromVMDeletion(ctx, volumeID); err != nil {
+		log.Errorf("Failed to clear keepAfterDeleteVm for volume %s (PVC %s/%s): %v",
+			volumeID, pvc.Namespace, pvc.Name, err)
+		return false
+	}
+
+	// Set annotation to prevent repeated VSLM calls
+	if err := setVMDeleteProtectionClearedAnnotation(ctx, k8sClient, pvc); err != nil {
+		log.Errorf("Failed to set protection-cleared annotation on PVC %s/%s: %v",
+			pvc.Namespace, pvc.Name, err)
+	}
+
+	return true
 }

--- a/pkg/syncer/util_test.go
+++ b/pkg/syncer/util_test.go
@@ -2,9 +2,12 @@ package syncer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
 )
 
@@ -475,4 +479,362 @@ func TestHasClusterDistributionSet(t *testing.T) {
 			assert.Equal(t, test.expectedResult, result)
 		})
 	}
+}
+
+func TestHasVMOwnerRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		pvc      *corev1.PersistentVolumeClaim
+		expected bool
+	}{
+		{
+			name:     "nil PVC",
+			pvc:      nil,
+			expected: false,
+		},
+		{
+			name: "PVC with no owner references",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-pvc",
+					Namespace:       "test-ns",
+					OwnerReferences: nil,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "PVC with empty owner references",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-pvc",
+					Namespace:       "test-ns",
+					OwnerReferences: []metav1.OwnerReference{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "PVC with VM ownerRef (v1alpha3)",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: "test-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "vmoperator.vmware.com/v1alpha3",
+							Kind:       "VirtualMachine",
+							Name:       "my-vm",
+							UID:        "vm-uid-123",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "PVC with VM ownerRef (v1alpha5)",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: "test-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "vmoperator.vmware.com/v1alpha5",
+							Kind:       "VirtualMachine",
+							Name:       "my-vm",
+							UID:        "vm-uid-123",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "PVC with non-VM ownerRef",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: "test-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "StatefulSet",
+							Name:       "my-sts",
+							UID:        "sts-uid-123",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "PVC with VirtualMachine kind but wrong API group",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: "test-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "other.vmware.com/v1",
+							Kind:       "VirtualMachine",
+							Name:       "my-vm",
+							UID:        "vm-uid-123",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "PVC with multiple ownerRefs including VM",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: "test-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "StatefulSet",
+							Name:       "my-sts",
+							UID:        "sts-uid-123",
+						},
+						{
+							APIVersion: "vmoperator.vmware.com/v1alpha5",
+							Kind:       "VirtualMachine",
+							Name:       "my-vm",
+							UID:        "vm-uid-456",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasVMOwnerRef(tc.pvc)
+			assert.Equal(t, tc.expected, result, "hasVMOwnerRef result mismatch")
+		})
+	}
+}
+
+// vmOwnerRefTestVolumeManager is a mock volume manager for testing handleVMOwnerRefChange.
+// It tracks calls to ProtectVolumeFromVMDeletion and UnprotectVolumeFromVMDeletion.
+type vmOwnerRefTestVolumeManager struct {
+	*unittestcommon.MockVolumeManager
+
+	mu             sync.Mutex
+	protectCalls   []string
+	unprotectCalls []string
+	protectErr     error
+	unprotectErr   error
+}
+
+func (m *vmOwnerRefTestVolumeManager) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.protectCalls = append(m.protectCalls, volumeID)
+	return m.protectErr
+}
+
+func (m *vmOwnerRefTestVolumeManager) UnprotectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.unprotectCalls = append(m.unprotectCalls, volumeID)
+	return m.unprotectErr
+}
+
+func (m *vmOwnerRefTestVolumeManager) getProtectCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string{}, m.protectCalls...)
+}
+
+func (m *vmOwnerRefTestVolumeManager) getUnprotectCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string{}, m.unprotectCalls...)
+}
+
+func TestHandleVMOwnerRefChange(t *testing.T) {
+	ctx := context.Background()
+	volumeID := "test-volume-id"
+
+	basePVC := func() *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pvc",
+				Namespace: "test-ns",
+			},
+		}
+	}
+
+	vmOwnerRef := metav1.OwnerReference{
+		APIVersion: "vmoperator.vmware.com/v1alpha5",
+		Kind:       "VirtualMachine",
+		Name:       "my-vm",
+		UID:        "vm-uid-123",
+	}
+
+	tests := []struct {
+		name            string
+		oldPvc          *corev1.PersistentVolumeClaim
+		newPvc          *corev1.PersistentVolumeClaim
+		expectProtect   bool
+		expectUnprotect bool
+	}{
+		{
+			name:            "No change - neither has VM ownerRef",
+			oldPvc:          basePVC(),
+			newPvc:          basePVC(),
+			expectProtect:   false,
+			expectUnprotect: false,
+		},
+		{
+			name: "No change - both have VM ownerRef",
+			oldPvc: func() *corev1.PersistentVolumeClaim {
+				p := basePVC()
+				p.OwnerReferences = []metav1.OwnerReference{vmOwnerRef}
+				return p
+			}(),
+			newPvc: func() *corev1.PersistentVolumeClaim {
+				p := basePVC()
+				p.OwnerReferences = []metav1.OwnerReference{vmOwnerRef}
+				return p
+			}(),
+			expectProtect:   false,
+			expectUnprotect: false,
+		},
+		{
+			name:   "VM ownerRef added - should unprotect (clear keepAfterDeleteVm)",
+			oldPvc: basePVC(),
+			newPvc: func() *corev1.PersistentVolumeClaim {
+				p := basePVC()
+				p.OwnerReferences = []metav1.OwnerReference{vmOwnerRef}
+				return p
+			}(),
+			expectProtect:   false,
+			expectUnprotect: true,
+		},
+		{
+			name: "VM ownerRef removed - should protect (set keepAfterDeleteVm)",
+			oldPvc: func() *corev1.PersistentVolumeClaim {
+				p := basePVC()
+				p.OwnerReferences = []metav1.OwnerReference{vmOwnerRef}
+				return p
+			}(),
+			newPvc:          basePVC(),
+			expectProtect:   true,
+			expectUnprotect: false,
+		},
+		{
+			name: "VM ownerRef removed but PVC has deletion timestamp - skip protect",
+			oldPvc: func() *corev1.PersistentVolumeClaim {
+				p := basePVC()
+				p.OwnerReferences = []metav1.OwnerReference{vmOwnerRef}
+				return p
+			}(),
+			newPvc: func() *corev1.PersistentVolumeClaim {
+				p := basePVC()
+				now := metav1.NewTime(time.Now())
+				p.DeletionTimestamp = &now
+				return p
+			}(),
+			expectProtect:   false,
+			expectUnprotect: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockMgr := &vmOwnerRefTestVolumeManager{
+				MockVolumeManager: &unittestcommon.MockVolumeManager{},
+			}
+
+			// Pass nil for k8sClient since we're only testing the protect/unprotect logic,
+			// not the annotation update (which requires a real k8s client).
+			handleVMOwnerRefChange(ctx, tc.oldPvc, tc.newPvc, volumeID, mockMgr, nil)
+
+			protectCalls := mockMgr.getProtectCalls()
+			unprotectCalls := mockMgr.getUnprotectCalls()
+
+			if tc.expectProtect {
+				assert.Len(t, protectCalls, 1, "Expected exactly 1 protect call")
+				assert.Equal(t, volumeID, protectCalls[0], "Protect called with wrong volumeID")
+			} else {
+				assert.Empty(t, protectCalls, "Expected no protect calls")
+			}
+
+			if tc.expectUnprotect {
+				assert.Len(t, unprotectCalls, 1, "Expected exactly 1 unprotect call")
+				assert.Equal(t, volumeID, unprotectCalls[0], "Unprotect called with wrong volumeID")
+			} else {
+				assert.Empty(t, unprotectCalls, "Expected no unprotect calls")
+			}
+		})
+	}
+}
+
+func TestHandleVMOwnerRefChange_ErrorCases(t *testing.T) {
+	ctx := context.Background()
+	volumeID := "test-volume-id"
+
+	vmOwnerRef := metav1.OwnerReference{
+		APIVersion: "vmoperator.vmware.com/v1alpha5",
+		Kind:       "VirtualMachine",
+		Name:       "my-vm",
+		UID:        "vm-uid-123",
+	}
+
+	t.Run("Protect error is logged but does not panic", func(t *testing.T) {
+		oldPvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-pvc",
+				Namespace:       "test-ns",
+				OwnerReferences: []metav1.OwnerReference{vmOwnerRef},
+			},
+		}
+		newPvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pvc",
+				Namespace: "test-ns",
+			},
+		}
+
+		mockMgr := &vmOwnerRefTestVolumeManager{
+			MockVolumeManager: &unittestcommon.MockVolumeManager{},
+			protectErr:        errors.New("protect failed"),
+		}
+
+		// Should not panic (pass nil for k8sClient)
+		handleVMOwnerRefChange(ctx, oldPvc, newPvc, volumeID, mockMgr, nil)
+		assert.Len(t, mockMgr.getProtectCalls(), 1, "Protect should have been called")
+	})
+
+	t.Run("Unprotect error is logged but does not panic", func(t *testing.T) {
+		oldPvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pvc",
+				Namespace: "test-ns",
+			},
+		}
+		newPvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-pvc",
+				Namespace:       "test-ns",
+				OwnerReferences: []metav1.OwnerReference{vmOwnerRef},
+			},
+		}
+
+		mockMgr := &vmOwnerRefTestVolumeManager{
+			MockVolumeManager: &unittestcommon.MockVolumeManager{},
+			unprotectErr:      errors.New("unprotect failed"),
+		}
+
+		// Should not panic (pass nil for k8sClient)
+		handleVMOwnerRefChange(ctx, oldPvc, newPvc, volumeID, mockMgr, nil)
+		assert.Len(t, mockMgr.getUnprotectCalls(), 1, "Unprotect should have been called")
+	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This change is required to ensure when vm is deleted, vm directory also gets deleted along with, otherwise if fcds are preserved and deleted later, vm directory is leaked on the datastore.

**CnsRegisterVolume: clear flag on non-removable VM-imported PVCs**
When CnsRegisterVolume registers a disk via CreateVolume, CNS automatically sets the keepAfterDeleteVm control flag on the resulting FCD. For PVCs that VM Operator creates with a DataSourceRef pointing at a VirtualMachine and where the matching VM volume entry has removable=false, this ties the FCD lifecycle to the VM rather than to the PVC.

After registration and before PV creation, look up the referencing VirtualMachine CR, find the matching volume entry by claim name, and clear the keepAfterDeleteVm flag when removable=false. The new code path uses the VSLM endpoint directly, so no FSS gate is required. On VM lookup or clear errors the FCD stays registered and the reconciler requeues; both CreateVolume and VSLM clear are idempotent on retry.

Add unit tests covering: removable=false (flag cleared), removable=true/nil (no-op), nil PVC / no DataSourceRef (no-op), non-VirtualMachine DataSourceRef (no-op), VM CR not found (requeue), VSLM Clear API error (requeue), and PVC claim name mismatch (no-op).

**Metadatasyncer: dynamic flag management based on PVC VM ownerRef**
The keepAfterDeleteVm control flag must also be kept in sync with the VirtualMachine ownerRef on a PVC throughout its lifetime. A PVC that gains a VM ownerRef should have the flag cleared; if the ownerRef is later removed while the PVC is still alive, the flag must be restored so the FCD is not
deleted when the VM is removed.

Extend the metadatasyncer on the Supervisor cluster to detect VM ownerRef changes on PVC updates and call UnprotectVolumeFromVMDeletion or ProtectVolumeFromVMDeletion accordingly. Add a pvcAdded handler so that on CSI driver upgrade or syncer restart, any existing bound PVC that already carries a VM ownerRef but has not yet been processed gets its keepAfterDeleteVm flag cleared immediately.

Set the annotation cns.vmware.com/vm-delete-protection-cleared=true on the PVC after clearing the flag to prevent redundant VSLM calls on syncer restarts or informer resyncs. Remove the annotation when the flag is restored
(VM ownerRef removed). PVCs with a deletion timestamp are skipped when restoring the flag.

Add unit tests covering ownerRef added/removed, no-op cases (no change, both sides equal), deletion-timestamp skip, and error logging paths for both protect and unprotect failures.


**Testing done**:
Verified that after importing a VM into the Supervisor cluster and subsequently deleting the VM, the corresponding VM directory is also removed from the datastore. Without this fix, the VM directory remains orphaned on the datastore after VM deletion.


Upgrade Logs for exiting PVCs

> {"level":"info","time":"2026-06-02T20:01:26.620763881Z","caller":"syncer/util.go:1161","msg":"Existing PVC test-ns/test-vm-6e6bff88 has VM ownerRef; clearing keepAfterDeleteVm for volume c6d9214a-492b-4901-aeac-ee86ed7b39f8","TraceId":"f2b944c4-bf99-45d7-aceb-9eea8976cd25"}
{"level":"info","time":"2026-06-02T20:01:28.092206785Z","caller":"volume/manager.go:3721","msg":"Successfully cleared keepAfterDeleteVm control flag for volumeID: \"c6d9214a-492b-4901-aeac-ee86ed7b39f8\"","TraceId":"f2b944c4-bf99-45d7-aceb-9eea8976cd25"}
{"level":"info","time":"2026-06-02T20:01:28.478470854Z","caller":"syncer/util.go:1101","msg":"Set cns.vmware.com/vm-delete-protection-cleared annotation on PVC test-ns/test-vm-6e6bff88","TraceId":"f2b944c4-bf99-45d7-aceb-9eea8976cd25"}



Logs for new PVC registered with OwnerRef for VM

> {"level":"info","time":"2026-06-02T21:10:48.254082947Z","caller":"volume/util.go:365","msg":"Volume created successfully. VolumeName: \"static-pv-8406d3a3-5ec7-11f1-b9c3-005056a22312\", volumeID: \"5290c879-afb1-4ecf-ae27-112b9849770c\"","TraceId":"49109b17-bd40-4c92-8a5b-f4d65c90b057"}
{"level":"info","time":"2026-06-02T21:10:48.254147115Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:349","msg":"Created CNS volume with volumeID: 5290c879-afb1-4ecf-ae27-112b9849770c","TraceId":"49109b17-bd40-4c92-8a5b-f4d65c90b057"}
{"level":"info","time":"2026-06-02T21:10:48.254183914Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:353","msg":"Querying volume: 5290c879-afb1-4ecf-ae27-112b9849770c for CnsRegisterVolume request with name: \"test-vm2-012b143a\" on namespace: \"test-ns\"","TraceId":"49109b17-bd40-4c92-8a5b-f4d65c90b057"}
{"level":"info","time":"2026-06-02T21:10:48.799451385Z","caller":"cnsregistervolume/util.go:164","msg":"Clearing keepAfterDeleteVm for volumeID 5290c879-afb1-4ecf-ae27-112b9849770c (PVC test-ns/test-vm2-012b143a mounted as non-removable on VM test-vm2)","TraceId":"49109b17-bd40-4c92-8a5b-f4d65c90b057"}
{"level":"info","time":"2026-06-02T21:10:49.839771952Z","caller":"volume/manager.go:3721","msg":"Successfully cleared keepAfterDeleteVm control flag for volumeID: \"5290c879-afb1-4ecf-ae27-112b9849770c\"","TraceId":"49109b17-bd40-4c92-8a5b-f4d65c90b057"}


Logs for adding back keepafterdeletevm flag when PVC no longer have ownerRef for VM. Note even when PVC from imported vm is detached from the vm, ownerRef on the PVC is not removed. to test the case, I removed ownerRef manually.

> {"level":"info","time":"2026-06-02T22:50:10.197830084Z","caller":"volume/manager.go:3686","msg":"Successfully re-registered volume to set control flag to protect volume from vm deletion","TraceId":"3a18a71e-18cd-4d8c-8716-2e8d63505d6f"}
{"level":"info","time":"2026-06-02T22:50:10.236069463Z","caller":"syncer/util.go:1130","msg":"Removed cns.vmware.com/vm-delete-protection-cleared annotation from PVC test-ns/test-vm-6e6bff88","TraceId":"3a18a71e-18cd-4d8c-8716-2e8d63505d6f"}

**Special notes for your reviewer**:

Pre-checkin
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1609/ - Pass

```
Ran 16 of 2357 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2341 Skipped | 0 Flaked
```

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1224/ - Pass

```
Ran 6 of 2357 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2351 Skipped | 0 Flaked
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Clear keepAfterDeleteVm on FCDs registered for non-removable VM-imported PVCs
```
