### PR TITLE
Misc changes for CSI CBT support from pvCSI

### DIFF
--- a/pkg/csi/service/driver.go
+++ b/pkg/csi/service/driver.go
@@ -214,10 +214,14 @@ func (driver *vsphereCSIDriver) Run(ctx context.Context, endpoint string) {
 	}
 
 	// Determine if SnapshotMetadata service should be registered
-	// The service is only registered in controller mode when CBT feature is enabled
+	// The service is only registered in controller mode when CBT feature is enabled for both
+	// Supervisor and guest cluster CSI drivers.
 	var snapshotMetadataServer csi.SnapshotMetadataServer
 	if driver.mode == "controller" && commonco.ContainerOrchestratorUtility != nil &&
-		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API) {
+		((clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API)) ||
+			(clusterFlavor == cnstypes.CnsClusterFlavorGuest &&
+				commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API_FSS))) {
 		// Pass the controller server which implements the SnapshotMetadata RPCs
 		snapshotMetadataServer = controllerServer.(csi.SnapshotMetadataServer)
 		log.Info("SnapshotMetadata service will be registered (CBT support enabled)")

--- a/pkg/csi/service/identity.go
+++ b/pkg/csi/service/identity.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
@@ -69,11 +70,15 @@ func (driver *vsphereCSIDriver) GetPluginCapabilities(
 		},
 	}
 
-	// Advertise SnapshotMetadata service for CBT support if CBT feature is enabled.
+	// Advertise SnapshotMetadata service for CBT support if CBT feature is enabled for both
+	// Supervisor and guest cluster CSI drivers.
 	// The SnapshotMetadata service provides GetMetadataAllocated and GetMetadataDelta RPCs
 	// for efficient backup and restore operations (CSI spec v1.10.0+).
 	if commonco.ContainerOrchestratorUtility != nil &&
