### PR TITLE
Add pagination to iterate over all entries received from VADP CBT API

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -175,11 +175,11 @@ type Manager interface {
 	// ReRegisterVolume re-registers a volume to CNS when CnsNotRegisteredFault is encountered
 	ReRegisterVolume(ctx context.Context, volumeID string) error
 	// QueryFCDAllocatedBlocks returns allocated block ranges using FCD VSLM QueryChangedDiskAreas (changeId "*").
-	QueryFCDAllocatedBlocks(ctx context.Context, volumeID, snapshotID string, startingOffset uint64,
-		maxResults uint32) ([]AllocatedArea, uint64, error)
+	QueryFCDAllocatedBlocks(ctx context.Context, volumeID, snapshotID string,
+		startingOffset uint64) ([]DiskArea, uint64, error)
 	// QueryFCDChangedBlocks returns changed block ranges using FCD VSLM QueryChangedDiskAreas with baseChangeID.
-	QueryFCDChangedBlocks(ctx context.Context, volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64,
-		maxResults uint32) ([]ChangedArea, uint64, error)
+	QueryFCDChangedBlocks(ctx context.Context, volumeID, targetSnapshotID, baseChangeID string,
+		startingOffset uint64) ([]DiskArea, uint64, error)
 }
 
 // CnsVolumeInfo hold information related to volume created by CNS.
