### PR TITLE
fix(e2e): Fix multiple volume expansion test

### DIFF
--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -2787,13 +2787,19 @@ func increaseOnlineVolumeMultipleTimes(ctx context.Context, f *framework.Framewo
 	for i := 0; i < 10; i++ {
 		newSize.Add(resource.MustParse("1Gi"))
 		ginkgo.By(fmt.Sprintf("Expanding pvc to new size: %v", newSize))
-		pvclaim, err := expandPVCSize(pvclaim, newSize, client)
+		pvclaim, err = expandPVCSize(pvclaim, newSize, client)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 
 		ginkgo.By("Waiting for controller volume resize to finish")
 		err = waitForPvResizeForGivenPvc(pvclaim, client, totalResizeWaitPeriod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if i < 9 {
+			ginkgo.By("Waiting for file system resize to finish")
+			pvclaim, err = waitForFSResize(pvclaim, client)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 
 		pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
 		if pvcSize.Cmp(newSize) != 0 {


### PR DESCRIPTION
This fixes the 'Verify volume expansion multiple times on the same PVC' e2e test by:
1. Fixing variable shadowing of pvclaim inside the expansion loop
2. Adding a wait for filesystem resize between consecutive expansions to avoid skipping expansions

**Testing done**:
Yes, multiple times
[expansion.txt](https://github.com/user-attachments/files/28543256/expansion.txt)



