### PR TITLE
Add pagination to parse over all result entries received from VADP FCD calls for CBT APIs

### DIFF
--- a/pkg/csi/service/wcp/controller_cbt.go
+++ b/pkg/csi/service/wcp/controller_cbt.go
@@ -79,10 +79,14 @@ func (c *controller) GetMetadataAllocated(req *csi.GetMetadataAllocatedRequest,
 	start := time.Now()
 	volumeType := prometheus.PrometheusBlockVolumeType
 
-	getMetadataAllocatedInternal := func() (*csi.GetMetadataAllocatedResponse, error) {
+	// getMetadataAllocatedInternal performs the full streaming loop: it queries
+	// allocated blocks in batches (each bounded by maxResults) and sends each
+	// batch to the client via server.Send.  The loop continues until
+	// QueryFCDAllocatedBlocks signals completion by returning nextOffset == 0.
+	getMetadataAllocatedInternal := func() error {
 		// Validate request
 		if err := validateGetMetadataAllocatedRequest(ctx, req); err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"validation for GetMetadataAllocated Request: %+v has failed. Error: %v", req, err)
 		}
 
@@ -98,7 +102,7 @@ func (c *controller) GetMetadataAllocated(req *csi.GetMetadataAllocatedRequest,
 		// CSI snapshot ID format: "volumeID+snapshotID"
 		volumeID, cnsSnapshotID, err := common.ParseCSISnapshotID(snapshotID)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"failed to parse snapshot ID %s: %v", snapshotID, err)
 		}
 
@@ -113,72 +117,91 @@ func (c *controller) GetMetadataAllocated(req *csi.GetMetadataAllocatedRequest,
 
 		queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, cnsQueryFilter)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to query volume %s: %v", volumeID, err)
 		}
 
 		if len(queryResult.Volumes) == 0 {
-			return nil, logger.LogNewErrorCodef(log, codes.NotFound,
+			return logger.LogNewErrorCodef(log, codes.NotFound,
 				"volume %s not found", volumeID)
 		}
 
 		// Verify volume type
 		cnsVolumeType := queryResult.Volumes[0].VolumeType
 		if cnsVolumeType != common.BlockVolumeType {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"GetMetadataAllocated is only supported for block volumes, got volume type: %s",
 				cnsVolumeType)
 		}
 
 		blockBacking, ok := queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 		if !ok {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return logger.LogNewErrorCodef(log, codes.Internal,
 				"volume %s does not have block backing details", volumeID)
 		}
 		volumeCapacityBytes := blockBacking.CapacityInMb * common.MbInBytes
 
-		allocatedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDAllocatedBlocks(
-			ctx, volumeID, cnsSnapshotID, uint64(startingOffset), uint32(maxResults))
-		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
-				"failed to query allocated blocks: %v", err)
+		// GetMetadataAllocated is a server-streaming RPC. The CSI spec requires
+		// the plugin to stream ALL allocated blocks from startingOffset until the
+		// data is exhausted, sending each batch (bounded by maxResults) as a
+		// separate server.Send() message.
+		//
+		// QueryFCDAllocatedBlocks signals that a batch is not the last one by
+		// returning nextOffset > 0. We loop and re-query from nextOffset until
+		// nextOffset == 0 (all blocks delivered).
+		currentOffset := uint64(startingOffset)
+		totalBlocks := 0
+		for {
+			allocatedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDAllocatedBlocks(
+				ctx, volumeID, cnsSnapshotID, currentOffset, uint32(maxResults))
+			if err != nil {
+				return logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
+					"failed to query allocated blocks: %v", err)
+			}
+
+			if len(allocatedAreas) > 0 {
+				// Convert to CSI response format
+				blockMetadata := make([]*csi.BlockMetadata, 0, len(allocatedAreas))
+				for _, area := range allocatedAreas {
+					blockMetadata = append(blockMetadata, &csi.BlockMetadata{
+						ByteOffset: int64(area.Offset),
+						SizeBytes:  int64(area.Length),
+					})
+				}
+
+				resp := &csi.GetMetadataAllocatedResponse{
+					BlockMetadata:       blockMetadata,
+					VolumeCapacityBytes: int64(volumeCapacityBytes),
+					BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+				}
+				if err := server.Send(resp); err != nil {
+					return logger.LogNewErrorCodef(log, codes.Internal,
+						"failed to send allocated metadata to client: %v", err)
+				}
+				totalBlocks += len(blockMetadata)
+			}
+
+			if nextOffset == 0 {
+				// All blocks from startingOffset have been streamed.
+				break
+			}
+			currentOffset = nextOffset
 		}
 
