### PR TITLE
Implement VAC-based StoragePolicyUsage creation

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -34,6 +34,7 @@ import (
 	"github.com/go-co-op/gocron"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -43,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -4132,7 +4134,225 @@ func getOrCreateStoragePolicyUsageCR(ctx context.Context, storagePolicyId string
 			}
 		}
 	}
+	// Also create SPUs for all VolumeAttributesClasses in the namespace.
+	// This is only supported in Supervisor clusters with VM_PVC_STORAGE_POLICY_MUTABILITY FSS enabled.
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.VMPVCStoragePolicyMutability) {
+		err = createVACStoragePolicyUsageCRs(ctx, storageQuotaClient, namespace, metadataSyncer)
+		if err != nil {
+			log.Errorf("getOrCreateStoragePolicyUsageCR: Failed to create VAC-based SPUs. Err: %+v", err)
+			return nil, err
+		}
+	}
+
 	return usageCR, nil
+}
+
+// createVACStoragePolicyUsageCRs creates StoragePolicyUsage CRs for all VolumeAttributesClasses.
+// Each VAC's own storage policy ID is read from its parameters and stored in the SPU.
+func createVACStoragePolicyUsageCRs(ctx context.Context, quotaClient client.Client,
+	namespace string, metadataSyncer *metadataSyncInformer) error {
+	log := logger.GetLogger(ctx)
+
+	config, err := k8s.GetKubeConfig(ctx)
+	if err != nil {
+		log.Errorf("createVACStoragePolicyUsageCRs: Failed to get KubeConfig. err: %v", err)
+		return err
+	}
+
+	k8sClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		log.Errorf("createVACStoragePolicyUsageCRs: Failed to create kubernetes client. Err: %+v", err)
+		return err
+	}
+
+	// Check if VAC API is available (requires K8s 1.34+)
+	vacSupported, vacErr := vacAPIAvailable(config)
+	if vacErr != nil {
+		log.Warnf("createVACStoragePolicyUsageCRs: Could not discover VolumeAttributesClass API; "+
+			"skipping VAC SPU creation. Err: %v", vacErr)
+		return nil
+	}
+	if !vacSupported {
+		log.Debugf("createVACStoragePolicyUsageCRs: VolumeAttributesClass API not available; skipping VAC SPU creation")
+		return nil
+	}
+
+	vacList, err := k8sClient.StorageV1().VolumeAttributesClasses().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("createVACStoragePolicyUsageCRs: Failed to list VolumeAttributesClasses. Err: %+v", err)
+		return err
+	}
+
+	return createVACStoragePolicyUsageCRsFromList(ctx, quotaClient, vacList.Items, namespace)
+}
+
+// createVACStoragePolicyUsageCRsFromList is the inner loop used by createVACStoragePolicyUsageCRs
+// and the full sync path. It operates on an already-resolved VAC list and a pre-built CNS operator
+// client, making it straightforward to unit test.
+//
+// Each VAC is identified by its name (VolumeAttributesClassName). The storage policy ID is read
+// from the VAC's own parameters and stored in the SPU for informational purposes only — it is not
+// used as a lookup key.
+func createVACStoragePolicyUsageCRsFromList(ctx context.Context, quotaClient client.Client,
+	vacItems []storagev1.VolumeAttributesClass, namespace string) error {
+	log := logger.GetLogger(ctx)
+
+	// Get existing SPUs to check what already exists
+	policyUsageList := &storagepolicyv1alpha3.StoragePolicyUsageList{}
+	err := quotaClient.List(ctx, policyUsageList, &client.ListOptions{
+		Namespace: namespace,
+	})
+	if err != nil {
+		log.Errorf("createVACStoragePolicyUsageCRsFromList: Failed to list StoragePolicyUsage CRs in namespace %v. Err: %+v",
+			namespace, err)
+		return err
+	}
+
+	for _, vac := range vacItems {
+		// The VAC's own parameters carry the storage policy ID; it is stored in the SPU for
+		// informational purposes. The VAC name is the unique key that identifies the SPU.
+		vacPolicyID := getStoragePolicyIDFromVAC(&vac)
+
+		// Check if VAC-based SPUs already exist, keyed on VolumeAttributesClassName.
+		foundPvcUsageInstance := false
+		foundSnapUsageInstance := false
+		for _, usage := range policyUsageList.Items {
+			if usage.Spec.VolumeAttributesClassName == vac.Name {
+				if usage.Spec.ResourceKind == ResourceKindPVC {
+					foundPvcUsageInstance = true
+				}
+				if usage.Spec.ResourceKind == ResourceKindSnapshot {
+					foundSnapUsageInstance = true
+				}
+			}
+		}
+
+		// Create PVC SPU for this VAC if it doesn't exist.
+		// Name is prefixed with "vac-" to avoid collisions with StorageClass-based SPU names.
+		if !foundPvcUsageInstance {
+			pvcQuotaUsageInstanceName := "vac-" + vac.Name + "-" + storagepolicyv1alpha3.NameSuffixForPVC
+			_, err = createVACStoragePolicyUsageCR(ctx, quotaClient, pvcQuotaUsageInstanceName,
+				namespace, vacPolicyID, vac.Name, ResourceKindPVC, ResourceAPIgroupPVC,
+				PVCQuotaExtensionServiceName)
+			if err != nil {
+				log.Errorf("createVACStoragePolicyUsageCRsFromList: Failed to create VAC-based PVC SPU for %v. Err: %+v",
+					vac.Name, err)
+				continue
+			}
+			log.Infof("createVACStoragePolicyUsageCRsFromList: Created VAC-based PVC SPU %v in namespace %v "+
+				"for policy %v VAC %v", pvcQuotaUsageInstanceName, namespace, vacPolicyID, vac.Name)
+		}
+
+		// Create Snapshot SPU for this VAC if it doesn't exist.
+		// Name is prefixed with "vac-" to avoid collisions with StorageClass-based SPU names.
+		if !foundSnapUsageInstance {
+			snapQuotaUsageInstanceName := "vac-" + vac.Name + "-" + storagepolicyv1alpha3.NameSuffixForSnapshot
+			_, err = createVACStoragePolicyUsageCR(ctx, quotaClient, snapQuotaUsageInstanceName,
+				namespace, vacPolicyID, vac.Name, ResourceKindSnapshot, ResourceAPIgroupSnapshot,
+				SnapQuotaExtensionServiceName)
+			if err != nil {
+				log.Errorf("createVACStoragePolicyUsageCRsFromList: Failed to create VAC-based Snapshot SPU for %v. Err: %+v",
+					vac.Name, err)
+				continue
+			}
+			log.Infof("createVACStoragePolicyUsageCRsFromList: Created VAC-based Snapshot SPU %v in namespace %v "+
+				"for policy %v VAC %v", snapQuotaUsageInstanceName, namespace, vacPolicyID, vac.Name)
+		}
+	}
+
+	return nil
+}
+
+// getStoragePolicyIDFromVAC extracts storage policy ID from VolumeAttributesClass parameters
+func getStoragePolicyIDFromVAC(vac *storagev1.VolumeAttributesClass) string {
+	if vac.Parameters == nil {
+		return ""
+	}
+	// Check for storage policy ID with case-insensitive comparison
+	for key, value := range vac.Parameters {
+		if strings.ToLower(key) == "storagepolicyid" {
+			return value
+		}
+	}
+	return ""
+}
+
+// createVACStoragePolicyUsageCR creates a VAC-based StoragePolicyUsage CR
+func createVACStoragePolicyUsageCR(ctx context.Context, quotaClient client.Client, name, namespace,
+	storagePolicyId, vacName, resourceKind, resourceApiGroup,
+	extensionName string) (*storagepolicyv1alpha3.StoragePolicyUsage, error) {
+	log := logger.GetLogger(ctx)
+	newUsageInstance := storagepolicyv1alpha3.StoragePolicyUsage{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       cnsoperatorv1alpha1.GroupName,
+			APIVersion: cnsoperatorv1alpha1.Version,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			Generation:        0,
+			CreationTimestamp: metav1.Time{},
+		},
+		Spec: storagepolicyv1alpha3.StoragePolicyUsageSpec{
+			StoragePolicyId:           storagePolicyId,
+			StorageClassName:          "", // Empty for VAC-based SPUs per design
+			VolumeAttributesClassName: vacName,
+			VolumeClassName:           vacName, // Same as VAC name per v1alpha3 spec
+			ResourceKind:              resourceKind,
+			ResourceAPIgroup:          &resourceApiGroup,
+			ResourceExtensionName:     extensionName,
+		},
+	}
+	err := quotaClient.Create(ctx, &newUsageInstance, &client.CreateOptions{})
+	if err != nil {
+		log.Errorf("createVACStoragePolicyUsageCR: Failed to create VAC-based StoragePolicyUsage "+
+			"for policyID %v VAC %v resourceKind %v. Err: %+v", storagePolicyId, vacName, resourceKind, err)
+		return nil, err
+	}
+	log.Infof("createVACStoragePolicyUsageCR: Successfully created VAC-based StoragePolicyUsage "+
+		"%q/%q for policyID %v VAC %v resourceKind %v.", name, namespace, storagePolicyId, vacName, resourceKind)
+	return &newUsageInstance, nil
+}
+
+// vacAPIAvailable is a package-level function variable so unit tests can replace it with a stub
+// that returns a fixed (supported, nil) result without hitting a real API server.
+var vacAPIAvailable = volumeAttributesClassAPIAvailableFromConfig
+
+// vacAPIAvailableCheck wraps GetKubeConfig + vacAPIAvailable as a context-based check.
+// Unit tests replace this var with a stub that bypasses cluster connectivity.
+var vacAPIAvailableCheck = func(ctx context.Context) (bool, error) {
+	cfg, err := k8s.GetKubeConfig(ctx)
+	if err != nil {
+		return false, err
+	}
+	return vacAPIAvailable(cfg)
+}
+
+// TODO: re-evaluate whether we need to check VAC API after the check is added to the storage quota webhook
+
+// volumeAttributesClassAPIAvailableFromConfig checks if VAC API is available from REST config
+func volumeAttributesClassAPIAvailableFromConfig(cfg *restclient.Config) (bool, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return false, err
+	}
+	_, lists, err := dc.ServerGroupsAndResources()
+	if lists == nil && err != nil {
+		return false, err
+	}
+	gv := storagev1.SchemeGroupVersion.String()
+	for _, list := range lists {
+		if list.GroupVersion != gv {
+			continue
+		}
+		for i := range list.APIResources {
+			if list.APIResources[i].Name == "volumeattributesclasses" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // deleteStoragePolicyUsageCR deletes StoragePolicyUsage CR for given storagePolicyId and namespace
@@ -4240,6 +4460,30 @@ func createStoragePolicyUsageCRS(ctx context.Context, metadataSyncer *metadataSy
 		return
 	}
 	isStorageQuotaM2Enabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.StorageQuotaM2)
+
+	// Resolve VAC support and list all VolumeAttributesClasses once for the entire full-sync cycle.
+	// VACs are cluster-scoped, so a single check and a single list cover all SPQ namespaces.
+	// Doing this here avoids a redundant discovery + list call for every SPQ namespace in the loop below.
+	var vacItems []storagev1.VolumeAttributesClass
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+		metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.VMPVCStoragePolicyMutability) {
+		vacSupported, vacErr := vacAPIAvailableCheck(ctx)
+		if vacErr != nil {
+			log.Warnf("createStoragePolicyUsageCRS: Could not discover VolumeAttributesClass API; "+
+				"skipping VAC SPU creation. Err: %v", vacErr)
+		} else if !vacSupported {
+			log.Debugf("createStoragePolicyUsageCRS: VolumeAttributesClass API not available; skipping VAC SPU creation")
+		} else {
+			vacList, listErr := k8sClient.StorageV1().VolumeAttributesClasses().List(ctx, metav1.ListOptions{})
+			if listErr != nil {
+				log.Errorf("createStoragePolicyUsageCRS: Failed to list VolumeAttributesClasses; "+
+					"skipping VAC SPU creation. Err: %v", listErr)
+			} else {
+				vacItems = vacList.Items
+			}
+		}
+	}
+
 	for _, spq := range spqList.Items {
 		// Make sure storagePolicyQuota instance is not getting deleted.
 		if spq.DeletionTimestamp != nil {
@@ -4313,6 +4557,16 @@ func createStoragePolicyUsageCRS(ctx context.Context, metadataSyncer *metadataSy
 						continue
 					}
 				}
+			}
+		}
+
+		// Create VAC-based SPUs for this namespace using the VAC list resolved once before the loop.
+		// vacItems is non-nil only when the FSS is enabled and the VAC API is available.
+		if len(vacItems) > 0 {
+			if err = createVACStoragePolicyUsageCRsFromList(ctx, cnsOperatorClient, vacItems, spq.Namespace); err != nil {
+				log.Errorf("createStoragePolicyUsageCRS: Failed to create VAC-based SPUs in namespace %v. Err: %+v",
+					spq.Namespace, err)
+				// Continue processing other namespaces even if VAC SPU creation fails.
 			}
 		}
 	}
