### PR TITLE
Populate volume capabilities in InfraSPI CR

### DIFF
--- a/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1/infrastoragepolicyinfo_types.go
+++ b/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1/infrastoragepolicyinfo_types.go
@@ -30,6 +30,18 @@ import (
 // +kubebuilder:validation:Enum=SupportsPersistentVolumeBlock;SupportsPersistentVolumeFilesystem;SupportsHighPerformanceLinkedClone;SupportsLinkedClone
 type VolumeCapability string
 
+const (
+	// SupportsVolumeModeBlock indicates that the policy supports PersistentVolume with Block volume mode.
+	SupportsVolumeModeBlock VolumeCapability = "SupportsPersistentVolumeBlock"
+	// SupportsVolumeModeFilesystem indicates that the policy supports PersistentVolume with Filesystem volume mode.
+	SupportsVolumeModeFilesystem VolumeCapability = "SupportsPersistentVolumeFilesystem"
+	// SupportsHighPerformanceLinkedClone indicates that the policy supports high-performance linked clones
+	// on vSAN ESA clusters with ESXi 9.1 or above hosts.
+	SupportsHighPerformanceLinkedClone VolumeCapability = "SupportsHighPerformanceLinkedClone"
+	// SupportsLinkedClone indicates that the policy supports linked clones with at least one ESXi 9.1+ host.
+	SupportsLinkedClone VolumeCapability = "SupportsLinkedClone"
+)
+
 // Topology describes topology accessibility for the storage policy within the cluster.
 type Topology struct {
 

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -58,7 +58,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
+	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 // backOffDuration is a map of ClusterStoragePolicyInfo names to the time after
@@ -149,7 +149,7 @@ func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 
 func add(mgr manager.Manager, r *ReconcileClusterStoragePolicyInfo) error {
 	ctx, log := logger.GetNewContextWithLogger()
-	maxWorkerThreads := util.GetMaxWorkerThreads(ctx, workerThreadsEnvVar, defaultMaxWorkerThreads)
+	maxWorkerThreads := cnsoperatorutil.GetMaxWorkerThreads(ctx, workerThreadsEnvVar, defaultMaxWorkerThreads)
 	scVacPredicates := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return e.Object != nil
@@ -669,21 +669,32 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 	log.Infof("Syncing InfraSPI attributes for %q (policy ID: %s, name: %s)",
 		instance.Name, profile.ID, profile.Name)
 
-	// Populate topology capabilities for InfraSPI if policy uses zonal topology
-	err := r.populateTopologyCapabilities(ctx, instance, infraSPI, profile.ID, vc)
-	if err != nil {
+	var overallErr error
+
+	// Create a cache for datastore information to be shared across capability calculations
+	// This avoids redundant vCenter calls when populating both topology and volume capabilities
+	clusterDatastoreCache := make(map[string][]*cnsvsphere.DatastoreInfo)
+
+	// Populate topology capabilities for InfraSPI.
+	if err := r.populateTopologyCapabilities(ctx, instance, infraSPI, profile.ID, vc, clusterDatastoreCache); err != nil {
 		log.Errorf("Failed to populate topology capabilities for profile %s: %v", profile.ID, err)
-		return err
+		overallErr = errors.Join(overallErr, err)
 	}
 
-	return nil
+	// Populate volume capabilities.
+	if err := populateVolumeCapabilities(ctx, infraSPI, vc, profile.ID, r.topologyMgr, clusterDatastoreCache); err != nil {
+		log.Errorf("Failed to populate volume capabilities for profile %s: %v", profile.ID, err)
+		overallErr = errors.Join(overallErr, err)
+	}
+
+	return overallErr
 }
 
 // populateTopologyCapabilities populates topology information for the storage policy in InfraSPI
 func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx context.Context,
 	clusterSPI *clusterspiv1alpha1.ClusterStoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo, profileID string,
-	vc *cnsvsphere.VirtualCenter) error {
+	vc *cnsvsphere.VirtualCenter, clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) error {
 	log := logger.GetLogger(ctx)
 
 	// Marker policies (e.g. vSAN File Service) derive their cluster-wide accessible zones from
@@ -694,7 +705,7 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 		zonesFn := func(ns string) map[string]struct{} {
 			return commonco.ContainerOrchestratorUtility.GetZonesForNamespace(ns)
 		}
-		zones, err := util.GetZonesForvSANFileServiceMarkerPolicy(ctx, r.k8sClient, zonesFn)
+		zones, err := cnsoperatorutil.GetZonesForvSANFileServiceMarkerPolicy(ctx, r.k8sClient, zonesFn)
 		if err != nil {
 			return fmt.Errorf("failed to compute cluster zones for vSAN File Service marker policy %q: %w", clusterSPI.Name, err)
 		}
@@ -727,10 +738,10 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 		TopologyType: topologyType,
 	}
 
-	log.Infof("Storage policy %s uses zonal topology, populating accessible zones", profileID)
+	log.Infof("Storage policy %s: populating accessible zones", profileID)
 
-	// Get accessible zones directly using topology service
-	accessibleZones, err := getAccessibleZonesForPolicy(ctx, r.topologyMgr, vc, profileID)
+	accessibleZones, err := cnsoperatorutil.GetAccessibleZonesForPolicy(ctx, r.topologyMgr, vc, profileID,
+		clusterDatastoreCache)
 	if err != nil {
 		return fmt.Errorf("failed to get accessible zones: %w", err)
 	}

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -23,13 +23,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/simulator"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -2160,267 +2164,6 @@ func TestGetStorageTopologyType(t *testing.T) {
 	}
 }
 
