### PR TITLE
Remove inClusterClnt bool param from NewInformer

### DIFF
--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -49,7 +49,7 @@ func (nodes *Nodes) Initialize(ctx context.Context) error {
 		return err
 	}
 	nodes.cnsNodeManager.SetKubernetesClient(k8sclient)
-	nodes.informMgr = k8s.NewInformer(ctx, k8sclient, true)
+	nodes.informMgr = k8s.NewInformer(ctx, k8sclient)
 	err = nodes.informMgr.AddCSINodeListener(ctx, nodes.csiNodeAdd,
 		nodes.csiNodeUpdate, nodes.csiNodeDelete)
 	if err != nil {

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -329,7 +329,7 @@ func Newk8sOrchestrator(ctx context.Context, controllerClusterFlavor cnstypes.Cn
 			k8sOrchestratorInstance.clusterFlavor = controllerClusterFlavor
 			k8sOrchestratorInstance.k8sClient = k8sClient
 			k8sOrchestratorInstance.snapshotterClient = snapshotterClient
-			k8sOrchestratorInstance.informerManager = k8s.NewInformer(ctx, k8sClient, true)
+			k8sOrchestratorInstance.informerManager = k8s.NewInformer(ctx, k8sClient)
 			coInstanceErr = initFSS(ctx, k8sClient, controllerClusterFlavor, params)
 			if coInstanceErr != nil {
 				log.Errorf("Failed to initialize the orchestrator. Error: %v", coInstanceErr)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -369,7 +369,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		}
 		log.Info("Initialized FileVolume Kubernetes client")
 
-		im := k8s.NewInformer(ctx, c.k8sClient, true)
+		im := k8s.NewInformer(ctx, c.k8sClient)
 		im.InitNamespaceInformer()
 		im.Listen()
 		if nsSynced := im.NamespaceInformerSynced(); nsSynced != nil && !cache.WaitForCacheSync(ctx.Done(), nsSynced) {

--- a/pkg/internalapis/featurestates/featurestates.go
+++ b/pkg/internalapis/featurestates/featurestates.go
@@ -123,7 +123,7 @@ func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapNam
 	}
 
 	// Create k8s Informer and watch on configmaps and namespaces.
-	informer := k8s.NewInformer(ctx, k8sClient, true)
+	informer := k8s.NewInformer(ctx, k8sClient)
 	// Configmap informer to watch on SV featurestate config-map.
 	err = informer.AddConfigMapListener(
 		ctx,

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -45,10 +45,8 @@ const (
 )
 
 var (
-	inClusterInformerManagerInstance  *InformerManager = nil
-	inClusterInformerInstanceLock                      = &sync.Mutex{}
-	supervisorInformerManagerInstance *InformerManager = nil
-	supervisorInformerInstanceLock                     = &sync.Mutex{}
+	informerManagerInstance *InformerManager = nil
+	informerInstanceLock                     = &sync.Mutex{}
 )
 
 func noResyncPeriodFunc() time.Duration {
@@ -73,39 +71,22 @@ func NewInformerFromFactory(
 // NOTE: This function expects caller function to pass appropriate client
 // as per config to be created Informer for.
 // This function creates shared informer factory against the client provided.
-func NewInformer(ctx context.Context, client clientset.Interface, inClusterClnt bool) *InformerManager {
-	var informerInstance *InformerManager
+func NewInformer(ctx context.Context, client clientset.Interface) *InformerManager {
 	log := logger.GetLogger(ctx)
 
-	if inClusterClnt {
-		inClusterInformerInstanceLock.Lock()
-		defer inClusterInformerInstanceLock.Unlock()
+	informerInstanceLock.Lock()
+	defer informerInstanceLock.Unlock()
 
-		informerInstance = inClusterInformerManagerInstance
-	} else {
-		supervisorInformerInstanceLock.Lock()
-		defer supervisorInformerInstanceLock.Unlock()
-
-		informerInstance = supervisorInformerManagerInstance
-	}
-
-	if informerInstance == nil {
-		informerInstance = &InformerManager{
+	if informerManagerInstance == nil {
+		informerManagerInstance = &InformerManager{
 			client:          client,
 			stopCh:          signals.SetupSignalHandler().Done(),
 			informerFactory: informers.NewSharedInformerFactory(client, noResyncPeriodFunc()),
 		}
-
-		if inClusterClnt {
-			inClusterInformerManagerInstance = informerInstance
-			log.Info("Created new informer factory for in-cluster client")
-		} else {
-			supervisorInformerManagerInstance = informerInstance
-			log.Info("Created new informer factory for supervisor client")
-		}
+		log.Info("Created new informer factory")
 	}
 
-	return informerInstance
+	return informerManagerInstance
 }
 
 // AddNodeListener hooks up add, update, delete callbacks.

--- a/pkg/syncer/dpoperator/manager.go
+++ b/pkg/syncer/dpoperator/manager.go
@@ -85,7 +85,7 @@ func NewManager(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubernetes client for dp operator: %w", err)
 	}
-	informerManager := k8s.NewInformer(ctx, k8sClient, true)
+	informerManager := k8s.NewInformer(ctx, k8sClient)
 	informerManager.InitVolumeAttachmentInformer()
 	informerManager.Listen()
 

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -510,7 +510,7 @@ func setupMetadataSyncerForFullSync(
 	cfg.Cfg.Global.ClusterID = "test-cluster-id"
 
 	// Create fake informer manager with listers
-	informerManager := k8s.NewInformer(ctx, k8sClient, true)
+	informerManager := k8s.NewInformer(ctx, k8sClient)
 	informerManager.Listen()
 
 	// Initialize volumeManagers map for multi-vCenter support

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -723,7 +723,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	}
 
 	// Set up kubernetes resource listeners for metadata syncer.
-	metadataSyncer.k8sInformerManager = k8s.NewInformer(ctx, k8sClient, true)
+	metadataSyncer.k8sInformerManager = k8s.NewInformer(ctx, k8sClient)
 
 	// Initialize listers BEFORE registering listeners. This ensures that when
 	// pvcAdded is called, it can look up PVs via pvLister without nil panics.

--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -120,7 +120,7 @@ func InitStoragePoolService(ctx context.Context,
 			log.Errorf("Creating Kubernetes client failed. Err: %v", err)
 			return
 		}
-		k8sInformerManager := k8s.NewInformer(ctx, k8sClient, true)
+		k8sInformerManager := k8s.NewInformer(ctx, k8sClient)
 		err = InitNodeAnnotationListener(ctx, k8sInformerManager, scWatchCntlr, spController)
 		if err != nil {
 			log.Errorf("InitNodeAnnotationListener failed. err: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
All callers on master pass true, making the supervisor singleton dead code. Collapse to a single informerManagerInstance and remove the redundant parameter from all 8 call sites.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # N/A

**Testing done**:
Since no behaviour change is being introduced, precheckin runs are sufficient.

## Precheckins
### [WCP](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1629/)
```
Ran 16 of 2357 Specs
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 2341 Skipped | 0 Flaked
```
### [VKS](https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1251/)
```
Ran 6 of 2357 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2351 Skipped | 0 Flaked
```

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