@@ -4396,7 +4650,17 @@ func storagePolicyUsageCRSync(ctx context.Context, metadataSyncer *metadataSyncI
 							volumeHandle = strings.Replace(pv.Spec.CSI.VolumeHandle, ":", "-", 1)
 						}
 						if cnsVolumeInfo, ok := cnsVolumeInfoMap[volumeHandle]; ok {
-							if cnsVolumeInfo.Spec.StorageClassName == storagePolicyUsage.Spec.StorageClassName &&
+							// Check if this volume matches the SPU - either StorageClass-based or VAC-based
+							var matches bool
+							if storagePolicyUsage.Spec.StorageClassName != "" {
+								// StorageClass-based SPU: match by StorageClassName
+								matches = cnsVolumeInfo.Spec.StorageClassName == storagePolicyUsage.Spec.StorageClassName
+							} else if storagePolicyUsage.Spec.VolumeAttributesClassName != "" {
+								// VAC-based SPU: match by VolumeAttributeClassName
+								matches = cnsVolumeInfo.Spec.VolumeAttributeClassName == storagePolicyUsage.Spec.VolumeAttributesClassName
+							}
+
+							if matches &&
 								cnsVolumeInfo.Spec.StoragePolicyID == storagePolicyUsage.Spec.StoragePolicyId &&
 								cnsVolumeInfo.Spec.Namespace == storagePolicyUsage.Namespace {
 								// Compute the total used capacity for the voluems in the current namespace(iteration)
@@ -4409,7 +4673,16 @@ func storagePolicyUsageCRSync(ctx context.Context, metadataSyncer *metadataSyncI
 					updateSpu = true
 				}
 			} else if isStorageQuotaM2FSSEnabled && storagePolicyUsage.Spec.ResourceKind == ResourceKindSnapshot {
-				spuKey := strings.Join([]string{storagePolicyUsage.Spec.StorageClassName,
+				// Generate SPU key - use StorageClassName for SC-based SPUs, "vac-" + VolumeAttributesClassName
+				// for VAC-based SPUs (prefix avoids collisions when a StorageClass and VolumeAttributesClass
+				// share the same name; must match generateSPUKey).
+				var keyComponent string
+				if storagePolicyUsage.Spec.StorageClassName != "" {
+					keyComponent = storagePolicyUsage.Spec.StorageClassName
+				} else {
+					keyComponent = "vac-" + storagePolicyUsage.Spec.VolumeAttributesClassName
+				}
+				spuKey := strings.Join([]string{keyComponent,
 					storagePolicyUsage.Spec.StoragePolicyId, storagePolicyUsage.Namespace}, "-")
 				if usedQty, ok := spuAggregatedSumMap[spuKey]; ok {
 					log.Infof("storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: %s "+
@@ -4469,7 +4742,17 @@ func storagePolicyUsageCRSync(ctx context.Context, metadataSyncer *metadataSyncI
 }
 
 func generateSPUKey(cnsVolumeInfoObj *cnsvolumeinfov1alpha1.CNSVolumeInfo) string {
-	return strings.Join([]string{cnsVolumeInfoObj.Spec.StorageClassName, cnsVolumeInfoObj.Spec.StoragePolicyID,
+	// Generate SPU key. VAC-based volumes use a "vac-" prefix to avoid key collisions with
+	// StorageClass-based volumes when the names happen to be identical. SC-based volumes use
+	// the StorageClassName directly. Must remain consistent with the snapshot aggregation
+	// map key in storagePolicyUsageCRSync.
+	var keyComponent string
+	if cnsVolumeInfoObj.Spec.VolumeAttributeClassName != "" {
+		keyComponent = "vac-" + cnsVolumeInfoObj.Spec.VolumeAttributeClassName
+	} else {
+		keyComponent = cnsVolumeInfoObj.Spec.StorageClassName
+	}
+	return strings.Join([]string{keyComponent, cnsVolumeInfoObj.Spec.StoragePolicyID,
 		cnsVolumeInfoObj.Spec.Namespace}, "-")
 }
 

--- a/pkg/syncer/metadatasyncer_test.go
+++ b/pkg/syncer/metadatasyncer_test.go
@@ -19,9 +19,11 @@ package syncer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1938,4 +1940,185 @@ func TestInitMigrationWatchersOnStartup(t *testing.T) {
 
 		// Test passes if no panic occurred and function processed PVCs correctly
 	})
+}
+
+// ---------------------------------------------------------------------------
+// TestCreateVACStoragePolicyUsageCRsFromList – unit tests for the inner
+// VAC-SPU creation loop that is exercised by both
+// createVACStoragePolicyUsageCRs and createVACStoragePolicyUsageCRsForFullSync.
+// ---------------------------------------------------------------------------
+
+// newVACFakeClient returns a fake controller-runtime client seeded with the
+// CNS operator scheme so StoragePolicyUsage objects can be created/listed.
+func newVACFakeClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = cnsoperatorv1alpha1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+// makeVAC builds a VolumeAttributesClass with the given policy ID in its
+// parameters (the same key that getStoragePolicyIDFromVAC looks for).
+func makeVAC(name, policyID string) storagev1.VolumeAttributesClass {
+	return storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Parameters: map[string]string{"storagePolicyID": policyID},
+	}
+}
+
+// listSPUs is a test helper that returns all StoragePolicyUsage CRs in a namespace.
+func listSPUs(t *testing.T, ctx context.Context, cl client.Client, namespace string,
+) []storagepolicyv1alpha3.StoragePolicyUsage {
+	t.Helper()
+	list := &storagepolicyv1alpha3.StoragePolicyUsageList{}
+	if err := cl.List(ctx, list, &client.ListOptions{Namespace: namespace}); err != nil {
+		t.Fatalf("listSPUs: %v", err)
+	}
+	return list.Items
+}
+
+// TestCreateVACStoragePolicyUsageCRsFromList_NamingPrefix verifies that
+// VAC-based SPU names are prefixed with "vac-" to avoid collisions with
+// StorageClass-based SPU names.
+func TestCreateVACStoragePolicyUsageCRsFromList_NamingPrefix(t *testing.T) {
+	const (
+		ns       = "test-ns"
+		policyID = "policy-abc"
+		vacName  = "gold-vac"
+	)
+
+	ctx := context.Background()
+	cl := newVACFakeClient()
+	vacs := []storagev1.VolumeAttributesClass{makeVAC(vacName, policyID)}
+
+	err := createVACStoragePolicyUsageCRsFromList(ctx, cl, vacs, ns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spus := listSPUs(t, ctx, cl, ns)
+	// Both PVC and Snapshot SPUs are always created (no StorageQuotaM2 gating for VACs).
+	if len(spus) != 2 {
+		t.Fatalf("expected 2 SPUs (PVC + Snapshot), got %d: %v", len(spus), spuNames(spus))
+	}
+
+	wantPVC := fmt.Sprintf("vac-%s-%s", vacName, storagepolicyv1alpha3.NameSuffixForPVC)
+	if !contains(spuNames(spus), wantPVC) {
+		t.Errorf("PVC SPU %q not found among %v", wantPVC, spuNames(spus))
+	}
+}
+
+// TestCreateVACStoragePolicyUsageCRsFromList_CreatesBothSPUs verifies that both a PVC SPU and a
+// Snapshot SPU are always created for a matching VAC. VAC-based SPU creation is already gated by
+// the VMPVCStoragePolicyMutability FSS at the call site, so no additional StorageQuotaM2 check is
+// needed inside this function.
+func TestCreateVACStoragePolicyUsageCRsFromList_CreatesBothSPUs(t *testing.T) {
+	const (
+		ns       = "test-ns"
+		policyID = "policy-xyz"
+		vacName  = "silver-vac"
+	)
+	vacs := []storagev1.VolumeAttributesClass{makeVAC(vacName, policyID)}
+
+	wantPVC := fmt.Sprintf("vac-%s-%s", vacName, storagepolicyv1alpha3.NameSuffixForPVC)
+	wantSnap := fmt.Sprintf("vac-%s-%s", vacName, storagepolicyv1alpha3.NameSuffixForSnapshot)
+
+	ctx := context.Background()
+	cl := newVACFakeClient()
+
+	if err := createVACStoragePolicyUsageCRsFromList(ctx, cl, vacs, ns); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spus := listSPUs(t, ctx, cl, ns)
+	if len(spus) != 2 {
+		t.Fatalf("expected 2 SPUs (PVC + Snapshot), got %d: %v", len(spus), spuNames(spus))
+	}
+
+	names := spuNames(spus)
+	if !contains(names, wantPVC) {
+		t.Errorf("PVC SPU %q not found among %v", wantPVC, names)
+	}
+	if !contains(names, wantSnap) {
+		t.Errorf("Snapshot SPU %q not found among %v", wantSnap, names)
+	}
+}
+
+// TestCreateVACStoragePolicyUsageCRsFromList_IdempotentWhenSPUExists verifies
+// that calling the function twice does not produce duplicate SPUs.
+func TestCreateVACStoragePolicyUsageCRsFromList_IdempotentWhenSPUExists(t *testing.T) {
+	const (
+		ns       = "test-ns"
+		policyID = "policy-idem"
+		vacName  = "idem-vac"
+	)
+	vacs := []storagev1.VolumeAttributesClass{makeVAC(vacName, policyID)}
+	ctx := context.Background()
+	cl := newVACFakeClient()
+
+	for i := range 2 {
+		if err := createVACStoragePolicyUsageCRsFromList(ctx, cl, vacs, ns); err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i+1, err)
+		}
+	}
+
+	spus := listSPUs(t, ctx, cl, ns)
+	// Expect exactly 2 SPUs (PVC + Snapshot) — no duplicates from the second call.
+	if len(spus) != 2 {
+		t.Errorf("expected exactly 2 SPUs after two calls, got %d: %v", len(spus), spuNames(spus))
+	}
+}
+
+// TestCreateVACStoragePolicyUsageCRsFromList_MultipleVACs verifies that SPUs are created
+// independently for each VAC in the list, using each VAC's own storage policy ID.
+// The VAC name is the unique key — policy ID is informational only.
+func TestCreateVACStoragePolicyUsageCRsFromList_MultipleVACs(t *testing.T) {
+	const ns = "test-ns"
+	vacs := []storagev1.VolumeAttributesClass{
+		makeVAC("vac-alpha", "policy-alpha"),
+		makeVAC("vac-beta", "policy-beta"),
+	}
+	ctx := context.Background()
+	cl := newVACFakeClient()
+
+	if err := createVACStoragePolicyUsageCRsFromList(ctx, cl, vacs, ns); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spus := listSPUs(t, ctx, cl, ns)
+	// Each VAC produces PVC + Snapshot SPUs independently.
+	if len(spus) != 4 {
+		t.Errorf("expected 4 SPUs (2 VACs × 2 kinds), got %d: %v", len(spus), spuNames(spus))
+	}
+
+	wantNames := []string{
+		fmt.Sprintf("vac-vac-alpha-%s", storagepolicyv1alpha3.NameSuffixForPVC),
+		fmt.Sprintf("vac-vac-alpha-%s", storagepolicyv1alpha3.NameSuffixForSnapshot),
+		fmt.Sprintf("vac-vac-beta-%s", storagepolicyv1alpha3.NameSuffixForPVC),
+		fmt.Sprintf("vac-vac-beta-%s", storagepolicyv1alpha3.NameSuffixForSnapshot),
+	}
+	names := spuNames(spus)
+	for _, want := range wantNames {
+		if !contains(names, want) {
+			t.Errorf("SPU %q not found among %v", want, names)
+		}
+	}
+}
+
+// spuNames extracts the names from a StoragePolicyUsage slice for readable error messages.
+func spuNames(spus []storagepolicyv1alpha3.StoragePolicyUsage) []string {
+	names := make([]string, len(spus))
+	for i, s := range spus {
+		names[i] = s.Name
+	}
+	return names
+}
+
+// contains reports whether s is in the slice.
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/syncer/storage_policy_quota_reconciler_test.go
+++ b/pkg/syncer/storage_policy_quota_reconciler_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// makeUnstructuredSPQ returns a minimal *unstructured.Unstructured representing
+// a StoragePolicyQuota with the given name, namespace, and storagePolicyId.
+// The structure mirrors what the dynamic SPQ informer stores in its cache.
+func makeUnstructuredSPQ(name, namespace, policyID string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cns.vmware.com/v1alpha3",
+			"kind":       "StoragePolicyQuota",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"storagePolicyId": policyID,
+				"limit":           "9223372036854775807",
+			},
+		},
+	}
+}
+
+// newTestReconciler creates a storagePolicyQuotaReconciler with a real (but
+// unstarted) rate-limiting queue and no cluster connectivity, suitable for
+// unit-testing the handler methods in isolation.
+func newTestReconciler() *storagePolicyQuotaReconciler {
+	q := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[any](),
+		workqueue.TypedRateLimitingQueueConfig[any]{Name: "test-spq"},
+	)
+	return &storagePolicyQuotaReconciler{
+		svcQuotaOpsQueue: q,
+	}
+}
+
+// drainQueue returns all items currently in the queue without blocking.
+func drainQueue(q workqueue.TypedRateLimitingInterface[any]) []*ObjectToProcess {
+	var items []*ObjectToProcess
+	for q.Len() > 0 {
+		obj, _ := q.Get()
+		items = append(items, obj.(*ObjectToProcess))
+		q.Done(obj)
+	}
+	return items
+}
+
+// TestAddStoragePolicyQuota_EnqueuesWithIsDeletedFalse verifies that a valid
+// Unstructured SPQ is parsed and enqueued with isDeleted=false, and that the
+// SPQ's name, namespace, and storagePolicyId are faithfully preserved.
+func TestAddStoragePolicyQuota_EnqueuesWithIsDeletedFalse(t *testing.T) {
+	rc := newTestReconciler()
+	spq := makeUnstructuredSPQ("my-spq", "my-ns", "policy-123")
+
+	rc.addStoragePolicyQuota(spq)
+
+	items := drainQueue(rc.svcQuotaOpsQueue)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 queued item, got %d", len(items))
+	}
+	if items[0].isDeleted {
+		t.Errorf("isDeleted = true, want false")
+	}
+	if items[0].policyQuota.Name != "my-spq" {
+		t.Errorf("Name = %q, want %q", items[0].policyQuota.Name, "my-spq")
+	}
+	if items[0].policyQuota.Namespace != "my-ns" {
+		t.Errorf("Namespace = %q, want %q", items[0].policyQuota.Namespace, "my-ns")
+	}
+	if items[0].policyQuota.Spec.StoragePolicyId != "policy-123" {
+		t.Errorf("StoragePolicyId = %q, want %q", items[0].policyQuota.Spec.StoragePolicyId, "policy-123")
+	}
+}
+
+// TestDelStoragePolicyQuota_EnqueuesWithIsDeletedTrue verifies that a valid
+// Unstructured SPQ is parsed and enqueued with isDeleted=true when the
+// DeleteFunc fires, so the worker calls syncStoragePolicyQuotaDelCase.
+func TestDelStoragePolicyQuota_EnqueuesWithIsDeletedTrue(t *testing.T) {
+	rc := newTestReconciler()
+	spq := makeUnstructuredSPQ("del-spq", "del-ns", "policy-del")
+
+	rc.delStoragePolicyQuota(spq)
+
+	items := drainQueue(rc.svcQuotaOpsQueue)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 queued item, got %d", len(items))
+	}
+	if !items[0].isDeleted {
+		t.Errorf("isDeleted = false, want true")
+	}
+	if items[0].policyQuota.Name != "del-spq" {
+		t.Errorf("Name = %q, want %q", items[0].policyQuota.Name, "del-spq")
+	}
+	if items[0].policyQuota.Spec.StoragePolicyId != "policy-del" {
+		t.Errorf("StoragePolicyId = %q, want %q", items[0].policyQuota.Spec.StoragePolicyId, "policy-del")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR implements VAC-based StoragePolicyUsage creation.

When a VolumeAttributesClass (VAC) is created on the supervisor cluster, the CSI syncer now automatically creates StoragePolicyUsage (SPU) CRs for that VAC in every namespace that has a StoragePolicyQuota for the same storage policy.

This is the storage quota tracking counterpart to the existing StorageClass-based SPUs — VAC-based SPUs allow the quota system to track PVC and snapshot capacity by VolumeAttributesClass rather than by StorageClass.

Changes in storage_policy_quota_reconciler.go also ensures VAC-based SPUs are created for pre-existing quotas even if the syncer was restarted or the capability was enabled after initial deployment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1696/ (passed)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1274/ (passed)

Manual Testing:

```
Create a VolumeAttributesClass manually:

kubectl describe volumeattributesclass test-vac-zonal-policy

Name:         test-vac-zonal-policy
Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"storage.k8s.io/v1","driverName":"csi.vsphere.vmware.com","kind":"VolumeAttributesClass","metadata":{"annotations":{},"name":"test-vac-zonal-policy"},"parameters":{"storagePolicyID":"280f0a30-e2bc-4511-8738-3ae2ba4e38a9"}}
DriverName:  csi.vsphere.vmware.com
Parameters:  storagePolicyID=280f0a30-e2bc-4511-8738-3ae2ba4e38a9
Events:      <none>
kubectl describe storagepolicyusage test-vac-zonal-policy-pvc-usage -n my-ns

Two StoragePolicyUsage CRs are created automatically, one for PVC and one for VolumeSnapshot.

Name:         vac-test-vac-zonal-policy-pvc-usage
Namespace:    my-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha3
Kind:         StoragePolicyUsage
Metadata:
  Creation Timestamp:  2026-06-12T01:57:44Z
  Generation:          1
  Resource Version:    7558745
  UID:                 ec7b0c72-febc-4d15-88a4-4e5bc0c8aad3
Spec:
  Resource API Group:            
  Resource Extension Name:       volume.cns.vsphere.vmware.com
  Resource Kind:                 PersistentVolumeClaim
  Storage Class Name:            
  Storage Policy Id:             280f0a30-e2bc-4511-8738-3ae2ba4e38a9
  Volume Attributes Class Name:  test-vac-zonal-policy
  Volume Class Name:             test-vac-zonal-policy
Status:
  Quota Usage:
    Reserved:  0
    Used:      0
Events:        <none>

Name:        vac-test-vac-zonal-policy-snapshot-usage
Namespace:    my-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha3
Kind:         StoragePolicyUsage
Metadata:
  Creation Timestamp:  2026-06-12T01:57:45Z
  Generation:          1
  Resource Version:    7558748
  UID:                 c0370187-80f2-4ddc-be31-3bf9b3313df9
Spec:
  Resource API Group:            snapshot.storage.k8s.io
  Resource Extension Name:       snapshot.cns.vsphere.vmware.com
  Resource Kind:                 VolumeSnapshot
  Storage Class Name:            
  Storage Policy Id:             280f0a30-e2bc-4511-8738-3ae2ba4e38a9
  Volume Attributes Class Name:  test-vac-zonal-policy
  Volume Class Name:             test-vac-zonal-policy
Status:
  Quota Usage:
    Reserved:  0
    Used:      0
Events:        <none>
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Implements VolumeAttributesClass-based StoragePolicyUsage creation.
```
