### PR TITLE
Add controller for the StoragePolicyInfo CRD, which carries namespace-level storage policy topology information.

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -49,10 +49,10 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status", "clusterstoragepolicyinfos", "clusterstoragepolicyinfos/status", "infrastoragepolicyinfos", "infrastoragepolicyinfos/status"]
+    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status", "clusterstoragepolicyinfos", "clusterstoragepolicyinfos/status", "infrastoragepolicyinfos", "infrastoragepolicyinfos/status", "storagepolicyinfos", "storagepolicyinfos/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["clusterstoragepolicyinfos", "infrastoragepolicyinfos"]
+    resources: ["clusterstoragepolicyinfos", "infrastoragepolicyinfos", "storagepolicyinfos"]
     verbs: ["create"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]
@@ -517,6 +517,8 @@ spec:
             - name: WORKER_THREADS_NODEVM_BATCH_ATTACH
               value: "20"
             - name: WORKER_THREADS_CLUSTER_STORAGE_POLICY_INFO
+              value: "4"
+            - name: WORKER_THREADS_STORAGE_POLICY_INFO
               value: "4"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -49,10 +49,10 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status", "clusterstoragepolicyinfos", "clusterstoragepolicyinfos/status", "infrastoragepolicyinfos", "infrastoragepolicyinfos/status"]
+    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status", "clusterstoragepolicyinfos", "clusterstoragepolicyinfos/status", "infrastoragepolicyinfos", "infrastoragepolicyinfos/status", "storagepolicyinfos", "storagepolicyinfos/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["clusterstoragepolicyinfos", "infrastoragepolicyinfos"]
+    resources: ["clusterstoragepolicyinfos", "infrastoragepolicyinfos", "storagepolicyinfos"]
     verbs: ["create"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]
@@ -534,6 +534,8 @@ spec:
             - name: WORKER_THREADS_NODEVM_BATCH_ATTACH
               value: "20"
             - name: WORKER_THREADS_CLUSTER_STORAGE_POLICY_INFO
+              value: "4"
+            - name: WORKER_THREADS_STORAGE_POLICY_INFO
               value: "4"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -49,10 +49,10 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status", "clusterstoragepolicyinfos", "clusterstoragepolicyinfos/status", "infrastoragepolicyinfos", "infrastoragepolicyinfos/status"]
+    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status", "clusterstoragepolicyinfos", "clusterstoragepolicyinfos/status", "infrastoragepolicyinfos", "infrastoragepolicyinfos/status", "storagepolicyinfos", "storagepolicyinfos/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["clusterstoragepolicyinfos", "infrastoragepolicyinfos"]
+    resources: ["clusterstoragepolicyinfos", "infrastoragepolicyinfos", "storagepolicyinfos"]
     verbs: ["create"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]
@@ -534,6 +534,8 @@ spec:
             - name: WORKER_THREADS_NODEVM_BATCH_ATTACH
               value: "20"
             - name: WORKER_THREADS_CLUSTER_STORAGE_POLICY_INFO
+              value: "4"
+            - name: WORKER_THREADS_STORAGE_POLICY_INFO
               value: "4"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -49,10 +49,10 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status", "clusterstoragepolicyinfos", "clusterstoragepolicyinfos/status", "infrastoragepolicyinfos", "infrastoragepolicyinfos/status"]
+    resources: ["cnsvolumemetadatas", "cnsfileaccessconfigs", "cnsfileaccessconfigs/status", "clusterstoragepolicyinfos", "clusterstoragepolicyinfos/status", "infrastoragepolicyinfos", "infrastoragepolicyinfos/status", "storagepolicyinfos", "storagepolicyinfos/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["clusterstoragepolicyinfos", "infrastoragepolicyinfos"]
+    resources: ["clusterstoragepolicyinfos", "infrastoragepolicyinfos", "storagepolicyinfos"]
     verbs: ["create"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsnodevmbatchattachments", "cnsnodevmbatchattachments/status", "cnsnodevmattachments/status"]
@@ -534,6 +534,8 @@ spec:
             - name: WORKER_THREADS_NODEVM_BATCH_ATTACH
               value: "20"
             - name: WORKER_THREADS_CLUSTER_STORAGE_POLICY_INFO
+              value: "4"
+            - name: WORKER_THREADS_STORAGE_POLICY_INFO
               value: "4"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"

--- a/pkg/syncer/cnsoperator/controller/add_storagepolicyinfo.go
+++ b/pkg/syncer/cnsoperator/controller/add_storagepolicyinfo.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/storagepolicyinfo"
+)
+
+func init() {
+	AddToManagerFuncs = append(AddToManagerFuncs, storagepolicyinfo.Add)
+}

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -45,8 +45,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
-	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
+	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
@@ -290,27 +290,8 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 	timeout = backOffDuration[request.NamespacedName]
 	backOffDurationMapMutex.Unlock()
 
-	// Fetch or create the StoragePolicyInfo instance. If the CR was just
-	// created here, the creation event will trigger another reconcile automatically,
-	// so we return early and let the next reconcile populate its fields.
-	instance, wasCreated, err := r.ensureSPIExists(ctx, request.Namespace, request.Name)
-	if err != nil {
-		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
-	}
-	if wasCreated {
-		log.Infof("StoragePolicyInfo %q was just created; creation event will trigger next reconcile",
-			request.NamespacedName)
-		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
-	}
-
-	if instance != nil && instance.DeletionTimestamp != nil {
-		log.Infof("StoragePolicyInfo %q is being deleted, skipping reconciliation",
-			request.NamespacedName)
-		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
-	}
-
-	// Fetch the cluster-scoped InfraStoragePolicyInfo (same name as StoragePolicyInfo)
-	// to obtain topology data already computed by the ClusterStoragePolicyInfo controller.
+	// Fetch the cluster-scoped InfraStoragePolicyInfo first so we can set the
+	// owner reference at SPI creation time.
 	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{}
 	if err := r.client.Get(ctx,
 		apitypes.NamespacedName{Name: request.Name}, infraSPI); err != nil {
@@ -326,8 +307,27 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
-	// Ensure SPI holds an owner reference to InfraStoragePolicyInfo so that the SPI
-	// is garbage-collected when the InfraStoragePolicyInfo is deleted.
+	// Fetch or create the StoragePolicyInfo instance, stamping the InfraSPI owner
+	// reference at creation time so the SPI is always GC-eligible.
+	instance, wasCreated, err := r.ensureSPIExists(ctx, request.Namespace, request.Name, infraSPI)
+	if err != nil {
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	}
+	if wasCreated {
+		log.Infof("StoragePolicyInfo %q was just created; creation event will trigger next reconcile",
+			request.NamespacedName)
+		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
+	}
+
+	if instance.DeletionTimestamp != nil {
+		log.Infof("StoragePolicyInfo %q is being deleted, skipping reconciliation",
+			request.NamespacedName)
+		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
+	}
+
+	// Ensure SPI holds an owner reference to InfraStoragePolicyInfo. This is a
+	// no-op for newly created SPIs (owner ref set at creation) but handles SPIs
+	// that pre-date this logic or had the ref removed.
 	if err := r.ensureInfraSPIOwnerReference(ctx, instance, infraSPI); err != nil {
 		log.Errorf("Failed to set owner reference on StoragePolicyInfo %q: %v",
 			request.NamespacedName, err)
@@ -357,9 +357,11 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 }
 
 // ensureSPIExists returns the existing StoragePolicyInfo for the given
-// namespace/name. If absent, it creates the CR and returns wasCreated=true.
+// namespace/name. If absent, it creates the CR with an owner reference to
+// infraSPI so it is GC-eligible, and returns wasCreated=true.
 func (r *ReconcileStoragePolicyInfo) ensureSPIExists(ctx context.Context,
-	namespace, name string) (*spiv1alpha1.StoragePolicyInfo, bool, error) {
+	namespace, name string,
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) (*spiv1alpha1.StoragePolicyInfo, bool, error) {
 	log := logger.GetLogger(ctx)
 
 	instance := &spiv1alpha1.StoragePolicyInfo{}
@@ -372,15 +374,22 @@ func (r *ReconcileStoragePolicyInfo) ensureSPIExists(ctx context.Context,
 		return nil, false, err
 	}
 
-	// Create the StoragePolicyInfo CR.
+	ownerRef, err := generateOwnerReference(r.scheme, infraSPI)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to generate owner reference for InfraStoragePolicyInfo %q: %w",
+			infraSPI.Name, err)
+	}
+
+	// Create the StoragePolicyInfo CR with the owner reference already set.
 	instance = &spiv1alpha1.StoragePolicyInfo{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: apis.SchemeGroupVersion.String(),
 			Kind:       "StoragePolicyInfo",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:            name,
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 	}
 	if err := r.client.Create(ctx, instance); err != nil {
@@ -396,7 +405,8 @@ func (r *ReconcileStoragePolicyInfo) ensureSPIExists(ctx context.Context,
 		// The object already existed, so treat it as not newly created.
 		return instance, false, nil
 	}
-	log.Infof("Created StoragePolicyInfo %s/%s", namespace, name)
+	log.Infof("Created StoragePolicyInfo %s/%s with owner reference to InfraStoragePolicyInfo %q",
+		namespace, name, infraSPI.Name)
 	return instance, true, nil
 }
 

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -157,14 +157,12 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 
 	// Only re-reconcile when InfraStoragePolicyInfo status actually changes.
 	// Generation-based predicates don't work for status-only updates, so we
-	// compare the resource version instead.
+	// gate updates on resource-version changes.
 	infraSPIPredicates := predicate.Funcs{
 		CreateFunc: func(_ event.CreateEvent) bool {
 			return false
 		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
-		},
+		UpdateFunc: predicate.ResourceVersionChangedPredicate{}.Update,
 		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return false
 		},

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -68,16 +68,6 @@ type zonesProvider interface {
 	GetZonesForNamespace(ns string) map[string]struct{}
 }
 
-// backOffDuration is a map of StoragePolicyInfo NamespacedNames to the time after
-// which a request for this instance will be requeued.
-// Initialized to 1 second for new instances and for instances whose latest
-// reconcile operation succeeded.
-// If the reconcile fails, backoff is incremented exponentially.
-var (
-	backOffDuration         map[apitypes.NamespacedName]time.Duration
-	backOffDurationMapMutex = sync.Mutex{}
-)
-
 const (
 	workerThreadsEnvVar     = "WORKER_THREADS_STORAGE_POLICY_INFO"
 	defaultMaxWorkerThreads = 4
@@ -137,6 +127,7 @@ func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 		recorder:                       recorder,
 		zonesProvider:                  zp,
 		workloadDomainIsolationEnabled: workloadDomainIsolationEnabled,
+		backOffDuration:                make(map[apitypes.NamespacedName]time.Duration),
 	}
 }
 
@@ -193,8 +184,6 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 		return err
 	}
 
-	// Initialize the backoff duration map
-	backOffDuration = make(map[apitypes.NamespacedName]time.Duration)
 	return nil
 }
 
@@ -269,6 +258,10 @@ type ReconcileStoragePolicyInfo struct {
 	// namespaceFilteredZones skips the GetZonesForNamespace call entirely,
 	// which avoids a nil-informer panic on non-zonal deployments.
 	workloadDomainIsolationEnabled bool
+	// backOffDuration tracks per-instance requeue delays, incremented
+	// exponentially on failure and reset to 1s on success.
+	backOffDuration         map[apitypes.NamespacedName]time.Duration
+	backOffDurationMapMutex sync.Mutex
 }
 
 // Reconcile creates or updates the StoragePolicyInfo for the given namespace
@@ -282,13 +275,13 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 	log.Infof("Reconciling StoragePolicyInfo")
 
 	// Initialize backOffDuration for the instance, if required.
-	backOffDurationMapMutex.Lock()
+	r.backOffDurationMapMutex.Lock()
 	var timeout time.Duration
-	if _, exists := backOffDuration[request.NamespacedName]; !exists {
-		backOffDuration[request.NamespacedName] = time.Second
+	if _, exists := r.backOffDuration[request.NamespacedName]; !exists {
+		r.backOffDuration[request.NamespacedName] = time.Second
 	}
-	timeout = backOffDuration[request.NamespacedName]
-	backOffDurationMapMutex.Unlock()
+	timeout = r.backOffDuration[request.NamespacedName]
+	r.backOffDurationMapMutex.Unlock()
 
 	// Fetch the cluster-scoped InfraStoragePolicyInfo first so we can set the
 	// owner reference at SPI creation time.
@@ -533,9 +526,9 @@ func (r *ReconcileStoragePolicyInfo) completeReconciliationWithSuccess(ctx conte
 	namespacedName apitypes.NamespacedName) (reconcile.Result, error) {
 	log := logger.GetLogger(ctx).With("name", namespacedName)
 
-	backOffDurationMapMutex.Lock()
-	delete(backOffDuration, namespacedName)
-	backOffDurationMapMutex.Unlock()
+	r.backOffDurationMapMutex.Lock()
+	delete(r.backOffDuration, namespacedName)
+	r.backOffDurationMapMutex.Unlock()
 
 	log.Infof("Successfully reconciled StoragePolicyInfo")
 	return reconcile.Result{}, nil
@@ -547,10 +540,10 @@ func (r *ReconcileStoragePolicyInfo) completeReconciliationWithError(ctx context
 	namespacedName apitypes.NamespacedName, timeout time.Duration, err error) (reconcile.Result, error) {
 	log := logger.GetLogger(ctx).With("name", namespacedName)
 
-	backOffDurationMapMutex.Lock()
-	backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
+	r.backOffDurationMapMutex.Lock()
+	r.backOffDuration[namespacedName] = min(r.backOffDuration[namespacedName]*2,
 		types.MaxBackOffDurationForReconciler)
-	backOffDurationMapMutex.Unlock()
+	r.backOffDurationMapMutex.Unlock()
 
 	log.Errorf("Failed to reconcile StoragePolicyInfo %q. Err: %v", namespacedName, err)
 	return reconcile.Result{RequeueAfter: timeout}, nil

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -32,6 +32,7 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -58,8 +59,12 @@ import (
 
 // zonesProvider is the narrow slice of COCommonInterface that this controller
 // actually needs. Declaring it here lets tests inject a minimal stub instead of
-// implementing the entire ~30-method COCommonInterface.
+// implementing the entire COCommonInterface.
 type zonesProvider interface {
+	// StartZonesInformer starts the dynamic informer watching Zone CRs. It must
+	// be called before GetZonesForNamespace; otherwise GetZonesForNamespace will
+	// dereference a nil informer and panic.
+	StartZonesInformer(ctx context.Context, restClientConfig *restclient.Config, namespace string) error
 	GetZonesForNamespace(ns string) map[string]struct{}
 }
 
@@ -101,6 +106,15 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
+	workloadDomainIsolationEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.WorkloadDomainIsolation)
+	if workloadDomainIsolationEnabled {
+		if err := commonco.ContainerOrchestratorUtility.StartZonesInformer(
+			ctx, nil, metav1.NamespaceAll); err != nil {
+			return logger.LogNewErrorf(log, "failed to start zone informer for StoragePolicyInfo controller. Err: %v", err)
+		}
+	}
+
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(
 		&typedcorev1.EventSinkImpl{
@@ -108,18 +122,21 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		},
 	)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: apis.GroupName})
-	return add(mgr, newReconciler(mgr, configInfo, recorder, commonco.ContainerOrchestratorUtility))
+	return add(mgr, newReconciler(mgr, configInfo, recorder,
+		commonco.ContainerOrchestratorUtility, workloadDomainIsolationEnabled))
 }
 
 func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
