### PR TITLE
Remove omitempty from accessibleZones in infra SPI CR

### DIFF
--- a/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1/infrastoragepolicyinfo_types.go
+++ b/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1/infrastoragepolicyinfo_types.go
@@ -43,7 +43,7 @@ type Topology struct {
 	// +listType=set
 	// +kubebuilder:validation:items:MinLength=1
 	// +optional
-	AccessibleZones []string `json:"accessibleZones,omitempty"`
+	AccessibleZones []string `json:"accessibleZones"`
 }
 
 // InfraStoragePolicyInfoStatus defines the observed state of InfraStoragePolicyInfo.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR removes omitempty from accessibleZones field in infraSPI CRD.
This will better reflect that the accessibleZones list is empty to the devops users.


**Testing done**:
```
When no accessible zones are present:

k get infraspi test-policy -oyaml
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
metadata:
  creationTimestamp: "2026-06-02T15:16:14Z"
  generation: 1
  name: test-policy
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: test-policy
    uid: 6834ef3d-5c14-49b9-b971-3c846b01c352
  resourceVersion: "736881"
  uid: 9f5f4944-7331-4b3b-bdb3-4e8c035c4cc3
status:
  topology:
    accessibleZones: []
    topologyType: zonal
```

When accessible zones are present:

```
k get infraspi -oyaml vm-encryption-policy
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
metadata:
  creationTimestamp: "2026-06-02T14:23:46Z"
  generation: 1
  name: vm-encryption-policy
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: vm-encryption-policy
    uid: 871e4b16-50bb-4026-8264-5321f00dc714
  resourceVersion: "138954"
  uid: d46dccc9-80b2-48b3-b071-c7dd87122742
status:
  topology:
    accessibleZones:
    - az1
    topologyType: ""
```

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1625/
VKS precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1248/