@@ -4271,14 +4271,8 @@ func (m *defaultManager) unregisterVolume(ctx context.Context, volumeID string, 
 // vslmNewClientFunc creates a VSLM client (overridable in unit tests).
 var vslmNewClientFunc = vslm.NewClient
 
-// AllocatedArea is a byte range reported as allocated on an FCD snapshot.
-type AllocatedArea struct {
-	Offset uint64
-	Length uint64
-}
-
-// ChangedArea is a byte range reported as changed between FCD snapshots.
-type ChangedArea struct {
+// DiskArea is a byte range reported as allocated or changed on an FCD snapshot.
+type DiskArea struct {
 	Offset uint64
 	Length uint64
 }
@@ -4363,13 +4357,8 @@ func (m *defaultManager) connectVirtualCenter(ctx context.Context) (*cnsvsphere.
 	return m.virtualCenter, nil
 }
 
-// QueryFCDAllocatedBlocks returns allocated block ranges using FCD VSLM QueryChangedDiskAreas with changeId "*".
-func (m *defaultManager) QueryFCDAllocatedBlocks(ctx context.Context, volumeID, snapshotID string,
-	startingOffset uint64, maxResults uint32) ([]AllocatedArea, uint64, error) {
-	log := logger.GetLogger(ctx)
-	log.Debugf("QueryFCDAllocatedBlocks: volume=%s snapshot=%s offset=%d maxResults=%d",
-		volumeID, snapshotID, startingOffset, maxResults)
-
+func (m *defaultManager) queryFCDBlocks(ctx context.Context, volumeID, snapshotID, changeID string,
+	startingOffset uint64) ([]DiskArea, uint64, error) {
 	vcenter, err := m.connectVirtualCenter(ctx)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get vCenter from volume manager: %v", err)
@@ -4377,81 +4366,51 @@ func (m *defaultManager) QueryFCDAllocatedBlocks(ctx context.Context, volumeID, 
 
 	vslmVolumeID := vim25types.ID{Id: volumeID}
 	vslmSnapshotID := vim25types.ID{Id: snapshotID}
-	const allocatedChangeID = "*"
 
-	log.Debugf("Calling QueryChangedDiskAreasHook with changeId='*' for all allocated blocks")
 	diskChangeInfo, err := QueryChangedDiskAreasHook(
-		ctx, vcenter, vslmVolumeID, vslmSnapshotID, int64(startingOffset), allocatedChangeID)
+		ctx, vcenter, vslmVolumeID, vslmSnapshotID, int64(startingOffset), changeID)
 	if err != nil {
 		return nil, 0, TranslateVslmError(ctx, err)
 	}
 
-	var allocatedAreas []AllocatedArea
-	nextOffset := startingOffset
+	var diskAreas []DiskArea
 	for _, area := range diskChangeInfo.ChangedArea {
-		if uint32(len(allocatedAreas)) >= maxResults {
-			break
-		}
-		allocatedAreas = append(allocatedAreas, AllocatedArea{
+		diskAreas = append(diskAreas, DiskArea{
 			Offset: uint64(area.Start),
 			Length: uint64(area.Length),
 		})
-		areaEnd := uint64(area.Start) + uint64(area.Length)
-		if areaEnd > nextOffset {
-			nextOffset = areaEnd
-		}
 	}
-	if uint32(len(allocatedAreas)) < maxResults {
-		nextOffset = 0
+	nextOffset := uint64(diskChangeInfo.StartOffset + diskChangeInfo.Length)
+	return diskAreas, nextOffset, nil
+}
+
+// QueryFCDAllocatedBlocks returns allocated block ranges using FCD VSLM QueryChangedDiskAreas with changeId "*".
+func (m *defaultManager) QueryFCDAllocatedBlocks(ctx context.Context, volumeID, snapshotID string,
+	startingOffset uint64) ([]DiskArea, uint64, error) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("QueryFCDAllocatedBlocks: volume=%s snapshot=%s offset=%d",
+		volumeID, snapshotID, startingOffset)
+
+	const allocatedChangeID = "*"
+	diskAreas, nextOffset, err := m.queryFCDBlocks(ctx, volumeID, snapshotID, allocatedChangeID, startingOffset)
+	if err == nil {
+		log.Debugf("QueryFCDAllocatedBlocks: returned %d allocated areas, next offset %d", len(diskAreas), nextOffset)
 	}
-	log.Debugf("QueryFCDAllocatedBlocks: returned %d allocated areas, next offset %d",
-		len(allocatedAreas), nextOffset)
-	return allocatedAreas, nextOffset, nil
+	return diskAreas, nextOffset, err
 }
 
 // QueryFCDChangedBlocks returns changed block ranges using FCD VSLM QueryChangedDiskAreas with baseChangeID.
 func (m *defaultManager) QueryFCDChangedBlocks(ctx context.Context, volumeID, targetSnapshotID, baseChangeID string,
-	startingOffset uint64, maxResults uint32) ([]ChangedArea, uint64, error) {
+	startingOffset uint64) ([]DiskArea, uint64, error) {
 	log := logger.GetLogger(ctx)
-	log.Debugf("QueryFCDChangedBlocks: volume=%s target=%s offset=%d maxResults=%d",
-		volumeID, targetSnapshotID, startingOffset, maxResults)
+	log.Debugf("QueryFCDChangedBlocks: volume=%s target=%s offset=%d",
+		volumeID, targetSnapshotID, startingOffset)
 
-	vcenter, err := m.connectVirtualCenter(ctx)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get vCenter from volume manager: %v", err)
+	diskAreas, nextOffset, err := m.queryFCDBlocks(ctx, volumeID, targetSnapshotID, baseChangeID, startingOffset)
+	if err == nil {
+		log.Debugf("QueryFCDChangedBlocks: returned %d changed areas, next offset %d", len(diskAreas), nextOffset)
 	}
-
-	vslmVolumeID := vim25types.ID{Id: volumeID}
-	vslmTargetSnapshotID := vim25types.ID{Id: targetSnapshotID}
-
-	log.Debugf("Calling QueryChangedDiskAreasHook with base changeId for delta")
-	diskChangeInfo, err := QueryChangedDiskAreasHook(
-		ctx, vcenter, vslmVolumeID, vslmTargetSnapshotID, int64(startingOffset), baseChangeID)
-	if err != nil {
-		return nil, 0, TranslateVslmError(ctx, err)
-	}
-
-	var changedAreas []ChangedArea
-	nextOffset := startingOffset
-	for _, area := range diskChangeInfo.ChangedArea {
-		if uint32(len(changedAreas)) >= maxResults {
-			break
-		}
-		changedAreas = append(changedAreas, ChangedArea{
-			Offset: uint64(area.Start),
-			Length: uint64(area.Length),
-		})
-		areaEnd := uint64(area.Start) + uint64(area.Length)
-		if areaEnd > nextOffset {
-			nextOffset = areaEnd
-		}
-	}
-	if uint32(len(changedAreas)) < maxResults {
-		nextOffset = 0
-	}
-	log.Debugf("QueryFCDChangedBlocks: returned %d changed areas, next offset %d",
-		len(changedAreas), nextOffset)
-	return changedAreas, nextOffset, nil
+	return diskAreas, nextOffset, err
 }
 
 // TranslateVslmError maps VSLM and VADP error codes to standard CSI gRPC error codes.

--- a/pkg/common/cns-lib/volume/manager_mock.go
+++ b/pkg/common/cns-lib/volume/manager_mock.go
@@ -224,14 +224,14 @@ func (m MockManager) ReRegisterVolume(ctx context.Context, volumeID string) erro
 }
 
 func (m MockManager) QueryFCDAllocatedBlocks(ctx context.Context,
-	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]AllocatedArea, uint64, error) {
+	volumeID, snapshotID string, startingOffset uint64) ([]DiskArea, uint64, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
 func (m MockManager) QueryFCDChangedBlocks(ctx context.Context,
-	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
-	[]ChangedArea, uint64, error) {
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64) (
+	[]DiskArea, uint64, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/common/cns-lib/volume/manager_test.go
+++ b/pkg/common/cns-lib/volume/manager_test.go
@@ -762,16 +762,18 @@ func TestQueryFCDAllocatedBlocks(t *testing.T) {
 	) (*vim25types.DiskChangeInfo, error) {
 		assert.Equal(t, "*", changeID)
 		return &vim25types.DiskChangeInfo{
+			StartOffset: 0,
+			Length:      12288,
 			ChangedArea: []vim25types.DiskChangeExtent{
 				{Start: 0, Length: 4096},
 				{Start: 8192, Length: 4096},
 			},
 		}, nil
 	}
-	areas, next, err := m.QueryFCDAllocatedBlocks(ctx, "vol", "snap", 0, 10)
+	areas, next, err := m.QueryFCDAllocatedBlocks(ctx, "vol", "snap", 0)
 	assert.NoError(t, err)
 	assert.Len(t, areas, 2)
-	assert.Equal(t, uint64(0), next)
+	assert.Equal(t, uint64(12288), next)
 
 	QueryChangedDiskAreasHook = func(
 		ctx context.Context,
@@ -781,13 +783,15 @@ func TestQueryFCDAllocatedBlocks(t *testing.T) {
 		changeID string,
 	) (*vim25types.DiskChangeInfo, error) {
 		return &vim25types.DiskChangeInfo{
+			StartOffset: 0,
+			Length:      8192,
 			ChangedArea: []vim25types.DiskChangeExtent{
 				{Start: 0, Length: 4096},
 				{Start: 4096, Length: 4096},
 			},
 		}, nil
 	}
-	areas, next, err = m.QueryFCDAllocatedBlocks(ctx, "vol", "snap", 0, 2)
+	areas, next, err = m.QueryFCDAllocatedBlocks(ctx, "vol", "snap", 0)
 	assert.NoError(t, err)
 	assert.Len(t, areas, 2)
 	assert.Equal(t, uint64(8192), next)
@@ -800,6 +804,8 @@ func TestQueryFCDAllocatedBlocks(t *testing.T) {
 		changeID string,
 	) (*vim25types.DiskChangeInfo, error) {
 		return &vim25types.DiskChangeInfo{
+			StartOffset: 0,
+			Length:      12288,
 			ChangedArea: []vim25types.DiskChangeExtent{
 				{Start: 0, Length: 4096},
 				{Start: 4096, Length: 4096},
@@ -807,10 +813,10 @@ func TestQueryFCDAllocatedBlocks(t *testing.T) {
 			},
 		}, nil
 	}
-	areas, next, err = m.QueryFCDAllocatedBlocks(ctx, "vol", "snap", 0, 2)
+	areas, next, err = m.QueryFCDAllocatedBlocks(ctx, "vol", "snap", 0)
 	assert.NoError(t, err)
-	assert.Len(t, areas, 2)
-	assert.Equal(t, uint64(8192), next)
+	assert.Len(t, areas, 3)
+	assert.Equal(t, uint64(12288), next)
 
 	QueryChangedDiskAreasHook = func(
 		ctx context.Context,
@@ -821,12 +827,11 @@ func TestQueryFCDAllocatedBlocks(t *testing.T) {
 	) (*vim25types.DiskChangeInfo, error) {
 		return nil, fmt.Errorf("vslm down")
 	}
-	_, _, err = m.QueryFCDAllocatedBlocks(ctx, "v", "s", 0, 10)
+	_, _, err = m.QueryFCDAllocatedBlocks(ctx, "v", "s", 0)
 	assert.Error(t, err)
-	assert.Equal(t, codes.Internal, status.Code(err))
 
 	mNil := &defaultManager{virtualCenter: nil}
-	_, _, err = mNil.QueryFCDAllocatedBlocks(ctx, "v", "s", 0, 10)
+	_, _, err = mNil.QueryFCDAllocatedBlocks(ctx, "v", "s", 0)
 	assert.Error(t, err)
 }
 
@@ -848,13 +853,15 @@ func TestQueryFCDChangedBlocks(t *testing.T) {
 	) (*vim25types.DiskChangeInfo, error) {
 		assert.Equal(t, "base-cid", changeID)
 		return &vim25types.DiskChangeInfo{
+			StartOffset: 0,
+			Length:      300,
 			ChangedArea: []vim25types.DiskChangeExtent{{Start: 100, Length: 200}},
 		}, nil
 	}
-	areas, next, err := m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "base-cid", 0, 5)
+	areas, next, err := m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "base-cid", 0)
 	assert.NoError(t, err)
 	assert.Len(t, areas, 1)
-	assert.Equal(t, uint64(0), next)
+	assert.Equal(t, uint64(300), next)
 
 	QueryChangedDiskAreasHook = func(
 		ctx context.Context,
@@ -864,13 +871,15 @@ func TestQueryFCDChangedBlocks(t *testing.T) {
 		changeID string,
 	) (*vim25types.DiskChangeInfo, error) {
 		return &vim25types.DiskChangeInfo{
+			StartOffset: 0,
+			Length:      1024,
 			ChangedArea: []vim25types.DiskChangeExtent{
 				{Start: 0, Length: 512},
 				{Start: 512, Length: 512},
 			},
 		}, nil
 	}
-	areas, next, err = m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "cid", 0, 2)
+	areas, next, err = m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "cid", 0)
 	assert.NoError(t, err)
 	assert.Len(t, areas, 2)
 	assert.Equal(t, uint64(1024), next)
@@ -884,12 +893,11 @@ func TestQueryFCDChangedBlocks(t *testing.T) {
 	) (*vim25types.DiskChangeInfo, error) {
 		return nil, createFCDSoapFault(&vim25types.InvalidArgument{InvalidProperty: "snapshotId"}, "")
 	}
-	_, _, err = m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "cid", 0, 10)
+	_, _, err = m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "cid", 0)
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, status.Code(err))
 
 	mNil := &defaultManager{virtualCenter: nil}
-	_, _, err = mNil.QueryFCDChangedBlocks(ctx, "v", "t", "c", 0, 10)
+	_, _, err = mNil.QueryFCDChangedBlocks(ctx, "v", "t", "c", 0)
 	assert.Error(t, err)
 
 	QueryChangedDiskAreasHook = func(
@@ -900,6 +908,8 @@ func TestQueryFCDChangedBlocks(t *testing.T) {
 		changeID string,
 	) (*vim25types.DiskChangeInfo, error) {
 		return &vim25types.DiskChangeInfo{
+			StartOffset: 0,
+			Length:      500,
 			ChangedArea: []vim25types.DiskChangeExtent{
 				{Start: 0, Length: 100},
 				{Start: 200, Length: 100},
@@ -907,10 +917,10 @@ func TestQueryFCDChangedBlocks(t *testing.T) {
 			},
 		}, nil
 	}
-	areas, next, err = m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "cid", 0, 2)
+	areas, next, err = m.QueryFCDChangedBlocks(ctx, "vol", "tgt", "cid", 0)
 	assert.NoError(t, err)
-	assert.Len(t, areas, 2)
-	assert.Equal(t, uint64(300), next)
+	assert.Len(t, areas, 3)
+	assert.Equal(t, uint64(500), next)
 }
 
 func TestRunQueryChangedDiskAreasViaVslmNilClient(t *testing.T) {

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -175,12 +175,12 @@ func (m *MockVolumeManager) ResetManager(ctx context.Context, vcenter *vsphere.V
 	return nil
 }
 func (m *MockVolumeManager) QueryFCDAllocatedBlocks(ctx context.Context,
-	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]cnsvolume.AllocatedArea, uint64, error) {
+	volumeID, snapshotID string, startingOffset uint64) ([]cnsvolume.DiskArea, uint64, error) {
 	return nil, 0, nil
 }
 func (m *MockVolumeManager) QueryFCDChangedBlocks(ctx context.Context,
-	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
-	[]cnsvolume.ChangedArea, uint64, error) {
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64) (
+	[]cnsvolume.DiskArea, uint64, error) {
 	return nil, 0, nil
 }
 func (m *MockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -957,11 +957,11 @@ func (m *cbtFlagsMockVolumeManager) ReRegisterVolume(context.Context, string) er
 	return nil
 }
 func (m *cbtFlagsMockVolumeManager) QueryFCDAllocatedBlocks(context.Context,
-	string, string, uint64, uint32) ([]cnsvolume.AllocatedArea, uint64, error) {
+	string, string, uint64) ([]cnsvolume.DiskArea, uint64, error) {
 	return nil, 0, nil
 }
 func (m *cbtFlagsMockVolumeManager) QueryFCDChangedBlocks(context.Context,
-	string, string, string, uint64, uint32) ([]cnsvolume.ChangedArea, uint64, error) {
+	string, string, string, uint64) ([]cnsvolume.DiskArea, uint64, error) {
 	return nil, 0, nil
 }
 

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -84,12 +84,12 @@ func (m *mockVolumeManager) ResetManager(ctx context.Context, vcenter *vsphere.V
 	return nil
 }
 func (m *mockVolumeManager) QueryFCDAllocatedBlocks(ctx context.Context,
-	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]cnsvolume.AllocatedArea, uint64, error) {
+	volumeID, snapshotID string, startingOffset uint64) ([]cnsvolume.DiskArea, uint64, error) {
 	return nil, 0, nil
 }
 func (m *mockVolumeManager) QueryFCDChangedBlocks(ctx context.Context,
-	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
-	[]cnsvolume.ChangedArea, uint64, error) {
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64) (
+	[]cnsvolume.DiskArea, uint64, error) {
 	return nil, 0, nil
 }
 func (m *mockVolumeManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {

--- a/pkg/csi/service/wcp/controller_cbt.go
+++ b/pkg/csi/service/wcp/controller_cbt.go
@@ -39,7 +39,7 @@ const (
 )
 
 // vslmErrorToCSICode returns the gRPC status code from err if it is already a
-// gRPC status error (e.g. one produced by cnsvolume.TranslateVslmError, which
+// gRPC status error (e.g. one produced by volume.TranslateVslmError, which
 // already classifies VSLM faults as FailedPrecondition / OutOfRange /
 // InvalidArgument / NotFound / Internal). Errors without a status default to
 // codes.Internal. This lets callers wrap with a contextual message without
@@ -79,17 +79,21 @@ func (c *controller) GetMetadataAllocated(req *csi.GetMetadataAllocatedRequest,
 	start := time.Now()
 	volumeType := prometheus.PrometheusBlockVolumeType
 
-	getMetadataAllocatedInternal := func() (*csi.GetMetadataAllocatedResponse, error) {
+	// getMetadataAllocatedInternal performs the full streaming loop: it queries
+	// allocated blocks in batches (each bounded by maxResults) and sends each
+	// batch to the client via server.Send.  The loop continues until
+	// QueryFCDAllocatedBlocks signals completion by returning nextOffset == volumeCapacityBytes.
+	getMetadataAllocatedInternal := func() error {
 		// Validate request
 		if err := validateGetMetadataAllocatedRequest(ctx, req); err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"validation for GetMetadataAllocated Request: %+v has failed. Error: %v", req, err)
 		}
 
 		snapshotID := req.GetSnapshotId()
 		startingOffset := req.GetStartingOffset()
-		maxResults := req.GetMaxResults()
-		if maxResults == 0 {
+		maxResults := (uint32)(req.GetMaxResults())
+		if maxResults == 0 || maxResults > defaultMaxResults {
 			// CSI spec: If zero, the Plugin MUST choose a reasonable maximum number of results.
 			maxResults = defaultMaxResults
 		}
@@ -98,7 +102,7 @@ func (c *controller) GetMetadataAllocated(req *csi.GetMetadataAllocatedRequest,
 		// CSI snapshot ID format: "volumeID+snapshotID"
 		volumeID, cnsSnapshotID, err := common.ParseCSISnapshotID(snapshotID)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"failed to parse snapshot ID %s: %v", snapshotID, err)
 		}
 
@@ -113,72 +117,111 @@ func (c *controller) GetMetadataAllocated(req *csi.GetMetadataAllocatedRequest,
 
 		queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, cnsQueryFilter)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to query volume %s: %v", volumeID, err)
 		}
 
 		if len(queryResult.Volumes) == 0 {
-			return nil, logger.LogNewErrorCodef(log, codes.NotFound,
+			return logger.LogNewErrorCodef(log, codes.NotFound,
 				"volume %s not found", volumeID)
 		}
 
 		// Verify volume type
 		cnsVolumeType := queryResult.Volumes[0].VolumeType
 		if cnsVolumeType != common.BlockVolumeType {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"GetMetadataAllocated is only supported for block volumes, got volume type: %s",
 				cnsVolumeType)
 		}
 
 		blockBacking, ok := queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 		if !ok {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return logger.LogNewErrorCodef(log, codes.Internal,
 				"volume %s does not have block backing details", volumeID)
 		}
 		volumeCapacityBytes := blockBacking.CapacityInMb * common.MbInBytes
 
-		allocatedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDAllocatedBlocks(
-			ctx, volumeID, cnsSnapshotID, uint64(startingOffset), uint32(maxResults))
-		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
-				"failed to query allocated blocks: %v", err)
+		// GetMetadataAllocated is a server-streaming RPC. The CSI spec requires
+		// the plugin to stream ALL allocated blocks from startingOffset until the
+		// data is exhausted, sending each batch (bounded by maxResults) as a
+		// separate server.Send() message.
+		//
+		// QueryFCDAllocatedBlocks signals that a batch is not the last one by
+		// returning nextOffset < volumeCapacityBytes. We loop and re-query from nextOffset until
+		// nextOffset == volumeCapacityBytes (all blocks delivered).
+		currentOffset := uint64(startingOffset)
+		totalBlocks := 0
+		for {
+			allocatedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDAllocatedBlocks(
+				ctx, volumeID, cnsSnapshotID, currentOffset)
+			if err != nil {
+				return logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
+					"failed to query allocated blocks: %v", err)
+			}
+
+			for i := 0; i < len(allocatedAreas); i += int(maxResults) {
+				end := i + int(maxResults)
+				if end > len(allocatedAreas) {
+					end = len(allocatedAreas)
+				}
+				batch := allocatedAreas[i:end]
+
+				// Convert to CSI response format
+				blockMetadata := make([]*csi.BlockMetadata, 0, len(batch))
+				for _, area := range batch {
+					blockMetadata = append(blockMetadata, &csi.BlockMetadata{
+						ByteOffset: int64(area.Offset),
+						SizeBytes:  int64(area.Length),
+					})
+				}
+
+				resp := &csi.GetMetadataAllocatedResponse{
+					BlockMetadata:       blockMetadata,
+					VolumeCapacityBytes: int64(volumeCapacityBytes),
+					BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+				}
+				if err := server.Send(resp); err != nil {
+					return logger.LogNewErrorCodef(log, codes.Internal,
+						"failed to send allocated metadata to client: %v", err)
+				}
+			}
+
+			totalBlocks += len(allocatedAreas)
+
+			if nextOffset == uint64(volumeCapacityBytes) {
+				// All blocks from startingOffset have been streamed.
+				break
+			}
+			currentOffset = nextOffset
 		}
 