-	recorder record.EventRecorder, zp zonesProvider) *ReconcileStoragePolicyInfo {
+	recorder record.EventRecorder, zp zonesProvider,
+	workloadDomainIsolationEnabled bool) *ReconcileStoragePolicyInfo {
 
 	return &ReconcileStoragePolicyInfo{
-		client:        mgr.GetClient(),
-		scheme:        mgr.GetScheme(),
-		configInfo:    configInfo,
-		recorder:      recorder,
-		zonesProvider: zp,
+		client:                         mgr.GetClient(),
+		scheme:                         mgr.GetScheme(),
+		configInfo:                     configInfo,
+		recorder:                       recorder,
+		zonesProvider:                  zp,
+		workloadDomainIsolationEnabled: workloadDomainIsolationEnabled,
 	}
 }
 
@@ -141,6 +158,21 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 		},
 	}
 
+	// Only re-reconcile when InfraStoragePolicyInfo status actually changes.
+	// Generation-based predicates don't work for status-only updates, so we
+	// compare the resource version instead.
+	infraSPIPredicates := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object != nil
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return false
+		},
+	}
+
 	err := ctrl.NewControllerManagedBy(mgr).Named("storagepolicyinfo-controller").
 		For(&spiv1alpha1.StoragePolicyInfo{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
@@ -148,6 +180,11 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 			&storagepolicyv1alpha2.StoragePolicyQuota{},
 			handler.EnqueueRequestsFromMapFunc(r.mapSPQtoSPI),
 			builder.WithPredicates(spqPredicates),
+		).
+		Watches(
+			&infraspiv1alpha1.InfraStoragePolicyInfo{},
+			handler.EnqueueRequestsFromMapFunc(r.mapInfraSPItoSPI),
+			builder.WithPredicates(infraSPIPredicates),
 		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxWorkerThreads}).
 		Complete(r)
@@ -183,6 +220,42 @@ func (r *ReconcileStoragePolicyInfo) mapSPQtoSPI(ctx context.Context,
 	}}}
 }
 
+// mapInfraSPItoSPI maps an InfraStoragePolicyInfo event to reconcile requests
+// for all namespace-scoped StoragePolicyInfo CRs that share the same name.
+// This keeps namespace-scoped topology in sync whenever the cluster-scoped
+// InfraStoragePolicyInfo status changes (e.g., zones added or removed).
+func (r *ReconcileStoragePolicyInfo) mapInfraSPItoSPI(ctx context.Context,
+	obj client.Object) []reconcile.Request {
+	if obj == nil {
+		return nil
+	}
+	log := logger.GetLogger(ctx)
+
+	// List all StoragePolicyInfo instances across all namespaces and filter
+	// to those whose name matches the InfraStoragePolicyInfo name. A field
+	// indexer would be more efficient at scale, but SPI count per cluster is
+	// bounded by (policies × namespaces) which is manageable with a full list.
+	spiList := &spiv1alpha1.StoragePolicyInfoList{}
+	if err := r.client.List(ctx, spiList); err != nil {
+		log.Errorf("Failed to list StoragePolicyInfo for InfraStoragePolicyInfo %q: %v",
+			obj.GetName(), err)
+		return nil
+	}
+
+	reqs := make([]reconcile.Request, 0, len(spiList.Items))
+	for i := range spiList.Items {
+		if spiList.Items[i].Name == obj.GetName() {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: apitypes.NamespacedName{
+					Namespace: spiList.Items[i].Namespace,
+					Name:      spiList.Items[i].Name,
+				},
+			})
+		}
+	}
+	return reqs
+}
+
 var _ reconcile.Reconciler = &ReconcileStoragePolicyInfo{}
 
 // ReconcileStoragePolicyInfo reconciles StoragePolicyInfo objects.
@@ -192,6 +265,10 @@ type ReconcileStoragePolicyInfo struct {
 	configInfo    *config.ConfigurationInfo
 	recorder      record.EventRecorder
 	zonesProvider zonesProvider
+	// workloadDomainIsolationEnabled gates zone-filtering logic. When false,
+	// namespaceFilteredZones skips the GetZonesForNamespace call entirely,
+	// which avoids a nil-informer panic on non-zonal deployments.
+	workloadDomainIsolationEnabled bool
 }
 
 // Reconcile creates or updates the StoragePolicyInfo for the given namespace
@@ -238,6 +315,9 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 	if err := r.client.Get(ctx,
 		apitypes.NamespacedName{Name: request.Name}, infraSPI); err != nil {
 		if apierrors.IsNotFound(err) {
+			// InfraStoragePolicyInfo may not be created yet (controller startup ordering).
+			// The InfraStoragePolicyInfo watch will re-enqueue this reconcile once InfraSPI
+			// is available, so returning success here is safe.
 			log.Infof("InfraStoragePolicyInfo %q not yet available; topology will be synced on next reconcile",
 				request.Name)
 			return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
@@ -382,9 +462,17 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 
 // namespaceFilteredZones returns the subset of clusterZones that are also
 // assigned to the given namespace, by consulting the namespace-scoped Zone CRs.
+// Zone filtering is only performed when WorkloadDomainIsolation is enabled and
+// the zones informer has been started; otherwise all cluster zones are returned.
 func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 	namespace string, clusterZones []string) []string {
 	log := logger.GetLogger(ctx)
+
+	if !r.workloadDomainIsolationEnabled {
+		log.Debugf("WorkloadDomainIsolation disabled; using all %d cluster-accessible zones for namespace %q",
+			len(clusterZones), namespace)
+		return clusterZones
+	}
 
 	nsZones := r.zonesProvider.GetZonesForNamespace(namespace)
 	if len(nsZones) == 0 {

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepolicyinfo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
+	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
+	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
+	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
+)
+
+// backOffDuration is a map of StoragePolicyInfo NamespacedNames to the time after
+// which a request for this instance will be requeued.
+// Initialized to 1 second for new instances and for instances whose latest
+// reconcile operation succeeded.
+// If the reconcile fails, backoff is incremented exponentially.
+var (
+	backOffDuration         map[apitypes.NamespacedName]time.Duration
+	backOffDurationMapMutex = sync.Mutex{}
+)
+
+const (
+	workerThreadsEnvVar     = "WORKER_THREADS_STORAGE_POLICY_INFO"
+	defaultMaxWorkerThreads = 4
+	// storagePolicyQuotaSuffix is the suffix appended to the K8s-compliant storage
+	// policy name to form the corresponding StoragePolicyQuota CR name.
+	storagePolicyQuotaSuffix = "-storagepolicyquota"
+)
+
+// Add registers the StoragePolicyInfo controller with the Manager (WCP / Workload only).
+func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
+	configInfo *config.ConfigurationInfo, _ volumes.Manager) error {
+	ctx, log := logger.GetNewContextWithLogger()
+	if clusterFlavor != cnstypes.CnsClusterFlavorWorkload {
+		log.Debug("Not initializing the StoragePolicyInfo Controller: unsupported cluster flavor")
+		return nil
+	}
+	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupportsExposingStoragePolicyAttributes) {
+		log.Infof("Not initializing the StoragePolicyInfo Controller: capability %q is not activated",
+			common.SupportsExposingStoragePolicyAttributes)
+		return nil
+	}
+
+	k8sclient, err := k8s.NewClient(ctx)
+	if err != nil {
+		log.Errorf("creating Kubernetes client failed. Err: %v", err)
+		return err
+	}
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(
+		&typedcorev1.EventSinkImpl{
+			Interface: k8sclient.CoreV1().Events(""),
+		},
+	)
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: apis.GroupName})
+	return add(mgr, newReconciler(mgr, configInfo, recorder))
+}
+
+func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
+	recorder record.EventRecorder) *ReconcileStoragePolicyInfo {
+
+	return &ReconcileStoragePolicyInfo{
+		client:     mgr.GetClient(),
+		scheme:     mgr.GetScheme(),
+		configInfo: configInfo,
+		recorder:   recorder,
+	}
+}
+
+func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
+	ctx, log := logger.GetNewContextWithLogger()
+	maxWorkerThreads := util.GetMaxWorkerThreads(ctx, workerThreadsEnvVar, defaultMaxWorkerThreads)
+
+	// Only reconcile on StoragePolicyQuota CREATE events. Updates to the quota
+	// spec/status do not affect the StoragePolicyInfo topology data.
+	spqPredicates := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object != nil
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return false
+		},
+	}
+
+	err := ctrl.NewControllerManagedBy(mgr).Named("storagepolicyinfo-controller").
+		For(&spiv1alpha1.StoragePolicyInfo{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&storagepolicyv1alpha2.StoragePolicyQuota{},
+			handler.EnqueueRequestsFromMapFunc(r.mapSPQtoSPI),
+			builder.WithPredicates(spqPredicates),
+		).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxWorkerThreads}).
+		Complete(r)
+	if err != nil {
+		log.Errorf("failed to build storagepolicyinfo controller. Err: %v", err)
+		return err
+	}
+
+	// Initialize the backoff duration map
+	backOffDuration = make(map[apitypes.NamespacedName]time.Duration)
+	return nil
+}
+
+// mapSPQtoSPI maps a StoragePolicyQuota object to the reconcile request for
+// the corresponding StoragePolicyInfo in the same namespace.
+// The StoragePolicyInfo name is derived by stripping the "-storagepolicyquota"
+// suffix from the StoragePolicyQuota name.
+func (r *ReconcileStoragePolicyInfo) mapSPQtoSPI(ctx context.Context,
+	obj client.Object) []reconcile.Request {
+	if obj == nil {
+		return nil
+	}
+	spiName := strings.TrimSuffix(obj.GetName(), storagePolicyQuotaSuffix)
+	if spiName == obj.GetName() {
+		// Name did not end with the expected suffix; not a quota CR we manage.
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: apitypes.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      spiName,
+	}}}
+}
+
+var _ reconcile.Reconciler = &ReconcileStoragePolicyInfo{}
+
+// ReconcileStoragePolicyInfo reconciles StoragePolicyInfo objects.
+type ReconcileStoragePolicyInfo struct {
+	client     client.Client
+	scheme     *runtime.Scheme
+	configInfo *config.ConfigurationInfo
+	recorder   record.EventRecorder
+}
+
+// Reconcile creates or updates the StoragePolicyInfo for the given namespace
+// and storage policy, deriving topology from the corresponding
+// InfraStoragePolicyInfo.
+func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
+	request reconcile.Request) (reconcile.Result, error) {
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx).With("name", request.NamespacedName)
+
+	log.Infof("Reconciling StoragePolicyInfo")
+
+	// Initialize backOffDuration for the instance, if required.
+	backOffDurationMapMutex.Lock()
+	var timeout time.Duration
+	if _, exists := backOffDuration[request.NamespacedName]; !exists {
+		backOffDuration[request.NamespacedName] = time.Second
+	}
+	timeout = backOffDuration[request.NamespacedName]
+	backOffDurationMapMutex.Unlock()
+
+	// Ensure the StoragePolicyInfo instance exists (create if absent).
+	instance, err := r.ensureSPIExists(ctx, request.Namespace, request.Name)
+	if err != nil {
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	}
+
+	if instance.DeletionTimestamp != nil {
+		log.Infof("StoragePolicyInfo %q is being deleted, skipping reconciliation",
+			request.NamespacedName)
+		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
+	}
+
+	// Verify the corresponding StoragePolicyQuota exists for this namespace+policy.
+	spqName := request.Name + storagePolicyQuotaSuffix
+	spq := &storagepolicyv1alpha2.StoragePolicyQuota{}
+	if err := r.client.Get(ctx,
+		apitypes.NamespacedName{Namespace: request.Namespace, Name: spqName}, spq); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Infof("StoragePolicyQuota %s/%s not found; skipping topology sync",
+				request.Namespace, spqName)
+			return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
+		}
+		log.Errorf("Failed to get StoragePolicyQuota %s/%s: %v", request.Namespace, spqName, err)
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	}
+
+	// Fetch the cluster-scoped InfraStoragePolicyInfo (same name as StoragePolicyInfo)
+	// to obtain topology data already computed by the ClusterStoragePolicyInfo controller.
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{}
+	if err := r.client.Get(ctx,
+		apitypes.NamespacedName{Name: request.Name}, infraSPI); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Infof("InfraStoragePolicyInfo %q not yet available; topology will be synced on next reconcile",
+				request.Name)
+			return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
+		}
+		log.Errorf("Failed to get InfraStoragePolicyInfo %q: %v", request.Name, err)
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	}
+
+	// Populate TopologyInfo from InfraStoragePolicyInfo.
+	if err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI); err != nil {
+		log.Errorf("Failed to sync topology for StoragePolicyInfo %q: %v",
+			request.NamespacedName, err)
+		instance.Status.Error = fmt.Sprintf("Failed to sync topology: %v", err)
+		if updateErr := k8s.UpdateStatus(ctx, r.client, instance); updateErr != nil {
+			log.Errorf("Failed to update StoragePolicyInfo %q status: %v",
+				request.NamespacedName, updateErr)
+		}
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	}
+
+	instance.Status.Error = ""
+	if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
+		log.Errorf("Failed to update StoragePolicyInfo %q status: %v",
+			request.NamespacedName, err)
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	}
+
+	log.Infof("Successfully reconciled StoragePolicyInfo %q", request.NamespacedName)
+	return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
+}
+
+// ensureSPIExists returns the existing StoragePolicyInfo for the given
+// namespace/name, creating it first if it does not exist.
+func (r *ReconcileStoragePolicyInfo) ensureSPIExists(ctx context.Context,
+	namespace, name string) (*spiv1alpha1.StoragePolicyInfo, error) {
+	log := logger.GetLogger(ctx)
+
+	instance := &spiv1alpha1.StoragePolicyInfo{}
+	err := r.client.Get(ctx,
+		apitypes.NamespacedName{Namespace: namespace, Name: name}, instance)
+	if err == nil {
+		return instance, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	// Create the StoragePolicyInfo CR.
+	instance = &spiv1alpha1.StoragePolicyInfo{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apis.SchemeGroupVersion.String(),
+			Kind:       "StoragePolicyInfo",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if err := r.client.Create(ctx, instance); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			log.Errorf("Failed to create StoragePolicyInfo %s/%s: %v", namespace, name, err)
+			return nil, err
+		}
+		// Race condition: another reconcile beat us; fetch the existing object.
+		if err := r.client.Get(ctx,
+			apitypes.NamespacedName{Namespace: namespace, Name: name}, instance); err != nil {
+			return nil, err
+		}
+	} else {
+		log.Infof("Created StoragePolicyInfo %s/%s", namespace, name)
+	}
+	return instance, nil
+}
+
+// syncTopologyFromInfraSPI copies topology information from the cluster-scoped
+// InfraStoragePolicyInfo into the namespace-scoped StoragePolicyInfo status,
+// filtering accessible zones down to only those assigned to the namespace.
+
+func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Context,
+	instance *spiv1alpha1.StoragePolicyInfo,
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) error {
+	log := logger.GetLogger(ctx)
+
+	if infraSPI.Status.Topology == nil {
+		log.Debugf("InfraStoragePolicyInfo %q has no topology; clearing StoragePolicyInfo topology",
+			infraSPI.Name)
+		instance.Status.TopologyInfo = nil
+		return nil
+	}
+
+	accessibleZones := r.namespaceFilteredZones(ctx, instance.Namespace,
+		infraSPI.Status.Topology.AccessibleZones)
+
+	instance.Status.TopologyInfo = &spiv1alpha1.Topology{
+		TopologyType:    infraSPI.Status.Topology.TopologyType,
+		AccessibleZones: accessibleZones,
+	}
+	log.Debugf("Synced topology for StoragePolicyInfo %s/%s: type=%q zones=%v",
+		instance.Namespace, instance.Name,
+		instance.Status.TopologyInfo.TopologyType,
+		instance.Status.TopologyInfo.AccessibleZones)
+	return nil
+}
+
+// namespaceFilteredZones returns the subset of clusterZones that are also
+// assigned to the given namespace, by consulting the namespace-scoped Zone CRs.
+func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
+	namespace string, clusterZones []string) []string {
+	log := logger.GetLogger(ctx)
+
+	nsZones := commonco.ContainerOrchestratorUtility.GetZonesForNamespace(namespace)
+	if len(nsZones) == 0 {
+		// Non-zonal deployment or namespace has no zone constraints; expose all
+		// cluster-accessible zones.
+		log.Debugf("Namespace %q has no zone assignments; using all %d cluster-accessible zones",
+			namespace, len(clusterZones))
+		return clusterZones
+	}
+
+	// Intersect cluster-accessible zones with namespace-assigned zones.
+	filtered := make([]string, 0, len(clusterZones))
+	for _, zone := range clusterZones {
+		if _, assigned := nsZones[zone]; assigned {
+			filtered = append(filtered, zone)
+		}
+	}
+	log.Debugf("Namespace %q has zone assignments %v; filtered %d cluster zones → %d namespace-accessible zones",
+		namespace, nsZones, len(clusterZones), len(filtered))
+	return filtered
+}
+
+// completeReconciliationWithSuccess resets the backoff duration for the instance
+// and records a successful reconciliation.
+func (r *ReconcileStoragePolicyInfo) completeReconciliationWithSuccess(ctx context.Context,
+	namespacedName apitypes.NamespacedName) (reconcile.Result, error) {
+	log := logger.GetLogger(ctx).With("name", namespacedName)
+
+	backOffDurationMapMutex.Lock()
+	delete(backOffDuration, namespacedName)
+	backOffDurationMapMutex.Unlock()
+
+	log.Infof("Successfully reconciled StoragePolicyInfo")
+	return reconcile.Result{}, nil
+}
+
+// completeReconciliationWithError updates the backoff duration for the instance
+// and schedules a retry after the backoff timeout.
+func (r *ReconcileStoragePolicyInfo) completeReconciliationWithError(ctx context.Context,
+	namespacedName apitypes.NamespacedName, timeout time.Duration, err error) (reconcile.Result, error) {
+	log := logger.GetLogger(ctx).With("name", namespacedName)
+
+	backOffDurationMapMutex.Lock()
+	backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
+		types.MaxBackOffDurationForReconciler)
+	backOffDurationMapMutex.Unlock()
+
+	log.Errorf("Failed to reconcile StoragePolicyInfo %q. Err: %v", namespacedName, err)
+	return reconcile.Result{RequeueAfter: timeout}, nil
+}

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -74,6 +74,9 @@ const (
 	// storagePolicyQuotaSuffix is the suffix appended to the K8s-compliant storage
 	// policy name to form the corresponding StoragePolicyQuota CR name.
 	storagePolicyQuotaSuffix = "-storagepolicyquota"
+	// spiNameIndexField is the field index key used to look up StoragePolicyInfo
+	// objects by name, enabling efficient cross-namespace lookups in mapInfraSPItoSPI.
+	spiNameIndexField = ".metadata.name"
 )
 
 // Add registers the StoragePolicyInfo controller with the Manager (WCP / Workload only).