-		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API) {
+		((clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API)) ||
+			(clusterFlavor == cnstypes.CnsClusterFlavorGuest &&
+				commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API_FSS))) {
 		caps = append(caps, &csi.PluginCapability{
 			Type: &csi.PluginCapability_Service_{
 				Service: &csi.PluginCapability_Service{

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -104,6 +104,14 @@ const snapshotMetadataServiceCRName = csitypes.Name
 // --service-account-max-token-expiration.
 const snapshotMetadataTokenExpirationSeconds int64 = 3600
 
+// snapMetadataSrvName is the canonical in-cluster DNS name
+// used as the TLS ServerName when dialing the Supervisor Snapshot Metadata
+// Service. Supplying an explicit DNS name (rather than deriving it from the
+// dial address, which is a LoadBalancer IP) means the service certificate
+// only needs DNS SANs — no IP SAN is required, so the cert stays valid
+// regardless of which LoadBalancer IP is allocated.
+const snapMetadataSrvName = "vmware-system-csi-snapshot-metadata-service.vmware-system-csi.svc.cluster.local"
+
 // dialSnapshotMetadata builds the gRPC client connection to the Supervisor
 // Snapshot Metadata Service. It is intentionally a package-level function
 // variable so unit tests can override it to dial an in-process mock with
@@ -2543,7 +2551,7 @@ func (c *controller) getSnapshotMetadataClient(
 			return nil, nil, "", fmt.Errorf("failed to append caCert to pool after base64 decode")
 		}
 	}
-	transportCreds := credentials.NewClientTLSFromCert(certPool, "")
+	transportCreds := credentials.NewClientTLSFromCert(certPool, snapMetadataSrvName)
 
 	// Mint a fresh audience-bound token via TokenRequest on every call.
 	// We pass the bootstrap pvcsi-provider bearer token (loaded by

--- a/pkg/csi/service/wcpguest/controller_cbt_test.go
+++ b/pkg/csi/service/wcpguest/controller_cbt_test.go
@@ -348,7 +348,10 @@ func testLocalhostTLSCert(t *testing.T) (caPEM []byte, serverCert tls.Certificat
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
-		DNSNames:     []string{"localhost"},
+		// Include the production TLS ServerName so tests that use the real TLS
+		// dial path (withProductionTLSDialForSubtest) pass the same DNS-SAN
+		// check that production clients perform.
+		DNSNames: []string{"localhost", snapMetadataSrvName},
 	}
 	servDER, err := x509.CreateCertificate(rand.Reader, servTmpl, caTmpl, &servKey.PublicKey, caKey)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds some of minor changes required for CSI CBT functionality in pvCSI such as below
1. Enable CBT capability for FSS enabled on supervisor cluster as well as guest cluster
2. Use supervisor CBT service DNSname for cert verification. This is to perform cert verification irespective of external IP/DNS name, associated with load-balancer type supervisor CBT service, present in SnapshotMetadataService(SMS) CR in supervisor cluster 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1791/
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```
VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1355/
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```

Tested change by manually replacing image on guest cluster, with manual FSS enabled on guest cluster

```
root@4220aa9517848144d8ab950faadceb07 [ ~ ]# export KUBECONFIG=gc_kubeconfig.yaml

root@4220aa9517848144d8ab950faadceb07 [ ~ ]# kubectl edit cm -n vmware-system-csi internal-feature-states.csi.vsphere.vmware.com
configmap/internal-feature-states.csi.vsphere.vmware.com edited
root@4220aa9517848144d8ab950faadceb07 [ ~ ]#

root@4220aa9517848144d8ab950faadceb07 [ ~ ]# kubectl set image deployment/vsphere-csi-controller   -n vmware-system-csi vsphere-csi-controller=cns-docker-dev-local.packages.vcfd.broadcom.net/pansea/csi:cbt-pvcsi-0608-1

root@4220aa9517848144d8ab950faadceb07 [ ~ ]# k get vs -A
NAMESPACE   NAME                         READYTOUSE   SOURCEPVC      SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
default     example-raw-block-snapshot   true         cbt-test-pvc                           1Gi           volumesnapshotclass-delete   snapcontent-417c886f-971b-44eb-af6b-197d5f216df9   17m            19m
root@4220aa9517848144d8ab950faadceb07 [ ~ ]#

root@4220aa9517848144d8ab950faadceb07 [ ~ ]# k get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS       AGE
vsphere-csi-controller-55cb9846b6-ktzqz   8/8     Running   0              51s
vsphere-csi-node-dvl22                    3/3     Running   4 (7d2h ago)   7d2h
vsphere-csi-node-mdrsf                    3/3     Running   4 (7d2h ago)   7d2h
vsphere-csi-node-w897z                    3/3     Running   4 (7d2h ago)   7d2h
root@4220aa9517848144d8ab950faadceb07 [ ~ ]#

root@4220aa9517848144d8ab950faadceb07 [ ~ ]# kubectl exec csi-client -c run-client -it -- /bin/sh
~ $ /tmp/lister -n default -s example-raw-block-snapshot
~ $
```

CSI controller logs

```
{"level":"info","time":"2026-06-08T09:56:21.388739656Z","caller":"wcpguest/controller_cbt.go:50","msg":"GetMetadataAllocated: called with args snapshot_id:\
"06c5ed24-5c3c-436a-81fc-fb2827a95d8a-417c886f-971b-44eb-af6b-197d5f216df9\"","TraceId":"88096925-aa91-4ccf-93eb-f09577f20522"}
{"level":"info","time":"2026-06-08T09:56:21.397477092Z","caller":"wcpguest/controller.go:2349","msg":"Resolved CSI snapshot handle 06c5ed24-5c3c-436a-81fc-f
b2827a95d8a-417c886f-971b-44eb-af6b-197d5f216df9 to supervisor VolumeSnapshot test-vadp-supervisor-ns/06c5ed24-5c3c-436a-81fc-fb2827a95d8a-417c886f-971b-44e
b-af6b-197d5f216df9","TraceId":"88096925-aa91-4ccf-93eb-f09577f20522"}
{"level":"info","time":"2026-06-08T09:56:21.439719685Z","caller":"wcpguest/controller.go:2313","msg":"Dialing SnapshotMetadataService at 192.168.130.1:8100
(audience=csi.vsphere.vmware.com)","TraceId":"88096925-aa91-4ccf-93eb-f09577f20522"}
{"level":"info","time":"2026-06-08T09:56:21.44064465Z","caller":"wcpguest/controller_cbt.go:92","msg":"Forwarding GetMetadataAllocated to Supervisor for tes
t-vadp-supervisor-ns/06c5ed24-5c3c-436a-81fc-fb2827a95d8a-417c886f-971b-44eb-af6b-197d5f216df9 (CSI handle=06c5ed24-5c3c-436a-81fc-fb2827a95d8a-417c886f-971
b-44eb-af6b-197d5f216df9)","TraceId":"88096925-aa91-4ccf-93eb-f09577f20522"}
{"level":"info","time":"2026-06-08T09:56:21.87174707Z","caller":"wcpguest/controller_cbt.go:123","msg":"Successfully completed GetMetadataAllocated call to
Supervisor for test-vadp-supervisor-ns/06c5ed24-5c3c-436a-81fc-fb2827a95d8a-417c886f-971b-44eb-af6b-197d5f216df9 (CSI handle=06c5ed24-5c3c-436a-81fc-fb2827a
95d8a-417c886f-971b-44eb-af6b-197d5f216df9)","TraceId":"88096925-aa91-4ccf-93eb-f09577f20522"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Misc changes for CSI CBT support from pvCSI
```
