### PR TITLE
Full sync PVC Annotation update.

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -421,6 +421,16 @@ const (
 	// AnnKeyGuestCluster is the guest cluster annotation containing JSON with cluster info, PVC name and namespace
 	AnnKeyGuestClusterPvc = "csi.vsphere.volume/guest-cluster-pvc"
 
+	// The following constants are the field keys inside the JSON value stored under
+	// the AnnKeyGuestClusterPvc annotation on a supervisor PVC. They are the single
+	// source of truth shared by the provisioning path, the full-sync backfill, and
+	// the metadata-syncer cleanup so the key set cannot drift between them.
+	GuestClusterPvcAnnotKeyClusterID   = "clusterId"
+	GuestClusterPvcAnnotKeyClusterName = "clusterName"
+	GuestClusterPvcAnnotKeyName        = "name"
+	GuestClusterPvcAnnotKeyNamespace   = "namespace"
+	GuestClusterPvcAnnotKeyVolumeName  = "volumeName"
+
 	// AnnKeyGuestClusterSnapshot is the guest cluster annotation containing JSON with cluster info, PVC name and namespace
 	AnnKeyGuestClusterSnapshot = "csi.vsphere.volume/guest-cluster-snapshot"
 

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -421,18 +421,23 @@ const (
 	// AnnKeyGuestCluster is the guest cluster annotation containing JSON with cluster info, PVC name and namespace
 	AnnKeyGuestClusterPvc = "csi.vsphere.volume/guest-cluster-pvc"
 
-	// The following constants are the field keys inside the JSON value stored under
-	// the AnnKeyGuestClusterPvc annotation on a supervisor PVC. They are the single
-	// source of truth shared by the provisioning path, the full-sync backfill, and
-	// the metadata-syncer cleanup so the key set cannot drift between them.
-	GuestClusterPvcAnnotKeyClusterID   = "clusterId"
-	GuestClusterPvcAnnotKeyClusterName = "clusterName"
-	GuestClusterPvcAnnotKeyName        = "name"
-	GuestClusterPvcAnnotKeyNamespace   = "namespace"
-	GuestClusterPvcAnnotKeyVolumeName  = "volumeName"
-
 	// AnnKeyGuestClusterSnapshot is the guest cluster annotation containing JSON with cluster info, PVC name and namespace
 	AnnKeyGuestClusterSnapshot = "csi.vsphere.volume/guest-cluster-snapshot"
+
+	// The following constants are the field keys inside the JSON value stored under
+	// the guest-cluster annotations on supervisor resources: AnnKeyGuestClusterPvc
+	// on a supervisor PVC and AnnKeyGuestClusterSnapshot on a supervisor
+	// VolumeSnapshot. They are the single source of truth shared by the provisioning
+	// paths, the full-sync backfill, and the metadata-syncer cleanup so the key set
+	// cannot drift between them. clusterId/volumeName apply to PVCs and
+	// volumeSnapshotContentName applies to snapshots; clusterName/name/namespace are
+	// common to both.
+	GuestClusterAnnotKeyClusterID   = "clusterId"
+	GuestClusterAnnotKeyClusterName = "clusterName"
+	GuestClusterAnnotKeyName        = "name"
+	GuestClusterAnnotKeyNamespace   = "namespace"
+	GuestClusterAnnotKeyVolumeName  = "volumeName"
+	GuestClusterAnnotKeyVSCName     = "volumeSnapshotContentName"
 
 	// AnnKeyBackingDiskType is the type of the backing disk.
 	// It is added on the PVC during static volume provisioning

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -688,17 +688,42 @@ func IsFVSPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) bool {
 // annotation through this helper so the two cannot drift.
 func BuildGuestPvcAnnotation(clusterID, clusterName, pvcName, pvcNamespace, volumeName string) map[string]string {
 	annot := map[string]string{
-		GuestClusterPvcAnnotKeyClusterID:   clusterID,
-		GuestClusterPvcAnnotKeyClusterName: clusterName,
+		GuestClusterAnnotKeyClusterID:   clusterID,
+		GuestClusterAnnotKeyClusterName: clusterName,
 	}
 	if pvcName != "" {
-		annot[GuestClusterPvcAnnotKeyName] = pvcName
+		annot[GuestClusterAnnotKeyName] = pvcName
 	}
 	if pvcNamespace != "" {
-		annot[GuestClusterPvcAnnotKeyNamespace] = pvcNamespace
+		annot[GuestClusterAnnotKeyNamespace] = pvcNamespace
 	}
 	if volumeName != "" {
-		annot[GuestClusterPvcAnnotKeyVolumeName] = volumeName
+		annot[GuestClusterAnnotKeyVolumeName] = volumeName
+	}
+	return annot
+}
+
+// BuildGuestSnapshotAnnotation constructs the value map stored on a supervisor
+// VolumeSnapshot under the AnnKeyGuestClusterSnapshot annotation. It records the
+// originating guest cluster name and, when known, the guest VolumeSnapshot name,
+// namespace, and the guest VolumeSnapshotContent name. Empty optional fields are
+// omitted so the serialized annotation never carries blank values.
+//
+// This is the single source of truth for the annotation's key set; both the
+// CreateSnapshot provisioning path and the full-sync upgrade backfill build their
+// annotation through this helper so the two cannot drift.
+func BuildGuestSnapshotAnnotation(clusterName, snapshotName, snapshotNamespace, vscName string) map[string]string {
+	annot := map[string]string{
+		GuestClusterAnnotKeyClusterName: clusterName,
+	}
+	if snapshotName != "" {
+		annot[GuestClusterAnnotKeyName] = snapshotName
+	}
+	if snapshotNamespace != "" {
+		annot[GuestClusterAnnotKeyNamespace] = snapshotNamespace
+	}
+	if vscName != "" {
+		annot[GuestClusterAnnotKeyVSCName] = vscName
 	}
 	return annot
 }

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -676,3 +676,29 @@ func IsFVSPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) bool {
 	}
 	return IsFVSStorageClassName(*pvc.Spec.StorageClassName)
 }