-		// Convert to CSI response format
-		var blockMetadata []*csi.BlockMetadata
-		for _, area := range allocatedAreas {
-			blockMetadata = append(blockMetadata, &csi.BlockMetadata{
-				ByteOffset: int64(area.Offset),
-				SizeBytes:  int64(area.Length),
-			})
+		// If no blocks are found, send an empty response to indicate that the snapshot is empty.
+		if totalBlocks == 0 {
+			resp := &csi.GetMetadataAllocatedResponse{
+				BlockMetadata:       nil,
+				VolumeCapacityBytes: int64(volumeCapacityBytes),
+				BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+			}
+			if err := server.Send(resp); err != nil {
+				return logger.LogNewErrorCodef(log, codes.Internal,
+					"failed to send allocated metadata to client: %v", err)
+			}
 		}
 
-		response := &csi.GetMetadataAllocatedResponse{
-			BlockMetadata:       blockMetadata,
-			VolumeCapacityBytes: int64(volumeCapacityBytes),
-			BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
-		}
-
-		// Note: CSI spec doesn't have StartingOffset in response for pagination.
-		// Clients should track nextOffset from the number of results returned.
-		// If fewer results than maxResults are returned, pagination is complete.
-
-		log.Infof("GetMetadataAllocated succeeded for snapshot %s, returned %d allocated blocks, next offset %d",
-			snapshotID, len(blockMetadata), nextOffset)
-
-		return response, nil
+		log.Infof("GetMetadataAllocated succeeded for snapshot %s, streamed %d allocated blocks total",
+			snapshotID, totalBlocks)
+		return nil
 	}
 