@@ -96,13 +99,9 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
-	workloadDomainIsolationEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
-		common.WorkloadDomainIsolation)
-	if workloadDomainIsolationEnabled {
-		if err := commonco.ContainerOrchestratorUtility.StartZonesInformer(
-			ctx, nil, metav1.NamespaceAll); err != nil {
-			return logger.LogNewErrorf(log, "failed to start zone informer for StoragePolicyInfo controller. Err: %v", err)
-		}
+	if err := commonco.ContainerOrchestratorUtility.StartZonesInformer(
+		ctx, nil, metav1.NamespaceAll); err != nil {
+		return logger.LogNewErrorf(log, "failed to start zone informer for StoragePolicyInfo controller. Err: %v", err)
 	}
 
 	eventBroadcaster := record.NewBroadcaster()
@@ -112,28 +111,35 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		},
 	)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: apis.GroupName})
-	return add(mgr, newReconciler(mgr, configInfo, recorder,
-		commonco.ContainerOrchestratorUtility, workloadDomainIsolationEnabled))
+	return add(mgr, newReconciler(mgr, configInfo, recorder, commonco.ContainerOrchestratorUtility))
 }
 
 func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
-	recorder record.EventRecorder, zp zonesProvider,
-	workloadDomainIsolationEnabled bool) *ReconcileStoragePolicyInfo {
+	recorder record.EventRecorder, zp zonesProvider) *ReconcileStoragePolicyInfo {
 
 	return &ReconcileStoragePolicyInfo{
-		client:                         mgr.GetClient(),
-		scheme:                         mgr.GetScheme(),
-		configInfo:                     configInfo,
-		recorder:                       recorder,
-		zonesProvider:                  zp,
-		workloadDomainIsolationEnabled: workloadDomainIsolationEnabled,
-		backOffDuration:                make(map[apitypes.NamespacedName]time.Duration),
+		client:          mgr.GetClient(),
+		scheme:          mgr.GetScheme(),
+		configInfo:      configInfo,
+		recorder:        recorder,
+		zonesProvider:   zp,
+		backOffDuration: make(map[apitypes.NamespacedName]time.Duration),
 	}
 }
 
 func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 	ctx, log := logger.GetNewContextWithLogger()
 	maxWorkerThreads := util.GetMaxWorkerThreads(ctx, workerThreadsEnvVar, defaultMaxWorkerThreads)
+
+	// Index StoragePolicyInfo by name so mapInfraSPItoSPI can list only matching
+	// objects rather than doing a full cross-namespace list.
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &spiv1alpha1.StoragePolicyInfo{},
+		spiNameIndexField, func(obj client.Object) []string {
+			return []string{obj.GetName()}
+		}); err != nil {
+		log.Errorf("failed to add field index for StoragePolicyInfo name: %v", err)
+		return err
+	}
 
 	// Only reconcile on StoragePolicyQuota CREATE events. Updates to the quota
 	// spec/status do not affect the StoragePolicyInfo topology data.
@@ -153,8 +159,8 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 	// Generation-based predicates don't work for status-only updates, so we
 	// compare the resource version instead.
 	infraSPIPredicates := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object != nil
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
@@ -220,12 +226,11 @@ func (r *ReconcileStoragePolicyInfo) mapInfraSPItoSPI(ctx context.Context,
 	}
 	log := logger.GetLogger(ctx)
 
-	// List all StoragePolicyInfo instances across all namespaces and filter
-	// to those whose name matches the InfraStoragePolicyInfo name. A field
-	// indexer would be more efficient at scale, but SPI count per cluster is
-	// bounded by (policies × namespaces) which is manageable with a full list.
+	// Use the name field index to list only StoragePolicyInfo objects whose name
+	// matches the InfraStoragePolicyInfo, avoiding a full cross-namespace scan.
 	spiList := &spiv1alpha1.StoragePolicyInfoList{}
-	if err := r.client.List(ctx, spiList); err != nil {
+	if err := r.client.List(ctx, spiList,
+		client.MatchingFields{spiNameIndexField: obj.GetName()}); err != nil {
 		log.Errorf("Failed to list StoragePolicyInfo for InfraStoragePolicyInfo %q: %v",
 			obj.GetName(), err)
 		return nil
@@ -233,14 +238,12 @@ func (r *ReconcileStoragePolicyInfo) mapInfraSPItoSPI(ctx context.Context,
 
 	reqs := make([]reconcile.Request, 0, len(spiList.Items))
 	for i := range spiList.Items {
-		if spiList.Items[i].Name == obj.GetName() {
-			reqs = append(reqs, reconcile.Request{
-				NamespacedName: apitypes.NamespacedName{
-					Namespace: spiList.Items[i].Namespace,
-					Name:      spiList.Items[i].Name,
-				},
-			})
-		}
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: apitypes.NamespacedName{
+				Namespace: spiList.Items[i].Namespace,
+				Name:      spiList.Items[i].Name,
+			},
+		})
 	}
 	return reqs
 }