+
+// BuildGuestPvcAnnotation constructs the value map stored on a supervisor PVC
+// under the AnnKeyGuestClusterPvc annotation. It records the originating guest
+// cluster identity (clusterId, clusterName) and, when known, the guest PVC name,
+// namespace, and the bound supervisor volume name. Empty optional fields are
+// omitted so the serialized annotation never carries blank values.
+//
+// This is the single source of truth for the annotation's key set; both the
+// CreateVolume provisioning path and the full-sync upgrade backfill build their
+// annotation through this helper so the two cannot drift.
+func BuildGuestPvcAnnotation(clusterID, clusterName, pvcName, pvcNamespace, volumeName string) map[string]string {
+	annot := map[string]string{
+		GuestClusterPvcAnnotKeyClusterID:   clusterID,
+		GuestClusterPvcAnnotKeyClusterName: clusterName,
+	}
+	if pvcName != "" {
+		annot[GuestClusterPvcAnnotKeyName] = pvcName
+	}
+	if pvcNamespace != "" {
+		annot[GuestClusterPvcAnnotKeyNamespace] = pvcNamespace
+	}
+	if volumeName != "" {
+		annot[GuestClusterPvcAnnotKeyVolumeName] = volumeName
+	}
+	return annot
+}

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -1026,11 +1026,11 @@ func TestBuildGuestPvcAnnotation(t *testing.T) {
 			pvcNamespace: "guest-ns",
 			volumeName:   "sv-pv-1",
 			expected: map[string]string{
-				GuestClusterPvcAnnotKeyClusterID:   "tkc-uid",
-				GuestClusterPvcAnnotKeyClusterName: "my-tkc",
-				GuestClusterPvcAnnotKeyName:        "guest-pvc",
-				GuestClusterPvcAnnotKeyNamespace:   "guest-ns",
-				GuestClusterPvcAnnotKeyVolumeName:  "sv-pv-1",
+				GuestClusterAnnotKeyClusterID:   "tkc-uid",
+				GuestClusterAnnotKeyClusterName: "my-tkc",
+				GuestClusterAnnotKeyName:        "guest-pvc",
+				GuestClusterAnnotKeyNamespace:   "guest-ns",
+				GuestClusterAnnotKeyVolumeName:  "sv-pv-1",
 			},
 		},
 		{
@@ -1038,8 +1038,8 @@ func TestBuildGuestPvcAnnotation(t *testing.T) {
 			clusterID:   "tkc-uid",
 			clusterName: "my-tkc",
 			expected: map[string]string{
-				GuestClusterPvcAnnotKeyClusterID:   "tkc-uid",
-				GuestClusterPvcAnnotKeyClusterName: "my-tkc",
+				GuestClusterAnnotKeyClusterID:   "tkc-uid",
+				GuestClusterAnnotKeyClusterName: "my-tkc",
 			},
 		},
 		{
@@ -1050,9 +1050,9 @@ func TestBuildGuestPvcAnnotation(t *testing.T) {
 			pvcNamespace: "guest-ns",
 			volumeName:   "",
 			expected: map[string]string{
-				GuestClusterPvcAnnotKeyClusterID:   "tkc-uid",
-				GuestClusterPvcAnnotKeyClusterName: "my-tkc",
-				GuestClusterPvcAnnotKeyNamespace:   "guest-ns",
+				GuestClusterAnnotKeyClusterID:   "tkc-uid",
+				GuestClusterAnnotKeyClusterName: "my-tkc",
+				GuestClusterAnnotKeyNamespace:   "guest-ns",
 			},
 		},
 	}
@@ -1063,6 +1063,60 @@ func TestBuildGuestPvcAnnotation(t *testing.T) {
 				tt.pvcName, tt.pvcNamespace, tt.volumeName)
 			assert.Equal(t, tt.expected, got)
 			// No optional key should ever carry a blank value.
+			for k, v := range got {
+				assert.NotEmpty(t, v, "key %q must not have a blank value", k)
+			}
+		})
+	}
+}
+
+func TestBuildGuestSnapshotAnnotation(t *testing.T) {
+	tests := []struct {
+		name              string
+		clusterName       string
+		snapshotName      string
+		snapshotNamespace string
+		vscName           string
+		expected          map[string]string
+	}{
+		{
+			name:              "all fields populated",
+			clusterName:       "my-tkc",
+			snapshotName:      "guest-snap",
+			snapshotNamespace: "guest-ns",
+			vscName:           "snapcontent-abc",
+			expected: map[string]string{
+				GuestClusterAnnotKeyClusterName: "my-tkc",
+				GuestClusterAnnotKeyName:        "guest-snap",
+				GuestClusterAnnotKeyNamespace:   "guest-ns",
+				GuestClusterAnnotKeyVSCName:     "snapcontent-abc",
+			},
+		},
+		{
+			name:        "only cluster name",
+			clusterName: "my-tkc",
+			expected: map[string]string{
+				GuestClusterAnnotKeyClusterName: "my-tkc",
+			},
+		},
+		{
+			name:              "empty optional fields are omitted, not blank",
+			clusterName:       "my-tkc",
+			snapshotName:      "guest-snap",
+			snapshotNamespace: "",
+			vscName:           "",
+			expected: map[string]string{
+				GuestClusterAnnotKeyClusterName: "my-tkc",
+				GuestClusterAnnotKeyName:        "guest-snap",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildGuestSnapshotAnnotation(tt.clusterName, tt.snapshotName,
+				tt.snapshotNamespace, tt.vscName)
+			assert.Equal(t, tt.expected, got)
 			for k, v := range got {
 				assert.NotEmpty(t, v, "key %q must not have a blank value", k)
 			}

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -1007,3 +1007,65 @@ func TestSyncVolumeCBTState(t *testing.T) {
 		assert.True(t, vm.clearCalled)
 	})
 }
+
+func TestBuildGuestPvcAnnotation(t *testing.T) {
+	tests := []struct {
+		name         string
+		clusterID    string
+		clusterName  string
+		pvcName      string
+		pvcNamespace string
+		volumeName   string
+		expected     map[string]string
+	}{
+		{
+			name:         "all fields populated",
+			clusterID:    "tkc-uid",
+			clusterName:  "my-tkc",
+			pvcName:      "guest-pvc",
+			pvcNamespace: "guest-ns",
+			volumeName:   "sv-pv-1",
+			expected: map[string]string{
+				GuestClusterPvcAnnotKeyClusterID:   "tkc-uid",
+				GuestClusterPvcAnnotKeyClusterName: "my-tkc",
+				GuestClusterPvcAnnotKeyName:        "guest-pvc",
+				GuestClusterPvcAnnotKeyNamespace:   "guest-ns",
+				GuestClusterPvcAnnotKeyVolumeName:  "sv-pv-1",
+			},
+		},
+		{
+			name:        "only cluster identity (provision time, before binding)",
+			clusterID:   "tkc-uid",
+			clusterName: "my-tkc",
+			expected: map[string]string{
+				GuestClusterPvcAnnotKeyClusterID:   "tkc-uid",
+				GuestClusterPvcAnnotKeyClusterName: "my-tkc",
+			},
+		},
+		{
+			name:         "empty optional fields are omitted, not blank",
+			clusterID:    "tkc-uid",
+			clusterName:  "my-tkc",
+			pvcName:      "",
+			pvcNamespace: "guest-ns",
+			volumeName:   "",
+			expected: map[string]string{
+				GuestClusterPvcAnnotKeyClusterID:   "tkc-uid",
+				GuestClusterPvcAnnotKeyClusterName: "my-tkc",
+				GuestClusterPvcAnnotKeyNamespace:   "guest-ns",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildGuestPvcAnnotation(tt.clusterID, tt.clusterName,
+				tt.pvcName, tt.pvcNamespace, tt.volumeName)
+			assert.Equal(t, tt.expected, got)
+			// No optional key should ever carry a blank value.
+			for k, v := range got {
+				assert.NotEmpty(t, v, "key %q must not have a blank value", k)
+			}
+		})
+	}
+}

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -618,7 +618,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		}
 
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
-			guestPvcAnnot[common.GuestClusterPvcAnnotKeyVolumeName] = boundPVC.Spec.VolumeName
+			guestPvcAnnot[common.GuestClusterAnnotKeyVolumeName] = boundPVC.Spec.VolumeName
 			err := patchSupervisorPVCAnnotation(ctx, c.supervisorClient, guestPvcAnnot, supervisorPVCName, c.supervisorNamespace)
 			if err != nil {
 				log.Error("failed to patch supervisor PVC annotation: %v", err.Error())
@@ -1828,16 +1828,12 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 				annotation := make(map[string]string)
 				annotation[common.SupervisorVolumeSnapshotAnnotationKey] = "true"
 				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
-					guestSnapAnnot := make(map[string]string)
-					guestSnapAnnot["name"] = volumeSnapshotName
-					guestSnapAnnot["namespace"] = volumeSnapshotNamespace
-					guestSnapAnnot["clusterName"] = c.tanzukubernetesClusterName
-					// Record the guest-cluster VolumeSnapshotContent name, injected into the
-					// CreateSnapshot parameters by the external-snapshotter sidecar running in
-					// the guest cluster.
-					if _, ok := req.Parameters[common.VolumeSnapshotContentNameKey]; ok {
-						guestSnapAnnot["volumeSnapshotContentName"] = req.Parameters[common.VolumeSnapshotContentNameKey]
-					}
+					// The guest-cluster VolumeSnapshotContent name is injected into the
+					// CreateSnapshot parameters by the external-snapshotter sidecar running
+					// in the guest cluster.
+					guestSnapAnnot := common.BuildGuestSnapshotAnnotation(c.tanzukubernetesClusterName,
+						volumeSnapshotName, volumeSnapshotNamespace,
+						req.Parameters[common.VolumeSnapshotContentNameKey])
 
 					guestSnapAnnotJSON, err := json.Marshal(guestSnapAnnot)
 					if err != nil {

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -455,17 +455,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				}
 			}
 		}