-	resp, err := getMetadataAllocatedInternal()
+	err := getMetadataAllocatedInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataAllocated",
 			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
 		return err
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataAllocated",
-			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
 	}
-	return server.Send(resp)
+	prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataAllocated",
+		prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
+	return nil
 }
 
 // GetMetadataDelta returns the metadata for the changed blocks between two snapshots using
@@ -215,10 +258,14 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 	start := time.Now()
 	volumeType := prometheus.PrometheusBlockVolumeType
 
-	getMetadataDeltaInternal := func() (*csi.GetMetadataDeltaResponse, error) {
+	// getMetadataDeltaInternal performs the full streaming loop: it queries
+	// changed blocks in batches (each bounded by maxResults) and sends each
+	// batch to the client via server.Send.  The loop continues until
+	// QueryFCDChangedBlocks signals completion by returning nextOffset == volumeCapacityBytes.
+	getMetadataDeltaInternal := func() error {
 		// Validate request
 		if err := validateGetMetadataDeltaRequest(ctx, req); err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"validation for GetMetadataDelta Request: %+v has failed. Error: %v", req, err)
 		}
 
@@ -227,8 +274,8 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 		baseChangeID := req.GetBaseSnapshotId()
 		targetSnapshotID := req.GetTargetSnapshotId()
 		startingOffset := req.GetStartingOffset()
-		maxResults := req.GetMaxResults()
-		if maxResults == 0 {
+		maxResults := (uint32)(req.GetMaxResults())
+		if maxResults == 0 || maxResults > defaultMaxResults {
 			// CSI spec: If zero, the Plugin MUST choose a reasonable maximum number of results.
 			maxResults = defaultMaxResults
 		}
@@ -237,7 +284,7 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 		// must exist on the Supervisor for VSLM to query its blocks.
 		volumeID, targetCnsSnapshotID, err := common.ParseCSISnapshotID(targetSnapshotID)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"failed to parse target snapshot ID %s: %v", targetSnapshotID, err)
 		}
 
@@ -253,74 +300,111 @@ func (c *controller) GetMetadataDelta(req *csi.GetMetadataDeltaRequest,
 
 		queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, cnsQueryFilter)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to query volume %s: %v", volumeID, err)
 		}
 
 		if len(queryResult.Volumes) == 0 {
-			return nil, logger.LogNewErrorCodef(log, codes.NotFound,
+			return logger.LogNewErrorCodef(log, codes.NotFound,
 				"volume %s not found", volumeID)
 		}
 
 		// Verify volume type
 		cnsVolumeType := queryResult.Volumes[0].VolumeType
 		if cnsVolumeType != common.BlockVolumeType {
-			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
 				"GetMetadataDelta is only supported for block volumes, got volume type: %s",
 				cnsVolumeType)
 		}
 
 		blockBacking, ok := queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 		if !ok {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return logger.LogNewErrorCodef(log, codes.Internal,
 				"volume %s does not have block backing details", volumeID)
 		}
 		volumeCapacityBytes := blockBacking.CapacityInMb * common.MbInBytes
 