@@ -254,10 +257,6 @@ type ReconcileStoragePolicyInfo struct {
 	configInfo    *config.ConfigurationInfo
 	recorder      record.EventRecorder
 	zonesProvider zonesProvider
-	// workloadDomainIsolationEnabled gates zone-filtering logic. When false,
-	// namespaceFilteredZones skips the GetZonesForNamespace call entirely,
-	// which avoids a nil-informer panic on non-zonal deployments.
-	workloadDomainIsolationEnabled bool
 	// backOffDuration tracks per-instance requeue delays, incremented
 	// exponentially on failure and reset to 1s on success.
 	backOffDuration         map[apitypes.NamespacedName]time.Duration
@@ -289,19 +288,17 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 	if err := r.client.Get(ctx,
 		apitypes.NamespacedName{Name: request.Name}, infraSPI); err != nil {
 		if apierrors.IsNotFound(err) {
-			// InfraStoragePolicyInfo may not be created yet (controller startup ordering).
-			// The InfraStoragePolicyInfo watch will re-enqueue this reconcile once InfraSPI
-			// is available, so returning success here is safe.
-			log.Infof("InfraStoragePolicyInfo %q not yet available; topology will be synced on next reconcile",
+			log.Infof("InfraStoragePolicyInfo %q not yet available; will retry",
 				request.Name)
-			return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
+		} else {
+			log.Errorf("Failed to get InfraStoragePolicyInfo %q: %v", request.Name, err)
 		}
-		log.Errorf("Failed to get InfraStoragePolicyInfo %q: %v", request.Name, err)
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
 	// Fetch or create the StoragePolicyInfo instance, stamping the InfraSPI owner
-	// reference at creation time so the SPI is always GC-eligible.
+	// reference at creation time so the SPI is deleted automatically when the
+	// InfraStoragePolicyInfo is deleted.
 	instance, wasCreated, err := r.ensureSPIExists(ctx, request.Namespace, request.Name, infraSPI)
 	if err != nil {
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
@@ -351,7 +348,7 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 
 // ensureSPIExists returns the existing StoragePolicyInfo for the given
 // namespace/name. If absent, it creates the CR with an owner reference to
-// infraSPI so it is GC-eligible, and returns wasCreated=true.
+// infraSPI and returns wasCreated=true.
 func (r *ReconcileStoragePolicyInfo) ensureSPIExists(ctx context.Context,
 	namespace, name string,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) (*spiv1alpha1.StoragePolicyInfo, bool, error) {
@@ -465,17 +462,9 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 
 // namespaceFilteredZones returns the subset of clusterZones that are also
 // assigned to the given namespace, by consulting the namespace-scoped Zone CRs.
-// Zone filtering is only performed when WorkloadDomainIsolation is enabled and
-// the zones informer has been started; otherwise all cluster zones are returned.
 func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 	namespace string, clusterZones []string) []string {
 	log := logger.GetLogger(ctx)
-
-	if !r.workloadDomainIsolationEnabled {
-		log.Debugf("WorkloadDomainIsolation disabled; using all %d cluster-accessible zones for namespace %q",
-			len(clusterZones), namespace)
-		return clusterZones
-	}
 
 	nsZones := r.zonesProvider.GetZonesForNamespace(namespace)
 	if len(nsZones) == 0 {

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -25,6 +25,7 @@ import (
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,6 +55,13 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
+
+// zonesProvider is the narrow slice of COCommonInterface that this controller
+// actually needs. Declaring it here lets tests inject a minimal stub instead of
+// implementing the entire ~30-method COCommonInterface.
+type zonesProvider interface {
+	GetZonesForNamespace(ns string) map[string]struct{}
+}
 
 // backOffDuration is a map of StoragePolicyInfo NamespacedNames to the time after
 // which a request for this instance will be requeued.
@@ -100,17 +108,18 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		},
 	)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: apis.GroupName})
-	return add(mgr, newReconciler(mgr, configInfo, recorder))
+	return add(mgr, newReconciler(mgr, configInfo, recorder, commonco.ContainerOrchestratorUtility))
 }
 
 func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
-	recorder record.EventRecorder) *ReconcileStoragePolicyInfo {
+	recorder record.EventRecorder, zp zonesProvider) *ReconcileStoragePolicyInfo {
 
 	return &ReconcileStoragePolicyInfo{
-		client:     mgr.GetClient(),
-		scheme:     mgr.GetScheme(),
-		configInfo: configInfo,
-		recorder:   recorder,
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		configInfo:    configInfo,
+		recorder:      recorder,
+		zonesProvider: zp,
 	}
 }
 
@@ -162,8 +171,10 @@ func (r *ReconcileStoragePolicyInfo) mapSPQtoSPI(ctx context.Context,
 		return nil
 	}
 	spiName := strings.TrimSuffix(obj.GetName(), storagePolicyQuotaSuffix)
+	// If the name was unchanged, this object does not follow the expected
+	// "<policy>-storagepolicyquota" naming convention; skip it so we don't
+	// accidentally reconcile an unrelated StoragePolicyInfo.
 	if spiName == obj.GetName() {
-		// Name did not end with the expected suffix; not a quota CR we manage.
 		return nil
 	}
 	return []reconcile.Request{{NamespacedName: apitypes.NamespacedName{
@@ -176,10 +187,11 @@ var _ reconcile.Reconciler = &ReconcileStoragePolicyInfo{}
 
 // ReconcileStoragePolicyInfo reconciles StoragePolicyInfo objects.
 type ReconcileStoragePolicyInfo struct {
-	client     client.Client
-	scheme     *runtime.Scheme
-	configInfo *config.ConfigurationInfo
-	recorder   record.EventRecorder
+	client        client.Client
+	scheme        *runtime.Scheme
+	configInfo    *config.ConfigurationInfo
+	recorder      record.EventRecorder
+	zonesProvider zonesProvider
 }
 
 // Reconcile creates or updates the StoragePolicyInfo for the given namespace
@@ -201,30 +213,23 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 	timeout = backOffDuration[request.NamespacedName]
 	backOffDurationMapMutex.Unlock()
 
-	// Ensure the StoragePolicyInfo instance exists (create if absent).
-	instance, err := r.ensureSPIExists(ctx, request.Namespace, request.Name)
+	// Fetch or create the StoragePolicyInfo instance. If the CR was just
+	// created here, the creation event will trigger another reconcile automatically,
+	// so we return early and let the next reconcile populate its fields.
+	instance, wasCreated, err := r.ensureSPIExists(ctx, request.Namespace, request.Name)
 	if err != nil {
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
-
-	if instance.DeletionTimestamp != nil {
-		log.Infof("StoragePolicyInfo %q is being deleted, skipping reconciliation",
+	if wasCreated {
+		log.Infof("StoragePolicyInfo %q was just created; creation event will trigger next reconcile",
 			request.NamespacedName)
 		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
 	}
 
-	// Verify the corresponding StoragePolicyQuota exists for this namespace+policy.
-	spqName := request.Name + storagePolicyQuotaSuffix
-	spq := &storagepolicyv1alpha2.StoragePolicyQuota{}
-	if err := r.client.Get(ctx,
-		apitypes.NamespacedName{Namespace: request.Namespace, Name: spqName}, spq); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Infof("StoragePolicyQuota %s/%s not found; skipping topology sync",
-				request.Namespace, spqName)
-			return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
-		}
-		log.Errorf("Failed to get StoragePolicyQuota %s/%s: %v", request.Namespace, spqName, err)
-		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	if instance != nil && instance.DeletionTimestamp != nil {
+		log.Infof("StoragePolicyInfo %q is being deleted, skipping reconciliation",
+			request.NamespacedName)
+		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName)
 	}
 
 	// Fetch the cluster-scoped InfraStoragePolicyInfo (same name as StoragePolicyInfo)
@@ -241,23 +246,30 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
+	// Ensure SPI holds an owner reference to InfraStoragePolicyInfo so that the SPI
+	// is garbage-collected when the InfraStoragePolicyInfo is deleted.
+	if err := r.ensureInfraSPIOwnerReference(ctx, instance, infraSPI); err != nil {
+		log.Errorf("Failed to set owner reference on StoragePolicyInfo %q: %v",
+			request.NamespacedName, err)
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	}
+
 	// Populate TopologyInfo from InfraStoragePolicyInfo.
 	if err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI); err != nil {
 		log.Errorf("Failed to sync topology for StoragePolicyInfo %q: %v",
 			request.NamespacedName, err)
-		instance.Status.Error = fmt.Sprintf("Failed to sync topology: %v", err)
-		if updateErr := k8s.UpdateStatus(ctx, r.client, instance); updateErr != nil {
+		if setErr := r.setSPIError(ctx, instance,
+			fmt.Sprintf("Failed to sync topology: %v", err)); setErr != nil {
 			log.Errorf("Failed to update StoragePolicyInfo %q status: %v",
-				request.NamespacedName, updateErr)
+				request.NamespacedName, setErr)
 		}
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
-	instance.Status.Error = ""
-	if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
+	if setErr := r.setSPISuccess(ctx, instance, "Successfully synced topology"); setErr != nil {
 		log.Errorf("Failed to update StoragePolicyInfo %q status: %v",
-			request.NamespacedName, err)
-		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+			request.NamespacedName, setErr)
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, setErr)
 	}
 
 	log.Infof("Successfully reconciled StoragePolicyInfo %q", request.NamespacedName)
@@ -265,19 +277,19 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 }
 
 // ensureSPIExists returns the existing StoragePolicyInfo for the given
-// namespace/name, creating it first if it does not exist.
+// namespace/name. If absent, it creates the CR and returns wasCreated=true.
 func (r *ReconcileStoragePolicyInfo) ensureSPIExists(ctx context.Context,
-	namespace, name string) (*spiv1alpha1.StoragePolicyInfo, error) {
+	namespace, name string) (*spiv1alpha1.StoragePolicyInfo, bool, error) {
 	log := logger.GetLogger(ctx)
 
 	instance := &spiv1alpha1.StoragePolicyInfo{}
 	err := r.client.Get(ctx,
 		apitypes.NamespacedName{Namespace: namespace, Name: name}, instance)
 	if err == nil {
-		return instance, nil
+		return instance, false, nil
 	}
 	if !apierrors.IsNotFound(err) {
-		return nil, err
+		return nil, false, err
 	}
 
 	// Create the StoragePolicyInfo CR.
@@ -294,23 +306,54 @@ func (r *ReconcileStoragePolicyInfo) ensureSPIExists(ctx context.Context,
 	if err := r.client.Create(ctx, instance); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			log.Errorf("Failed to create StoragePolicyInfo %s/%s: %v", namespace, name, err)
-			return nil, err
+			return nil, false, err
 		}
 		// Race condition: another reconcile beat us; fetch the existing object.
 		if err := r.client.Get(ctx,
 			apitypes.NamespacedName{Namespace: namespace, Name: name}, instance); err != nil {
-			return nil, err
+			return nil, false, err
 		}
-	} else {
-		log.Infof("Created StoragePolicyInfo %s/%s", namespace, name)
+		// The object already existed, so treat it as not newly created.
+		return instance, false, nil
 	}
-	return instance, nil
+	log.Infof("Created StoragePolicyInfo %s/%s", namespace, name)
+	return instance, true, nil
+}
+
+// ensureInfraSPIOwnerReference sets an owner reference on the StoragePolicyInfo
+// pointing to the given InfraStoragePolicyInfo. This causes the SPI to be
+// garbage-collected when the InfraStoragePolicyInfo is deleted.
+func (r *ReconcileStoragePolicyInfo) ensureInfraSPIOwnerReference(ctx context.Context,
+	instance *spiv1alpha1.StoragePolicyInfo,
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) error {
+	log := logger.GetLogger(ctx)
+
+	ownerRef, err := generateOwnerReference(r.scheme, infraSPI)
+	if err != nil {
+		return fmt.Errorf("failed to generate owner reference for InfraStoragePolicyInfo %q: %w",
+			infraSPI.Name, err)
+	}
+
+	updatedRefs := mergeOwnerReference(instance.OwnerReferences, ownerRef)
+	if equality.Semantic.DeepEqual(instance.OwnerReferences, updatedRefs) {
+		return nil
+	}
+
+	base := instance.DeepCopy()
+	instance.OwnerReferences = updatedRefs
+	if err := r.client.Patch(ctx, instance, client.MergeFrom(base)); err != nil {
+		log.Errorf("Failed to patch StoragePolicyInfo %s/%s owner references: %v",
+			instance.Namespace, instance.Name, err)
+		return err
+	}
+	log.Infof("Set owner reference on StoragePolicyInfo %s/%s → InfraStoragePolicyInfo %q",
+		instance.Namespace, instance.Name, infraSPI.Name)
+	return nil
 }
 
 // syncTopologyFromInfraSPI copies topology information from the cluster-scoped
 // InfraStoragePolicyInfo into the namespace-scoped StoragePolicyInfo status,
 // filtering accessible zones down to only those assigned to the namespace.
-
 func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Context,
 	instance *spiv1alpha1.StoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) error {
@@ -343,7 +386,7 @@ func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 	namespace string, clusterZones []string) []string {
 	log := logger.GetLogger(ctx)
 
-	nsZones := commonco.ContainerOrchestratorUtility.GetZonesForNamespace(namespace)
+	nsZones := r.zonesProvider.GetZonesForNamespace(namespace)
 	if len(nsZones) == 0 {
 		// Non-zonal deployment or namespace has no zone constraints; expose all
 		// cluster-accessible zones.
@@ -362,6 +405,28 @@ func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 	log.Debugf("Namespace %q has zone assignments %v; filtered %d cluster zones → %d namespace-accessible zones",
 		namespace, nsZones, len(clusterZones), len(filtered))
 	return filtered
+}
+
+// setSPIError sets the error status and records a Warning event on the instance.
+func (r *ReconcileStoragePolicyInfo) setSPIError(ctx context.Context,
+	instance *spiv1alpha1.StoragePolicyInfo, errMsg string) error {
+	instance.Status.Error = errMsg
+	if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
+		return err
+	}
+	r.recorder.Event(instance, v1.EventTypeWarning, "StoragePolicyInfoFailed", errMsg)
+	return nil
+}
+
+// setSPISuccess clears the error status and records a Normal event on the instance.
+func (r *ReconcileStoragePolicyInfo) setSPISuccess(ctx context.Context,
+	instance *spiv1alpha1.StoragePolicyInfo, msg string) error {
+	instance.Status.Error = ""
+	if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
+		return err
+	}
+	r.recorder.Event(instance, v1.EventTypeNormal, "StoragePolicyInfoSynced", msg)
+	return nil
 }
 
 // completeReconciliationWithSuccess resets the backoff duration for the instance

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -34,8 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
-	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
+	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
@@ -485,7 +485,6 @@ func TestNamespaceFilteredZones(t *testing.T) {
 func TestReconcile_CreatesWithOwnerRef(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
@@ -500,10 +499,11 @@ func TestReconcile_CreatesWithOwnerRef(t *testing.T) {
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
 		WithObjects(infraSPI).Build()
 	r := &ReconcileStoragePolicyInfo{
-		client:        cli,
-		scheme:        scheme,
-		recorder:      record.NewFakeRecorder(10),
-		zonesProvider: &mockZonesProvider{},
+		client:          cli,
+		scheme:          scheme,
+		recorder:        record.NewFakeRecorder(10),
+		zonesProvider:   &mockZonesProvider{},
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
@@ -524,7 +524,6 @@ func TestReconcile_CreatesWithOwnerRef(t *testing.T) {
 func TestReconcile_SkipsDeletion(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 	now := metav1.Now()
 	spi := &spiv1alpha1.StoragePolicyInfo{
@@ -537,10 +536,11 @@ func TestReconcile_SkipsDeletion(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
 	r := &ReconcileStoragePolicyInfo{
-		client:        cli,
-		scheme:        scheme,
-		recorder:      record.NewFakeRecorder(10),
-		zonesProvider: &mockZonesProvider{},
+		client:          cli,
+		scheme:          scheme,
+		recorder:        record.NewFakeRecorder(10),
+		zonesProvider:   &mockZonesProvider{},
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
@@ -555,7 +555,6 @@ func TestReconcile_SkipsDeletion(t *testing.T) {
 func TestReconcile_SyncsTopologyAndRecordsEvent(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 	spi := &spiv1alpha1.StoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
@@ -574,10 +573,11 @@ func TestReconcile_SyncsTopologyAndRecordsEvent(t *testing.T) {
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
 		WithObjects(spi, infraSPI).Build()
 	r := &ReconcileStoragePolicyInfo{
-		client:        cli,
-		scheme:        scheme,
-		recorder:      recorder,
-		zonesProvider: &mockZonesProvider{},
+		client:          cli,
+		scheme:          scheme,
+		recorder:        recorder,
+		zonesProvider:   &mockZonesProvider{},
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
@@ -602,7 +602,6 @@ func TestReconcile_SyncsTopologyAndRecordsEvent(t *testing.T) {
 func TestReconcile_InfraSPINotFound(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 	spi := &spiv1alpha1.StoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
@@ -610,10 +609,11 @@ func TestReconcile_InfraSPINotFound(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
 	r := &ReconcileStoragePolicyInfo{
-		client:        cli,
-		scheme:        scheme,
-		recorder:      record.NewFakeRecorder(10),
-		zonesProvider: &mockZonesProvider{},
+		client:          cli,
+		scheme:          scheme,
+		recorder:        record.NewFakeRecorder(10),
+		zonesProvider:   &mockZonesProvider{},
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
@@ -700,22 +700,21 @@ func TestCompleteReconciliationWithSuccess(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
 	r := &ReconcileStoragePolicyInfo{
-		client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
-		scheme:   scheme,
-		recorder: record.NewFakeRecorder(10),
+		client:          fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:          scheme,
+		recorder:        record.NewFakeRecorder(10),
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
 	}
 	nn := types.NamespacedName{Namespace: "ns1", Name: "gold"}
-
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
-	backOffDuration[nn] = 5 * time.Second
+	r.backOffDuration[nn] = 5 * time.Second
 
 	result, err := r.completeReconciliationWithSuccess(ctx, nn)
 	require.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, result)
 
-	backOffDurationMapMutex.Lock()
-	_, exists := backOffDuration[nn]
-	backOffDurationMapMutex.Unlock()
+	r.backOffDurationMapMutex.Lock()
+	_, exists := r.backOffDuration[nn]
+	r.backOffDurationMapMutex.Unlock()
 	assert.False(t, exists, "expected backoff entry to be deleted on success")
 }
 
@@ -725,22 +724,21 @@ func TestCompleteReconciliationWithError(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
 	r := &ReconcileStoragePolicyInfo{
-		client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
-		scheme:   scheme,
-		recorder: record.NewFakeRecorder(10),
+		client:          fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:          scheme,
+		recorder:        record.NewFakeRecorder(10),
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
 	}
 	nn := types.NamespacedName{Namespace: "ns1", Name: "gold"}
-
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
-	backOffDuration[nn] = time.Second
+	r.backOffDuration[nn] = time.Second
 
 	result, err := r.completeReconciliationWithError(ctx, nn, time.Second, assert.AnError)
 	require.NoError(t, err)
 	assert.Equal(t, reconcile.Result{RequeueAfter: time.Second}, result)
 
-	backOffDurationMapMutex.Lock()
-	got := backOffDuration[nn]
-	backOffDurationMapMutex.Unlock()
+	r.backOffDurationMapMutex.Lock()
+	got := r.backOffDuration[nn]
+	r.backOffDurationMapMutex.Unlock()
 	assert.Equal(t, 2*time.Second, got, "expected backoff to be doubled on error")
 }
 
@@ -750,7 +748,6 @@ func TestCompleteReconciliationWithError(t *testing.T) {
 func TestReconcile_WDIEnabled_ZoneFilteringApplied(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 	spi := &spiv1alpha1.StoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
@@ -778,6 +775,7 @@ func TestReconcile_WDIEnabled_ZoneFilteringApplied(t *testing.T) {
 		recorder:                       recorder,
 		zonesProvider:                  &mockZonesProvider{zonesForNamespace: nsZones},
 		workloadDomainIsolationEnabled: true,
+		backOffDuration:                make(map[types.NamespacedName]time.Duration),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
@@ -800,7 +798,6 @@ func TestReconcile_WDIEnabled_ZoneFilteringApplied(t *testing.T) {
 func TestReconcile_WDIEnabled_NoNamespaceZonesReturnsAll(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 	spi := &spiv1alpha1.StoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
@@ -824,6 +821,7 @@ func TestReconcile_WDIEnabled_NoNamespaceZonesReturnsAll(t *testing.T) {
 		// zonesForNamespace is nil → GetZonesForNamespace returns nil for ns1.
 		zonesProvider:                  &mockZonesProvider{},
 		workloadDomainIsolationEnabled: true,
+		backOffDuration:                make(map[types.NamespacedName]time.Duration),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
@@ -844,7 +842,6 @@ func TestReconcile_WDIEnabled_NoNamespaceZonesReturnsAll(t *testing.T) {
 func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
 	spi := &spiv1alpha1.StoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
@@ -870,10 +867,11 @@ func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
 		WithObjects(spi, infraSPI).Build()
 	r := &ReconcileStoragePolicyInfo{
-		client:        cli,
-		scheme:        scheme,
-		recorder:      recorder,
-		zonesProvider: &mockZonesProvider{},
+		client:          cli,
+		scheme:          scheme,
+		recorder:        recorder,
+		zonesProvider:   &mockZonesProvider{},
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
@@ -133,6 +134,19 @@ func TestMapInfraSPItoSPI_NilObject(t *testing.T) {
 	assert.Nil(t, reqs)
 }
 
+// spiNameIndexer returns a fake client builder with the spiNameIndexField index
+// registered, mirroring what add() does against the real manager.
+func spiNameIndexer(t *testing.T, scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithIndex(&spiv1alpha1.StoragePolicyInfo{}, spiNameIndexField, func(obj client.Object) []string {
+			return []string{obj.GetName()}
+		}).
+		Build()
+}
+
 // TestMapInfraSPItoSPI_EnqueuesMatchingNamespaces verifies that mapInfraSPItoSPI
 // returns one reconcile request per namespace-scoped StoragePolicyInfo whose name
 // matches the InfraStoragePolicyInfo name.
@@ -151,7 +165,7 @@ func TestMapInfraSPItoSPI_EnqueuesMatchingNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "silver", Namespace: "ns1"},
 	}
 
-	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spi1, spi2, spiOther).Build()
+	cli := spiNameIndexer(t, scheme, spi1, spi2, spiOther)
 	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
 
 	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
@@ -164,7 +178,7 @@ func TestMapInfraSPItoSPI_EnqueuesMatchingNamespaces(t *testing.T) {
 }
 
 // TestMapInfraSPItoSPI_NoMatchingStoragePolicyInfos verifies that mapInfraSPItoSPI
-// returns an empty (non-nil) slice when no StoragePolicyInfo shares the name.
+// returns an empty slice when no StoragePolicyInfo shares the name.
 func TestMapInfraSPItoSPI_NoMatchingStoragePolicyInfos(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
@@ -173,7 +187,7 @@ func TestMapInfraSPItoSPI_NoMatchingStoragePolicyInfos(t *testing.T) {
 	spiOther := &spiv1alpha1.StoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "silver", Namespace: "ns1"},
 	}
-	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spiOther).Build()
+	cli := spiNameIndexer(t, scheme, spiOther)
 	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
 
 	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
@@ -463,10 +477,9 @@ func TestNamespaceFilteredZones(t *testing.T) {
 				zonesMap = map[string]map[string]struct{}{"ns1": tt.nsZones}
 			}
 			r := &ReconcileStoragePolicyInfo{
-				client:                         fake.NewClientBuilder().WithScheme(scheme).Build(),
-				scheme:                         scheme,
-				zonesProvider:                  &mockZonesProvider{zonesForNamespace: zonesMap},
-				workloadDomainIsolationEnabled: true,
+				client:        fake.NewClientBuilder().WithScheme(scheme).Build(),
+				scheme:        scheme,
+				zonesProvider: &mockZonesProvider{zonesForNamespace: zonesMap},
 			}
 
 			got := r.namespaceFilteredZones(ctx, "ns1", tt.clusterZones)
@@ -481,7 +494,8 @@ func TestNamespaceFilteredZones(t *testing.T) {
 
 // TestReconcile_CreatesWithOwnerRef verifies that when a StoragePolicyInfo does
 // not yet exist, Reconcile creates it with an owner reference to InfraStoragePolicyInfo
-// baked in at creation time, so the SPI is GC-eligible from birth.
+// baked in at creation time so it is deleted automatically when InfraStoragePolicyInfo
+// is deleted.
 func TestReconcile_CreatesWithOwnerRef(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
@@ -533,8 +547,11 @@ func TestReconcile_SkipsDeletion(t *testing.T) {
 			Finalizers:        []string{"test"},
 		},
 	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+	}
 	cli := fake.NewClientBuilder().WithScheme(scheme).
-		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi, infraSPI).Build()
 	r := &ReconcileStoragePolicyInfo{
 		client:          cli,
 		scheme:          scheme,
@@ -596,9 +613,8 @@ func TestReconcile_SyncsTopologyAndRecordsEvent(t *testing.T) {
 }
 
 // TestReconcile_InfraSPINotFound verifies that when InfraStoragePolicyInfo does
-// not yet exist, Reconcile returns success without a requeue. The InfraStoragePolicyInfo
-// watch will re-enqueue this reconcile once InfraSPI is created, so an explicit
-// requeue is unnecessary.
+// not yet exist, Reconcile returns a requeue-after result so the reconcile is
+// retried with backoff.
 func TestReconcile_InfraSPINotFound(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
@@ -620,8 +636,8 @@ func TestReconcile_InfraSPINotFound(t *testing.T) {
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, reconcile.Result{}, result,
-		"expected success with no requeue when InfraStoragePolicyInfo is not yet available")
+	assert.Greater(t, result.RequeueAfter, time.Duration(0),
+		"expected requeue-after when InfraStoragePolicyInfo is not yet available")
 }
 
 // TestSetSPISuccess verifies that setSPISuccess clears the error field and
@@ -742,10 +758,10 @@ func TestCompleteReconciliationWithError(t *testing.T) {
 	assert.Equal(t, 2*time.Second, got, "expected backoff to be doubled on error")
 }
 
-// TestReconcile_WDIEnabled_ZoneFilteringApplied verifies that when
-// the namespace is assigned to a subset of zones, only those
-// zones appear in the StoragePolicyInfo topology.
-func TestReconcile_WDIEnabled_ZoneFilteringApplied(t *testing.T) {
+// TestReconcile_ZoneFilteringApplied verifies that when the namespace is
+// assigned to a subset of zones, only those zones appear in the
+// StoragePolicyInfo topology.
+func TestReconcile_ZoneFilteringApplied(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
 
@@ -770,12 +786,11 @@ func TestReconcile_WDIEnabled_ZoneFilteringApplied(t *testing.T) {
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
 		WithObjects(spi, infraSPI).Build()
 	r := &ReconcileStoragePolicyInfo{
-		client:                         cli,
-		scheme:                         scheme,
-		recorder:                       recorder,
-		zonesProvider:                  &mockZonesProvider{zonesForNamespace: nsZones},
-		workloadDomainIsolationEnabled: true,
-		backOffDuration:                make(map[types.NamespacedName]time.Duration),
+		client:          cli,
+		scheme:          scheme,
+		recorder:        recorder,
+		zonesProvider:   &mockZonesProvider{zonesForNamespace: nsZones},
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
@@ -792,10 +807,10 @@ func TestReconcile_WDIEnabled_ZoneFilteringApplied(t *testing.T) {
 		"az2 should be filtered out because ns1 is not assigned to it")
 }
 
-// TestReconcile_WDIEnabled_NoNamespaceZonesReturnsAll verifies that when WDI is
-// enabled but the namespace has no zone assignments (non-zonal namespace or
-// unconstrained namespace), all cluster-accessible zones are exposed.
-func TestReconcile_WDIEnabled_NoNamespaceZonesReturnsAll(t *testing.T) {
+// TestReconcile_NoNamespaceZonesReturnsAll verifies that when a namespace has
+// no zone assignments (non-zonal or unconstrained namespace), all
+// cluster-accessible zones are exposed.
+func TestReconcile_NoNamespaceZonesReturnsAll(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
 
@@ -815,13 +830,11 @@ func TestReconcile_WDIEnabled_NoNamespaceZonesReturnsAll(t *testing.T) {
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
 		WithObjects(spi, infraSPI).Build()
 	r := &ReconcileStoragePolicyInfo{
-		client:   cli,
-		scheme:   scheme,
-		recorder: record.NewFakeRecorder(10),
-		// zonesForNamespace is nil → GetZonesForNamespace returns nil for ns1.
-		zonesProvider:                  &mockZonesProvider{},
-		workloadDomainIsolationEnabled: true,
-		backOffDuration:                make(map[types.NamespacedName]time.Duration),
+		client:          cli,
+		scheme:          scheme,
+		recorder:        record.NewFakeRecorder(10),
+		zonesProvider:   &mockZonesProvider{},
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -261,17 +261,20 @@ func TestGenerateOwnerReference_UnknownType(t *testing.T) {
 }
 
 // TestEnsureSPIExists_AlreadyExists verifies that ensureSPIExists returns the
-// existing instance (wasCreated=false) when the CR is already present.
+// existing instance when the CR is already present.
 func TestEnsureSPIExists_AlreadyExists(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
 	existing := &spiv1alpha1.StoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "test-ns"},
 	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+	}
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
 	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
 
-	inst, wasCreated, err := r.ensureSPIExists(ctx, "test-ns", "gold")
+	inst, wasCreated, err := r.ensureSPIExists(ctx, "test-ns", "gold", infraSPI)
 	require.NoError(t, err)
 	assert.False(t, wasCreated)
 	require.NotNil(t, inst)
@@ -279,23 +282,29 @@ func TestEnsureSPIExists_AlreadyExists(t *testing.T) {
 }
 
 // TestEnsureSPIExists_NotFound verifies that ensureSPIExists creates and persists
-// a new StoragePolicyInfo (wasCreated=true) when the CR does not exist.
+// a new StoragePolicyInfo with an owner reference to InfraStoragePolicyInfo.
 func TestEnsureSPIExists_NotFound(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+	}
 	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
 
-	inst, wasCreated, err := r.ensureSPIExists(ctx, "test-ns", "gold")
+	inst, wasCreated, err := r.ensureSPIExists(ctx, "test-ns", "gold", infraSPI)
 	require.NoError(t, err)
 	assert.True(t, wasCreated)
 	require.NotNil(t, inst)
 	assert.Equal(t, "gold", inst.Name)
 	assert.Equal(t, "test-ns", inst.Namespace)
 
-	// Verify the CR is persisted in the fake client.
+	// Verify the CR is persisted with the owner reference already set.
 	got := &spiv1alpha1.StoragePolicyInfo{}
 	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "test-ns", Name: "gold"}, got))
+	require.Len(t, got.OwnerReferences, 1)
+	assert.Equal(t, "InfraStoragePolicyInfo", got.OwnerReferences[0].Kind)
+	assert.Equal(t, types.UID("gold-uid"), got.OwnerReferences[0].UID)
 }
 
 // TestEnsureInfraSPIOwnerReference_SetWhenAbsent verifies that the owner reference
@@ -470,16 +479,26 @@ func TestNamespaceFilteredZones(t *testing.T) {
 	}
 }
 
-// TestReconcile_CreatesAndReturnsEarly verifies that when a StoragePolicyInfo does
-// not yet exist Reconcile creates it, returns early, and lets the creation event
-// drive the next reconcile.
-func TestReconcile_CreatesAndReturnsEarly(t *testing.T) {
+// TestReconcile_CreatesWithOwnerRef verifies that when a StoragePolicyInfo does
+// not yet exist, Reconcile creates it with an owner reference to InfraStoragePolicyInfo
+// baked in at creation time, so the SPI is GC-eligible from birth.
+func TestReconcile_CreatesWithOwnerRef(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
 	backOffDuration = make(map[types.NamespacedName]time.Duration)
 
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"az1"},
+			},
+		},
+	}
 	cli := fake.NewClientBuilder().WithScheme(scheme).
-		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).Build()
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
+		WithObjects(infraSPI).Build()
 	r := &ReconcileStoragePolicyInfo{
 		client:        cli,
 		scheme:        scheme,
@@ -495,6 +514,9 @@ func TestReconcile_CreatesAndReturnsEarly(t *testing.T) {
 
 	got := &spiv1alpha1.StoragePolicyInfo{}
 	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "gold"}, got))
+	require.Len(t, got.OwnerReferences, 1)
+	assert.Equal(t, "InfraStoragePolicyInfo", got.OwnerReferences[0].Kind)
+	assert.Equal(t, types.UID("gold-uid"), got.OwnerReferences[0].UID)
 }
 
 // TestReconcile_SkipsDeletion verifies that Reconcile exits immediately when

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -52,6 +53,10 @@ func testScheme(t *testing.T) *runtime.Scheme {
 // to control which zones are returned per namespace.
 type mockZonesProvider struct {
 	zonesForNamespace map[string]map[string]struct{}
+}
+
+func (m *mockZonesProvider) StartZonesInformer(_ context.Context, _ *restclient.Config, _ string) error {
+	return nil
 }
 
 func (m *mockZonesProvider) GetZonesForNamespace(ns string) map[string]struct{} {
@@ -114,6 +119,68 @@ func TestMapSPQtoSPI_NoSuffix(t *testing.T) {
 	}
 	reqs := r.mapSPQtoSPI(ctx, spq)
 	assert.Nil(t, reqs)
+}
+
+// TestMapInfraSPItoSPI_NilObject verifies that mapInfraSPItoSPI returns nil for nil input.
+func TestMapInfraSPItoSPI_NilObject(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme: scheme,
+	}
+	reqs := r.mapInfraSPItoSPI(ctx, nil)
+	assert.Nil(t, reqs)
+}
+
+// TestMapInfraSPItoSPI_EnqueuesMatchingNamespaces verifies that mapInfraSPItoSPI
+// returns one reconcile request per namespace-scoped StoragePolicyInfo whose name
+// matches the InfraStoragePolicyInfo name.
+func TestMapInfraSPItoSPI_EnqueuesMatchingNamespaces(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	spi1 := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	spi2 := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns2"},
+	}
+	// A StoragePolicyInfo with a different name should not be enqueued.
+	spiOther := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "silver", Namespace: "ns1"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spi1, spi2, spiOther).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
+	}
+	reqs := r.mapInfraSPItoSPI(ctx, infraSPI)
+	require.Len(t, reqs, 2)
+	names := []string{reqs[0].Namespace + "/" + reqs[0].Name, reqs[1].Namespace + "/" + reqs[1].Name}
+	assert.ElementsMatch(t, []string{"ns1/gold", "ns2/gold"}, names)
+}
+
+// TestMapInfraSPItoSPI_NoMatchingStoragePolicyInfos verifies that mapInfraSPItoSPI
+// returns an empty (non-nil) slice when no StoragePolicyInfo shares the name.
+func TestMapInfraSPItoSPI_NoMatchingStoragePolicyInfos(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	// Only a "silver" SPI exists; trigger is for "gold".
+	spiOther := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "silver", Namespace: "ns1"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spiOther).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
+	}
+	reqs := r.mapInfraSPItoSPI(ctx, infraSPI)
+	assert.Empty(t, reqs)
 }
 
 // TestMergeOwnerReference exercises the four cases of the mergeOwnerReference helper.
@@ -387,9 +454,10 @@ func TestNamespaceFilteredZones(t *testing.T) {
 				zonesMap = map[string]map[string]struct{}{"ns1": tt.nsZones}
 			}
 			r := &ReconcileStoragePolicyInfo{
-				client:        fake.NewClientBuilder().WithScheme(scheme).Build(),
-				scheme:        scheme,
-				zonesProvider: &mockZonesProvider{zonesForNamespace: zonesMap},
+				client:                         fake.NewClientBuilder().WithScheme(scheme).Build(),
+				scheme:                         scheme,
+				zonesProvider:                  &mockZonesProvider{zonesForNamespace: zonesMap},
+				workloadDomainIsolationEnabled: true,
 			}
 
 			got := r.namespaceFilteredZones(ctx, "ns1", tt.clusterZones)
@@ -506,8 +574,9 @@ func TestReconcile_SyncsTopologyAndRecordsEvent(t *testing.T) {
 }
 
 // TestReconcile_InfraSPINotFound verifies that when InfraStoragePolicyInfo does
-// not yet exist, Reconcile returns success (the event-driven next reconcile will
-// populate topology once InfraStoragePolicyInfo is available).
+// not yet exist, Reconcile returns success without a requeue. The InfraStoragePolicyInfo
+// watch will re-enqueue this reconcile once InfraSPI is created, so an explicit
+// requeue is unnecessary.
 func TestReconcile_InfraSPINotFound(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
@@ -529,7 +598,8 @@ func TestReconcile_InfraSPINotFound(t *testing.T) {
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, reconcile.Result{}, result)
+	assert.Equal(t, reconcile.Result{}, result,
+		"expected success with no requeue when InfraStoragePolicyInfo is not yet available")
 }
 
 // TestSetSPISuccess verifies that setSPISuccess clears the error field and
@@ -650,4 +720,158 @@ func TestCompleteReconciliationWithError(t *testing.T) {
 	got := backOffDuration[nn]
 	backOffDurationMapMutex.Unlock()
 	assert.Equal(t, 2*time.Second, got, "expected backoff to be doubled on error")
+}
+
+// TestReconcile_WDIEnabled_ZoneFilteringApplied verifies that when
+// the namespace is assigned to a subset of zones, only those
+// zones appear in the StoragePolicyInfo topology.
+func TestReconcile_WDIEnabled_ZoneFilteringApplied(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"az1", "az2", "az3"},
+			},
+		},
+	}
+	// Namespace "ns1" is only assigned to az1 and az3; az2 should be filtered out.
+	nsZones := map[string]map[string]struct{}{
+		"ns1": {"az1": {}, "az3": {}},
+	}
+	recorder := record.NewFakeRecorder(10)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
+		WithObjects(spi, infraSPI).Build()
+	r := &ReconcileStoragePolicyInfo{
+		client:                         cli,
+		scheme:                         scheme,
+		recorder:                       recorder,
+		zonesProvider:                  &mockZonesProvider{zonesForNamespace: nsZones},
+		workloadDomainIsolationEnabled: true,
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	got := &spiv1alpha1.StoragePolicyInfo{}
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "gold"}, got))
+	require.NotNil(t, got.Status.TopologyInfo)
+	assert.Equal(t, "zonal", got.Status.TopologyInfo.TopologyType)
+	assert.ElementsMatch(t, []string{"az1", "az3"}, got.Status.TopologyInfo.AccessibleZones,
+		"az2 should be filtered out because ns1 is not assigned to it")
+}
+
+// TestReconcile_WDIEnabled_NoNamespaceZonesReturnsAll verifies that when WDI is
+// enabled but the namespace has no zone assignments (non-zonal namespace or
+// unconstrained namespace), all cluster-accessible zones are exposed.
+func TestReconcile_WDIEnabled_NoNamespaceZonesReturnsAll(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"az1", "az2"},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
+		WithObjects(spi, infraSPI).Build()
+	r := &ReconcileStoragePolicyInfo{
+		client:   cli,
+		scheme:   scheme,
+		recorder: record.NewFakeRecorder(10),
+		// zonesForNamespace is nil → GetZonesForNamespace returns nil for ns1.
+		zonesProvider:                  &mockZonesProvider{},
+		workloadDomainIsolationEnabled: true,
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	got := &spiv1alpha1.StoragePolicyInfo{}
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "gold"}, got))
+	require.NotNil(t, got.Status.TopologyInfo)
+	assert.ElementsMatch(t, []string{"az1", "az2"}, got.Status.TopologyInfo.AccessibleZones,
+		"all cluster zones should be exposed when namespace has no zone constraints")
+}
+
+// TestReconcile_InfraSPITopologyUpdated verifies the scenario where an InfraStoragePolicyInfo
+// status update changes the accessible zones, the next reconcile correctly reflects the updated topology
+func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+		Status: spiv1alpha1.StoragePolicyInfoStatus{
+			TopologyInfo: &spiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"az1"}, // stale — az2 was added to InfraSPI
+			},
+		},
+	}
+	// Simulate InfraStoragePolicyInfo having been updated to include az2.
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"az1", "az2"},
+			},
+		},
+	}
+	recorder := record.NewFakeRecorder(10)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
+		WithObjects(spi, infraSPI).Build()
+	r := &ReconcileStoragePolicyInfo{
+		client:        cli,
+		scheme:        scheme,
+		recorder:      recorder,
+		zonesProvider: &mockZonesProvider{},
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	got := &spiv1alpha1.StoragePolicyInfo{}
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "gold"}, got))
+	require.NotNil(t, got.Status.TopologyInfo)
+	assert.ElementsMatch(t, []string{"az1", "az2"}, got.Status.TopologyInfo.AccessibleZones,
+		"topology should be updated to include az2 after InfraStoragePolicyInfo status update")
+
+	// A Normal sync event must be recorded to confirm the reconcile ran to completion.
+	select {
+	case ev := <-recorder.Events:
+		assert.Contains(t, ev, "Normal")
+		assert.Contains(t, ev, "StoragePolicyInfoSynced")
+	default:
+		t.Error("expected a Normal StoragePolicyInfoSynced event after topology update")
+	}
 }

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -1,0 +1,653 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepolicyinfo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
+	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
+	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, apis.SchemeBuilder.AddToScheme(s))
+	require.NoError(t, storagev1.AddToScheme(s))
+	return s
+}
+
+// mockZonesProvider is a minimal test double for the zonesProvider interface.
+// Only GetZonesForNamespace carries real behaviour; tests set zonesForNamespace
+// to control which zones are returned per namespace.
+type mockZonesProvider struct {
+	zonesForNamespace map[string]map[string]struct{}
+}
+
+func (m *mockZonesProvider) GetZonesForNamespace(ns string) map[string]struct{} {
+	if m.zonesForNamespace != nil {
+		return m.zonesForNamespace[ns]
+	}
+	return nil
+}
+
+var _ zonesProvider = &mockZonesProvider{}
+
+// TestMapSPQtoSPI_NilObject verifies that mapSPQtoSPI returns nil for a nil input.
+func TestMapSPQtoSPI_NilObject(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme: scheme,
+	}
+	reqs := r.mapSPQtoSPI(ctx, nil)
+	assert.Nil(t, reqs)
+}
+
+// TestMapSPQtoSPI_CorrectSuffix verifies that an SPQ with the expected suffix maps to
+// the right SPI reconcile request.
+func TestMapSPQtoSPI_CorrectSuffix(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme: scheme,
+	}
+	spq := &storagepolicyv1alpha2.StoragePolicyQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gold-policy-storagepolicyquota",
+			Namespace: "test-ns",
+		},
+	}
+	reqs := r.mapSPQtoSPI(ctx, spq)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "gold-policy"},
+	}, reqs[0])
+}
+
+// TestMapSPQtoSPI_NoSuffix verifies that an object whose name does not end with the
+// expected suffix is silently ignored.
+func TestMapSPQtoSPI_NoSuffix(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme: scheme,
+	}
+	spq := &storagepolicyv1alpha2.StoragePolicyQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-other-object",
+			Namespace: "test-ns",
+		},
+	}
+	reqs := r.mapSPQtoSPI(ctx, spq)
+	assert.Nil(t, reqs)
+}
+
+// TestMergeOwnerReference exercises the four cases of the mergeOwnerReference helper.
+func TestMergeOwnerReference(t *testing.T) {
+	controllerFalse := false
+	blockFalse := false
+	base := metav1.OwnerReference{
+		APIVersion: "cns.vmware.com/v1alpha1", Kind: "InfraStoragePolicyInfo", Name: "gold",
+		UID:        types.UID("aaaa"),
+		Controller: &controllerFalse, BlockOwnerDeletion: &blockFalse,
+	}
+	other := metav1.OwnerReference{
+		APIVersion: "cns.vmware.com/v1alpha1", Kind: "InfraStoragePolicyInfo", Name: "silver",
+		UID:        types.UID("bbbb"),
+		Controller: &controllerFalse, BlockOwnerDeletion: &blockFalse,
+	}
+	sameKeyNewUID := metav1.OwnerReference{
+		APIVersion: base.APIVersion, Kind: base.Kind, Name: base.Name,
+		UID:        types.UID("cccc"),
+		Controller: &controllerFalse, BlockOwnerDeletion: &blockFalse,
+	}
+
+	t.Run("append when new", func(t *testing.T) {
+		out := mergeOwnerReference([]metav1.OwnerReference{base}, other)
+		require.Len(t, out, 2)
+		assert.Equal(t, base, out[0])
+		assert.Equal(t, other, out[1])
+	})
+
+	t.Run("unchanged when same key and UID", func(t *testing.T) {
+		refs := []metav1.OwnerReference{base}
+		out := mergeOwnerReference(refs, base)
+		assert.Equal(t, refs, out)
+	})
+
+	t.Run("replace when same key different UID", func(t *testing.T) {
+		out := mergeOwnerReference([]metav1.OwnerReference{base}, sameKeyNewUID)
+		require.Len(t, out, 1)
+		assert.Equal(t, sameKeyNewUID, out[0])
+	})
+
+	t.Run("empty slice adds one", func(t *testing.T) {
+		out := mergeOwnerReference(nil, base)
+		require.Len(t, out, 1)
+		assert.Equal(t, base, out[0])
+	})
+}
+
+// TestGenerateOwnerReference_InfraSPI verifies the fields produced for an
+// InfraStoragePolicyInfo owner reference.
+func TestGenerateOwnerReference_InfraSPI(t *testing.T) {
+	scheme := testScheme(t)
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("1111")},
+	}
+	ref, err := generateOwnerReference(scheme, infraSPI)
+	require.NoError(t, err)
+	assert.Equal(t, "cns.vmware.com/v1alpha1", ref.APIVersion)
+	assert.Equal(t, "InfraStoragePolicyInfo", ref.Kind)
+	assert.Equal(t, "gold", ref.Name)
+	assert.Equal(t, types.UID("1111"), ref.UID)
+	require.NotNil(t, ref.Controller)
+	assert.False(t, *ref.Controller)
+	require.NotNil(t, ref.BlockOwnerDeletion)
+	assert.False(t, *ref.BlockOwnerDeletion)
+}
+
+// TestGenerateOwnerReference_UnknownType verifies that an error is returned when
+// the type is not registered in the scheme.
+func TestGenerateOwnerReference_UnknownType(t *testing.T) {
+	emptyScheme := runtime.NewScheme()
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "x"},
+	}
+	_, err := generateOwnerReference(emptyScheme, infraSPI)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no kind is registered")
+}
+
+// TestEnsureSPIExists_AlreadyExists verifies that ensureSPIExists returns the
+// existing instance (wasCreated=false) when the CR is already present.
+func TestEnsureSPIExists_AlreadyExists(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	existing := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "test-ns"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	inst, wasCreated, err := r.ensureSPIExists(ctx, "test-ns", "gold")
+	require.NoError(t, err)
+	assert.False(t, wasCreated)
+	require.NotNil(t, inst)
+	assert.Equal(t, "gold", inst.Name)
+}
+
+// TestEnsureSPIExists_NotFound verifies that ensureSPIExists creates and persists
+// a new StoragePolicyInfo (wasCreated=true) when the CR does not exist.
+func TestEnsureSPIExists_NotFound(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	inst, wasCreated, err := r.ensureSPIExists(ctx, "test-ns", "gold")
+	require.NoError(t, err)
+	assert.True(t, wasCreated)
+	require.NotNil(t, inst)
+	assert.Equal(t, "gold", inst.Name)
+	assert.Equal(t, "test-ns", inst.Namespace)
+
+	// Verify the CR is persisted in the fake client.
+	got := &spiv1alpha1.StoragePolicyInfo{}
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "test-ns", Name: "gold"}, got))
+}
+
+// TestEnsureInfraSPIOwnerReference_SetWhenAbsent verifies that the owner reference
+// is created when the SPI has no owner references yet.
+func TestEnsureInfraSPIOwnerReference_SetWhenAbsent(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "test-ns"},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spi).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	err := r.ensureInfraSPIOwnerReference(ctx, spi, infraSPI)
+	require.NoError(t, err)
+	require.Len(t, spi.OwnerReferences, 1)
+	assert.Equal(t, "InfraStoragePolicyInfo", spi.OwnerReferences[0].Kind)
+	assert.Equal(t, "gold", spi.OwnerReferences[0].Name)
+	assert.Equal(t, types.UID("gold-uid"), spi.OwnerReferences[0].UID)
+}
+
+// TestEnsureInfraSPIOwnerReference_NoOpWhenAlreadySet verifies that no patch is
+// issued when the owner reference already points to the same UID.
+func TestEnsureInfraSPIOwnerReference_NoOpWhenAlreadySet(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	controllerFalse := false
+	blockFalse := false
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+	}
+	existingRef := metav1.OwnerReference{
+		APIVersion:         "cns.vmware.com/v1alpha1",
+		Kind:               "InfraStoragePolicyInfo",
+		Name:               "gold",
+		UID:                types.UID("gold-uid"),
+		Controller:         &controllerFalse,
+		BlockOwnerDeletion: &blockFalse,
+	}
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gold", Namespace: "test-ns",
+			OwnerReferences: []metav1.OwnerReference{existingRef},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spi).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	err := r.ensureInfraSPIOwnerReference(ctx, spi, infraSPI)
+	require.NoError(t, err)
+	require.Len(t, spi.OwnerReferences, 1, "owner reference count must not change")
+}
+
+// TestSyncTopologyFromInfraSPI_CopiesTopology verifies that topology data is
+// correctly copied from InfraStoragePolicyInfo into the StoragePolicyInfo status.
+func TestSyncTopologyFromInfraSPI_CopiesTopology(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client:        fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:        scheme,
+		zonesProvider: &mockZonesProvider{},
+	}
+
+	inst := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"az1", "az2"},
+			},
+		},
+	}
+
+	err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
+	require.NoError(t, err)
+	require.NotNil(t, inst.Status.TopologyInfo)
+	assert.Equal(t, "zonal", inst.Status.TopologyInfo.TopologyType)
+	assert.ElementsMatch(t, []string{"az1", "az2"}, inst.Status.TopologyInfo.AccessibleZones)
+}
+
+// TestSyncTopologyFromInfraSPI_ClearsWhenNilTopology verifies that when
+// InfraStoragePolicyInfo has no Topology, the StoragePolicyInfo TopologyInfo is
+// set to nil.
+func TestSyncTopologyFromInfraSPI_ClearsWhenNilTopology(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme: scheme,
+	}
+
+	inst := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+		Status: spiv1alpha1.StoragePolicyInfoStatus{
+			TopologyInfo: &spiv1alpha1.Topology{TopologyType: "zonal"},
+		},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
+	}
+
+	err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
+	require.NoError(t, err)
+	assert.Nil(t, inst.Status.TopologyInfo)
+}
+
+// TestNamespaceFilteredZones exercises the zone-intersection logic used by
+// namespaceFilteredZones with a table of representative inputs.
+func TestNamespaceFilteredZones(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	tests := []struct {
+		name          string
+		nsZones       map[string]struct{} // zones for "ns1"; nil = no constraint
+		clusterZones  []string
+		expectedZones []string
+	}{
+		{
+			name:          "no namespace zone constraints returns all cluster zones",
+			nsZones:       nil,
+			clusterZones:  []string{"az1", "az2", "az3"},
+			expectedZones: []string{"az1", "az2", "az3"},
+		},
+		{
+			name:          "namespace zones intersect cluster zones",
+			nsZones:       map[string]struct{}{"az1": {}, "az3": {}},
+			clusterZones:  []string{"az1", "az2", "az3"},
+			expectedZones: []string{"az1", "az3"},
+		},
+		{
+			name:          "namespace zones disjoint from cluster zones returns empty",
+			nsZones:       map[string]struct{}{"az9": {}},
+			clusterZones:  []string{"az1", "az2"},
+			expectedZones: nil,
+		},
+		{
+			name:          "empty cluster zones returns empty",
+			nsZones:       map[string]struct{}{"az1": {}},
+			clusterZones:  nil,
+			expectedZones: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var zonesMap map[string]map[string]struct{}
+			if tt.nsZones != nil {
+				zonesMap = map[string]map[string]struct{}{"ns1": tt.nsZones}
+			}
+			r := &ReconcileStoragePolicyInfo{
+				client:        fake.NewClientBuilder().WithScheme(scheme).Build(),
+				scheme:        scheme,
+				zonesProvider: &mockZonesProvider{zonesForNamespace: zonesMap},
+			}
+
+			got := r.namespaceFilteredZones(ctx, "ns1", tt.clusterZones)
+			if len(tt.expectedZones) == 0 {
+				assert.Empty(t, got)
+			} else {
+				assert.ElementsMatch(t, tt.expectedZones, got)
+			}
+		})
+	}
+}
+
+// TestReconcile_CreatesAndReturnsEarly verifies that when a StoragePolicyInfo does
+// not yet exist Reconcile creates it, returns early, and lets the creation event
+// drive the next reconcile.
+func TestReconcile_CreatesAndReturnsEarly(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).Build()
+	r := &ReconcileStoragePolicyInfo{
+		client:        cli,
+		scheme:        scheme,
+		recorder:      record.NewFakeRecorder(10),
+		zonesProvider: &mockZonesProvider{},
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	got := &spiv1alpha1.StoragePolicyInfo{}
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "gold"}, got))
+}
+
+// TestReconcile_SkipsDeletion verifies that Reconcile exits immediately when
+// DeletionTimestamp is set on the StoragePolicyInfo.
+func TestReconcile_SkipsDeletion(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	now := metav1.Now()
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gold", Namespace: "ns1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test"},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
+	r := &ReconcileStoragePolicyInfo{
+		client:        cli,
+		scheme:        scheme,
+		recorder:      record.NewFakeRecorder(10),
+		zonesProvider: &mockZonesProvider{},
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+}
+
+// TestReconcile_SyncsTopologyAndRecordsEvent verifies the full happy-path:
+// topology is copied from InfraStoragePolicyInfo and a Normal event is emitted.
+func TestReconcile_SyncsTopologyAndRecordsEvent(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"az1"},
+			},
+		},
+	}
+	recorder := record.NewFakeRecorder(10)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
+		WithObjects(spi, infraSPI).Build()
+	r := &ReconcileStoragePolicyInfo{
+		client:        cli,
+		scheme:        scheme,
+		recorder:      recorder,
+		zonesProvider: &mockZonesProvider{},
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	select {
+	case ev := <-recorder.Events:
+		assert.Contains(t, ev, string(v1.EventTypeNormal))
+		assert.Contains(t, ev, "StoragePolicyInfoSynced")
+	default:
+		t.Error("expected a Normal StoragePolicyInfoSynced event")
+	}
+}
+
+// TestReconcile_InfraSPINotFound verifies that when InfraStoragePolicyInfo does
+// not yet exist, Reconcile returns success (the event-driven next reconcile will
+// populate topology once InfraStoragePolicyInfo is available).
+func TestReconcile_InfraSPINotFound(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
+	r := &ReconcileStoragePolicyInfo{
+		client:        cli,
+		scheme:        scheme,
+		recorder:      record.NewFakeRecorder(10),
+		zonesProvider: &mockZonesProvider{},
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+}
+
+// TestSetSPISuccess verifies that setSPISuccess clears the error field and
+// records a Normal "StoragePolicyInfoSynced" event.
+func TestSetSPISuccess(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+		Status:     spiv1alpha1.StoragePolicyInfoStatus{Error: "previous error"},
+	}
+	recorder := record.NewFakeRecorder(10)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
+
+	err := r.setSPISuccess(ctx, spi, "all good")
+	require.NoError(t, err)
+	assert.Empty(t, spi.Status.Error, "expected error field to be cleared")
+
+	select {
+	case ev := <-recorder.Events:
+		assert.Contains(t, ev, "Normal")
+		assert.Contains(t, ev, "StoragePolicyInfoSynced")
+	default:
+		t.Error("expected a Normal StoragePolicyInfoSynced event")
+	}
+}
+
+// TestSetSPIError verifies that setSPIError populates the error field and
+// records a Warning "StoragePolicyInfoFailed" event.
+func TestSetSPIError(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	recorder := record.NewFakeRecorder(10)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
+
+	err := r.setSPIError(ctx, spi, "something failed")
+	require.NoError(t, err)
+	assert.Equal(t, "something failed", spi.Status.Error)
+
+	select {
+	case ev := <-recorder.Events:
+		assert.Contains(t, ev, "Warning")
+		assert.Contains(t, ev, "StoragePolicyInfoFailed")
+	default:
+		t.Error("expected a Warning StoragePolicyInfoFailed event")
+	}
+}
+
+// TestUpdateStatus_StatusFieldPersisted verifies that k8s.UpdateStatus correctly
+// persists changes to the StoragePolicyInfo status subresource.
+func TestUpdateStatus_StatusFieldPersisted(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
+
+	spi.Status.Error = "injected error"
+	err := k8s.UpdateStatus(ctx, cli, spi)
+	assert.NoError(t, err)
+	assert.Equal(t, "injected error", spi.Status.Error)
+}
+
+// TestCompleteReconciliationWithSuccess verifies that a successful reconciliation
+// removes the entry from the backoff map.
+func TestCompleteReconciliationWithSuccess(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:   scheme,
+		recorder: record.NewFakeRecorder(10),
+	}
+	nn := types.NamespacedName{Namespace: "ns1", Name: "gold"}
+
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+	backOffDuration[nn] = 5 * time.Second
+
+	result, err := r.completeReconciliationWithSuccess(ctx, nn)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	backOffDurationMapMutex.Lock()
+	_, exists := backOffDuration[nn]
+	backOffDurationMapMutex.Unlock()
+	assert.False(t, exists, "expected backoff entry to be deleted on success")
+}
+
+// TestCompleteReconciliationWithError verifies that a failed reconciliation
+// doubles the backoff duration.
+func TestCompleteReconciliationWithError(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:   scheme,
+		recorder: record.NewFakeRecorder(10),
+	}
+	nn := types.NamespacedName{Namespace: "ns1", Name: "gold"}
+
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+	backOffDuration[nn] = time.Second
+
+	result, err := r.completeReconciliationWithError(ctx, nn, time.Second, assert.AnError)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{RequeueAfter: time.Second}, result)
+
+	backOffDurationMapMutex.Lock()
+	got := backOffDuration[nn]
+	backOffDurationMapMutex.Unlock()
+	assert.Equal(t, 2*time.Second, got, "expected backoff to be doubled on error")
+}

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/helper.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/helper.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepolicyinfo
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// ownerReferenceKey returns an OwnerReference key concatenated from APIVersion, Kind and Name.
+func ownerReferenceKey(ref metav1.OwnerReference) string {
+	return ref.APIVersion + "/" + ref.Kind + "/" + ref.Name
+}
+
+// mergeOwnerReference merges add into refs:
+//   - if a reference with the same (APIVersion, Kind, Name) already exists and has
+//     the same UID, refs is returned unchanged;
+//   - if it exists with a different UID, the entry is replaced;
+//   - otherwise add is appended.
+func mergeOwnerReference(refs []metav1.OwnerReference, add metav1.OwnerReference) []metav1.OwnerReference {
+	key := ownerReferenceKey(add)
+	for i := range refs {
+		if ownerReferenceKey(refs[i]) == key {
+			if refs[i].UID == add.UID {
+				return refs
+			}
+			out := make([]metav1.OwnerReference, len(refs))
+			copy(out, refs)
+			out[i] = add
+			return out
+		}
+	}
+	out := make([]metav1.OwnerReference, len(refs), len(refs)+1)
+	copy(out, refs)
+	return append(out, add)
+}
+
+// generateOwnerReference returns an OwnerReference for the given client.Object.
+func generateOwnerReference(scheme *runtime.Scheme, owner client.Object) (metav1.OwnerReference, error) {
+	gvk, err := apiutil.GVKForObject(owner, scheme)
+	if err != nil {
+		return metav1.OwnerReference{}, err
+	}
+	controllerRef := false
+	block := false
+	return metav1.OwnerReference{
+		APIVersion:         gvk.GroupVersion().String(),
+		Kind:               gvk.Kind,
+		Name:               owner.GetName(),
+		UID:                owner.GetUID(),
+		Controller:         &controllerRef,
+		BlockOwnerDeletion: &block,
+	}, nil
+}