-// TestGetAccessibleZonesForPolicy tests the getAccessibleZonesForPolicy function
-func TestGetAccessibleZonesForPolicy(t *testing.T) {
-	ctx := logger.NewContextWithLogger(context.Background())
-
-	// Mock VirtualCenter for testing
-	mockVC := &cnsvsphere.VirtualCenter{}
-
-	tests := []struct {
-		name             string
-		topologyMgr      commoncotypes.ControllerTopologyService
-		profileID        string
-		mockPBMResponse  []pbmtypes.PbmPlacementHub
-		mockPBMError     error
-		expectedZones    []string
-		expectedError    string
-		mockCandidateDS  map[string][]*cnsvsphere.DatastoreInfo
-		mockCandidateErr map[string]error
-	}{
-		{
-			name:          "Nil topology manager returns empty zones",
-			topologyMgr:   nil,
-			profileID:     "test-policy",
-			expectedZones: []string{},
-		},
-		{
-			name: "Empty AZ clusters map returns empty zones",
-			topologyMgr: &mockControllerTopologyService{
-				azClustersMap: map[string][]string{},
-			},
-			profileID:     "test-policy",
-			expectedZones: []string{},
-		},
-		{
-			name: "PbmQueryMatchingHub error",
-			topologyMgr: &mockControllerTopologyService{
-				azClustersMap: map[string][]string{
-					"zone1": {"cluster1"},
-				},
-			},
-			profileID:     "test-policy",
-			mockPBMError:  fmt.Errorf("vCenter connection failed"),
-			expectedError: "failed to query compatible datastores for policy: vCenter connection failed",
-		},
-		{
-			name: "No compatible datastores found",
-			topologyMgr: &mockControllerTopologyService{
-				azClustersMap: map[string][]string{
-					"zone1": {"cluster1"},
-					"zone2": {"cluster2"},
-				},
-			},
-			profileID:       "test-policy",
-			mockPBMResponse: []pbmtypes.PbmPlacementHub{}, // Empty response
-			expectedZones:   []string{},
-		},
-		{
-			name: "Single zone with compatible datastores",
-			topologyMgr: &mockControllerTopologyService{
-				azClustersMap: map[string][]string{
-					"zone1": {"cluster1"},
-					"zone2": {"cluster2"},
-				},
-			},
-			profileID: "test-policy",
-			mockPBMResponse: []pbmtypes.PbmPlacementHub{
-				{HubId: "datastore1", HubType: "Datastore"},
-			},
-			mockCandidateDS: map[string][]*cnsvsphere.DatastoreInfo{
-				"cluster1": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore1"}),
-						},
-					},
-				},
-				"cluster2": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore2"}),
-						},
-					},
-				},
-			},
-			expectedZones: []string{"zone1"}, // Only zone1 has compatible datastore1
-		},
-		{
-			name: "Multiple zones with compatible datastores",
-			topologyMgr: &mockControllerTopologyService{
-				azClustersMap: map[string][]string{
-					"zone1": {"cluster1"},
-					"zone2": {"cluster2"},
-					"zone3": {"cluster3"},
-				},
-			},
-			profileID: "test-policy",
-			mockPBMResponse: []pbmtypes.PbmPlacementHub{
-				{HubId: "datastore1", HubType: "Datastore"},
-				{HubId: "datastore2", HubType: "Datastore"},
-			},
-			mockCandidateDS: map[string][]*cnsvsphere.DatastoreInfo{
-				"cluster1": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore1"}),
-						},
-					},
-				},
-				"cluster2": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore2"}),
-						},
-					},
-				},
-				"cluster3": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore3"}),
-						},
-					},
-				},
-			},
-			expectedZones: []string{"zone1", "zone2"}, // zones 1 and 2 have compatible datastores
-		},
-		{
-			name: "Zone with multiple clusters, one has compatible datastore",
-			topologyMgr: &mockControllerTopologyService{
-				azClustersMap: map[string][]string{
-					"zone1": {"cluster1", "cluster2"},
-				},
-			},
-			profileID: "test-policy",
-			mockPBMResponse: []pbmtypes.PbmPlacementHub{
-				{HubId: "datastore2", HubType: "Datastore"},
-			},
-			mockCandidateDS: map[string][]*cnsvsphere.DatastoreInfo{
-				"cluster1": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore1"}),
-						},
-					},
-				},
-				"cluster2": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore2"}),
-						},
-					},
-				},
-			},
-			expectedZones: []string{"zone1"}, // zone1 has datastore2 in cluster2
-		},
-		{
-			name: "Cluster datastore fetch error should not fail entire operation",
-			topologyMgr: &mockControllerTopologyService{
-				azClustersMap: map[string][]string{
-					"zone1": {"cluster1", "cluster2"},
-					"zone2": {"cluster3"},
-				},
-			},
-			profileID: "test-policy",
-			mockPBMResponse: []pbmtypes.PbmPlacementHub{
-				{HubId: "datastore3", HubType: "Datastore"},
-			},
-			mockCandidateDS: map[string][]*cnsvsphere.DatastoreInfo{
-				"cluster3": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore3"}),
-						},
-					},
-				},
-			},
-			mockCandidateErr: map[string]error{
-				"cluster1": fmt.Errorf("cluster1 unavailable"),
-				"cluster2": fmt.Errorf("cluster2 unavailable"),
-			},
-			expectedZones: []string{"zone2"}, // zone2 still works despite cluster1,2 errors
-		},
-		{
-			name: "No zones have compatible datastores",
-			topologyMgr: &mockControllerTopologyService{
-				azClustersMap: map[string][]string{
-					"zone1": {"cluster1"},
-					"zone2": {"cluster2"},
-				},
-			},
-			profileID: "test-policy",
-			mockPBMResponse: []pbmtypes.PbmPlacementHub{
-				{HubId: "datastore999", HubType: "Datastore"}, // Non-existent datastore
-			},
-			mockCandidateDS: map[string][]*cnsvsphere.DatastoreInfo{
-				"cluster1": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore1"}),
-						},
-					},
-				},
-				"cluster2": {
-					{
-						Datastore: &cnsvsphere.Datastore{
-							Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{
-								Type: "Datastore", Value: "datastore2"}),
-						},
-					},
-				},
-			},
-			expectedZones: []string{}, // No zones match datastore999
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// This test would require mocking the VirtualCenter methods and
-			// cnsvsphere.GetCandidateDatastoresInCluster function
-			// For now, we'll test the core logic and structure
-
-			// The actual implementation would require complex mocking of:
-			// - vc.PbmQueryMatchingHub
-			// - cnsvsphere.GetCandidateDatastoresInCluster
-
-			// Since these are external dependencies, we'll focus on testing
-			// the logic we can control and provide a simplified test structure
-
-			if tt.topologyMgr == nil {
-				result, err := getAccessibleZonesForPolicy(ctx, nil, mockVC, tt.profileID)
-				if tt.expectedError != "" {
-					require.Error(t, err)
-					assert.Contains(t, err.Error(), tt.expectedError)
-				} else {
-					require.NoError(t, err)
-					assert.Equal(t, tt.expectedZones, result)
-				}
-				return
-			}
-
-			if len(tt.topologyMgr.GetAZClustersMap(ctx)) == 0 {
-				result, err := getAccessibleZonesForPolicy(ctx, tt.topologyMgr, mockVC, tt.profileID)
-				require.NoError(t, err)
-				assert.Equal(t, tt.expectedZones, result)
-				return
-			}
-
-			// For tests that need full mocking, we skip actual execution
-			// and just verify the test structure is correct
-			t.Skip("Full integration test requires complex mocking of VirtualCenter and PBM APIs")
-		})
-	}
-}
-
 // TestFindStoragePolicyProfile tests the findStoragePolicyProfile function
 func TestFindStoragePolicyProfile(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
@@ -2678,17 +2421,20 @@ func testPopulateTopologyCapabilities(r *ReconcileClusterStoragePolicyInfo, ctx 
 
 	// For unit tests, we'll use a simplified zone calculation that doesn't require full VirtualCenter
 	// This tests the main logic flow without the complex datastore compatibility checks
-	accessibleZones := []string{} // Always initialize as empty slice, not nil
-	if r.topologyMgr != nil {
-		azClustersMap := r.topologyMgr.GetAZClustersMap(ctx)
-		// For unit test: if we have zones and mock compatible hubs, return the zones
-		if len(azClustersMap) > 0 && len(mockVCConfig.compatibleHubs) == 0 {
-			// Empty compatible hubs means no zones are accessible
-			accessibleZones = []string{}
-		}
-		// In a real implementation, this would call getAccessibleZonesForPolicy
-		// which requires complex VirtualCenter mocking that's more suitable for integration tests
+	if r.topologyMgr == nil {
+		log.Warnf("Topology manager not available")
+		return fmt.Errorf("topology manager is not available")
 	}
+
+	accessibleZones := []string{} // Always initialize as empty slice, not nil
+	azClustersMap := r.topologyMgr.GetAZClustersMap(ctx)
+	// For unit test: if we have zones and mock compatible hubs, return the zones
+	if len(azClustersMap) > 0 && len(mockVCConfig.compatibleHubs) == 0 {
+		// Empty compatible hubs means no zones are accessible
+		accessibleZones = []string{}
+	}
+	// In a real implementation, this would call cnsoperatorutil.GetAccessibleZonesForPolicy
+	// which requires complex VirtualCenter mocking that's more suitable for integration tests
 
 	// Update InfraSPI with topology information including accessible zones
 	infraSPI.Status.Topology.AccessibleZones = accessibleZones
@@ -2825,7 +2571,7 @@ func TestPopulateTopologyCapabilities(t *testing.T) {
 				"found referencing storage policy ID \"duplicate-policy\", expected exactly one",
 		},
 		{
-			name:      "Success with nil topology manager",
+			name:      "Error with nil topology manager",
 			profileID: "policy-nil-topo",
 			storageClasses: []*storagev1.StorageClass{
 				{
@@ -2840,10 +2586,7 @@ func TestPopulateTopologyCapabilities(t *testing.T) {
 			mockVCConfig: &mockVirtualCenter{
 				compatibleHubs: []pbmtypes.PbmPlacementHub{},
 			},
-			expectedTopology: &infraspiv1alpha1.Topology{
-				TopologyType:    "zonal",
-				AccessibleZones: []string{}, // Empty because topology manager is nil
-			},
+			expectedError: "topology manager is not available",
 		},
 		{
 			name:      "Skip WaitForFirstConsumer StorageClasses",
@@ -2937,7 +2680,7 @@ func TestPopulateTopologyCapabilities(t *testing.T) {
 					// For accessible zones, we can only verify the structure since the actual
 					// zone population requires complex VirtualCenter mocking
 					assert.NotNil(t, infraSPI.Status.Topology.AccessibleZones)
-					// In our simplified test, zones will be empty because getAccessibleZonesForPolicy
+					// In our simplified test, zones will be empty because cnsoperatorutil.GetAccessibleZonesForPolicy
 					// requires complex VirtualCenter mocking which is beyond the scope of unit tests
 					assert.Equal(t, []string{}, infraSPI.Status.Topology.AccessibleZones)
 				}
@@ -3771,4 +3514,401 @@ func TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker(t *testing.T) {
 			assert.Equal(t, tc.isMarker, common.IsvSANFileServiceMarkerPolicyName(tc.name))
 		})
 	}
+}
+
+func TestPopulateVolumeCapabilities_MarkerPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name                          string
+		k8sCompliantName              string
+		expectedSupportsVolumeBlock   bool
+		expectedSupportsLinkedClone   bool
+		expectedSupportsHPLinkedClone bool
+		isMarkerPolicy                bool
+	}{
+		{
+			name:                          "Non-marker policy supports all capabilities",
+			k8sCompliantName:              "some-regular-policy",
+			expectedSupportsVolumeBlock:   true,
+			expectedSupportsLinkedClone:   false, // false: nil topology manager in test
+			expectedSupportsHPLinkedClone: false, // false: nil topology manager in test
+			isMarkerPolicy:                false,
+		},
+		{
+			name:                          "Marker policy does not support block volume mode and linked clone capabilities",
+			k8sCompliantName:              common.StorageClassVsanFileServicePolicy,
+			expectedSupportsVolumeBlock:   false,
+			expectedSupportsLinkedClone:   false,
+			expectedSupportsHPLinkedClone: false,
+			isMarkerPolicy:                true,
+		},
+		{
+			name:                          "Different policy name supports block volume mode",
+			k8sCompliantName:              "custom-storage-policy",
+			expectedSupportsVolumeBlock:   true,
+			expectedSupportsLinkedClone:   false, // false: nil topology manager in test
+			expectedSupportsHPLinkedClone: false, // false: nil topology manager in test
+			isMarkerPolicy:                false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock InfraStoragePolicyInfo with the test k8sCompliantName
+			infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{}
+			infraSPI.Name = tt.k8sCompliantName
+
+			// Call populateVolumeCapabilities with minimal required parameters
+			// We pass nil for vc, topologyMgr, and clusterDatastoreCache since we only want to test the logic
+			err := populateVolumeCapabilities(ctx, infraSPI, nil, "test-profile-id", nil, nil)
+
+			// For marker policies, there should be no error since we skip the HPLC check
+			// For non-marker policies, there may be an error due to nil parameters, but capabilities should still be set
+			if tt.isMarkerPolicy {
+				assert.NoError(t, err, "Marker policies should not cause errors")
+			}
+
+			// Verify that the volume capabilities are set
+			assert.NotNil(t, infraSPI.Status.VolumeCapabilities)
+
+			// Check SupportsVolumeModeFilesystem is always true
+			assert.True(t, infraSPI.Status.VolumeCapabilities[infraspiv1alpha1.SupportsVolumeModeFilesystem])
+
+			// Check SupportsVolumeModeBlock matches expected value
+			actual, exists := infraSPI.Status.VolumeCapabilities[infraspiv1alpha1.SupportsVolumeModeBlock]
+			assert.True(t, exists, "SupportsVolumeModeBlock should be set")
+			assert.Equal(t, tt.expectedSupportsVolumeBlock, actual,
+				"SupportsVolumeModeBlock should be %v for k8sCompliantName %s",
+				tt.expectedSupportsVolumeBlock, tt.k8sCompliantName)
+
+			// Check SupportsLinkedClone matches expected value
+			actualLC, existsLC := infraSPI.Status.VolumeCapabilities[infraspiv1alpha1.SupportsLinkedClone]
+			assert.True(t, existsLC, "SupportsLinkedClone should be set")
+			assert.Equal(t, tt.expectedSupportsLinkedClone, actualLC,
+				"SupportsLinkedClone should be %v for k8sCompliantName %s",
+				tt.expectedSupportsLinkedClone, tt.k8sCompliantName)
+
+			// Check SupportsHighPerformanceLinkedClone matches expected value
+			actualHPLC, existsHPLC := infraSPI.Status.VolumeCapabilities[infraspiv1alpha1.SupportsHighPerformanceLinkedClone]
+			assert.True(t, existsHPLC, "SupportsHighPerformanceLinkedClone should be set")
+			assert.Equal(t, tt.expectedSupportsHPLinkedClone, actualHPLC,
+				"SupportsHighPerformanceLinkedClone should be %v for k8sCompliantName %s",
+				tt.expectedSupportsHPLinkedClone, tt.k8sCompliantName)
+		})
+	}
+}
+
+// TestCheckHighPerformanceLinkedClone_EmptyInput verifies that an empty per-zone map
+// returns false without error and without making any vCenter calls.
+func TestCheckHighPerformanceLinkedClone_EmptyInput(t *testing.T) {
+	ctx := context.Background()
+	result, err := checkHighPerformanceLinkedClone(ctx, nil, map[string]map[string]vimtypes.ManagedObjectReference{})
+	assert.NoError(t, err)
+	assert.False(t, result, "empty per-zone input should yield HPLC=false")
+}
+
+// TestCheckHighPerformanceLinkedClone_ZonesWithNoHosts verifies that zones with no
+// ESXi 9.1+ hosts yield HPLC=false (no ESA check possible, all-zones requirement fails).
+func TestCheckHighPerformanceLinkedClone_ZonesWithNoHosts(t *testing.T) {
+	ctx := context.Background()
+	input := map[string]map[string]vimtypes.ManagedObjectReference{
+		"zone-a": {},
+		"zone-b": {},
+	}
+	result, err := checkHighPerformanceLinkedClone(ctx, nil, input)
+	assert.NoError(t, err)
+	assert.False(t, result, "HPLC must be false when no zone has ESXi 9.1+ hosts")
+}
+
+// TestCheckLinkedClone_NoZones verifies that checkLinkedClone returns
+// LC=false when the topology manager reports no zones (empty azClustersMap).
+func TestCheckLinkedClone_NoZones(t *testing.T) {
+	ctx := context.Background()
+	topoMgr := &mockControllerTopologyService{azClustersMap: map[string][]string{}}
+	stubVC := &cnsvsphere.VirtualCenter{Client: &govmomi.Client{}}
+	lc, perZone, err := checkLinkedClone(ctx, stubVC, "test-policy", topoMgr, nil)
+	assert.NoError(t, err)
+	assert.False(t, lc, "LC must be false when there are no zones")
+	assert.Empty(t, perZone)
+}
+
+// TestCheckLinkedClone_NilTopologyManager verifies that checkLinkedClone returns
+// an error when called without a topology manager.
+func TestCheckLinkedClone_NilTopologyManager(t *testing.T) {
+	ctx := context.Background()
+	lc, perZone, err := checkLinkedClone(ctx, nil, "test-policy", nil, nil)
+	assert.Error(t, err)
+	assert.False(t, lc)
+	assert.Nil(t, perZone)
+}
+
+// TestCheckHighPerformanceLinkedClone_NilVC verifies that HPLC check returns an error
+// when zones have hosts but no vCenter client is available.
+func TestCheckHighPerformanceLinkedClone_NilVC(t *testing.T) {
+	ctx := context.Background()
+	fakeHost := vimtypes.ManagedObjectReference{Type: "HostSystem", Value: "host-1"}
+	input := map[string]map[string]vimtypes.ManagedObjectReference{
+		"zone-a": {fakeHost.Value: fakeHost},
+	}
+	_, err := checkHighPerformanceLinkedClone(ctx, nil, input)
+	assert.Error(t, err, "nil vc should return an error when hosts are present")
+}
+
+// TestCheckHighPerformanceLinkedClone_PartialZoneSupport verifies that HPLC=false
+// when only a subset of zones have ESXi 9.1+ hosts (all-zones requirement).
+func TestCheckHighPerformanceLinkedClone_PartialZoneSupport(t *testing.T) {
+	ctx := context.Background()
+	fakeHost := vimtypes.ManagedObjectReference{Type: "HostSystem", Value: "host-1"}
+	// zone-a has a host; zone-b has none — all-zones requirement is not met.
+	input := map[string]map[string]vimtypes.ManagedObjectReference{
+		"zone-a": {fakeHost.Value: fakeHost},
+		"zone-b": {},
+	}
+	result, err := checkHighPerformanceLinkedClone(ctx, nil, input)
+	assert.NoError(t, err)
+	assert.False(t, result, "HPLC must be false when not all zones have ESXi 9.1+ hosts")
+}
+
+// --- simulator helpers ----------------------------------------------------------------
+
+// setupLCSim creates a VPX model with the requested number of clusters and hosts per cluster.
+// Each cluster gets its own datastores which are mounted by the cluster's hosts.
+func setupLCSim(t *testing.T, numClusters, hostsPerCluster int) (
+	ctx context.Context,
+	vc *cnsvsphere.VirtualCenter,
+	model *simulator.Model,
+	stop func(),
+) {
+	t.Helper()
+	ctx = logger.NewContextWithLogger(context.Background())
+	model = simulator.VPX()
+	model.Datacenter = 1
+	model.Cluster = numClusters
+	model.ClusterHost = hostsPerCluster
+	model.Host = 0
+	model.Machine = 0
+	require.NoError(t, model.Create())
+	s := model.Service.NewServer()
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		s.Close()
+		model.Remove()
+		t.Fatalf("failed to create govmomi client: %v", err)
+	}
+	vc = &cnsvsphere.VirtualCenter{
+		Config:      &cnsvsphere.VirtualCenterConfig{Host: "127.0.0.1"},
+		Client:      c,
+		ClientMutex: &sync.Mutex{},
+	}
+	stop = func() { s.Close(); model.Remove() }
+	return
+}
+
+// dsInfoFromSim wraps a simulator datastore reference in a cnsvsphere.DatastoreInfo.
+func dsInfoFromSim(c *govmomi.Client, ref vimtypes.ManagedObjectReference) *cnsvsphere.DatastoreInfo {
+	return &cnsvsphere.DatastoreInfo{
+		Datastore: &cnsvsphere.Datastore{
+			Datastore: object.NewDatastore(c.Client, ref),
+		},
+	}
+}
+
+// setHostESXiVersion sets the ESXi version string on a simulator HostSystem.
+func setHostESXiVersion(model *simulator.Model, hostRef vimtypes.ManagedObjectReference, version string) {
+	h := model.Map().Get(hostRef).(*simulator.HostSystem)
+	h.Config.Product.Version = version
+}
+
+// setClusterESA enables or disables vSAN-ESA on a simulator ClusterComputeResource.
+// It mutates the existing ConfigurationEx rather than replacing it so other simulator
+// fields (DRS, DAS config, etc.) are preserved.
+func setClusterESA(model *simulator.Model, clusterRef vimtypes.ManagedObjectReference, enabled bool) {
+	c := model.Map().Get(clusterRef).(*simulator.ClusterComputeResource)
+	cfgEx := c.ConfigurationEx.(*vimtypes.ClusterConfigInfoEx)
+	if cfgEx.VsanConfigInfo == nil {
+		cfgEx.VsanConfigInfo = &vimtypes.VsanClusterConfigInfo{}
+	}
+	cfgEx.VsanConfigInfo.VsanEsaEnabled = &enabled
+}
+
+// hostRefsInCluster returns the HostSystem MORs belonging to the given cluster.
+func hostRefsInCluster(model *simulator.Model, clusterRef vimtypes.ManagedObjectReference,
+) []vimtypes.ManagedObjectReference {
+	c := model.Map().Get(clusterRef).(*simulator.ClusterComputeResource)
+	return c.Host
+}
+
+// --- fetchESXi91HostsForDatastore tests -----------------------------------------------
+
+// TestFetchESXi91HostsForDatastore_AllOldHosts verifies that no hosts are returned
+// when all mounting hosts run ESXi older than 9.1.
+func TestFetchESXi91HostsForDatastore_AllOldHosts(t *testing.T) {
+	ctx, vc, model, stop := setupLCSim(t, 1, 2)
+	defer stop()
+
+	clusters := model.Map().All("ClusterComputeResource")
+	require.Len(t, clusters, 1)
+	clusterRef := clusters[0].Reference()
+
+	for _, hostRef := range hostRefsInCluster(model, clusterRef) {
+		setHostESXiVersion(model, hostRef, "7.0.3")
+	}
+
+	dsRef := model.Map().All("Datastore")[0].Reference()
+	ds := dsInfoFromSim(vc.Client, dsRef)
+	pc := property.DefaultCollector(vc.Client.Client)
+
+	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]bool))
+	require.NoError(t, err)
+	assert.Empty(t, hosts, "no ESXi 9.1+ hosts should be returned when all hosts run 7.0")
+}
+
+// TestFetchESXi91HostsForDatastore_MixedVersions verifies that only ESXi 9.1+ hosts
+// are returned when the datastore is mounted by a mix of host versions.
+func TestFetchESXi91HostsForDatastore_MixedVersions(t *testing.T) {
+	ctx, vc, model, stop := setupLCSim(t, 1, 2)
+	defer stop()
+
+	clusters := model.Map().All("ClusterComputeResource")
+	require.Len(t, clusters, 1)
+	clusterRef := clusters[0].Reference()
+	hostRefs := hostRefsInCluster(model, clusterRef)
+	require.GreaterOrEqual(t, len(hostRefs), 2)
+
+	setHostESXiVersion(model, hostRefs[0], "9.1.0")
+	setHostESXiVersion(model, hostRefs[1], "7.0.3")
+
+	dsRef := model.Map().All("Datastore")[0].Reference()
+	ds := dsInfoFromSim(vc.Client, dsRef)
+	pc := property.DefaultCollector(vc.Client.Client)
+
+	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]bool))
+	require.NoError(t, err)
+	require.Len(t, hosts, 1, "only the 9.1+ host should be returned")
+	assert.Equal(t, hostRefs[0].Value, hosts[0].Value)
+}
+
+// TestFetchESXi91HostsForDatastore_AllESXi91 verifies that all mounting hosts are
+// returned when every host runs ESXi 9.1+.
+func TestFetchESXi91HostsForDatastore_AllESXi91(t *testing.T) {
+	ctx, vc, model, stop := setupLCSim(t, 1, 2)
+	defer stop()
+
+	clusters := model.Map().All("ClusterComputeResource")
+	clusterRef := clusters[0].Reference()
+	hostRefs := hostRefsInCluster(model, clusterRef)
+	require.GreaterOrEqual(t, len(hostRefs), 2)
+
+	for _, ref := range hostRefs {
+		setHostESXiVersion(model, ref, "9.1.0")
+	}
+
+	dsRef := model.Map().All("Datastore")[0].Reference()
+	ds := dsInfoFromSim(vc.Client, dsRef)
+	pc := property.DefaultCollector(vc.Client.Client)
+
+	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]bool))
+	require.NoError(t, err)
+	assert.Len(t, hosts, len(hostRefs), "all ESXi 9.1+ hosts should be returned")
+}
+
+// --- checkHighPerformanceLinkedClone simulator tests ----------------------------------
+
+// TestCheckHighPerformanceLinkedClone_SingleZone_ESAEnabled verifies HPLC=true when
+// the single zone's cluster has vSAN-ESA enabled.
+func TestCheckHighPerformanceLinkedClone_SingleZone_ESAEnabled(t *testing.T) {
+	ctx, vc, model, stop := setupLCSim(t, 1, 1)
+	defer stop()
+
+	clusters := model.Map().All("ClusterComputeResource")
+	clusterRef := clusters[0].Reference()
+	setClusterESA(model, clusterRef, true)
+
+	hostRefs := hostRefsInCluster(model, clusterRef)
+	require.NotEmpty(t, hostRefs)
+
+	input := map[string]map[string]vimtypes.ManagedObjectReference{
+		"zone-a": {hostRefs[0].Value: hostRefs[0]},
+	}
+	result, err := checkHighPerformanceLinkedClone(ctx, vc, input)
+	require.NoError(t, err)
+	assert.True(t, result, "HPLC should be true when the zone's cluster has ESA enabled")
+}
+
+// TestCheckHighPerformanceLinkedClone_SingleZone_NoESA verifies HPLC=false when
+// the single zone's cluster does not have vSAN-ESA enabled.
+func TestCheckHighPerformanceLinkedClone_SingleZone_NoESA(t *testing.T) {
+	ctx, vc, model, stop := setupLCSim(t, 1, 1)
+	defer stop()
+
+	clusters := model.Map().All("ClusterComputeResource")
+	clusterRef := clusters[0].Reference()
+	setClusterESA(model, clusterRef, false)
+
+	hostRefs := hostRefsInCluster(model, clusterRef)
+	require.NotEmpty(t, hostRefs)
+
+	input := map[string]map[string]vimtypes.ManagedObjectReference{
+		"zone-a": {hostRefs[0].Value: hostRefs[0]},
+	}
+	result, err := checkHighPerformanceLinkedClone(ctx, vc, input)
+	require.NoError(t, err)
+	assert.False(t, result, "HPLC should be false when the zone's cluster has no ESA")
+}
+
+// TestCheckHighPerformanceLinkedClone_TwoZones_AllESA verifies HPLC=true only when
+// every zone has at least one host in an ESA-enabled cluster.
+func TestCheckHighPerformanceLinkedClone_TwoZones_AllESA(t *testing.T) {
+	ctx, vc, model, stop := setupLCSim(t, 2, 1)
+	defer stop()
+
+	clusters := model.Map().All("ClusterComputeResource")
+	require.Len(t, clusters, 2)
+
+	clusterARef := clusters[0].Reference()
+	clusterBRef := clusters[1].Reference()
+	setClusterESA(model, clusterARef, true)
+	setClusterESA(model, clusterBRef, true)
+
+	hostsA := hostRefsInCluster(model, clusterARef)
+	hostsB := hostRefsInCluster(model, clusterBRef)
+	require.NotEmpty(t, hostsA)
+	require.NotEmpty(t, hostsB)
+
+	input := map[string]map[string]vimtypes.ManagedObjectReference{
+		"zone-a": {hostsA[0].Value: hostsA[0]},
+		"zone-b": {hostsB[0].Value: hostsB[0]},
+	}
+	result, err := checkHighPerformanceLinkedClone(ctx, vc, input)
+	require.NoError(t, err)
+	assert.True(t, result, "HPLC should be true when all zones have ESA-enabled clusters")
+}
+
+// TestCheckHighPerformanceLinkedClone_TwoZones_PartialESA verifies HPLC=false when
+// only one of two zones has an ESA-enabled cluster (all-zones requirement).
+func TestCheckHighPerformanceLinkedClone_TwoZones_PartialESA(t *testing.T) {
+	ctx, vc, model, stop := setupLCSim(t, 2, 1)
+	defer stop()
+
+	clusters := model.Map().All("ClusterComputeResource")
+	require.Len(t, clusters, 2)
+
+	clusterARef := clusters[0].Reference()
+	clusterBRef := clusters[1].Reference()
+	setClusterESA(model, clusterARef, true)
+	setClusterESA(model, clusterBRef, false)
+
+	hostsA := hostRefsInCluster(model, clusterARef)
+	hostsB := hostRefsInCluster(model, clusterBRef)
+	require.NotEmpty(t, hostsA)
+	require.NotEmpty(t, hostsB)
+
+	input := map[string]map[string]vimtypes.ManagedObjectReference{
+		"zone-a": {hostsA[0].Value: hostsA[0]},
+		"zone-b": {hostsB[0].Value: hostsB[0]},
+	}
+	result, err := checkHighPerformanceLinkedClone(ctx, vc, input)
+	require.NoError(t, err)
+	assert.False(t, result, "HPLC should be false when not all zones have ESA-enabled clusters")
 }

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
@@ -22,6 +22,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,11 +35,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
+	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 // ownerReferenceKey returns OwnerReference key which is concatenated from the APIVersion, Kind and Name.
@@ -395,108 +400,6 @@ func getStorageTopologyType(ctx context.Context, sc *storagev1.StorageClass) (st
 	return "", nil
 }
 