-		// Query changed blocks via volume manager (FCD/VSLM). baseChangeID is supplied by the caller.
-		changedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDChangedBlocks(
-			ctx, volumeID, targetCnsSnapshotID, baseChangeID, uint64(startingOffset), uint32(maxResults))
-		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
-				"failed to query changed blocks: %v", err)
+		// GetMetadataDelta is a server-streaming RPC. The CSI spec requires the
+		// plugin to stream ALL changed blocks from startingOffset until the data
+		// is exhausted, sending each batch (bounded by maxResults) as a separate
+		// server.Send() message.
+		//
+		// QueryFCDChangedBlocks signals that a batch is not the last one by
+		// returning nextOffset < volumeCapacityBytes. We loop and re-query from nextOffset until
+		// nextOffset == volumeCapacityBytes (all blocks delivered).
+		currentOffset := uint64(startingOffset)
+		totalBlocks := 0
+		for {
+			changedAreas, nextOffset, err := c.manager.VolumeManager.QueryFCDChangedBlocks(
+				ctx, volumeID, targetCnsSnapshotID, baseChangeID, currentOffset)
+			if err != nil {
+				return logger.LogNewErrorCodef(log, vslmErrorToCSICode(err),
+					"failed to query changed blocks: %v", err)
+			}
+
+			for i := 0; i < len(changedAreas); i += int(maxResults) {
+				end := i + int(maxResults)
+				if end > len(changedAreas) {
+					end = len(changedAreas)
+				}
+				batch := changedAreas[i:end]
+
+				// Convert to CSI response format
+				blockMetadata := make([]*csi.BlockMetadata, 0, len(batch))
+				for _, area := range batch {
+					blockMetadata = append(blockMetadata, &csi.BlockMetadata{
+						ByteOffset: int64(area.Offset),
+						SizeBytes:  int64(area.Length),
+					})
+				}
+
+				resp := &csi.GetMetadataDeltaResponse{
+					BlockMetadata:       blockMetadata,
+					VolumeCapacityBytes: int64(volumeCapacityBytes),
+					BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+				}
+				if err := server.Send(resp); err != nil {
+					return logger.LogNewErrorCodef(log, codes.Internal,
+						"failed to send delta metadata to client: %v", err)
+				}
+			}
+
+			totalBlocks += len(changedAreas)
+
+			if nextOffset == uint64(volumeCapacityBytes) {
+				// All blocks from startingOffset have been streamed.
+				break
+			}
+			currentOffset = nextOffset
 		}
 
-		// Convert to CSI response format
-		var blockMetadata []*csi.BlockMetadata
-		for _, area := range changedAreas {
-			blockMetadata = append(blockMetadata, &csi.BlockMetadata{
-				ByteOffset: int64(area.Offset),
-				SizeBytes:  int64(area.Length),
-			})
+		// If no blocks are found, send an empty response to indicate that the snapshot delta is empty.
+		if totalBlocks == 0 {
+			resp := &csi.GetMetadataDeltaResponse{
+				BlockMetadata:       nil,
+				VolumeCapacityBytes: int64(volumeCapacityBytes),
+				BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+			}
+			if err := server.Send(resp); err != nil {
+				return logger.LogNewErrorCodef(log, codes.Internal,
+					"failed to send delta metadata to client: %v", err)
+			}
 		}
 
-		response := &csi.GetMetadataDeltaResponse{
-			BlockMetadata:       blockMetadata,
-			VolumeCapacityBytes: int64(volumeCapacityBytes),
-			BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
-		}
-
-		// Note: CSI spec doesn't have StartingOffset in response for pagination.
-		// Clients should track nextOffset from the number of results returned.
-		// If fewer results than maxResults are returned, pagination is complete.
-
-		log.Infof("GetMetadataDelta succeeded for target snapshot %s, "+
-			"returned %d changed blocks, next offset %d",
-			targetSnapshotID, len(blockMetadata), nextOffset)
-
-		return response, nil
+		log.Infof("GetMetadataDelta succeeded for target snapshot %s, streamed %d changed blocks total",
+			targetSnapshotID, totalBlocks)
+		return nil
 	}
 
-	resp, err := getMetadataDeltaInternal()
+	err := getMetadataDeltaInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataDelta",
 			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
 		return err
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataDelta",
-			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
 	}
-	return server.Send(resp)
+	prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, "GetMetadataDelta",
+		prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
+	return nil
 }
 
 // validateGetMetadataAllocatedRequest validates the GetMetadataAllocated request