### PR DESCRIPTION
StoragePolicyInfo (SPI) is the namespace-scoped counterpart to the cluster-scoped ClusterStoragePolicyInfo and InfraStoragePolicyInfo CRs. One StoragePolicyInfo instance is created per namespace per storage policy that is assigned to that namespace. Its topology data is derived from the corresponding InfraStoragePolicyInfo CR, filtered down to only the zones accessible within that specific namespace.

Following code changes are done:
(1) controller.go:
The core controller. It is gated on the SupportsExposingStoragePolicyAttributes FSS capability and runs only on Workload (Supervisor) clusters. It watches three event sources:
- StoragePolicyInfo objects directly (on spec/generation change via GenerationChangedPredicate)
- StoragePolicyQuota objects (on CREATE only) — when a new quota is created for a namespace+policy, a StoragePolicyInfo is triggered for the same namespace+policy
- InfraStoragePolicyInfo objects (on CREATE and on resource-version change) — re-enqueues all namespace-scoped StoragePolicyInfo CRs sharing the same name whenever the cluster-scoped topology changes.

On each reconcile the controller:
- Ensures the StoragePolicyInfo CR exists in the target namespace, creating it if absent. If the CR was just created, it returns early — the creation event will trigger another reconcile to populate the fields.
- Skips reconciliation if the CR has a DeletionTimestamp set.
- Reads the cluster-wide topology from the InfraStoragePolicyInfo CR (populated by the ClusterStoragePolicyInfo controller).
- Sets a non-controller owner reference on the StoragePolicyInfo pointing to InfraStoragePolicyInfo, so the SPI is garbage-collected when the InfraStoragePolicyInfo is deleted.
- Filters the accessible zones down to those assigned to the namespace via GetZonesForNamespace. 
- Writes the filtered topology into StoragePolicyInfo.status.topologyInfo.
- Updates StoragePolicyInfo.status.error and records a Kubernetes event