-// getAccessibleZonesForPolicy determines which zones can access datastores compatible with the given storage policy
-func getAccessibleZonesForPolicy(ctx context.Context, topologyMgr commoncotypes.ControllerTopologyService,
-	vc *cnsvsphere.VirtualCenter, profileID string) ([]string, error) {
-	log := logger.GetLogger(ctx)
-
-	// If topology manager is not available, fall back to basic implementation
-	if topologyMgr == nil {
-		log.Warnf("Topology manager not available, cannot determine accessible zones for policy")
-		return []string{}, nil
-	}
-
-	// Get all zones from the topology service
-	azClustersMap := topologyMgr.GetAZClustersMap(ctx)
-	if len(azClustersMap) == 0 {
-		log.Warnf("No zones found in topology service")
-		return []string{}, nil
-	}
-
-	// Get all datastores compatible with the policy directly (single efficient PBM call)
-	compatibleHubs, err := vc.PbmQueryMatchingHub(ctx, profileID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query compatible datastores for policy: %w", err)
-	}
-
-	if len(compatibleHubs) == 0 {
-		log.Warnf("No compatible datastores found for storage policy %s", profileID)
-		return []string{}, nil
-	}
-
-	// Build map of compatible datastore IDs for quick lookup
-	compatibleDSIDs := make(map[string]struct{})
-	for _, hub := range compatibleHubs {
-		compatibleDSIDs[hub.HubId] = struct{}{}
-	}
-
-	log.Infof("Found %d compatible datastores for policy %s", len(compatibleHubs), profileID)
-
-	// Cache for cluster datastore lookups to avoid redundant calls
-	clusterToDatastoresCache := make(map[string][]*cnsvsphere.DatastoreInfo)
-
-	accessibleZones := make(map[string]struct{})
-
-	// For each zone, check intersection with compatible datastores
-	for zone, clusters := range azClustersMap {
-		log.Debugf("Checking zone %s with clusters %v", zone, clusters)
-
-		zoneHasCompatibleDS := false
-
-		// Get datastores for this zone's clusters and check intersection
-		for _, clusterMoref := range clusters {
-			var clusterDSes []*cnsvsphere.DatastoreInfo
-			var err error
-
-			// Check cache first
-			if cachedDSes, exists := clusterToDatastoresCache[clusterMoref]; exists {
-				clusterDSes = cachedDSes
-				log.Debugf("Using cached datastores for cluster %s", clusterMoref)
-			} else {
-				// Cache miss - fetch from vCenter and cache the result
-				clusterDSes, _, err = cnsvsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterMoref, false)
-				if err != nil {
-					log.Warnf("Failed to get datastores for cluster %s in zone %s: %v", clusterMoref, zone, err)
-					continue
-				}
-				clusterToDatastoresCache[clusterMoref] = clusterDSes
-				log.Debugf("Cached %d datastores for cluster %s", len(clusterDSes), clusterMoref)
-			}
-
-			// Check if any datastores in this cluster are in the compatible list
-			for _, ds := range clusterDSes {
-				if _, isCompatible := compatibleDSIDs[ds.Reference().Value]; isCompatible {
-					zoneHasCompatibleDS = true
-					break
-				}
-			}
-
-			if zoneHasCompatibleDS {
-				break // Found compatible datastore in this zone, no need to check more clusters
-			}
-		}
-
-		if zoneHasCompatibleDS {
-			accessibleZones[zone] = struct{}{}
-			log.Debugf("Zone %s has compatible datastores for policy %s", zone, profileID)
-		}
-	}
-
-	// Convert map to slice
-	var zones []string
-	for zone := range accessibleZones {
-		zones = append(zones, zone)
-	}
-
-	if len(zones) == 0 {
-		log.Warnf("No accessible zones found for storage policy %s", profileID)
-	} else {
-		log.Infof("Storage policy %s is accessible from zones: %v", profileID, zones)
-	}
-
-	return zones, nil
-}
-
 // findStoragePolicyProfile finds a storage policy profile by K8s compliant name.
 // Returns (profile, policyDeleted, error) where:
 // - profile is the found profile (nil if policy deleted or error)