-		// Convert to CSI response format
-		var blockMetadata []*csi.BlockMetadata
-		for _, area := range allocatedAreas {
-			blockMetadata = append(blockMetadata, &csi.BlockMetadata{
-				ByteOffset: int64(area.Offset),
-				SizeBytes:  int64(area.Length),
-			})
-		}
-
-		response := &csi.GetMetadataAllocatedResponse{
-			BlockMetadata:       blockMetadata,
-			VolumeCapacityBytes: int64(volumeCapacityBytes),
-			BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
-		}
-
-		// Note: CSI spec doesn't have StartingOffset in response for pagination.
-		// Clients should track nextOffset from the number of results returned.
-		// If fewer results than maxResults are returned, pagination is complete.
-
-		log.Infof("GetMetadataAllocated succeeded for snapshot %s, returned %d allocated blocks, next offset %d",
-			snapshotID, len(blockMetadata), nextOffset)
-
-		return response, nil
+		log.Infof("GetMetadataAllocated succeeded for snapshot %s, streamed %d allocated blocks total",
+			snapshotID, totalBlocks)
+		return nil
 	}
 
-	resp, err := getMetadataAllocatedInternal()
+	err := getMetadataAllocatedInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataAllocated",
 			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
 		return err
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataAllocated",
-			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
 	}
-	return server.Send(resp)
+	prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataAllocated",
+		prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
+	return nil
 }
 
 // GetMetadataDelta returns the metadata for the changed blocks between two snapshots using
@@ -215,10 +238,14 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 	start := time.Now()
 	volumeType := prometheus.PrometheusBlockVolumeType
 
-	getMetadataDeltaInternal := func() (*csi.GetMetadataDeltaResponse, error) {
+	// getMetadataDeltaInternal performs the full streaming loop: it queries
+	// changed blocks in batches (each bounded by maxResults) and sends each
+	// batch to the client via server.Send.  The loop continues until
+	// QueryFCDChangedBlocks signals completion by returning nextOffset == 0.
+	getMetadataDeltaInternal := func() error {
 		// Validate request
 		if err := validateGetMetadataDeltaRequest(ctx, req); err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"validation for GetMetadataDelta Request: %+v has failed. Error: %v", req, err)
 		}
 
@@ -237,7 +264,7 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 		// must exist on the Supervisor for VSLM to query its blocks.
 		volumeID, targetCnsSnapshotID, err := common.ParseCSISnapshotID(targetSnapshotID)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"failed to parse target snapshot ID %s: %v", targetSnapshotID, err)
 		}
 
@@ -253,74 +280,91 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 
 		queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, cnsQueryFilter)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to query volume %s: %v", volumeID, err)
 		}
 
 		if len(queryResult.Volumes) == 0 {
-			return nil, logger.LogNewErrorCodef(log, codes.NotFound,
+			return logger.LogNewErrorCodef(log, codes.NotFound,
 				"volume %s not found", volumeID)
 		}
 
 		// Verify volume type
 		cnsVolumeType := queryResult.Volumes[0].VolumeType
 		if cnsVolumeType != common.BlockVolumeType {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"GetMetadataDelta is only supported for block volumes, got volume type: %s",
 				cnsVolumeType)
 		}
 
 		blockBacking, ok := queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 		if !ok {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return logger.LogNewErrorCodef(log, codes.Internal,
 				"volume %s does not have block backing details", volumeID)
 		}
 		volumeCapacityBytes := blockBacking.CapacityInMb * common.MbInBytes
 