-		guestPvcAnnot := make(map[string]string)
-
-		guestPvcAnnot["clusterId"] = c.tanzukubernetesClusterUID
-		guestPvcAnnot["clusterName"] = c.tanzukubernetesClusterName
-		// Add guest PVC information to the same JSON structure
-		if pvcName != "" {
-			guestPvcAnnot["name"] = pvcName
-		}
-		if pvcNamespace != "" {
-			guestPvcAnnot["namespace"] = pvcNamespace
-		}
+		// The bound supervisor volume name is not known yet; it is added below
+		// once the supervisor PVC is bound (see ImprovedVolumeVisiblity patch).
+		guestPvcAnnot := common.BuildGuestPvcAnnotation(c.tanzukubernetesClusterUID,
+			c.tanzukubernetesClusterName, pvcName, pvcNamespace, "")
 
 		accessMode := req.GetVolumeCapabilities()[0].GetAccessMode().GetMode()
 		pvc, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
@@ -625,7 +618,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		}
 
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
-			guestPvcAnnot["volumeName"] = boundPVC.Spec.VolumeName
+			guestPvcAnnot[common.GuestClusterPvcAnnotKeyVolumeName] = boundPVC.Spec.VolumeName
 			err := patchSupervisorPVCAnnotation(ctx, c.supervisorClient, guestPvcAnnot, supervisorPVCName, c.supervisorNamespace)
 			if err != nil {
 				log.Error("failed to patch supervisor PVC annotation: %v", err.Error())

--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -516,13 +516,37 @@ func setGuestClusterDetailsOnSupervisorPVC(ctx context.Context, metadataSyncer *
 			key := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
 				metadataSyncer.configInfo.Cfg.GC.ClusterDistribution)
 			val, ok := svPVC.Labels[key]
+			original := svPVC.DeepCopy()
+			patchNeeded := false
 			if !ok || val != metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID {
-				original := svPVC.DeepCopy()
+				patchNeeded = true
 				if svPVC.Labels == nil {
 					svPVC.Labels = make(map[string]string)
 				}
 				svPVC.Labels[key] = metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID
+			}
 
+			if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
+				if _, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; !ok {
+					guestPvcAnnot := common.BuildGuestPvcAnnotation(
+						metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID,
+						metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
+						pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace, svPVC.Spec.VolumeName)
+					// Marshal the guest cluster annotation to JSON
+					jsonAnnotation, err := json.Marshal(guestPvcAnnot)
+					if err != nil {
+						log.Errorf("failed to marshal guest cluster annotation: %+v", err)
+					} else {
+						if svPVC.Annotations == nil {
+							svPVC.Annotations = make(map[string]string)
+						}
+						svPVC.Annotations[common.AnnKeyGuestClusterPvc] = string(jsonAnnotation)
+						patchNeeded = true
+					}
+				}
+			}
+
+			if patchNeeded {
 				err = k8s.PatchObject(ctx, supervisorRuntimeClient, original, svPVC)
 				if err != nil {
 					msg := fmt.Sprintf("failed to patch supervisor PVC: %q with guest cluster labels in %q namespace."+

--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -174,9 +174,11 @@ func PvcsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) er
 	if err != nil {
 		log.Warnf("FullSync: Failed to set Guest Cluster data on SupervisorPVC. Err: %v", err)
 	}
-	// Set csi.vsphere-volume labels and CNS finalizer on the Supervisor VolumeSnapshot which is
-	// requested from TKC Cluster, if SVPVCSnapshotProtectionFinalizer FSS enabled
-	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.SVPVCSnapshotProtectionFinalizer) {
+	// Set csi.vsphere-volume labels and CNS finalizer (SVPVCSnapshotProtectionFinalizer FSS) and/or
+	// backfill the guest-cluster-snapshot annotation (ImprovedVolumeVisiblity FSS) on the Supervisor
+	// VolumeSnapshot which is requested from the TKC Cluster.
+	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.SVPVCSnapshotProtectionFinalizer) ||
+		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeVisiblity) {
 		err = setGuestClusterDetailsOnSupervisorSnapshot(ctx, metadataSyncer, supervisorNamespace)
 		if err != nil {
 			log.Warnf("FullSync: Failed to set Guest Cluster data on SupervisorSnapshot. Err: %v", err)
@@ -718,28 +720,59 @@ func setGuestClusterDetailsOnSupervisorSnapshot(ctx context.Context, metadataSyn
 		return err
 	}
 
-	// Define the processor for supervisor snapshots
-	processFunc := func(ctx context.Context, vsc *snapv1.VolumeSnapshotContent, svVS *snapv1.VolumeSnapshot) error {
-		// Add label to Supervisor Snapshot that contains guest cluster details, if not present already.
-		tkcLabelPresent := true
-		key := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
-			metadataSyncer.configInfo.Cfg.GC.ClusterDistribution)
-		if val, ok := svVS.Labels[key]; !ok || val != metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID {
-			if svVS.Labels == nil {
-				svVS.Labels = make(map[string]string)
-			}
-			svVS.Labels[key] = metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID
-			tkcLabelPresent = false
-		}
-		// Add finalizer "cns.vmware.com/volumesnapshot-protection" to Supervisor snapshot, if not present already,
-		// to prevent accidental deletion from supervisor cluster
-		cnsFinalizerPresent := slices.Contains(svVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer)
-		if !cnsFinalizerPresent || !tkcLabelPresent {
-			original := svVS.DeepCopy()
-			if !cnsFinalizerPresent {
-				svVS.ObjectMeta.Finalizers = append(svVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer)
-			}
+	snapshotProtectionEnabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx,
+		common.SVPVCSnapshotProtectionFinalizer)
+	improvedVisibilityEnabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx,
+		common.ImprovedVolumeVisiblity)
 
+	// Define the processor for supervisor snapshots. Label and finalizer mutations
+	// are gated by SVPVCSnapshotProtectionFinalizer; the guest-cluster annotation
+	// backfill is gated by ImprovedVolumeVisiblity. All applicable mutations are
+	// batched into a single PatchObject call.
+	processFunc := func(ctx context.Context, vsc *snapv1.VolumeSnapshotContent, svVS *snapv1.VolumeSnapshot) error {
+		original := svVS.DeepCopy()
+		patchNeeded := false
+
+		if snapshotProtectionEnabled {
+			// Add label to Supervisor Snapshot that contains guest cluster details, if not present already.
+			key := fmt.Sprintf("%s/%s", metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
+				metadataSyncer.configInfo.Cfg.GC.ClusterDistribution)
+			if val, ok := svVS.Labels[key]; !ok || val != metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID {
+				if svVS.Labels == nil {
+					svVS.Labels = make(map[string]string)
+				}
+				svVS.Labels[key] = metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID
+				patchNeeded = true
+			}
+			// Add finalizer "cns.vmware.com/volumesnapshot-protection" to Supervisor snapshot, if not present
+			// already, to prevent accidental deletion from supervisor cluster.
+			if !slices.Contains(svVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer) {
+				svVS.ObjectMeta.Finalizers = append(svVS.ObjectMeta.Finalizers, cnsoperatortypes.CNSSnapshotFinalizer)
+				patchNeeded = true
+			}
+		}
+
+		// Backfill the guest-cluster-snapshot annotation on the supervisor VolumeSnapshot
+		// for snapshots created before the feature was enabled (upgrade path).
+		if improvedVisibilityEnabled {
+			if _, ok := svVS.Annotations[common.AnnKeyGuestClusterSnapshot]; !ok {
+				guestSnapAnnot := common.BuildGuestSnapshotAnnotation(
+					metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterName,
+					vsc.Spec.VolumeSnapshotRef.Name, vsc.Spec.VolumeSnapshotRef.Namespace, vsc.Name)
+				jsonAnnotation, err := json.Marshal(guestSnapAnnot)
+				if err != nil {
+					log.Errorf("failed to marshal guest cluster snapshot annotation: %v", err)
+				} else {
+					if svVS.Annotations == nil {
+						svVS.Annotations = make(map[string]string)
+					}
+					svVS.Annotations[common.AnnKeyGuestClusterSnapshot] = string(jsonAnnotation)
+					patchNeeded = true
+				}
+			}
+		}
+
+		if patchNeeded {
 			supervisorRuntimeClient, err := newRuntimeClientWithSnapshotScheme(supervisorRestConfig)
 			if err != nil {
 				return fmt.Errorf("failed to create controller-runtime client for supervisor cluster. Error: %w", err)
@@ -747,7 +780,7 @@ func setGuestClusterDetailsOnSupervisorSnapshot(ctx context.Context, metadataSyn
 
 			err = k8s.PatchObject(ctx, supervisorRuntimeClient, original, svVS)
 			if err != nil {
-				return fmt.Errorf("failed to patch supervisor Snapshot %q with guest cluster labels in %q namespace. Error: %w",
+				return fmt.Errorf("failed to patch supervisor Snapshot %q with guest cluster details in %q namespace. Error: %w",
 					*vsc.Status.SnapshotHandle, supervisorNamespace, err)
 			}
 		}

--- a/pkg/syncer/pvcsi_fullsync_test.go
+++ b/pkg/syncer/pvcsi_fullsync_test.go
@@ -1327,11 +1327,11 @@ func TestSetGuestClusterDetailsOnSupervisorPVC_AnnotationBackfill(t *testing.T) 
 		var got map[string]string
 		require.NoError(t, json.Unmarshal([]byte(annots[common.AnnKeyGuestClusterPvc]), &got))
 		assert.Equal(t, map[string]string{
-			common.GuestClusterPvcAnnotKeyClusterID:   clusterUID,
-			common.GuestClusterPvcAnnotKeyClusterName: clusterName,
-			common.GuestClusterPvcAnnotKeyName:        guestPVCName,
-			common.GuestClusterPvcAnnotKeyNamespace:   guestPVCNS,
-			common.GuestClusterPvcAnnotKeyVolumeName:  svPVCVolName,
+			common.GuestClusterAnnotKeyClusterID:   clusterUID,
+			common.GuestClusterAnnotKeyClusterName: clusterName,
+			common.GuestClusterAnnotKeyName:        guestPVCName,
+			common.GuestClusterAnnotKeyNamespace:   guestPVCNS,
+			common.GuestClusterAnnotKeyVolumeName:  svPVCVolName,
 		}, got)
 	})
 
@@ -1345,6 +1345,105 @@ func TestSetGuestClusterDetailsOnSupervisorPVC_AnnotationBackfill(t *testing.T) 
 		annots := getUpdatedAnnot(t, fakeClient)
 		// Pre-existing annotation must be preserved untouched.
 		assert.Equal(t, existing, annots[common.AnnKeyGuestClusterPvc],
+			"pre-existing annotation must not be overwritten")
+	})
+}
+
+// TestSetGuestClusterDetailsOnSupervisorSnapshot_AnnotationBackfill tests the
+// upgrade-path annotation backfill added in setGuestClusterDetailsOnSupervisorSnapshot.
+// As with the PVC backfill, the private processor builds its own controller-runtime
+// client, so we drive the same patch sequence through the shared
+// common.BuildGuestSnapshotAnnotation helper plus k8s.PatchObject. The pure
+// key/value logic is covered directly by TestBuildGuestSnapshotAnnotation in the
+// common package.
+func TestSetGuestClusterDetailsOnSupervisorSnapshot_AnnotationBackfill(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		svVSName     = "sv-snap-1"
+		svNamespace  = "vmware-system-csi"
+		clusterName  = "my-tkc"
+		guestVSName  = "guest-snap-1"
+		guestVSNs    = "guest-ns"
+		guestVSCName = "snapcontent-guest-1"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, snapv1.AddToScheme(scheme))
+
+	// VSC whose VolumeSnapshotRef points at the guest VolumeSnapshot.
+	vsc := &snapv1.VolumeSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{Name: guestVSCName},
+		Spec: snapv1.VolumeSnapshotContentSpec{
+			VolumeSnapshotRef: v1.ObjectReference{Name: guestVSName, Namespace: guestVSNs},
+		},
+	}
+
+	makeSVVS := func(annots map[string]string) *snapv1.VolumeSnapshot {
+		return &snapv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        svVSName,
+				Namespace:   svNamespace,
+				Annotations: annots,
+			},
+		}
+	}
+
+	// runBackfill mirrors the ImprovedVolumeVisiblity block from
+	// setGuestClusterDetailsOnSupervisorSnapshot's processFunc.
+	runBackfill := func(t *testing.T, svVS *snapv1.VolumeSnapshot, fakeClient client.Client) {
+		t.Helper()
+		if _, ok := svVS.Annotations[common.AnnKeyGuestClusterSnapshot]; ok {
+			return
+		}
+		guestSnapAnnot := common.BuildGuestSnapshotAnnotation(clusterName,
+			vsc.Spec.VolumeSnapshotRef.Name, vsc.Spec.VolumeSnapshotRef.Namespace, vsc.Name)
+		jsonAnnotation, err := json.Marshal(guestSnapAnnot)
+		require.NoError(t, err)
+		original := svVS.DeepCopy()
+		if svVS.Annotations == nil {
+			svVS.Annotations = make(map[string]string)
+		}
+		svVS.Annotations[common.AnnKeyGuestClusterSnapshot] = string(jsonAnnotation)
+		require.NoError(t, k8s.PatchObject(ctx, fakeClient, original, svVS))
+	}
+
+	getUpdatedAnnot := func(t *testing.T, c client.Client) map[string]string {
+		t.Helper()
+		updated := &snapv1.VolumeSnapshot{}
+		require.NoError(t, c.Get(ctx, client.ObjectKey{
+			Name: svVSName, Namespace: svNamespace,
+		}, updated))
+		return updated.Annotations
+	}
+
+	t.Run("backfills annotation when absent", func(t *testing.T) {
+		svVS := makeSVVS(nil) // nil annotations — exercises the nil-map guard
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svVS).Build()
+
+		runBackfill(t, svVS, fakeClient)
+
+		annots := getUpdatedAnnot(t, fakeClient)
+		require.Contains(t, annots, common.AnnKeyGuestClusterSnapshot)
+		var got map[string]string
+		require.NoError(t, json.Unmarshal([]byte(annots[common.AnnKeyGuestClusterSnapshot]), &got))
+		assert.Equal(t, map[string]string{
+			common.GuestClusterAnnotKeyClusterName: clusterName,
+			common.GuestClusterAnnotKeyName:        guestVSName,
+			common.GuestClusterAnnotKeyNamespace:   guestVSNs,
+			common.GuestClusterAnnotKeyVSCName:     guestVSCName,
+		}, got)
+	})
+
+	t.Run("idempotent: skips when annotation already present", func(t *testing.T) {
+		existing := `{"clusterName":"old-name"}`
+		svVS := makeSVVS(map[string]string{common.AnnKeyGuestClusterSnapshot: existing})
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svVS).Build()
+
+		runBackfill(t, svVS, fakeClient)
+
+		annots := getUpdatedAnnot(t, fakeClient)
+		assert.Equal(t, existing, annots[common.AnnKeyGuestClusterSnapshot],
 			"pre-existing annotation must not be overwritten")
 	})
 }