@@ -531,4 +434,354 @@ func findStoragePolicyProfile(ctx context.Context,
 	instance.Status.StoragePolicyDeleted = false
 
 	return profile, false, nil // profile found, not deleted, no error
+}
+
+// populateVolumeCapabilities computes volume capabilities for the given storage policy and
+// writes them into infraSPI.Status.VolumeCapabilities.
+//
+// SupportsVolumeModeFilesystem is always true.
+//
+// SupportsVolumeModeBlock is always true except when the policy is a marker policy
+// (k8scompliantname is "vsan-file-service-policy").
+// For marker policies, SupportsHighPerformanceLinkedClone and SupportsLinkedClone are also false.
+//
+// SupportsLinkedClone is true only if every zone with compatible datastores has at least one
+// mounting host running ESXi 9.1 or above.
+//
+// SupportsHighPerformanceLinkedClone is true only if SupportsLinkedClone is true AND every zone
+// has at least one ESXi 9.1+ host in a cluster with vSAN-ESA enabled.
+//
+// This function accepts an optional cache from topology calculation to avoid redundant vCenter calls.
+func populateVolumeCapabilities(ctx context.Context,
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
+	vc *cnsvsphere.VirtualCenter, profileID string,
+	topologyMgr commoncotypes.ControllerTopologyService,
+	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) error {
+	log := logger.GetLogger(ctx)
+
+	caps := map[infraspiv1alpha1.VolumeCapability]bool{
+		infraspiv1alpha1.SupportsVolumeModeFilesystem: true,
+	}
+
+	// Check if this is a marker policy
+	// A marker policy is one where k8scompliantname is "vsan-file-service-policy"
+	k8sCompliantName := infraSPI.Name
+	isMarkerPolicy := k8sCompliantName == common.StorageClassVsanFileServicePolicy
+
+	// SupportsVolumeModeBlock is always true except when policy is marker policy
+	caps[infraspiv1alpha1.SupportsVolumeModeBlock] = !isMarkerPolicy
+	log.Infof("Storage policy %s SupportsVolumeModeBlock=%v (isMarkerPolicy=%v)",
+		profileID, !isMarkerPolicy, isMarkerPolicy)
+
+	// For marker policies, linked clone capabilities are always false
+	if isMarkerPolicy {
+		caps[infraspiv1alpha1.SupportsHighPerformanceLinkedClone] = false
+		caps[infraspiv1alpha1.SupportsLinkedClone] = false
+		log.Infof("Storage policy %s is a marker policy - SupportsHighPerformanceLinkedClone=false, "+
+			"SupportsLinkedClone=false", profileID)
+
+		infraSPI.Status.VolumeCapabilities = caps
+		return nil
+	}
+
+	if clusterDatastoreCache == nil {
+		clusterDatastoreCache = make(map[string][]*cnsvsphere.DatastoreInfo)
+	}
+
+	lc, esxi91HostsPerZone, err := checkLinkedClone(ctx, vc, profileID, topologyMgr, clusterDatastoreCache)
+	if err != nil {
+		log.Errorf("Failed to check SupportsLinkedClone for policy %s: %v", profileID, err)
+		caps[infraspiv1alpha1.SupportsHighPerformanceLinkedClone] = false
+		caps[infraspiv1alpha1.SupportsLinkedClone] = false
+		infraSPI.Status.VolumeCapabilities = caps
+		return err
+	}
+
+	caps[infraspiv1alpha1.SupportsLinkedClone] = lc
+
+	// If LinkedClone is not supported, then HighPerformanceLinkedClone cannot be supported either.
+	var hplc bool
+	if !lc {
+		hplc = false
+		log.Infof("Storage policy %s does not support LinkedClone or HighPerformanceLinkedClone", profileID)
+	} else {
+		// HPLC is supported only when every zone has at least one ESXi 9.1+ host in a vSAN-ESA cluster.
+		var err error
+		hplc, err = checkHighPerformanceLinkedClone(ctx, vc, esxi91HostsPerZone)
+		if err != nil {
+			log.Errorf("Failed to check SupportsHighPerformanceLinkedClone for policy %s: %v", profileID, err)
+			caps[infraspiv1alpha1.SupportsHighPerformanceLinkedClone] = false
+			infraSPI.Status.VolumeCapabilities = caps
+			return err
+		}
+	}
+
+	caps[infraspiv1alpha1.SupportsHighPerformanceLinkedClone] = hplc
+	log.Infof("Storage policy %s SupportsLinkedClone=%v, SupportsHighPerformanceLinkedClone=%v",
+		profileID, lc, hplc)
+
+	infraSPI.Status.VolumeCapabilities = caps
+	return nil
+}
+
+// checkLinkedClone returns whether LinkedClone is supported across ALL zones and the per-zone
+// ESXi 9.1+ hosts. LC is true only when every zone that has compatible datastores also has at
+// least one ESXi 9.1+ host mounting those datastores.
+func checkLinkedClone(ctx context.Context,
+	vc *cnsvsphere.VirtualCenter, profileID string,
+	topologyMgr commoncotypes.ControllerTopologyService,
+	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo,
+) (bool, map[string]map[string]vimtypes.ManagedObjectReference, error) {
+	log := logger.GetLogger(ctx)
+
+	if topologyMgr == nil {
+		log.Warnf("Topology manager unavailable; cannot determine SupportsLinkedClone")
+		return false, nil, fmt.Errorf("topology manager is not available")
+	}
+
+	if vc == nil || vc.Client == nil {
+		return false, nil, fmt.Errorf("virtual center client is not available")
+	}
+
+	zoneCompatibleDS, err := cnsoperatorutil.GetPolicyCompatibleDatastoresPerZone(ctx, topologyMgr, vc, profileID,
+		clusterDatastoreCache)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if len(zoneCompatibleDS) == 0 {
+		log.Infof("Storage policy %s has no zones with compatible datastores; SupportsLinkedClone=false", profileID)
+		return false, make(map[string]map[string]vimtypes.ManagedObjectReference), nil
+	}
+	pc := property.DefaultCollector(vc.Client.Client)
+	// esxi91HostsPerZone holds, per zone, the ESXi 9.1+ host refs found via that zone's datastores.
+	esxi91HostsPerZone := make(map[string]map[string]vimtypes.ManagedObjectReference)
+	// checkedHosts records whether each evaluated host is ESXi 9.1+ (true) or not (false).
+	// All evaluated hosts are stored so that a host mounting multiple datastores is only
+	// queried from vCenter once.
+	checkedHosts := make(map[string]bool)
+	// datastoreESXi91HostsCache caches the ESXi 9.1+ hosts for a given datastore so that when
+	// the same datastore appears in multiple zones we reuse the result.
+	datastoreESXi91HostsCache := make(map[string][]vimtypes.ManagedObjectReference)
+
+	// relevantZones counts zones that have at least one compatible datastore for the policy.
+	// Zones with no compatible datastores are excluded: the policy cannot be provisioned there,
+	// so they do not contribute to the LC/HPLC determination.
+	relevantZones := 0
+
+	// Check each zone for ESXi 9.1+ hosts.
+	for zone, compatibleDatastores := range zoneCompatibleDS {
+		if len(compatibleDatastores) == 0 {
+			continue
+		}
+		relevantZones++
+
+		esxi91HostsPerZone[zone] = make(map[string]vimtypes.ManagedObjectReference)
+
+		for _, ds := range compatibleDatastores {
+			dsHosts, err := getOrFetchESXi91HostsForDS(ctx, pc, ds, checkedHosts, datastoreESXi91HostsCache)
+			if err != nil {
+				return false, nil, err
+			}
+			for _, hostRef := range dsHosts {
+				esxi91HostsPerZone[zone][hostRef.Value] = hostRef
+				log.Debugf("Attributed ESXi 9.1+ host %s to zone %s via datastore %s",
+					hostRef.Value, zone, ds.Reference().Value)
+			}
+		}
+	}
+
+	if relevantZones == 0 {
+		log.Infof("Storage policy %s has no zones with compatible datastores; SupportsLinkedClone=false", profileID)
+		return false, make(map[string]map[string]vimtypes.ManagedObjectReference), nil
+	}
+
+	// LC is supported only when every relevant zone has at least one ESXi 9.1+ host.
+	zonesWithLC := 0
+	for _, hosts := range esxi91HostsPerZone {
+		if len(hosts) > 0 {
+			zonesWithLC++
+		}
+	}
+	linkedCloneSupported := zonesWithLC == relevantZones
+	if linkedCloneSupported {
+		log.Infof("Storage policy %s supports LinkedClone: all %d zones have ESXi 9.1+ hosts", profileID, relevantZones)
+	} else {
+		log.Infof("Storage policy %s does not support LinkedClone: only %d/%d zones have ESXi 9.1+ hosts",
+			profileID, zonesWithLC, relevantZones)
+	}
+
+	return linkedCloneSupported, esxi91HostsPerZone, nil
+}
+
+// getOrFetchESXi91HostsForDS returns the ESXi 9.1+ hosts for a datastore, using cache when
+// available. On a cache miss the hosts are fetched and stored. On error the result is not cached
+// so the next zone can retry.
+func getOrFetchESXi91HostsForDS(ctx context.Context, pc *property.Collector,
+	ds *cnsvsphere.DatastoreInfo, checkedHosts map[string]bool,
+	dsHostsCache map[string][]vimtypes.ManagedObjectReference,
+) ([]vimtypes.ManagedObjectReference, error) {
+	datastoreValue := ds.Reference().Value
+	if _, fetched := dsHostsCache[datastoreValue]; fetched {
+		return dsHostsCache[datastoreValue], nil
+	}
+	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, checkedHosts)
+	if err != nil {
+		return nil, fmt.Errorf("fetch ESXi 9.1+ hosts for datastore %s: %w", datastoreValue, err)
+	}
+	dsHostsCache[datastoreValue] = hosts
+	return hosts, nil
+}
+
+// fetchESXi91HostsForDatastore returns all ESXi 9.1+ hosts that mount the given datastore and
+// belong to a ClusterComputeResource. checkedHosts is a shared cache (hostValue → bool) storing
+// all evaluated hosts — true if ESXi 9.1+, false otherwise — to avoid redundant vCenter calls
+// for hosts shared across datastores.
+func fetchESXi91HostsForDatastore(ctx context.Context, pc *property.Collector,
+	ds *cnsvsphere.DatastoreInfo, checkedHosts map[string]bool,
+) ([]vimtypes.ManagedObjectReference, error) {
+	datastoreValue := ds.Reference().Value
+
+	var dsMO mo.Datastore
+	if err := pc.RetrieveOne(ctx, ds.Reference(), []string{"host"}, &dsMO); err != nil {
+		return nil, fmt.Errorf("retrieve host mounts for datastore %s: %w", datastoreValue, err)
+	}
+
+	hostRefs := make([]vimtypes.ManagedObjectReference, 0, len(dsMO.Host))
+	for _, mount := range dsMO.Host {
+		hostRefs = append(hostRefs, mount.Key)
+	}
+	if len(hostRefs) == 0 {
+		return nil, nil
+	}
+
+	var esxi91Hosts []vimtypes.ManagedObjectReference
+	for _, ref := range hostRefs {
+		if isESXi91, checked := checkedHosts[ref.Value]; checked {
+			if isESXi91 {
+				esxi91Hosts = append(esxi91Hosts, ref)
+			}
+			continue
+		}
+		var hostMO mo.HostSystem
+		if err := pc.RetrieveOne(ctx, ref, []string{"parent", "config.product"}, &hostMO); err != nil {
+			return nil, fmt.Errorf("retrieve properties for host %s: %w", ref.Value, err)
+		}
+		if hostMO.Parent == nil || hostMO.Parent.Type != "ClusterComputeResource" || hostMO.Config == nil {
+			checkedHosts[ref.Value] = false
+			continue
+		}
+		is91, err := cnsvsphere.IsvSphereVersion91orAbove(ctx, hostMO.Config.Product)
+		if err != nil {
+			return nil, fmt.Errorf("parse ESXi version for host %s: %w", ref.Value, err)
+		}
+		checkedHosts[ref.Value] = is91
+		if is91 {
+			esxi91Hosts = append(esxi91Hosts, ref)
+		}
+	}
+	return esxi91Hosts, nil
+}
+
+// checkHighPerformanceLinkedClone returns true only when every zone in esxi91HostsPerZone has at
+// least one ESXi 9.1+ host in a vSAN-ESA enabled cluster. A shared checkedClusters cache avoids
+// duplicate vCenter calls for clusters that span multiple zones.
+func checkHighPerformanceLinkedClone(ctx context.Context,
+	vc *cnsvsphere.VirtualCenter,
+	esxi91HostsPerZone map[string]map[string]vimtypes.ManagedObjectReference,
+) (bool, error) {
+	log := logger.GetLogger(ctx)
+
+	if len(esxi91HostsPerZone) == 0 {
+		return false, nil
+	}
+
+	// Any zone with no ESXi 9.1+ hosts can never satisfy the ESA requirement.
+	for zone, hosts := range esxi91HostsPerZone {
+		if len(hosts) == 0 {
+			log.Infof("Zone %s: no ESXi 9.1+ hosts; SupportsHighPerformanceLinkedClone=false", zone)
+			return false, nil
+		}
+	}
+
+	if vc == nil || vc.Client == nil {
+		return false, fmt.Errorf("virtual center client is not available")
+	}
+	pc := property.DefaultCollector(vc.Client.Client)
+	// checkedClusters caches vSAN-ESA state per cluster. A key present in the map (even false)
+	// means the cluster was already fetched; absence means not yet fetched (retry allowed).
+	checkedClusters := make(map[string]bool)
+	// hostClusterCache caches the parent cluster ref for each host so that hosts appearing in
+	// multiple zones are only fetched from vCenter once.
+	hostClusterCache := make(map[string]vimtypes.ManagedObjectReference)
+
+	for zone, esxi91Hosts := range esxi91HostsPerZone {
+		hplc, err := zoneHasHPLC(ctx, pc, zone, esxi91Hosts, checkedClusters, hostClusterCache)
+		if err != nil {
+			return false, err
+		}
+		if !hplc {
+			log.Infof("Zone %s: no ESXi 9.1+ host found in a vSAN-ESA enabled cluster; "+
+				"SupportsHighPerformanceLinkedClone=false", zone)
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// zoneHasHPLC returns true when at least one ESXi 9.1+ host in the zone belongs to a
+// vSAN-ESA enabled cluster. checkedClusters and hostClusterCache are shared caches across zones.
+func zoneHasHPLC(ctx context.Context, pc *property.Collector, zone string,
+	esxi91Hosts map[string]vimtypes.ManagedObjectReference,
+	checkedClusters map[string]bool,
+	hostClusterCache map[string]vimtypes.ManagedObjectReference,
+) (bool, error) {
+	log := logger.GetLogger(ctx)
+	for _, hostRef := range esxi91Hosts {
+		clusterRef, cached := hostClusterCache[hostRef.Value]
+		if !cached {
+			var hostMO mo.HostSystem
+			if err := pc.RetrieveOne(ctx, hostRef, []string{"parent"}, &hostMO); err != nil {
+				return false, fmt.Errorf("retrieve parent cluster for host %s: %w", hostRef.Value, err)
+			}
+			if hostMO.Parent == nil {
+				log.Warnf("Host %s has no parent cluster", hostRef.Value)
+				continue
+			}
+			clusterRef = *hostMO.Parent
+			hostClusterCache[hostRef.Value] = clusterRef
+		}
+		esa, err := isClusterESAEnabled(ctx, pc, clusterRef, checkedClusters)
+		if err != nil {
+			return false, err
+		}
+		if esa {
+			log.Infof("Zone %s: host %s in cluster %s has vSAN-ESA enabled",
+				zone, hostRef.Value, clusterRef.Value)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// isClusterESAEnabled returns whether the given cluster has vSAN-ESA enabled, using
+// checkedClusters as a cache. On a retrieval error the result is not cached so the next
+// call can retry.
+func isClusterESAEnabled(ctx context.Context, pc *property.Collector,
+	clusterRef vimtypes.ManagedObjectReference, checkedClusters map[string]bool,
+) (bool, error) {
+	clusterValue := clusterRef.Value
+	if _, fetched := checkedClusters[clusterValue]; fetched {
+		return checkedClusters[clusterValue], nil
+	}
+	var clusterMO mo.ClusterComputeResource
+	if err := pc.RetrieveOne(ctx, clusterRef, []string{"configurationEx"}, &clusterMO); err != nil {
+		return false, fmt.Errorf("retrieve configurationEx for cluster %s: %w", clusterValue, err)
+	}
+	cfgEx, ok := clusterMO.ConfigurationEx.(*vimtypes.ClusterConfigInfoEx)
+	esa := ok && cfgEx.VsanConfigInfo != nil &&
+		cfgEx.VsanConfigInfo.VsanEsaEnabled != nil && *cfgEx.VsanConfigInfo.VsanEsaEnabled
+	checkedClusters[clusterValue] = esa
+	return esa, nil
 }

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
@@ -539,4 +540,127 @@ func GetMaxWorkerThreads(ctx context.Context, key string, defaultVal int) int {
 			workerThreads)
 	}
 	return workerThreads
+}
+
+// GetPolicyCompatibleDatastoresFn is the implementation used by GetPolicyCompatibleDatastoresPerZone;
+// tests may replace it to inject fake compatible datastore IDs without a real PBM connection.
+var GetPolicyCompatibleDatastoresFn = GetPolicyCompatibleDatastores
+
+// GetPolicyCompatibleDatastores gets all datastores compatible with a storage policy using PBM
+func GetPolicyCompatibleDatastores(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+	profileID string) (map[string]struct{}, error) {
+	if vc == nil || vc.Client == nil {
+		return nil, fmt.Errorf("virtual center client is not available")
+	}
+	compatibleHubs, err := vc.PbmQueryMatchingHub(ctx, profileID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query compatible datastores for policy %s: %w", profileID, err)
+	}
+
+	compatibleDSIDs := make(map[string]struct{})
+	for _, hub := range compatibleHubs {
+		compatibleDSIDs[hub.HubId] = struct{}{}
+	}
+
+	return compatibleDSIDs, nil
+}
+
+// GetAccessibleZonesForPolicy determines which zones are accessible to the datastores
+// compatible with the given storage policy.
+func GetAccessibleZonesForPolicy(ctx context.Context, topologyMgr commoncotypes.ControllerTopologyService,
+	vc *cnsvsphere.VirtualCenter, profileID string,
+	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) ([]string, error) {
+	log := logger.GetLogger(ctx)
+
+	zoneCompatibleDS, err := GetPolicyCompatibleDatastoresPerZone(ctx, topologyMgr, vc, profileID, clusterDatastoreCache)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert map to slice of zones that have compatible datastores
+	zones := make([]string, 0)
+	for zone, compatibleDS := range zoneCompatibleDS {
+		if len(compatibleDS) > 0 {
+			zones = append(zones, zone)
+		}
+	}
+
+	if len(zones) == 0 {
+		log.Warnf("No accessible zones found for storage policy %s", profileID)
+	} else {
+		log.Infof("Storage policy %s is accessible from zones: %v", profileID, zones)
+	}
+
+	return zones, nil
+}
+
+// GetPolicyCompatibleDatastoresPerZone returns compatible datastores grouped by zone.
+func GetPolicyCompatibleDatastoresPerZone(ctx context.Context, topologyMgr commoncotypes.ControllerTopologyService,
+	vc *cnsvsphere.VirtualCenter, profileID string,
+	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) (map[string][]*cnsvsphere.DatastoreInfo, error) {
+	log := logger.GetLogger(ctx)
+
+	if topologyMgr == nil {
+		log.Warnf("Topology manager not available")
+		return nil, fmt.Errorf("topology manager is not available")
+	}
+
+	if clusterDatastoreCache == nil {
+		clusterDatastoreCache = make(map[string][]*cnsvsphere.DatastoreInfo)
+	}
+
+	azClustersMap := topologyMgr.GetAZClustersMap(ctx)
+	if len(azClustersMap) == 0 {
+		log.Warnf("No zones found in topology service")
+		return make(map[string][]*cnsvsphere.DatastoreInfo), nil
+	}
+
+	compatibleDSIDs, err := GetPolicyCompatibleDatastoresFn(ctx, vc, profileID)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Found %d compatible datastores for policy %s", len(compatibleDSIDs), profileID)
+
+	result := make(map[string][]*cnsvsphere.DatastoreInfo)
+
+	// For each zone, collect compatible datastores
+	for zone, clusters := range azClustersMap {
+		log.Debugf("Checking zone %s with clusters %v", zone, clusters)
+
+		// Collect all datastores for this zone
+		var zoneDS []*cnsvsphere.DatastoreInfo
+		for _, clusterMoref := range clusters {
+			// Check datastore cache first
+			var clusterDS []*cnsvsphere.DatastoreInfo
+			if cached, exists := clusterDatastoreCache[clusterMoref]; exists {
+				clusterDS = cached
+			} else {
+				// Cache miss - fetch from vCenter and cache the result
+				datastores, _, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterMoref, false)
+				if err != nil {
+					log.Warnf("Zone %s: failed to get datastores for cluster %s: %v", zone, clusterMoref, err)
+					continue
+				}
+				clusterDatastoreCache[clusterMoref] = datastores
+				clusterDS = datastores
+			}
+			zoneDS = append(zoneDS, clusterDS...)
+		}
+
+		// Filter to compatible datastores for this zone
+		var compatibleDatastores []*cnsvsphere.DatastoreInfo
+		for _, ds := range zoneDS {
+			if _, isCompatible := compatibleDSIDs[ds.Reference().Value]; isCompatible {
+				compatibleDatastores = append(compatibleDatastores, ds)
+			}
+		}
+
+		result[zone] = compatibleDatastores
+		if len(compatibleDatastores) > 0 {
+			log.Debugf("Zone %s has %d compatible datastores for policy %s", zone, len(compatibleDatastores), profileID)
+		}
+	}
+
+	return result, nil
 }

--- a/pkg/syncer/cnsoperator/util/util_test.go
+++ b/pkg/syncer/cnsoperator/util/util_test.go
@@ -20,11 +20,15 @@ import (
 	"context"
 	"errors"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	"github.com/vmware/govmomi/object"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +39,7 @@ import (
 	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -612,4 +617,236 @@ func TestGetTKGVMIP_PerNamespaceVDSUsesVMIP(t *testing.T) {
 	ip, err := GetTKGVMIPFromNetworkSettings(ctx, vmOpClient, dc, vmNamespace, vmName)
 	assert.NoError(t, err)
 	assert.Equal(t, "192.0.2.10", ip)
+}
+
+// --- helpers for GetPolicyCompatibleDatastoresPerZone / GetAccessibleZonesForPolicy ----
+
+// mockTopologyService is a minimal ControllerTopologyService for unit tests.
+type mockTopologyService struct {
+	azClustersMap map[string][]string
+}
+
+func (m *mockTopologyService) GetAZClustersMap(_ context.Context) map[string][]string {
+	return m.azClustersMap
+}
+func (m *mockTopologyService) GetSharedDatastoresInTopology(_ context.Context, _ interface{},
+) ([]*cnsvsphere.DatastoreInfo, error) {
+	return nil, nil
+}
+func (m *mockTopologyService) GetTopologyInfoFromNodes(_ context.Context, _ interface{},
+) ([]map[string]string, error) {
+	return nil, nil
+}
+func (m *mockTopologyService) ZonesWithMultipleClustersExist(_ context.Context) bool { return false }
+func (m *mockTopologyService) GetAccessibleZonesForDatastore(_ context.Context, _ string,
+	_ *cnsvsphere.VirtualCenter) ([]string, error) {
+	return nil, nil
+}
+
+// fakeDS builds a DatastoreInfo whose Reference().Value equals the given id.
+// nil is safe for the govmomi client because only Reference() is called in tests.
+func fakeDS(id string) *cnsvsphere.DatastoreInfo {
+	ref := vimtypes.ManagedObjectReference{Type: "Datastore", Value: id}
+	return &cnsvsphere.DatastoreInfo{
+		Datastore: &cnsvsphere.Datastore{
+			Datastore: object.NewDatastore(nil, ref),
+		},
+	}
+}
+
+// withCompatibleDSIDs replaces GetPolicyCompatibleDatastoresFn for the duration of a test.
+func withCompatibleDSIDs(ids map[string]struct{}, fn func()) {
+	orig := GetPolicyCompatibleDatastoresFn
+	GetPolicyCompatibleDatastoresFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ string) (map[string]struct{}, error) {
+		return ids, nil
+	}
+	defer func() { GetPolicyCompatibleDatastoresFn = orig }()
+	fn()
+}
+
+// --- GetPolicyCompatibleDatastoresPerZone tests ---------------------------------------
+
+// TestGetPolicyCompatibleDatastoresPerZone_NilTopologyManager verifies that a nil
+// topology manager returns an error immediately.
+func TestGetPolicyCompatibleDatastoresPerZone_NilTopologyManager(t *testing.T) {
+	ctx := context.Background()
+	result, err := GetPolicyCompatibleDatastoresPerZone(ctx, nil, nil, "policy-1", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// TestGetPolicyCompatibleDatastoresPerZone_NoZones verifies that an empty azClustersMap
+// returns an empty map without calling the VC.
+func TestGetPolicyCompatibleDatastoresPerZone_NoZones(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{}}
+	result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", nil)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// TestGetPolicyCompatibleDatastoresPerZone_AllCompatible verifies that when every
+// datastore in the cache matches the compatible set, all are returned per zone.
+func TestGetPolicyCompatibleDatastoresPerZone_AllCompatible(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{
+		azClustersMap: map[string][]string{
+			"zone-a": {"cluster-1"},
+			"zone-b": {"cluster-2"},
+		},
+	}
+	cache := map[string][]*cnsvsphere.DatastoreInfo{
+		"cluster-1": {fakeDS("ds-1"), fakeDS("ds-2")},
+		"cluster-2": {fakeDS("ds-3")},
+	}
+	compatible := map[string]struct{}{"ds-1": {}, "ds-2": {}, "ds-3": {}}
+
+	withCompatibleDSIDs(compatible, func() {
+		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+		require.NoError(t, err)
+		assert.Len(t, result["zone-a"], 2)
+		assert.Len(t, result["zone-b"], 1)
+	})
+}
+
+// TestGetPolicyCompatibleDatastoresPerZone_SomeCompatible verifies that only datastores
+// whose IDs are in the compatible set are included in the result.
+func TestGetPolicyCompatibleDatastoresPerZone_SomeCompatible(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{
+		azClustersMap: map[string][]string{"zone-a": {"cluster-1"}},
+	}
+	cache := map[string][]*cnsvsphere.DatastoreInfo{
+		"cluster-1": {fakeDS("ds-match"), fakeDS("ds-skip")},
+	}
+	compatible := map[string]struct{}{"ds-match": {}}
+
+	withCompatibleDSIDs(compatible, func() {
+		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+		require.NoError(t, err)
+		require.Len(t, result["zone-a"], 1)
+		assert.Equal(t, "ds-match", result["zone-a"][0].Reference().Value)
+	})
+}
+
+// TestGetPolicyCompatibleDatastoresPerZone_NoneCompatible verifies that a zone entry
+// is still created with an empty slice when no datastores match.
+func TestGetPolicyCompatibleDatastoresPerZone_NoneCompatible(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{
+		azClustersMap: map[string][]string{"zone-a": {"cluster-1"}},
+	}
+	cache := map[string][]*cnsvsphere.DatastoreInfo{
+		"cluster-1": {fakeDS("ds-1")},
+	}
+	compatible := map[string]struct{}{"ds-other": {}}
+
+	withCompatibleDSIDs(compatible, func() {
+		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+		require.NoError(t, err)
+		assert.Empty(t, result["zone-a"])
+	})
+}
+
+// TestGetPolicyCompatibleDatastoresPerZone_MultipleZonesSameDatastore verifies that a
+// datastore shared between two zones appears in the results for both.
+func TestGetPolicyCompatibleDatastoresPerZone_MultipleZonesSameDatastore(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{
+		azClustersMap: map[string][]string{
+			"zone-a": {"cluster-1"},
+			"zone-b": {"cluster-2"},
+		},
+	}
+	sharedDS := fakeDS("ds-shared")
+	cache := map[string][]*cnsvsphere.DatastoreInfo{
+		"cluster-1": {sharedDS},
+		"cluster-2": {sharedDS},
+	}
+	compatible := map[string]struct{}{"ds-shared": {}}
+
+	withCompatibleDSIDs(compatible, func() {
+		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+		require.NoError(t, err)
+		assert.Len(t, result["zone-a"], 1)
+		assert.Len(t, result["zone-b"], 1)
+	})
+}
+
+// TestGetPolicyCompatibleDatastoresPerZone_MultipleClustersPerZone verifies that
+// datastores from all clusters in a zone are aggregated before filtering.
+func TestGetPolicyCompatibleDatastoresPerZone_MultipleClustersPerZone(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{
+		azClustersMap: map[string][]string{
+			"zone-a": {"cluster-1", "cluster-2"},
+		},
+	}
+	cache := map[string][]*cnsvsphere.DatastoreInfo{
+		"cluster-1": {fakeDS("ds-1")},
+		"cluster-2": {fakeDS("ds-2")},
+	}
+	compatible := map[string]struct{}{"ds-1": {}, "ds-2": {}}
+
+	withCompatibleDSIDs(compatible, func() {
+		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+		require.NoError(t, err)
+		assert.Len(t, result["zone-a"], 2)
+	})
+}
+
+// --- GetAccessibleZonesForPolicy tests ------------------------------------------------
+
+// TestGetAccessibleZonesForPolicy_NilTopologyManager verifies that a nil topology
+// manager returns an error.
+func TestGetAccessibleZonesForPolicy_NilTopologyManager(t *testing.T) {
+	ctx := context.Background()
+	zones, err := GetAccessibleZonesForPolicy(ctx, nil, nil, "policy-1", nil)
+	assert.Error(t, err)
+	assert.Nil(t, zones)
+}
+
+// TestGetAccessibleZonesForPolicy_NoCompatibleDatastores verifies that zones without
+// any compatible datastores are excluded from the result.
+func TestGetAccessibleZonesForPolicy_NoCompatibleDatastores(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{
+		azClustersMap: map[string][]string{"zone-a": {"cluster-1"}},
+	}
+	cache := map[string][]*cnsvsphere.DatastoreInfo{
+		"cluster-1": {fakeDS("ds-1")},
+	}
+	// No compatible datastores → zone-a should not appear.
+	withCompatibleDSIDs(map[string]struct{}{}, func() {
+		zones, err := GetAccessibleZonesForPolicy(ctx, topo, nil, "policy-1", cache)
+		require.NoError(t, err)
+		assert.Empty(t, zones)
+	})
+}
+
+// TestGetAccessibleZonesForPolicy_OnlyZonesWithCompatibleDSReturned verifies that only
+// zones containing at least one compatible datastore are included in the result.
+func TestGetAccessibleZonesForPolicy_OnlyZonesWithCompatibleDSReturned(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{
+		azClustersMap: map[string][]string{
+			"zone-has-ds":   {"cluster-1"},
+			"zone-no-ds":    {"cluster-2"},
+			"zone-also-has": {"cluster-3"},
+		},
+	}
+	cache := map[string][]*cnsvsphere.DatastoreInfo{
+		"cluster-1": {fakeDS("ds-match")},
+		"cluster-2": {fakeDS("ds-other")},
+		"cluster-3": {fakeDS("ds-match2")},
+	}
+	compatible := map[string]struct{}{"ds-match": {}, "ds-match2": {}}
+
+	withCompatibleDSIDs(compatible, func() {
+		zones, err := GetAccessibleZonesForPolicy(ctx, topo, nil, "policy-1", cache)
+		require.NoError(t, err)
+		sort.Strings(zones)
+		assert.Equal(t, []string{"zone-also-has", "zone-has-ds"}, zones)
+	})
 }


### PR DESCRIPTION
This change populates volume capabilities for a policy.

SupportsLinkedClone and SupportsHighPerformanceLinkedClone in the InfraSPI volume capabilities are evaluated with all-zones semantics: both capabilities are reported as true only when every zone where the storage policy has compatible datastores satisfies the requirement (ESXi 9.1+ host for LC; ESXi 9.1+ host in a vSAN-ESA cluster for HPLC).

For marker policy, SupportsPersistentVolumeFilesystem is always true and rest of the capabilities are always false.

**Testing done**:
Example:

```
root@42351caf9b6cec287a380bc020614465 [ ~ ]# k get infraspi vsan-default-storage-policy -oyaml
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
metadata:
  creationTimestamp: "2026-06-22T13:53:26Z"
  generation: 1
  name: vsan-default-storage-policy
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: vsan-default-storage-policy
    uid: df11796f-45de-498f-b830-95aac2efc2c7
  resourceVersion: "9564185"
  uid: 2b938d5a-e0c5-4a3e-8771-7f26bde56f41
status:
  topology:
    accessibleZones:
    - az1
    topologyType: ""
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsLinkedClone: true
    SupportsPersistentVolumeBlock: true
    SupportsPersistentVolumeFilesystem: true
```


```
{"level":"info","time":"2026-06-22T13:53:27.56289323Z","caller":"clusterstoragepolicyinfo/controller.go:712","msg":"Storage policy b1263970-8662-69e2-adc6-fa8ae01abecc is accessible in zones: [az1]","TraceId":"d109f70d-28bc-4bdc-ac39-b80db3ad2253"}
{"level":"info","time":"2026-06-22T13:53:27.562910198Z","caller":"clusterstoragepolicyinfo/helper.go:472","msg":"Storage policy b1263970-8662-69e2-adc6-fa8ae01abecc SupportsVolumeModeBlock=true (isMarkerPolicy=false)","TraceId":"d109f70d-28bc-4bdc-ac39-b80db3ad2253"}
{"level":"info","time":"2026-06-22T13:53:27.882203984Z","caller":"vsphere/pbm.go:168","msg":"Found 3 compatible datastores for policy b1263970-8662-69e2-adc6-fa8ae01abecc","TraceId":"d109f70d-28bc-4bdc-ac39-b80db3ad2253"}
{"level":"info","time":"2026-06-22T13:53:27.882286565Z","caller":"util/util.go:612","msg":"Found 3 compatible datastores for policy b1263970-8662-69e2-adc6-fa8ae01abecc","TraceId":"d109f70d-28bc-4bdc-ac39-b80db3ad2253"}
{"level":"info","time":"2026-06-22T13:53:27.964566164Z","caller":"clusterstoragepolicyinfo/helper.go:667","msg":"Storage policy b1263970-8662-69e2-adc6-fa8ae01abecc supports LinkedClone: all 1 zones have ESXi 9.1+ hosts","TraceId":"d109f70d-28bc-4bdc-ac39-b80db3ad2253"}
{"level":"info","time":"2026-06-22T13:53:27.993442253Z","caller":"clusterstoragepolicyinfo/helper.go:740","msg":"Zone az1: no ESXi 9.1+ host found in a vSAN-ESA enabled cluster; SupportsHighPerformanceLinkedClone=false","TraceId":"d109f70d-28bc-4bdc-ac39-b80db3ad2253"}
{"level":"info","time":"2026-06-22T13:53:27.993681569Z","caller":"clusterstoragepolicyinfo/helper.go:519","msg":"Storage policy b1263970-8662-69e2-adc6-fa8ae01abecc SupportsLinkedClone=true, SupportsHighPerformanceLinkedClone=false","TraceId":"d109f70d-28bc-4bdc-ac39-b80db3ad2253"}
{"level":"info","time":"2026-06-22T13:53:28.019359027Z","caller":"clusterstoragepolicyinfo/controller.go:340","msg":"Successfully synced storage policy attributes for \"management-storage-policy-encryption\"","TraceId":"d109f70d-28bc-4bdc-ac39-b80db3ad2253","name":"/management-storage-policy-encryption"}
{"level":"info","time":"2026-06-22T13:53:28.019724597Z","caller":"clusterstoragepolicyinfo/controller.go:583","msg":"Successfully reconciled ClusterStoragePolicyInfo","TraceId":"d109f70d-28bc-4bdc-ac39-b80db3ad2253","name":"/management-storage-policy-encryption"}
```

Marker policy:

```
root@42351caf9b6cec287a380bc020614465 [ ~ ]# k get infraspi vsan-file-service-policy -oyaml
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
metadata:
  creationTimestamp: "2026-06-22T14:15:58Z"
  generation: 1
  name: vsan-file-service-policy
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: vsan-file-service-policy
    uid: 220bc435-5f5b-4006-bcf6-a21153461630
  resourceVersion: "9578188"
  uid: 4bf70d9a-61c6-4278-afad-37ccfb27d56d
status:
  topology:
    accessibleZones: []
    topologyType: ""
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsLinkedClone: false
    SupportsPersistentVolumeBlock: false
    SupportsPersistentVolumeFilesystem: true
```

```
{"level":"info","time":"2026-06-22T14:15:58.85278453Z","caller":"clusterstoragepolicyinfo/helper.go:472","msg":"Storage policy d30252c0-07d1-4a79-a597-e00b7a2265b4 SupportsVolumeModeBlock=false (isMarkerPolicy=true)","TraceId":"f66be719-8cf9-4918-8820-6b370102ce98"}
{"level":"info","time":"2026-06-22T14:15:58.853276425Z","caller":"clusterstoragepolicyinfo/helper.go:479","msg":"Storage policy d30252c0-07d1-4a79-a597-e00b7a2265b4 is a marker policy - SupportsHighPerformanceLinkedClone=false, SupportsLinkedClone=false","TraceId":"f66be719-8cf9-4918-8820-6b370102ce98"}
{"level":"info","time":"2026-06-22T14:15:58.870460273Z","caller":"clusterstoragepolicyinfo/controller.go:340","msg":"Successfully synced storage policy attributes for \"vsan-file-service-policy\"","TraceId":"f66be719-8cf9-4918-8820-6b370102ce98","name":"/vsan-file-service-policy"}
{"level":"info","time":"2026-06-22T14:15:58.87060282Z","caller":"clusterstoragepolicyinfo/controller.go:583","msg":"Successfully reconciled ClusterStoragePolicyInfo","TraceId":"f66be719-8cf9-4918-8820-6b370102ce98","name":"/vsan-file-service-policy"}
```

WCP precheckin (passes): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1754/
VKS precheckin (passes): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1317/