-		// Query changed blocks via volume manager (FCD/VSLM). baseChangeID is supplied by the caller.
-		changedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDChangedBlocks(
-			ctx, volumeID, targetCnsSnapshotID, baseChangeID, uint64(startingOffset), uint32(maxResults))
-		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
-				"failed to query changed blocks: %v", err)
+		// GetMetadataDelta is a server-streaming RPC. The CSI spec requires the
+		// plugin to stream ALL changed blocks from startingOffset until the data
+		// is exhausted, sending each batch (bounded by maxResults) as a separate
+		// server.Send() message.
+		//
+		// QueryFCDChangedBlocks signals that a batch is not the last one by
+		// returning nextOffset > 0. We loop and re-query from nextOffset until
+		// nextOffset == 0 (all blocks delivered).
+		currentOffset := uint64(startingOffset)
+		totalBlocks := 0
+		for {
+			changedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDChangedBlocks(
+				ctx, volumeID, targetCnsSnapshotID, baseChangeID, currentOffset, uint32(maxResults))
+			if err != nil {
+				return logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
+					"failed to query changed blocks: %v", err)
+			}
+
+			if len(changedAreas) > 0 {
+				// Convert to CSI response format
+				blockMetadata := make([]*csi.BlockMetadata, 0, len(changedAreas))
+				for _, area := range changedAreas {
+					blockMetadata = append(blockMetadata, &csi.BlockMetadata{
+						ByteOffset: int64(area.Offset),
+						SizeBytes:  int64(area.Length),
+					})
+				}
+
+				resp := &csi.GetMetadataDeltaResponse{
+					BlockMetadata:       blockMetadata,
+					VolumeCapacityBytes: int64(volumeCapacityBytes),
+					BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+				}
+				if err := server.Send(resp); err != nil {
+					return logger.LogNewErrorCodef(log, codes.Internal,
+						"failed to send delta metadata to client: %v", err)
+				}
+				totalBlocks += len(blockMetadata)
+			}
+
+			if nextOffset == 0 {
+				// All blocks from startingOffset have been streamed.
+				break
+			}
+			currentOffset = nextOffset
 		}
 
-		// Convert to CSI response format
-		var blockMetadata []*csi.BlockMetadata
-		for _, area := range changedAreas {
-			blockMetadata = append(blockMetadata, &csi.BlockMetadata{
-				ByteOffset: int64(area.Offset),
-				SizeBytes:  int64(area.Length),
-			})
-		}
-
-		response := &csi.GetMetadataDeltaResponse{
-			BlockMetadata:       blockMetadata,
-			VolumeCapacityBytes: int64(volumeCapacityBytes),
-			BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
-		}
-
-		// Note: CSI spec doesn't have StartingOffset in response for pagination.
-		// Clients should track nextOffset from the number of results returned.
-		// If fewer results than maxResults are returned, pagination is complete.
-
-		log.Infof("GetMetadataDelta succeeded for target snapshot %s, "+
-			"returned %d changed blocks, next offset %d",
-			targetSnapshotID, len(blockMetadata), nextOffset)
-
-		return response, nil
+		log.Infof("GetMetadataDelta succeeded for target snapshot %s, streamed %d changed blocks total",
+			targetSnapshotID, totalBlocks)
+		return nil
 	}
 
-	resp, err := getMetadataDeltaInternal()
+	err := getMetadataDeltaInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataDelta",
 			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
 		return err
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataDelta",
-			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
 	}
-	return server.Send(resp)
+	prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataDelta",
+		prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
+	return nil
 }
 
 // validateGetMetadataAllocatedRequest validates the GetMetadataAllocated request