--- a/pkg/syncer/pvcsi_fullsync_test.go
+++ b/pkg/syncer/pvcsi_fullsync_test.go
@@ -18,6 +18,7 @@ package syncer
 
 import (
 	"context"
+	"encoding/json"
 	"slices"
 	"testing"
 	"time"
@@ -1246,6 +1247,106 @@ func TestIsReadyVolumeSnapshotContent_NotReady(t *testing.T) {
 		},
 	}
 	assert.False(t, isReadyVolumeSnapshotContent(vsc), "Should return false for VSC with ReadyToUse=false")
+}
+
+// TestSetGuestClusterDetailsOnSupervisorPVC_AnnotationBackfill tests the upgrade-path
+// annotation backfill added in setGuestClusterDetailsOnSupervisorPVC. The private
+// function constructs its own controller-runtime client, so we drive the same
+// patch sequence through the shared common.BuildGuestPvcAnnotation helper (the
+// single source of truth for the annotation key set) plus k8s.PatchObject — the
+// same pattern used by TestPVCPatchFunctionality above. The pure key/value logic
+// is covered directly by TestBuildGuestPvcAnnotation in the common package.
+func TestSetGuestClusterDetailsOnSupervisorPVC_AnnotationBackfill(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		svPVCName    = "sv-pvc-1"
+		svPVCVolName = "sv-pv-1"
+		svNamespace  = "vmware-system-csi"
+		clusterUID   = "tkc-uid-abc"
+		clusterName  = "my-tkc"
+		guestPVCName = "guest-pvc-1"
+		guestPVCNS   = "guest-ns"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddToScheme(scheme))
+
+	// makeSVPVC builds a supervisor PVC with optional annotations and a bound volume.
+	makeSVPVC := func(annots map[string]string) *v1.PersistentVolumeClaim {
+		return &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        svPVCName,
+				Namespace:   svNamespace,
+				Annotations: annots,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				VolumeName: svPVCVolName,
+			},
+		}
+	}
+
+	// runBackfill mirrors the ImprovedVolumeVisiblity block from
+	// setGuestClusterDetailsOnSupervisorPVC: skip when already annotated, otherwise
+	// build the annotation via the shared helper and patch the supervisor PVC.
+	runBackfill := func(t *testing.T, svPVC *v1.PersistentVolumeClaim,
+		fakeClient client.Client) {
+		t.Helper()
+		if _, ok := svPVC.Annotations[common.AnnKeyGuestClusterPvc]; ok {
+			return
+		}
+		guestPvcAnnot := common.BuildGuestPvcAnnotation(clusterUID, clusterName,
+			guestPVCName, guestPVCNS, svPVC.Spec.VolumeName)
+		jsonAnnotation, err := json.Marshal(guestPvcAnnot)
+		require.NoError(t, err)
+		original := svPVC.DeepCopy()
+		if svPVC.Annotations == nil {
+			svPVC.Annotations = make(map[string]string)
+		}
+		svPVC.Annotations[common.AnnKeyGuestClusterPvc] = string(jsonAnnotation)
+		require.NoError(t, k8s.PatchObject(ctx, fakeClient, original, svPVC))
+	}
+
+	getUpdatedAnnot := func(t *testing.T, c client.Client) map[string]string {
+		t.Helper()
+		updated := &v1.PersistentVolumeClaim{}
+		require.NoError(t, c.Get(ctx, client.ObjectKey{
+			Name: svPVCName, Namespace: svNamespace,
+		}, updated))
+		return updated.Annotations
+	}
+
+	t.Run("backfills annotation when absent", func(t *testing.T) {
+		svPVC := makeSVPVC(nil) // nil annotations — also exercises the nil-map guard
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svPVC).Build()
+
+		runBackfill(t, svPVC, fakeClient)
+
+		annots := getUpdatedAnnot(t, fakeClient)
+		require.Contains(t, annots, common.AnnKeyGuestClusterPvc)
+		var got map[string]string
+		require.NoError(t, json.Unmarshal([]byte(annots[common.AnnKeyGuestClusterPvc]), &got))
+		assert.Equal(t, map[string]string{
+			common.GuestClusterPvcAnnotKeyClusterID:   clusterUID,
+			common.GuestClusterPvcAnnotKeyClusterName: clusterName,
+			common.GuestClusterPvcAnnotKeyName:        guestPVCName,
+			common.GuestClusterPvcAnnotKeyNamespace:   guestPVCNS,
+			common.GuestClusterPvcAnnotKeyVolumeName:  svPVCVolName,
+		}, got)
+	})
+
+	t.Run("idempotent: skips when annotation already present", func(t *testing.T) {
+		existing := `{"clusterId":"old-uid","clusterName":"old-name"}`
+		svPVC := makeSVPVC(map[string]string{common.AnnKeyGuestClusterPvc: existing})
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svPVC).Build()
+
+		runBackfill(t, svPVC, fakeClient)
+
+		annots := getUpdatedAnnot(t, fakeClient)
+		// Pre-existing annotation must be preserved untouched.
+		assert.Equal(t, existing, annots[common.AnnKeyGuestClusterPvc],
+			"pre-existing annotation must not be overwritten")
+	})
 }
 
 // TestIsReadyVolumeSnapshotContent_NilReadyToUse tests VSC with nil ReadyToUse

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -125,8 +125,8 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 					// for auditing only name and namespace are cleared.
 					var annMap map[string]string
 					if jsonErr := json.Unmarshal([]byte(annVal), &annMap); jsonErr == nil {
-						delete(annMap, common.GuestClusterPvcAnnotKeyName)
-						delete(annMap, common.GuestClusterPvcAnnotKeyNamespace)
+						delete(annMap, common.GuestClusterAnnotKeyName)
+						delete(annMap, common.GuestClusterAnnotKeyNamespace)
 						updated, marshalErr := json.Marshal(annMap)
 						if marshalErr == nil {
 							svPVC.Annotations[common.AnnKeyGuestClusterPvc] = string(updated)

--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -125,8 +125,8 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 					// for auditing only name and namespace are cleared.
 					var annMap map[string]string
 					if jsonErr := json.Unmarshal([]byte(annVal), &annMap); jsonErr == nil {
-						delete(annMap, "name")
-						delete(annMap, "namespace")
+						delete(annMap, common.GuestClusterPvcAnnotKeyName)
+						delete(annMap, common.GuestClusterPvcAnnotKeyNamespace)
 						updated, marshalErr := json.Marshal(annMap)
 						if marshalErr == nil {
 							svPVC.Annotations[common.AnnKeyGuestClusterPvc] = string(updated)


### PR DESCRIPTION
Full sync patching existing PVC

Add BuildGuestPvcAnnotation helper and JSON key constants (GuestClusterPvcAnnotKey*) to the common package to provide a single source of truth for the AnnKeyGuestClusterPvc annotation structure. Refactor the wcpguest controller CreateVolume path, fullsync upgrade backfill, and metadatasyncer cleanup to use the shared helper, ensuring the key set remains consistent across provisioning, backfill, and deletion operations. Update unit tests to leverage the new helper and remove redundant key-enumeration assertions now covered by the common package tests.


**What this PR does / why we need it**: To patch annotation for PVC which are created before this feature was enabeld.

**Testing done**:
Added unit test separately for new code path. Running pipeline and verified manually .

#### From real testbed
---------------------

##### PVC
```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
    csi.vsphere.volume-requested-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
    csi.vsphere.volume/guest-cluster-pvc: '{"clusterId":"15e13b7d-5eef-4271-aa85-a74986671ad4","clusterName":"test-cluster-e2e-script","volumeName":"pvc-49b3e833-cbd9-4042-b3ae-b6a75a726afc"}'
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    volumehealth.storage.kubernetes.io/health: accessible
    volumehealth.storage.kubernetes.io/health-timestamp: Thu Jun  4 11:06:53 UTC 2026
  creationTimestamp: "2026-06-04T11:05:17Z"
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    test-cluster-e2e-script/TKGService: 15e13b7d-5eef-4271-aa85-a74986671ad4
  name: 15e13b7d-5eef-4271-aa85-a74986671ad4-839c34e1-fb34-4991-9bc4-ce78a16a7e00
  namespace: test-gc-e2e-demo-ns
  resourceVersion: "1784084"
  uid: 49b3e833-cbd9-4042-b3ae-b6a75a726afc
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: gc-storage-profile
  volumeMode: Filesystem
  volumeName: pvc-49b3e833-cbd9-4042-b3ae-b6a75a726afc
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound
```

#### Snapshot
```yaml
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  annotations:
    csi.vsphere.guest-initiated-csi-snapshot: "true"
    csi.vsphere.volume/guest-cluster-snapshot: '{"clusterName":"test-cluster-e2e-script","name":"created-after-1","namespace":"default","volumeSnapshotContentName":"snapcontent-071f8f5c-e592-4886-97e1-0804c00d7977"}'
    csi.vsphere.volume/snapshot: 5f94ec68-17bc-413f-ae5e-fbca553a8ffe+3ee65678-3b12-487d-b1d8-7ba55bc62aff
  creationTimestamp: "2026-06-04T11:13:26Z"
  finalizers:
  - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
  - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
  generation: 1
  name: 15e13b7d-5eef-4271-aa85-a74986671ad4-071f8f5c-e592-4886-97e1-0804c00d7977
  namespace: test-gc-e2e-demo-ns
  resourceVersion: "1788218"
  uid: 3ee65678-3b12-487d-b1d8-7ba55bc62aff
spec:
  source:
    persistentVolumeClaimName: 15e13b7d-5eef-4271-aa85-a74986671ad4-a763c32c-809d-4b52-a29a-e530b8860e36
  volumeSnapshotClassName: volumesnapshotclass-delete
status:
  boundVolumeSnapshotContentName: snapcontent-3ee65678-3b12-487d-b1d8-7ba55bc62aff
  creationTime: "2026-06-04T11:13:35Z"
  readyToUse: true
  restoreSize: 1Gi