(2) add_storagepolicyinfo.go
Registers the new controller into the shared AddToManagerFuncs list via a Go init() function, following the same pattern as all other controllers in this package.

(3) Manifest files:
Adds RBAC entries to the vsphere-csi-controller ClusterRole to allow get, list, watch, update, patch on storagepolicyinfos and storagepolicyinfos/status, and create on storagepolicyinfos.

(4) helper.go
A new helper file providing owner-reference utilities used by the controller.

(5) controller_test.go
Comprehensive unit tests for the controller and helpers

TODOs: (1) Implementation specific to volume capabities will be added by separate code review.
              (2) Implementation to handle "namespace's zone assignments change after the initial SPI reconcile" will be addressed by separate code review.

Testing done:
(1) Verified storagepolicyinfo-controller appears in Starting Controller logs when supports_exposing_storage_policy_attributes FSS is enabled
```
root@4208084b41897408127b14fb98be5b4d [ ~ ]# kubectl logs -n vmware-system-csi deployment/vsphere-csi-controller \
  -c vsphere-syncer | grep "storagepolicyinfo-controller"

{"level":"info","time":"2026-06-10T06:30:37.904166552Z","caller":"controller/controller.go:305","msg":"Starting workers","TraceId":"c0eae078-964c-4ebc-b0d6-1a5bc075d51d","TraceId":"1fc148cb-cf02-4626-aa48-78e33a729abd","controller":"storagepolicyinfo-controller","controllerGroup":"cns.vmware.com","controllerKind":"StoragePolicyInfo","worker count":4}

```