--- a/pkg/csi/service/wcp/controller_cbt_test.go
+++ b/pkg/csi/service/wcp/controller_cbt_test.go
@@ -39,8 +39,10 @@ import (
 
 type mockAllocatedServer struct {
 	grpc.ServerStream
-	ctx context.Context
-	t   *testing.T
+	ctx       context.Context
+	t         *testing.T
+	sendCount int
+	allBlocks []*csi.BlockMetadata
 }
 
 func (m *mockAllocatedServer) Context() context.Context {
@@ -48,6 +50,8 @@ func (m *mockAllocatedServer) Context() context.Context {
 }
 
 func (m *mockAllocatedServer) Send(resp *csi.GetMetadataAllocatedResponse) error {
+	m.sendCount++
+	m.allBlocks = append(m.allBlocks, resp.BlockMetadata...)
 	if m.t != nil && resp.BlockMetadataType != csi.BlockMetadataType_VARIABLE_LENGTH {
 		m.t.Errorf("Expected BlockMetadataType to be %v, got %v",
 			csi.BlockMetadataType_VARIABLE_LENGTH, resp.BlockMetadataType)
@@ -57,8 +61,10 @@ func (m *mockAllocatedServer) Send(resp *csi.GetMetadataAllocatedResponse) error
 
 type mockDeltaServer struct {
 	grpc.ServerStream
-	ctx context.Context
-	t   *testing.T
+	ctx       context.Context
+	t         *testing.T
+	sendCount int
+	allBlocks []*csi.BlockMetadata
 }
 
 func (m *mockDeltaServer) Context() context.Context {
@@ -66,6 +72,8 @@ func (m *mockDeltaServer) Context() context.Context {
 }
 
 func (m *mockDeltaServer) Send(resp *csi.GetMetadataDeltaResponse) error {
+	m.sendCount++
+	m.allBlocks = append(m.allBlocks, resp.BlockMetadata...)
 	if m.t != nil && resp.BlockMetadataType != csi.BlockMetadataType_VARIABLE_LENGTH {
 		m.t.Errorf("Expected BlockMetadataType to be %v, got %v",
 			csi.BlockMetadataType_VARIABLE_LENGTH, resp.BlockMetadataType)
@@ -474,12 +482,19 @@ func TestGetMetadataAllocated_Success(t *testing.T) {
 
 	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
 		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
-		return &types.DiskChangeInfo{
-			ChangedArea: []types.DiskChangeExtent{
-				{Start: 0, Length: 4096},
-				{Start: 4096, Length: 8192},
-			},
-		}, nil
+		// Only return areas that start at or after startingOffset so the
+		// pagination loop terminates correctly (nextOffset → 0 on the last batch).
+		all := []types.DiskChangeExtent{
+			{Start: 0, Length: 4096},
+			{Start: 4096, Length: 8192},
+		}
+		var filtered []types.DiskChangeExtent
+		for _, a := range all {
+			if a.Start >= startingOffset {
+				filtered = append(filtered, a)
+			}
+		}
+		return &types.DiskChangeInfo{ChangedArea: filtered}, nil
 	}
 
 	req := &csi.GetMetadataAllocatedRequest{
@@ -531,11 +546,18 @@ func TestGetMetadataDelta_Success(t *testing.T) {
 
 	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
 		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
-		return &types.DiskChangeInfo{
-			ChangedArea: []types.DiskChangeExtent{
-				{Start: 8192, Length: 4096},
-			},
-		}, nil
+		// Only return areas at or after startingOffset so the pagination loop
+		// terminates correctly (nextOffset → 0 on the last batch).
+		all := []types.DiskChangeExtent{
+			{Start: 8192, Length: 4096},
+		}
+		var filtered []types.DiskChangeExtent
+		for _, a := range all {
+			if a.Start >= startingOffset {
+				filtered = append(filtered, a)
+			}
+		}
+		return &types.DiskChangeInfo{ChangedArea: filtered}, nil
 	}
 
 	// BaseSnapshotId is the vSphere CBT change-id supplied by backup software (read from the
@@ -727,4 +749,149 @@ func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
 
 	runVSLMErrorPropagationCase(t, "NotFound_FCD",
 		&types.NotFound{}, "", true, codes.NotFound)
+}
+
+// TestGetMetadataAllocated_Pagination verifies that GetMetadataAllocated streams
+// multiple server.Send() messages when the total allocated blocks exceed maxResults
+// per batch. This is the core bug that caused tc_008 to fail: the old code called
+// server.Send once and ignored nextOffset, truncating the result stream.
+func TestGetMetadataAllocated_Pagination(t *testing.T) {
+	ct := getControllerTest(t)
+	fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+	_ = fakeOrchestrator.EnableFSS(ctx, common.CSI_Backup_API)
+
+	origVolumeManager := ct.controller.manager.VolumeManager
+	ct.controller.manager.VolumeManager = &mockVolumeManager{Manager: origVolumeManager}
+	defer func() { ct.controller.manager.VolumeManager = origVolumeManager }()
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-alloc-pagination",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatalf("Failed to create volume: %v", err)
+	}
+	volID := respCreate.Volume.VolumeId
+
+	origHook := cnsvolume.QueryChangedDiskAreasHook
+	defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
+
+	// Stub the hook to return 3 contiguous areas regardless of startingOffset.
+	// With maxResults=1 the controller must call the hook 3 times (one area per
+	// batch) and issue 3 separate server.Send() calls.
+	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
+		// Return only the areas that start at or after startingOffset so that
+		// the pagination math matches what the real VSLM API would produce.
+		all := []types.DiskChangeExtent{
+			{Start: 0, Length: 4096},
+			{Start: 4096, Length: 4096},
+			{Start: 8192, Length: 4096},
+		}
+		var filtered []types.DiskChangeExtent
+		for _, a := range all {
+			if a.Start >= startingOffset {
+				filtered = append(filtered, a)
+			}
+		}
+		return &types.DiskChangeInfo{ChangedArea: filtered}, nil
+	}
+
+	srv := &mockAllocatedServer{ctx: ctx, t: t}
+	req := &csi.GetMetadataAllocatedRequest{
+		SnapshotId: volID + "+snapshot-pagination",
+		MaxResults: 1, // force one area per Send() call
+	}
+
+	if err := ct.controller.GetMetadataAllocated(req, srv); err != nil {
+		t.Fatalf("GetMetadataAllocated returned unexpected error: %v", err)
+	}
+
+	if srv.sendCount != 3 {
+		t.Errorf("Expected 3 server.Send() calls (one per block batch), got %d", srv.sendCount)
+	}
+	if len(srv.allBlocks) != 3 {
+		t.Errorf("Expected 3 total BlockMetadata entries, got %d", len(srv.allBlocks))
+	}
+}
+
+// TestGetMetadataDelta_Pagination is the equivalent pagination test for
+// GetMetadataDelta: verifies that multiple server.Send() calls are issued
+// when changed blocks span more than one maxResults-sized batch.
+func TestGetMetadataDelta_Pagination(t *testing.T) {
+	ct := getControllerTest(t)
+	fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+	_ = fakeOrchestrator.EnableFSS(ctx, common.CSI_Backup_API)
+
+	origVolumeManager := ct.controller.manager.VolumeManager
+	ct.controller.manager.VolumeManager = &mockVolumeManager{Manager: origVolumeManager}
+	defer func() { ct.controller.manager.VolumeManager = origVolumeManager }()
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-delta-pagination",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatalf("Failed to create volume: %v", err)
+	}
+	volID := respCreate.Volume.VolumeId
+
+	origHook := cnsvolume.QueryChangedDiskAreasHook
+	defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
+
+	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
+		all := []types.DiskChangeExtent{
+			{Start: 0, Length: 4096},
+			{Start: 4096, Length: 4096},
+			{Start: 8192, Length: 4096},
+		}
+		var filtered []types.DiskChangeExtent
+		for _, a := range all {
+			if a.Start >= startingOffset {
+				filtered = append(filtered, a)
+			}
+		}
+		return &types.DiskChangeInfo{ChangedArea: filtered}, nil
+	}
+
+	srv := &mockDeltaServer{ctx: ctx, t: t}
+	req := &csi.GetMetadataDeltaRequest{
+		BaseSnapshotId:   "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/123",
+		TargetSnapshotId: volID + "+snapshot-pagination",
+		MaxResults:       1, // force one area per Send() call
+	}
+
+	if err := ct.controller.GetMetadataDelta(req, srv); err != nil {
+		t.Fatalf("GetMetadataDelta returned unexpected error: %v", err)
+	}
+
+	if srv.sendCount != 3 {
+		t.Errorf("Expected 3 server.Send() calls (one per block batch), got %d", srv.sendCount)
+	}
+	if len(srv.allBlocks) != 3 {
+		t.Errorf("Expected 3 total BlockMetadata entries, got %d", len(srv.allBlocks))
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds pagination support for parsing CBT API call results received from VADP/FCD API call made in supervisor cluster. Current code in supervisor CBT API implementation returns only first page of results returned by VADP API , thereby missing rest of the result entries, leading to incomplete CBT metadata.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified fix on setup, where the new FVT testcase verifying CBT metadata was failing, that CBT metadata returned completely and testcase passed.

Testcase: Query all allocated disk areas with invalid parameters should return all changed blocks
```
Ran 1 of 10 Specs in 178.885 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 9 Skipped
PASS
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add pagination to parse over all result entries received from VADP FCD calls for CBT APIs
```