--- a/pkg/csi/service/wcp/controller_cbt_test.go
+++ b/pkg/csi/service/wcp/controller_cbt_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/vim25/soap"
-	"github.com/vmware/govmomi/vim25/types"
+	vim25types "github.com/vmware/govmomi/vim25/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -39,8 +39,10 @@ import (
 
 type mockAllocatedServer struct {
 	grpc.ServerStream
-	ctx context.Context
-	t   *testing.T
+	ctx       context.Context
+	t         *testing.T
+	sendCount int
+	allBlocks []*csi.BlockMetadata
 }
 
 func (m *mockAllocatedServer) Context() context.Context {
@@ -48,6 +50,8 @@ func (m *mockAllocatedServer) Context() context.Context {
 }
 
 func (m *mockAllocatedServer) Send(resp *csi.GetMetadataAllocatedResponse) error {
+	m.sendCount++
+	m.allBlocks = append(m.allBlocks, resp.BlockMetadata...)
 	if m.t != nil && resp.BlockMetadataType != csi.BlockMetadataType_VARIABLE_LENGTH {
 		m.t.Errorf("Expected BlockMetadataType to be %v, got %v",
 			csi.BlockMetadataType_VARIABLE_LENGTH, resp.BlockMetadataType)
@@ -57,8 +61,10 @@ func (m *mockAllocatedServer) Send(resp *csi.GetMetadataAllocatedResponse) error
 
 type mockDeltaServer struct {
 	grpc.ServerStream
-	ctx context.Context
-	t   *testing.T
+	ctx       context.Context
+	t         *testing.T
+	sendCount int
+	allBlocks []*csi.BlockMetadata
 }
 
 func (m *mockDeltaServer) Context() context.Context {
@@ -66,6 +72,8 @@ func (m *mockDeltaServer) Context() context.Context {
 }
 
 func (m *mockDeltaServer) Send(resp *csi.GetMetadataDeltaResponse) error {
+	m.sendCount++
+	m.allBlocks = append(m.allBlocks, resp.BlockMetadata...)
 	if m.t != nil && resp.BlockMetadataType != csi.BlockMetadataType_VARIABLE_LENGTH {
 		m.t.Errorf("Expected BlockMetadataType to be %v, got %v",
 			csi.BlockMetadataType_VARIABLE_LENGTH, resp.BlockMetadataType)
@@ -275,7 +283,7 @@ func TestGetMetadataAllocated_InvalidSnapshotID(t *testing.T) {
 
 // TestAllocatedAreaConversion tests the conversion from VSLM response to CSI format
 func TestAllocatedAreaConversion(t *testing.T) {
-	areas := []cnsvolume.AllocatedArea{
+	areas := []cnsvolume.DiskArea{
 		{Offset: 0, Length: 4096},
 		{Offset: 8192, Length: 4096},
 		{Offset: 16384, Length: 8192},
@@ -305,7 +313,7 @@ func TestAllocatedAreaConversion(t *testing.T) {
 
 // TestChangedAreaConversion tests the conversion from VSLM response to CSI format
 func TestChangedAreaConversion(t *testing.T) {
-	areas := []cnsvolume.ChangedArea{
+	areas := []cnsvolume.DiskArea{
 		{Offset: 4096, Length: 4096},
 		{Offset: 12288, Length: 4096},
 	}
@@ -324,76 +332,6 @@ func TestChangedAreaConversion(t *testing.T) {
 
 	if blockMetadata[0].ByteOffset != 4096 {
 		t.Errorf("First changed block offset incorrect: %d", blockMetadata[0].ByteOffset)
-	}
-}
-
-// TestPaginationLogic tests the nextOffset calculation
-func TestPaginationLogic(t *testing.T) {
-	tests := []struct {
-		name           string
-		areas          []cnsvolume.AllocatedArea
-		maxResults     uint32
-		startingOffset uint64
-		wantNextOffset uint64
-	}{
-		{
-			name: "fewer results than max",
-			areas: []cnsvolume.AllocatedArea{
-				{Offset: 0, Length: 4096},
-				{Offset: 8192, Length: 4096},
-			},
-			maxResults:     10,
-			startingOffset: 0,
-			wantNextOffset: 0, // Signals completion
-		},
-		{
-			name: "exactly max results",
-			areas: []cnsvolume.AllocatedArea{
-				{Offset: 0, Length: 4096},
-				{Offset: 4096, Length: 4096},
-			},
-			maxResults:     2,
-			startingOffset: 0,
-			wantNextOffset: 8192, // End of last area
-		},
-		{
-			name: "more results than max",
-			areas: []cnsvolume.AllocatedArea{
-				{Offset: 0, Length: 4096},
-				{Offset: 4096, Length: 4096},
-				{Offset: 8192, Length: 4096},
-			},
-			maxResults:     2,
-			startingOffset: 0,
-			wantNextOffset: 8192, // After taking first 2
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Simulate pagination logic
-			nextOffset := tt.startingOffset
-			resultCount := 0
-
-			for _, area := range tt.areas {
-				if uint32(resultCount) >= tt.maxResults {
-					break
-				}
-				resultCount++
-				areaEnd := area.Offset + area.Length
-				if areaEnd > nextOffset {
-					nextOffset = areaEnd
-				}
-			}
-
-			if uint32(resultCount) < tt.maxResults {
-				nextOffset = 0
-			}
-
-			if nextOffset != tt.wantNextOffset {
-				t.Errorf("nextOffset = %d, want %d", nextOffset, tt.wantNextOffset)
-			}
-		})
 	}
 }
 
@@ -446,11 +384,13 @@ func TestGetMetadataAllocated_Success(t *testing.T) {
 	ct.controller.manager.VolumeManager = &mockVolumeManager{Manager: origVolumeManager}
 	defer func() { ct.controller.manager.VolumeManager = origVolumeManager }()
 
+	volumeCapacityBytes := int64(1 * common.GbInBytes)
+
 	// Create a volume first to avoid NotFound error
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-allocated",
 		CapacityRange: &csi.CapacityRange{
-			RequiredBytes: 1 * common.GbInBytes,
+			RequiredBytes: volumeCapacityBytes,
 		},
 		VolumeCapabilities: []*csi.VolumeCapability{
 			{
@@ -473,12 +413,27 @@ func TestGetMetadataAllocated_Success(t *testing.T) {
 	defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
 
 	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
-		return &types.DiskChangeInfo{
-			ChangedArea: []types.DiskChangeExtent{
-				{Start: 0, Length: 4096},
-				{Start: 4096, Length: 8192},
-			},
+		volumeID vim25types.ID, snapshotID vim25types.ID, startingOffset int64,
+		changeID string) (*vim25types.DiskChangeInfo, error) {
+		// Only return areas that start at or after startingOffset so the
+		// pagination loop terminates correctly.
+		all := []vim25types.DiskChangeExtent{
+			{Start: 0, Length: 4096},
+			{Start: 4096, Length: 8192},
+		}
+		var filtered []vim25types.DiskChangeExtent
+		for _, a := range all {
+			if a.Start >= startingOffset {
+				filtered = append(filtered, a)
+			}
+		}
+
+		length := volumeCapacityBytes - startingOffset
+
+		return &vim25types.DiskChangeInfo{
+			StartOffset: startingOffset,
+			Length:      length,
+			ChangedArea: filtered,
 		}, nil
 	}
 
@@ -503,11 +458,13 @@ func TestGetMetadataDelta_Success(t *testing.T) {
 	ct.controller.manager.VolumeManager = &mockVolumeManager{Manager: origVolumeManager}
 	defer func() { ct.controller.manager.VolumeManager = origVolumeManager }()
 
+	volumeCapacityBytes := int64(1 * common.GbInBytes)
+
 	// Create a volume first to avoid NotFound error
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-delta",
 		CapacityRange: &csi.CapacityRange{
-			RequiredBytes: 1 * common.GbInBytes,
+			RequiredBytes: volumeCapacityBytes,
 		},
 		VolumeCapabilities: []*csi.VolumeCapability{
 			{
@@ -530,11 +487,26 @@ func TestGetMetadataDelta_Success(t *testing.T) {
 	defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
 
 	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-		volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
-		return &types.DiskChangeInfo{
-			ChangedArea: []types.DiskChangeExtent{
-				{Start: 8192, Length: 4096},
-			},
+		volumeID vim25types.ID, snapshotID vim25types.ID, startingOffset int64,
+		changeID string) (*vim25types.DiskChangeInfo, error) {
+		// Only return areas at or after startingOffset so the pagination loop
+		// terminates correctly.
+		all := []vim25types.DiskChangeExtent{
+			{Start: 8192, Length: 4096},
+		}
+		var filtered []vim25types.DiskChangeExtent
+		for _, a := range all {
+			if a.Start >= startingOffset {
+				filtered = append(filtered, a)
+			}
+		}
+
+		length := volumeCapacityBytes - startingOffset
+
+		return &vim25types.DiskChangeInfo{
+			StartOffset: startingOffset,
+			Length:      length,
+			ChangedArea: filtered,
 		}, nil
 	}
 
@@ -555,7 +527,7 @@ func TestGetMetadataDelta_Success(t *testing.T) {
 
 // makeFCDSoapFault builds a govmomi SOAP fault wrapping the given vim fault
 // payload. Mirrors the helper used in the cnsvolume package tests.
-func makeFCDSoapFault(fault types.AnyType, msg string) error {
+func makeFCDSoapFault(fault vim25types.AnyType, msg string) error {
 	f := &soap.Fault{String: msg}
 	f.Detail.Fault = fault
 	return soap.WrapSoapFault(f)
@@ -589,12 +561,12 @@ func TestVslmErrorToCSICode(t *testing.T) {
 }
 
 // runVSLMErrorPropagationCase asserts that the wcp controller propagates the
-// gRPC status code produced by cnsvolume.TranslateVslmError end-to-end (instead
+// gRPC status code produced by volume.TranslateVslmError end-to-end (instead
 // of overwriting it with codes.Internal).
 //
 // Each case: stub QueryChangedDiskAreasHook to return a SOAP fault, then drive
 // either GetMetadataAllocated or GetMetadataDelta and assert status.Code(err).
-func runVSLMErrorPropagationCase(t *testing.T, name string, vimFault types.AnyType,
+func runVSLMErrorPropagationCase(t *testing.T, name string, vimFault vim25types.AnyType,
 	faultMsg string, isDelta bool, wantCode codes.Code) {
 	t.Run(name, func(t *testing.T) {
 		ct := getControllerTest(t)
@@ -628,7 +600,8 @@ func runVSLMErrorPropagationCase(t *testing.T, name string, vimFault types.AnyTy
 		origHook := cnsvolume.QueryChangedDiskAreasHook
 		defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
 		cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
-			volumeID types.ID, snapshotID types.ID, startingOffset int64, changeID string) (*types.DiskChangeInfo, error) {
+			volumeID vim25types.ID, snapshotID vim25types.ID, startingOffset int64,
+			changeID string) (*vim25types.DiskChangeInfo, error) {
 			return nil, makeFCDSoapFault(vimFault, faultMsg)
 		}
 
@@ -658,36 +631,36 @@ func runVSLMErrorPropagationCase(t *testing.T, name string, vimFault types.AnyTy
 
 // TestGetMetadataAllocated_PreservesVSLMErrorCode verifies that for
 // GetMetadataAllocated the controller surfaces the gRPC code chosen by
-// cnsvolume.TranslateVslmError instead of clobbering it with codes.Internal.
+// volume.TranslateVslmError instead of clobbering it with codes.Internal.
 func TestGetMetadataAllocated_PreservesVSLMErrorCode(t *testing.T) {
 	// noTrack -> CBT not enabled -> FailedPrecondition.
 	runVSLMErrorPropagationCase(t, "FailedPrecondition_noTrack",
-		&types.FileFault{
-			VimFault: types.VimFault{
-				MethodFault: types.MethodFault{
-					FaultMessage: []types.LocalizableMessage{{Key: "vim.hostd.vmsvc.cbt.noTrack"}},
+		&vim25types.FileFault{
+			VimFault: vim25types.VimFault{
+				MethodFault: vim25types.MethodFault{
+					FaultMessage: []vim25types.LocalizableMessage{{Key: "vim.hostd.vmsvc.cbt.noTrack"}},
 				},
 			},
 		}, "", false, codes.FailedPrecondition)
 
 	// startOffset out of range -> OutOfRange.
 	runVSLMErrorPropagationCase(t, "OutOfRange_startOffset",
-		&types.InvalidArgument{InvalidProperty: "startOffset"}, "",
+		&vim25types.InvalidArgument{InvalidProperty: "startOffset"}, "",
 		false, codes.OutOfRange)
 
 	// snapshotId not found -> NotFound.
 	runVSLMErrorPropagationCase(t, "NotFound_snapshotId",
-		&types.InvalidArgument{InvalidProperty: "snapshotId"}, "",
+		&vim25types.InvalidArgument{InvalidProperty: "snapshotId"}, "",
 		false, codes.NotFound)
 
 	// changeId malformed -> InvalidArgument.
 	runVSLMErrorPropagationCase(t, "InvalidArgument_changeId",
-		&types.InvalidArgument{InvalidProperty: "changeId"}, "",
+		&vim25types.InvalidArgument{InvalidProperty: "changeId"}, "",
 		false, codes.InvalidArgument)
 
 	// Generic VSLM SystemError -> Internal (already-wrapped case still works).
 	runVSLMErrorPropagationCase(t, "Internal_systemError",
-		&types.SystemError{}, "", false, codes.Internal)
+		&vim25types.SystemError{}, "", false, codes.Internal)
 }
 
 // TestGetMetadataDelta_PreservesVSLMErrorCode is the same end-to-end
@@ -695,19 +668,19 @@ func TestGetMetadataAllocated_PreservesVSLMErrorCode(t *testing.T) {
 // QueryFCDChangedBlocks under the hood).
 func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
 	runVSLMErrorPropagationCase(t, "FailedPrecondition_noEpoch",
-		&types.FileFault{
-			VimFault: types.VimFault{
-				MethodFault: types.MethodFault{
-					FaultMessage: []types.LocalizableMessage{{Key: "vim.hostd.vmsvc.cbt.noEpoch"}},
+		&vim25types.FileFault{
+			VimFault: vim25types.VimFault{
+				MethodFault: vim25types.MethodFault{
+					FaultMessage: []vim25types.LocalizableMessage{{Key: "vim.hostd.vmsvc.cbt.noEpoch"}},
 				},
 			},
 		}, "", true, codes.FailedPrecondition)
 
 	runVSLMErrorPropagationCase(t, "FailedPrecondition_corruptCTK",
-		&types.FileFault{
-			VimFault: types.VimFault{
-				MethodFault: types.MethodFault{
-					FaultMessage: []types.LocalizableMessage{
+		&vim25types.FileFault{
+			VimFault: vim25types.VimFault{
+				MethodFault: vim25types.MethodFault{
+					FaultMessage: []vim25types.LocalizableMessage{
 						{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges", Message: "file is corrupted"},
 					},
 				},
@@ -715,10 +688,10 @@ func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
 		}, "file is corrupted", true, codes.FailedPrecondition)
 
 	runVSLMErrorPropagationCase(t, "InvalidArgument_changeIDMismatch",
-		&types.FileFault{
-			VimFault: types.VimFault{
-				MethodFault: types.MethodFault{
-					FaultMessage: []types.LocalizableMessage{
+		&vim25types.FileFault{
+			VimFault: vim25types.VimFault{
+				MethodFault: vim25types.MethodFault{
+					FaultMessage: []vim25types.LocalizableMessage{
 						{Key: "vim.hostd.vmsvc.cbt.cannotGetChanges"},
 					},
 				},
@@ -726,5 +699,182 @@ func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
 		}, "", true, codes.InvalidArgument)
 
 	runVSLMErrorPropagationCase(t, "NotFound_FCD",
-		&types.NotFound{}, "", true, codes.NotFound)
+		&vim25types.NotFound{}, "", true, codes.NotFound)
+}
+
+// TestGetMetadataAllocated_Pagination verifies that GetMetadataAllocated streams
+// multiple server.Send() messages when the total allocated blocks exceed maxResults
+// per batch. This is the core bug that caused tc_008 to fail: the old code called
+// server.Send once and ignored nextOffset, truncating the result stream.
+func TestGetMetadataAllocated_Pagination(t *testing.T) {
+	ct := getControllerTest(t)
+	fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+	_ = fakeOrchestrator.EnableFSS(ctx, common.CSI_Backup_API)
+
+	origVolumeManager := ct.controller.manager.VolumeManager
+	ct.controller.manager.VolumeManager = &mockVolumeManager{Manager: origVolumeManager}
+	defer func() { ct.controller.manager.VolumeManager = origVolumeManager }()
+
+	volumeCapacityBytes := int64(1 * common.GbInBytes)
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-alloc-pagination",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: volumeCapacityBytes,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatalf("Failed to create volume: %v", err)
+	}
+	volID := respCreate.Volume.VolumeId
+
+	origHook := cnsvolume.QueryChangedDiskAreasHook
+	defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
+
+	// Stub the hook to return areas in multiple pages to exercise VADP pagination.
+	// With maxResults=1 the controller will also batch the returned areas,
+	// issuing 3 separate server.Send() calls.
+	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID vim25types.ID, snapshotID vim25types.ID, startingOffset int64,
+		changeID string) (*vim25types.DiskChangeInfo, error) {
+
+		var area []vim25types.DiskChangeExtent
+		var length int64
+
+		switch startingOffset {
+		case 0:
+			area = []vim25types.DiskChangeExtent{
+				{Start: 0, Length: 4096},
+				{Start: 4096, Length: 4096},
+			}
+			length = 8192
+		case 8192:
+			area = []vim25types.DiskChangeExtent{
+				{Start: 8192, Length: 4096},
+			}
+			length = volumeCapacityBytes - 8192
+		default:
+			area = nil
+			length = volumeCapacityBytes - startingOffset
+		}
+
+		return &vim25types.DiskChangeInfo{
+			StartOffset: startingOffset,
+			Length:      length,
+			ChangedArea: area,
+		}, nil
+	}
+
+	srv := &mockAllocatedServer{ctx: ctx, t: t}
+	req := &csi.GetMetadataAllocatedRequest{
+		SnapshotId: volID + "+snapshot-pagination",
+		MaxResults: 1, // force one area per Send() call
+	}
+
+	if err := ct.controller.GetMetadataAllocated(req, srv); err != nil {
+		t.Fatalf("GetMetadataAllocated returned unexpected error: %v", err)
+	}
+
+	if srv.sendCount != 3 {
+		t.Errorf("Expected 3 server.Send() calls (one per block batch), got %d", srv.sendCount)
+	}
+	if len(srv.allBlocks) != 3 {
+		t.Errorf("Expected 3 total BlockMetadata entries, got %d", len(srv.allBlocks))
+	}
+}
+
+// TestGetMetadataDelta_Pagination is the equivalent pagination test for
+// GetMetadataDelta: verifies that multiple server.Send() calls are issued
+// when changed blocks span more than one maxResults-sized batch.
+func TestGetMetadataDelta_Pagination(t *testing.T) {
+	ct := getControllerTest(t)
+	fakeOrchestrator := commonco.ContainerOrchestratorUtility.(*unittestcommon.FakeK8SOrchestrator)
+	_ = fakeOrchestrator.EnableFSS(ctx, common.CSI_Backup_API)
+
+	origVolumeManager := ct.controller.manager.VolumeManager
+	ct.controller.manager.VolumeManager = &mockVolumeManager{Manager: origVolumeManager}
+	defer func() { ct.controller.manager.VolumeManager = origVolumeManager }()
+
+	volumeCapacityBytes := int64(1 * common.GbInBytes)
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-delta-pagination",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: volumeCapacityBytes,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatalf("Failed to create volume: %v", err)
+	}
+	volID := respCreate.Volume.VolumeId
+
+	origHook := cnsvolume.QueryChangedDiskAreasHook
+	defer func() { cnsvolume.QueryChangedDiskAreasHook = origHook }()
+
+	cnsvolume.QueryChangedDiskAreasHook = func(ctx context.Context, vcenter *cnsvsphere.VirtualCenter,
+		volumeID vim25types.ID, snapshotID vim25types.ID, startingOffset int64,
+		changeID string) (*vim25types.DiskChangeInfo, error) {
+
+		var area []vim25types.DiskChangeExtent
+		var length int64
+
+		switch startingOffset {
+		case 0:
+			area = []vim25types.DiskChangeExtent{
+				{Start: 0, Length: 4096},
+				{Start: 4096, Length: 4096},
+			}
+			length = 8192
+		case 8192:
+			area = []vim25types.DiskChangeExtent{
+				{Start: 8192, Length: 4096},
+			}
+			length = volumeCapacityBytes - 8192
+		default:
+			area = nil
+			length = volumeCapacityBytes - startingOffset
+		}
+
+		return &vim25types.DiskChangeInfo{
+			StartOffset: startingOffset,
+			Length:      length,
+			ChangedArea: area,
+		}, nil
+	}
+
+	srv := &mockDeltaServer{ctx: ctx, t: t}
+	req := &csi.GetMetadataDeltaRequest{
+		BaseSnapshotId:   "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/123",
+		TargetSnapshotId: volID + "+snapshot-pagination",
+		MaxResults:       1, // force one area per Send() call
+	}
+
+	if err := ct.controller.GetMetadataDelta(req, srv); err != nil {
+		t.Fatalf("GetMetadataDelta returned unexpected error: %v", err)
+	}
+
+	if srv.sendCount != 3 {
+		t.Errorf("Expected 3 server.Send() calls (one per block batch), got %d", srv.sendCount)
+	}
+	if len(srv.allBlocks) != 3 {
+		t.Errorf("Expected 3 total BlockMetadata entries, got %d", len(srv.allBlocks))
+	}
 }

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -144,14 +144,14 @@ func (m *mockVolumeManager) ResetManager(ctx context.Context, vcenter *cnsvspher
 }
 
 func (m *mockVolumeManager) QueryFCDAllocatedBlocks(ctx context.Context,
-	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]cnsvolume.AllocatedArea, uint64, error) {
+	volumeID, snapshotID string, startingOffset uint64) ([]cnsvolume.DiskArea, uint64, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
 func (m *mockVolumeManager) QueryFCDChangedBlocks(ctx context.Context,
-	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
-	[]cnsvolume.ChangedArea, uint64, error) {
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64) (
+	[]cnsvolume.DiskArea, uint64, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -869,13 +869,13 @@ func (m *mockVolumeManagerForFullSync) ResetManager(ctx context.Context, vcenter
 }
 
 func (m *mockVolumeManagerForFullSync) QueryFCDAllocatedBlocks(ctx context.Context,
-	volumeID, snapshotID string, startingOffset uint64, maxResults uint32) ([]volumes.AllocatedArea, uint64, error) {
+	volumeID, snapshotID string, startingOffset uint64) ([]volumes.DiskArea, uint64, error) {
 	return nil, 0, nil
 }
 
 func (m *mockVolumeManagerForFullSync) QueryFCDChangedBlocks(ctx context.Context,
-	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64, maxResults uint32) (
-	[]volumes.ChangedArea, uint64, error) {
+	volumeID, targetSnapshotID, baseChangeID string, startingOffset uint64) (
+	[]volumes.DiskArea, uint64, error) {
 	return nil, 0, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds pagination support for parsing CBT API call results received from VADP/FCD API call made in supervisor cluster. Current code in supervisor CBT API implementation returns only first page of results returned by VADP API , thereby missing rest of the result entries, leading to incomplete CBT metadata.
1,  this change refactor the function QueryFCDAllocatedBlocks&QueryFCDChangedBlocks
2, move the CSI CBT specific error translation function translateVslmError to controller_cbt.go

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified that the it returns every page (2000 entries) from VADP.

Verify with 10240 allocated blocks
```metadata allocate
./snapshot-metadata-lister -n test-vadp-supervisor-ns   -s snapshot-pvc-03  | wc
  10242   51210  727179
```

Verify with 2048 changed blocks
``` metadata delta
./snapshot-metadata-lister -max-results 10 -previous-snapshot-id "52 60 16 b5 8f 1f 7f 54-22 b2 fb f3 f9 30 46 f6/6" | wc
   2050   10250  145547
```
All unit tests passed.
FVT related tests with different maxResult passed

**Regression Test**:
Both passed
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1698/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1281/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add pagination to iterate over all entries received from VADP CBT API
```