(2) Verifed that CRD is installed:
```
kubectl get crd storagepolicyinfos.cns.vmware.com
kubectl get crd storagepolicyinfos.cns.vmware.com \
  -o jsonpath='{.spec.versions[*].name}'
NAME                                CREATED AT
storagepolicyinfos.cns.vmware.com   2026-06-10T06:20:56Z
v1alpha1
```

(3) StoragePolicyInfo is auto-created when a StoragePolicyQuota exists
```
root@4208084b41897408127b14fb98be5b4d [ ~ ]# kubectl get storagepolicyquota -A | head -5
NAMESPACE          NAME                                                          AGE
svc-cci-ns-zsemb   management-storage-policy-encryption-storagepolicyquota       43h
svc-cci-ns-zsemb   management-storage-policy-regular-storagepolicyquota          43h
svc-cci-ns-zsemb   management-storage-policy-single-node-storagepolicyquota      43h
svc-cci-ns-zsemb   management-storage-policy-stretched-lite-storagepolicyquota   43h

root@4208084b41897408127b14fb98be5b4d [ ~ ]# kubectl get storagepolicyinfo -A | head -5
NAMESPACE          NAME                                       AGE
svc-cci-ns-zsemb   management-storage-policy-encryption       4h54m
svc-cci-ns-zsemb   management-storage-policy-regular          4h54m
svc-cci-ns-zsemb   management-storage-policy-single-node      4h54m
svc-cci-ns-zsemb   management-storage-policy-stretched-lite   4h54m
```

(4) Create a test namespace using VC ui on supervisor and assigned a storage policy to it. Then, verified that SPI is created:
```
root@4208084b41897408127b14fb98be5b4d [ ~ ]# k get spi -n test
NAME                          AGE
vsan-default-storage-policy   91s
root@420867d27cd90527576dab35afb1d0f1 [ ~ ]# k get spi -n test -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyInfo
  metadata:
    creationTimestamp: "2026-06-10T07:00:16Z"
    generation: 1
    name: vsan-default-storage-policy
    namespace: test
    ownerReferences:
    - apiVersion: cns.vmware.com/v1alpha1
      blockOwnerDeletion: false
      controller: false
      kind: InfraStoragePolicyInfo
      name: vsan-default-storage-policy
      uid: 90d1a2da-bada-43b6-aca4-ff7e2b0103fc
    resourceVersion: "9677388"
    uid: 917950c7-0078-40e2-8c00-176e404acc5d
  status:
    topologyInfo:
      accessibleZones:
      - az1
      topologyType: ""
kind: List
metadata:
  resourceVersion: ""
```

```
{"level":"info","time":"2026-06-10T07:00:16.74172011Z","caller":"storagepolicyinfo/controller.go:305","msg":"Created StoragePolicyInfo test/vsan-default-storage-policy","TraceId":"4f34bbf1-d09a-47c0-85eb-7db2ed057a19"}
...
{"level":"info","time":"2026-06-10T07:00:16.772699188Z","caller":"storagepolicyinfo/controller.go:193","msg":"Reconciling StoragePolicyInfo","TraceId":"1ebfe4a4-ecd3-4cb3-9f82-41304cecf8d3","name":"test/vsan-default-storage-policy"}

...
{"level":"info","time":"2026-06-10T07:00:16.781392351Z","caller":"storagepolicyinfo/controller.go:390","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"1ebfe4a4-ecd3-4cb3-9f82-41304cecf8d3","name":"test/vsan-default-storage-policy"}
```

(5) Topology is populated from InfraStoragePolicyInfo:
```
root@4208084b41897408127b14fb98be5b4d [ ~ ]# kubectl get infrastoragepolicyinfo vsan-default-storage-policy -o yaml | grep -A10 topology
  topology:
    accessibleZones:
    - az1
    topologyType: ""
root@4208084b41897408127b14fb98be5b4d [ ~ ]#
root@4208084b41897408127b14fb98be5b4d [ ~ ]# kubectl get storagepolicyinfo -n test vsan-default-storage-policy -o yaml | grep -A10 topology
  topologyInfo:
    accessibleZones:
    - az1
    topologyType: ""

```

(6) Ownerreference example:
Logs corresponding to StoragePolicyInfo created with owner reference to InfraSPI :
```
{"level":"info","time":"2026-06-19T08:56:14.099975876Z","caller":"storagepolicyinfo/controller.go:478","msg":"Created StoragePolicyInfo svc-velero-s59bq/management-storage-policy-encryption with owner reference to InfraStoragePolicyInfo \"management-storage-policy-encryption\"","TraceId":"434e61d7-b6f3-40f7-b9a4-edfc4639e8ea"}

```

Verified it is set in  (InfraSPI → SPI, namespace-scoped):
```
root@421dcfc6144186089de8df9f0ea26da1 [ ~ ]# kubectl get storagepolicyinfo -n svc-cci-ns-zlw1q management-storage-policy-encryption -o yaml | grep -A 8 ownerReferences
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: InfraStoragePolicyInfo
    name: management-storage-policy-encryption
    uid: 260c2b76-14b2-4023-a469-cd74de8bedd8
  resourceVersion: "7297660"
  uid: ae9feed1-99ff-42a6-b663-0b1184091e69
  ```
 Also checked InfraStoragePolicyInfo owner ref (ClusterSPI → InfraSPI):
  ```
root@421dcfc6144186089de8df9f0ea26da1 [ ~ ]# kubectl get infrastoragepolicyinfo management-storage-policy-encryption -o yaml | grep -A 8 ownerReferences
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: management-storage-policy-encryption
    uid: cab3e445-0718-40c9-8b0d-a524123335ee
  resourceVersion: "7297649"
  uid: 260c2b76-14b2-4023-a469-cd74de8bedd8
```


