### PR TITLE
Update external-attacher image to v4.12.0_vmware.1

### DIFF
--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -380,7 +380,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1
           args:
             - "--reconcile-sync=5m"
             - "--v=4"

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -380,7 +380,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1
           args:
             - "--reconcile-sync=5m"
             - "--v=4"

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -380,7 +380,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1
           args:
             - "--reconcile-sync=5m"
             - "--v=4"


### PR DESCRIPTION
Updates the csi-attacher image tag to v4.12.0_vmware.1 in supervisorcluster manifests for versions 1.35, 1.34, and 1.33.

Tested complete regression for supervisor and VKS. Test logs attached below
[sanity-tests.txt](https://github.com/user-attachments/files/28825385/sanity-tests.txt)

[vks-logs.txt](https://github.com/user-attachments/files/28866610/vks-logs.txt)