Unit test results:
```
ms030990@53YP273:~/vsphere-csi-driver$ go test ./pkg/syncer/cnsoperator/controller/storagepolicyinfo/... -v -count=1
=== RUN   TestMapSPQtoSPI_NilObject
--- PASS: TestMapSPQtoSPI_NilObject (0.25s)
=== RUN   TestMapSPQtoSPI_CorrectSuffix
--- PASS: TestMapSPQtoSPI_CorrectSuffix (0.00s)
=== RUN   TestMapSPQtoSPI_NoSuffix
--- PASS: TestMapSPQtoSPI_NoSuffix (0.00s)
=== RUN   TestMapInfraSPItoSPI_NilObject
--- PASS: TestMapInfraSPItoSPI_NilObject (0.01s)
=== RUN   TestMapInfraSPItoSPI_EnqueuesMatchingNamespaces
--- PASS: TestMapInfraSPItoSPI_EnqueuesMatchingNamespaces (0.00s)
=== RUN   TestMapInfraSPItoSPI_NoMatchingStoragePolicyInfos
--- PASS: TestMapInfraSPItoSPI_NoMatchingStoragePolicyInfos (0.00s)
=== RUN   TestMergeOwnerReference
=== RUN   TestMergeOwnerReference/append_when_new
=== RUN   TestMergeOwnerReference/unchanged_when_same_key_and_UID
=== RUN   TestMergeOwnerReference/replace_when_same_key_different_UID
=== RUN   TestMergeOwnerReference/empty_slice_adds_one
--- PASS: TestMergeOwnerReference (0.00s)
    --- PASS: TestMergeOwnerReference/append_when_new (0.00s)
    --- PASS: TestMergeOwnerReference/unchanged_when_same_key_and_UID (0.00s)
    --- PASS: TestMergeOwnerReference/replace_when_same_key_different_UID (0.00s)
    --- PASS: TestMergeOwnerReference/empty_slice_adds_one (0.00s)
=== RUN   TestGenerateOwnerReference_InfraSPI
--- PASS: TestGenerateOwnerReference_InfraSPI (0.00s)
=== RUN   TestGenerateOwnerReference_UnknownType
--- PASS: TestGenerateOwnerReference_UnknownType (0.00s)
=== RUN   TestEnsureSPIExists_AlreadyExists
--- PASS: TestEnsureSPIExists_AlreadyExists (0.01s)
=== RUN   TestEnsureSPIExists_NotFound
{"level":"info","time":"2026-06-19T10:50:10.018258383Z","caller":"storagepolicyinfo/controller.go:396","msg":"Created StoragePolicyInfo test-ns/gold with owner reference to InfraStoragePolicyInfo \"gold\"","TraceId":"b33f047e-b9ee-410f-90d6-be62291ed345"}
--- PASS: TestEnsureSPIExists_NotFound (0.01s)
=== RUN   TestEnsureInfraSPIOwnerReference_SetWhenAbsent
{"level":"info","time":"2026-06-19T10:50:10.026678282Z","caller":"storagepolicyinfo/controller.go:427","msg":"Set owner reference on StoragePolicyInfo test-ns/gold → InfraStoragePolicyInfo \"gold\"","TraceId":"b1dd776b-73ce-40fd-b1b9-36b42a8e16f7"}
--- PASS: TestEnsureInfraSPIOwnerReference_SetWhenAbsent (0.01s)
=== RUN   TestEnsureInfraSPIOwnerReference_NoOpWhenAlreadySet
--- PASS: TestEnsureInfraSPIOwnerReference_NoOpWhenAlreadySet (0.00s)
=== RUN   TestSyncTopologyFromInfraSPI_CopiesTopology
--- PASS: TestSyncTopologyFromInfraSPI_CopiesTopology (0.00s)
=== RUN   TestSyncTopologyFromInfraSPI_ClearsWhenNilTopology
--- PASS: TestSyncTopologyFromInfraSPI_ClearsWhenNilTopology (0.01s)
=== RUN   TestNamespaceFilteredZones
=== RUN   TestNamespaceFilteredZones/no_namespace_zone_constraints_returns_all_cluster_zones
=== RUN   TestNamespaceFilteredZones/namespace_zones_intersect_cluster_zones
=== RUN   TestNamespaceFilteredZones/namespace_zones_disjoint_from_cluster_zones_returns_empty
=== RUN   TestNamespaceFilteredZones/empty_cluster_zones_returns_empty
--- PASS: TestNamespaceFilteredZones (0.02s)
    --- PASS: TestNamespaceFilteredZones/no_namespace_zone_constraints_returns_all_cluster_zones (0.00s)
    --- PASS: TestNamespaceFilteredZones/namespace_zones_intersect_cluster_zones (0.00s)
    --- PASS: TestNamespaceFilteredZones/namespace_zones_disjoint_from_cluster_zones_returns_empty (0.00s)
    --- PASS: TestNamespaceFilteredZones/empty_cluster_zones_returns_empty (0.01s)
=== RUN   TestReconcile_CreatesWithOwnerRef
{"level":"info","time":"2026-06-19T10:50:10.062678379Z","caller":"storagepolicyinfo/controller.go:272","msg":"Reconciling StoragePolicyInfo","TraceId":"7b8a9a3b-57c1-4853-8473-c8aa2bafa77b","TraceId":"c3d83236-7f4a-4317-a762-49891aa8d602","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.063977479Z","caller":"storagepolicyinfo/controller.go:396","msg":"Created StoragePolicyInfo ns1/gold with owner reference to InfraStoragePolicyInfo \"gold\"","TraceId":"7b8a9a3b-57c1-4853-8473-c8aa2bafa77b","TraceId":"c3d83236-7f4a-4317-a762-49891aa8d602"}
{"level":"info","time":"2026-06-19T10:50:10.064146079Z","caller":"storagepolicyinfo/controller.go:305","msg":"StoragePolicyInfo \"ns1/gold\" was just created; creation event will trigger next reconcile","TraceId":"7b8a9a3b-57c1-4853-8473-c8aa2bafa77b","TraceId":"c3d83236-7f4a-4317-a762-49891aa8d602","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.064217279Z","caller":"storagepolicyinfo/controller.go:520","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"7b8a9a3b-57c1-4853-8473-c8aa2bafa77b","TraceId":"c3d83236-7f4a-4317-a762-49891aa8d602","name":"ns1/gold"}
--- PASS: TestReconcile_CreatesWithOwnerRef (0.01s)
=== RUN   TestReconcile_SkipsDeletion
{"level":"info","time":"2026-06-19T10:50:10.068412578Z","caller":"storagepolicyinfo/controller.go:272","msg":"Reconciling StoragePolicyInfo","TraceId":"fca9d8c9-eaa5-48bb-954d-eb7d03cd1781","TraceId":"41a72bef-edcf-471e-9b2a-7c4c7a1d8413","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.068613278Z","caller":"storagepolicyinfo/controller.go:311","msg":"StoragePolicyInfo \"ns1/gold\" is being deleted, skipping reconciliation","TraceId":"fca9d8c9-eaa5-48bb-954d-eb7d03cd1781","TraceId":"41a72bef-edcf-471e-9b2a-7c4c7a1d8413","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.068671678Z","caller":"storagepolicyinfo/controller.go:520","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"fca9d8c9-eaa5-48bb-954d-eb7d03cd1781","TraceId":"41a72bef-edcf-471e-9b2a-7c4c7a1d8413","name":"ns1/gold"}
--- PASS: TestReconcile_SkipsDeletion (0.00s)
=== RUN   TestReconcile_SyncsTopologyAndRecordsEvent
{"level":"info","time":"2026-06-19T10:50:10.076115678Z","caller":"storagepolicyinfo/controller.go:272","msg":"Reconciling StoragePolicyInfo","TraceId":"7de01c68-ffdb-4c8e-a95a-cf0fd2af3d7b","TraceId":"559be71e-4b63-45a6-9a52-e60b65412ff4","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.079303277Z","caller":"storagepolicyinfo/controller.go:427","msg":"Set owner reference on StoragePolicyInfo ns1/gold → InfraStoragePolicyInfo \"gold\"","TraceId":"7de01c68-ffdb-4c8e-a95a-cf0fd2af3d7b","TraceId":"559be71e-4b63-45a6-9a52-e60b65412ff4"}
{"level":"info","time":"2026-06-19T10:50:10.080378677Z","caller":"storagepolicyinfo/controller.go:343","msg":"Successfully reconciled StoragePolicyInfo \"ns1/gold\"","TraceId":"7de01c68-ffdb-4c8e-a95a-cf0fd2af3d7b","TraceId":"559be71e-4b63-45a6-9a52-e60b65412ff4","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.080483277Z","caller":"storagepolicyinfo/controller.go:520","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"7de01c68-ffdb-4c8e-a95a-cf0fd2af3d7b","TraceId":"559be71e-4b63-45a6-9a52-e60b65412ff4","name":"ns1/gold"}
--- PASS: TestReconcile_SyncsTopologyAndRecordsEvent (0.01s)
=== RUN   TestReconcile_InfraSPINotFound
{"level":"info","time":"2026-06-19T10:50:10.083987877Z","caller":"storagepolicyinfo/controller.go:272","msg":"Reconciling StoragePolicyInfo","TraceId":"7f775a31-1240-40c5-9ac4-580053cc2c7b","TraceId":"adb38204-8bfd-460c-8249-6f9f582bd4b2","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.084094077Z","caller":"storagepolicyinfo/controller.go:289","msg":"InfraStoragePolicyInfo \"gold\" not yet available; will retry","TraceId":"7f775a31-1240-40c5-9ac4-580053cc2c7b","TraceId":"adb38204-8bfd-460c-8249-6f9f582bd4b2","name":"ns1/gold"}
{"level":"error","time":"2026-06-19T10:50:10.084172177Z","caller":"storagepolicyinfo/controller.go:535","msg":"Failed to reconcile StoragePolicyInfo \"ns1/gold\". Err: infrastoragepolicyinfos.cns.vmware.com \"gold\" not found","TraceId":"7f775a31-1240-40c5-9ac4-580053cc2c7b","TraceId":"adb38204-8bfd-460c-8249-6f9f582bd4b2","name":"ns1/gold","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/storagepolicyinfo.(*ReconcileStoragePolicyInfo).completeReconciliationWithError\n\t/home/ms030990/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go:535\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/storagepolicyinfo.(*ReconcileStoragePolicyInfo).Reconcile\n\t/home/ms030990/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go:294\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/storagepolicyinfo.TestReconcile_InfraSPINotFound\n\t/home/ms030990/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go:635\ntesting.tRunner\n\t/home/ms030990/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.3.linux-amd64/src/testing/testing.go:2036"}
--- PASS: TestReconcile_InfraSPINotFound (0.00s)
=== RUN   TestSetSPISuccess
--- PASS: TestSetSPISuccess (0.00s)
=== RUN   TestSetSPIError
--- PASS: TestSetSPIError (0.00s)
=== RUN   TestUpdateStatus_StatusFieldPersisted
--- PASS: TestUpdateStatus_StatusFieldPersisted (0.00s)
=== RUN   TestCompleteReconciliationWithSuccess
{"level":"info","time":"2026-06-19T10:50:10.100691476Z","caller":"storagepolicyinfo/controller.go:520","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"0d3c2bf1-3174-4827-9d2c-e15a62ddfb8c","name":"ns1/gold"}
--- PASS: TestCompleteReconciliationWithSuccess (0.00s)
=== RUN   TestCompleteReconciliationWithError
{"level":"error","time":"2026-06-19T10:50:10.104058675Z","caller":"storagepolicyinfo/controller.go:535","msg":"Failed to reconcile StoragePolicyInfo \"ns1/gold\". Err: assert.AnError general error for testing","TraceId":"fc6d818c-1d6a-449e-bfe4-9b1769609d63","name":"ns1/gold","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/storagepolicyinfo.(*ReconcileStoragePolicyInfo).completeReconciliationWithError\n\t/home/ms030990/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go:535\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/storagepolicyinfo.TestCompleteReconciliationWithError\n\t/home/ms030990/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go:751\ntesting.tRunner\n\t/home/ms030990/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.3.linux-amd64/src/testing/testing.go:2036"}
--- PASS: TestCompleteReconciliationWithError (0.00s)
=== RUN   TestReconcile_ZoneFilteringApplied
{"level":"info","time":"2026-06-19T10:50:10.111431275Z","caller":"storagepolicyinfo/controller.go:272","msg":"Reconciling StoragePolicyInfo","TraceId":"c9bcf89a-3267-4568-ad60-6d3b064065b5","TraceId":"46367714-6a42-4956-ab48-c737975105b5","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.112816175Z","caller":"storagepolicyinfo/controller.go:427","msg":"Set owner reference on StoragePolicyInfo ns1/gold → InfraStoragePolicyInfo \"gold\"","TraceId":"c9bcf89a-3267-4568-ad60-6d3b064065b5","TraceId":"46367714-6a42-4956-ab48-c737975105b5"}
{"level":"info","time":"2026-06-19T10:50:10.113887774Z","caller":"storagepolicyinfo/controller.go:343","msg":"Successfully reconciled StoragePolicyInfo \"ns1/gold\"","TraceId":"c9bcf89a-3267-4568-ad60-6d3b064065b5","TraceId":"46367714-6a42-4956-ab48-c737975105b5","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.113990674Z","caller":"storagepolicyinfo/controller.go:520","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"c9bcf89a-3267-4568-ad60-6d3b064065b5","TraceId":"46367714-6a42-4956-ab48-c737975105b5","name":"ns1/gold"}
--- PASS: TestReconcile_ZoneFilteringApplied (0.01s)
=== RUN   TestReconcile_NoNamespaceZonesReturnsAll
{"level":"info","time":"2026-06-19T10:50:10.118447774Z","caller":"storagepolicyinfo/controller.go:272","msg":"Reconciling StoragePolicyInfo","TraceId":"a8129d36-7378-4e91-b930-5092f5f37868","TraceId":"d8710473-aa98-4fd6-afb8-dfbafb235aed","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.119860174Z","caller":"storagepolicyinfo/controller.go:427","msg":"Set owner reference on StoragePolicyInfo ns1/gold → InfraStoragePolicyInfo \"gold\"","TraceId":"a8129d36-7378-4e91-b930-5092f5f37868","TraceId":"d8710473-aa98-4fd6-afb8-dfbafb235aed"}
{"level":"info","time":"2026-06-19T10:50:10.120792274Z","caller":"storagepolicyinfo/controller.go:343","msg":"Successfully reconciled StoragePolicyInfo \"ns1/gold\"","TraceId":"a8129d36-7378-4e91-b930-5092f5f37868","TraceId":"d8710473-aa98-4fd6-afb8-dfbafb235aed","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.120893674Z","caller":"storagepolicyinfo/controller.go:520","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"a8129d36-7378-4e91-b930-5092f5f37868","TraceId":"d8710473-aa98-4fd6-afb8-dfbafb235aed","name":"ns1/gold"}
--- PASS: TestReconcile_NoNamespaceZonesReturnsAll (0.01s)
=== RUN   TestReconcile_InfraSPITopologyUpdated
{"level":"info","time":"2026-06-19T10:50:10.124800073Z","caller":"storagepolicyinfo/controller.go:272","msg":"Reconciling StoragePolicyInfo","TraceId":"2f4060c9-ed21-4339-b873-427254863593","TraceId":"9fa5d8a1-cb29-434e-a886-c435633b7e4c","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.126568573Z","caller":"storagepolicyinfo/controller.go:427","msg":"Set owner reference on StoragePolicyInfo ns1/gold → InfraStoragePolicyInfo \"gold\"","TraceId":"2f4060c9-ed21-4339-b873-427254863593","TraceId":"9fa5d8a1-cb29-434e-a886-c435633b7e4c"}
{"level":"info","time":"2026-06-19T10:50:10.127692373Z","caller":"storagepolicyinfo/controller.go:343","msg":"Successfully reconciled StoragePolicyInfo \"ns1/gold\"","TraceId":"2f4060c9-ed21-4339-b873-427254863593","TraceId":"9fa5d8a1-cb29-434e-a886-c435633b7e4c","name":"ns1/gold"}
{"level":"info","time":"2026-06-19T10:50:10.127791573Z","caller":"storagepolicyinfo/controller.go:520","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"2f4060c9-ed21-4339-b873-427254863593","TraceId":"9fa5d8a1-cb29-434e-a886-c435633b7e4c","name":"ns1/gold"}
--- PASS: TestReconcile_InfraSPITopologyUpdated (0.01s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/storagepolicyinfo   0.488s

```
wcp e2e precheckin: passed successfully
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1685/

vks e2e precheckin: passed successfully
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1279/


