### PR TITLE
Clear NodeResizePending condition from SV PVC

### DIFF
--- a/pkg/syncer/resize_reconciler.go
+++ b/pkg/syncer/resize_reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020-2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -143,9 +143,12 @@ func (rc *resizeReconciler) updatePVC(oldObj, newObj interface{}) {
 		return
 	}
 
-	// Add tkgPVC to the claim queue only when the new size is bigger or oldPVC
-	// has FileSystemResizePending condition, newPVC does not have.
-	if newPVCSize.Cmp(oldPVCSize) > 0 || (checkFileSystemPendingOnPVC(oldPVC) && !checkFileSystemPendingOnPVC(newPVC)) {
+	// Add tkgPVC to the claim queue only when the new size is bigger, oldPVC
+	// has FileSystemResizePending and newPVC does not, or oldPVC has
+	// NodeResizePending and newPVC does not.
+	if newPVCSize.Cmp(oldPVCSize) > 0 ||
+		(checkFileSystemPendingOnPVC(oldPVC) && !checkFileSystemPendingOnPVC(newPVC)) ||
+		(hasNodeResizePending(oldPVC) && !hasNodeResizePending(newPVC)) {
 		objKey, err := getPVCKey(ctx, newObj)
 		if err != nil {
 			return
@@ -239,8 +242,24 @@ func (rc *resizeReconciler) syncPVC(ctx context.Context, key string) error {
 		svcPvcClone.Status.Capacity[v1.ResourceStorage] = tkgPvcSize
 		updatePVC = true
 	}
+
 	if !checkFileSystemPendingOnPVC(tkgPVC) && checkFileSystemPendingOnPVC(svcPVC) {
+		log.Infof("Clearing FileSystemResizePending from supervisor PVC %s/%s - guest completed resize",
+			rc.supervisorNamespace, svcPVC.Name)
 		svcPvcClone = mergeResizeConditionOnPVC(svcPvcClone, []v1.PersistentVolumeClaimCondition{})
+		updatePVC = true
+	}
+
+	// Clear stale NodeResizePending from supervisor when:
+	// 1. Supervisor has NodeResizePending (set by supervisor csi-resizer)
+	// 2. Guest no longer has NodeResizePending (guest node resize complete)
+	// 3. Supervisor does not have FileSystemResizePending
+	if hasNodeResizePending(svcPVC) &&
+		!hasNodeResizePending(tkgPVC) &&
+		!checkFileSystemPendingOnPVC(svcPvcClone) {
+		log.Infof("Clearing stale NodeResizePending from supervisor PVC %s/%s - resize complete",
+			rc.supervisorNamespace, svcPVC.Name)
+		delete(svcPvcClone.Status.AllocatedResourceStatuses, v1.ResourceStorage)
 		updatePVC = true
 	}
 
@@ -354,4 +373,13 @@ func checkFileSystemPendingOnPVC(
 		}
 	}
 	return false
+}
+
+// hasNodeResizePending checks whether PVC has NodeResizePending in allocatedResourceStatuses
+func hasNodeResizePending(pvc *v1.PersistentVolumeClaim) bool {
+	if pvc.Status.AllocatedResourceStatuses == nil {
+		return false
+	}
+	status, exists := pvc.Status.AllocatedResourceStatuses[v1.ResourceStorage]
+	return exists && status == v1.PersistentVolumeClaimNodeResizePending
 }

--- a/pkg/syncer/resize_reconciler_test.go
+++ b/pkg/syncer/resize_reconciler_test.go
@@ -1,0 +1,437 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// Test helper functions
+
+func createTestPVC(
+	name, namespace string,
+	capacity, requested string,
+	conditions []v1.PersistentVolumeClaimCondition,
+	allocatedResourceStatuses map[v1.ResourceName]v1.ClaimResourceStatus,
+) *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse(requested),
+				},
+			},
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse(capacity),
+			},
+			Conditions:                conditions,
+			AllocatedResourceStatuses: allocatedResourceStatuses,
+		},
+	}
+}
+
+func createTestPV(name, volumeHandle string) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: volumeHandle,
+				},
+			},
+		},
+	}
+}
+
+func createFileSystemResizePendingCondition() v1.PersistentVolumeClaimCondition {
+	return v1.PersistentVolumeClaimCondition{
+		Type:               v1.PersistentVolumeClaimFileSystemResizePending,
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Message:            "Waiting for user to (re-)start a pod to finish file system resize of volume on node.",
+	}
+}
+
+func newTestRateLimitingQueue(name string) workqueue.TypedRateLimitingInterface[any] {
+	return workqueue.NewNamedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[any](), name)
+}
+
+// setupSyncPVCTest creates a reconciler wired to fake clients with the given
+// guest and supervisor PVCs pre-populated. It returns the reconciler, the
+// supervisor fake client (for post-reconcile assertions), a context, and a
+// teardown function that must be deferred.
+func setupSyncPVCTest(
+	t *testing.T,
+	guestPVC *v1.PersistentVolumeClaim,
+	supervisorPVC *v1.PersistentVolumeClaim,
+) (*resizeReconciler, *testclient.Clientset, context.Context, func()) {
+	t.Helper()
+
+	tkgClient := testclient.NewSimpleClientset()
+	supervisorClient := testclient.NewSimpleClientset()
+	ctx := context.TODO()
+
+	guestPVC.Spec.VolumeName = "test-pv"
+	guestPV := createTestPV("test-pv", supervisorPVC.Name)
+
+	if _, err := tkgClient.CoreV1().PersistentVolumeClaims(guestPVC.Namespace).Create(
+		ctx, guestPVC, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create guest PVC: %v", err)
+	}
+	if _, err := tkgClient.CoreV1().PersistentVolumes().Create(
+		ctx, guestPV, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create guest PV: %v", err)
+	}
+	if _, err := supervisorClient.CoreV1().PersistentVolumeClaims(supervisorPVC.Namespace).Create(
+		ctx, supervisorPVC, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create supervisor PVC: %v", err)
+	}
+
+	informerFactory := informers.NewSharedInformerFactory(tkgClient, time.Hour)
+	rc := &resizeReconciler{
+		tkgClient:           tkgClient,
+		supervisorClient:    supervisorClient,
+		supervisorNamespace: supervisorPVC.Namespace,
+		pvcLister:           informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
+		pvLister:            informerFactory.Core().V1().PersistentVolumes().Lister(),
+		claimQueue:          newTestRateLimitingQueue("test-queue"),
+	}
+
+	stopCh := make(chan struct{})
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	return rc, supervisorClient, ctx, func() { close(stopCh) }
+}
+
+// TestHasNodeResizePending tests the hasNodeResizePending helper function.
+func TestHasNodeResizePending(t *testing.T) {
+	tests := []struct {
+		name     string
+		pvc      *v1.PersistentVolumeClaim
+		expected bool
+	}{
+		{
+			name: "PVC with NodeResizePending",
+			pvc: createTestPVC("test-pvc", "test-ns", "100Mi", "100Mi", nil,
+				map[v1.ResourceName]v1.ClaimResourceStatus{
+					v1.ResourceStorage: v1.PersistentVolumeClaimNodeResizePending,
+				}),
+			expected: true,
+		},
+		{
+			name:     "PVC without allocatedResourceStatuses",
+			pvc:      createTestPVC("test-pvc", "test-ns", "100Mi", "100Mi", nil, nil),
+			expected: false,
+		},
+		{
+			name: "PVC with empty allocatedResourceStatuses",
+			pvc: createTestPVC("test-pvc", "test-ns", "100Mi", "100Mi", nil,
+				map[v1.ResourceName]v1.ClaimResourceStatus{}),
+			expected: false,
+		},
+		{
+			name: "PVC with different status",
+			pvc: createTestPVC("test-pvc", "test-ns", "100Mi", "100Mi", nil,
+				map[v1.ResourceName]v1.ClaimResourceStatus{
+					v1.ResourceStorage: "SomeOtherStatus",
+				}),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasNodeResizePending(tt.pvc)
+			if result != tt.expected {
+				t.Errorf("hasNodeResizePending() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestUpdatePVCQueueConditions tests the queue trigger conditions in updatePVC.
+func TestUpdatePVCQueueConditions(t *testing.T) {
+	tests := []struct {
+		name        string
+		oldPVC      *v1.PersistentVolumeClaim
+		newPVC      *v1.PersistentVolumeClaim
+		shouldQueue bool
+		description string
+	}{
+		{
+			name:        "Capacity increased",
+			oldPVC:      createTestPVC("test-pvc", "test-ns", "100Mi", "200Mi", nil, nil),
+			newPVC:      createTestPVC("test-pvc", "test-ns", "200Mi", "200Mi", nil, nil),
+			shouldQueue: true,
+			description: "Should queue when capacity increases",
+		},
+		{
+			name: "FileSystemResizePending cleared",
+			oldPVC: createTestPVC("test-pvc", "test-ns", "100Mi", "200Mi",
+				[]v1.PersistentVolumeClaimCondition{createFileSystemResizePendingCondition()}, nil),
+			newPVC:      createTestPVC("test-pvc", "test-ns", "200Mi", "200Mi", nil, nil),
+			shouldQueue: true,
+			description: "Should queue when FileSystemResizePending is cleared",
+		},
+		{
+			name: "NodeResizePending cleared",
+			oldPVC: createTestPVC("test-pvc", "test-ns", "200Mi", "200Mi", nil,
+				map[v1.ResourceName]v1.ClaimResourceStatus{
+					v1.ResourceStorage: v1.PersistentVolumeClaimNodeResizePending,
+				}),
+			newPVC:      createTestPVC("test-pvc", "test-ns", "200Mi", "200Mi", nil, nil),
+			shouldQueue: true,
+			description: "Should queue when NodeResizePending is cleared",
+		},
+		{
+			name:        "No significant changes",
+			oldPVC:      createTestPVC("test-pvc", "test-ns", "100Mi", "100Mi", nil, nil),
+			newPVC:      createTestPVC("test-pvc", "test-ns", "100Mi", "100Mi", nil, nil),
+			shouldQueue: false,
+			description: "Should not queue when nothing significant changes",
+		},
+		{
+			name: "Both conditions present - no change",
+			oldPVC: createTestPVC("test-pvc", "test-ns", "100Mi", "200Mi",
+				[]v1.PersistentVolumeClaimCondition{createFileSystemResizePendingCondition()},
+				map[v1.ResourceName]v1.ClaimResourceStatus{
+					v1.ResourceStorage: v1.PersistentVolumeClaimNodeResizePending,
+				}),
+			newPVC: createTestPVC("test-pvc", "test-ns", "100Mi", "200Mi",
+				[]v1.PersistentVolumeClaimCondition{createFileSystemResizePendingCondition()},
+				map[v1.ResourceName]v1.ClaimResourceStatus{
+					v1.ResourceStorage: v1.PersistentVolumeClaimNodeResizePending,
+				}),
+			shouldQueue: false,
+			description: "Should not queue when both conditions remain unchanged",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tkgClient := testclient.NewSimpleClientset()
+			supervisorClient := testclient.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(tkgClient, time.Hour)
+
+			rc := &resizeReconciler{
+				tkgClient:           tkgClient,
+				supervisorClient:    supervisorClient,
+				supervisorNamespace: "test-supervisor-ns",
+				pvcLister:           informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
+				pvLister:            informerFactory.Core().V1().PersistentVolumes().Lister(),
+				claimQueue:          newTestRateLimitingQueue("test-queue"),
+			}
+
+			initialQueueLen := rc.claimQueue.Len()
+			rc.updatePVC(tt.oldPVC, tt.newPVC)
+			queuedItem := rc.claimQueue.Len() > initialQueueLen
+
+			if queuedItem != tt.shouldQueue {
+				t.Errorf("%s: queued = %v, expected %v", tt.description, queuedItem, tt.shouldQueue)
+			}
+		})
+	}
+}
+
+// TestClearFileSystemResizePending verifies that syncPVC clears (or preserves)
+// FileSystemResizePending on the supervisor PVC based on the guest PVC state.
+func TestClearFileSystemResizePending(t *testing.T) {
+	tests := []struct {
+		name                 string
+		guestConditions      []v1.PersistentVolumeClaimCondition
+		supervisorConditions []v1.PersistentVolumeClaimCondition
+		expectFSPendingOnSVC bool
+	}{
+		{
+			name:                 "guest clean, supervisor has FileSystemResizePending",
+			guestConditions:      nil,
+			supervisorConditions: []v1.PersistentVolumeClaimCondition{createFileSystemResizePendingCondition()},
+			expectFSPendingOnSVC: false,
+		},
+		{
+			name:                 "guest still has FileSystemResizePending",
+			guestConditions:      []v1.PersistentVolumeClaimCondition{createFileSystemResizePendingCondition()},
+			supervisorConditions: []v1.PersistentVolumeClaimCondition{createFileSystemResizePendingCondition()},
+			expectFSPendingOnSVC: true,
+		},
+		{
+			name:                 "both already clean",
+			guestConditions:      nil,
+			supervisorConditions: nil,
+			expectFSPendingOnSVC: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			guestPVC := createTestPVC("test-pvc", "test-ns", "200Mi", "200Mi", tt.guestConditions, nil)
+			supervisorPVC := createTestPVC("supervisor-pvc-handle", "sv-ns", "200Mi", "200Mi", tt.supervisorConditions, nil)
+
+			rc, supervisorClient, ctx, teardown := setupSyncPVCTest(t, guestPVC, supervisorPVC)
+			defer teardown()
+
+			if err := rc.syncPVC(ctx, "test-ns/test-pvc"); err != nil {
+				t.Fatalf("syncPVC: %v", err)
+			}
+
+			updated, err := supervisorClient.CoreV1().PersistentVolumeClaims("sv-ns").Get(
+				ctx, "supervisor-pvc-handle", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get supervisor PVC: %v", err)
+			}
+
+			if got := checkFileSystemPendingOnPVC(updated); got != tt.expectFSPendingOnSVC {
+				t.Errorf("FileSystemResizePending on supervisor PVC = %v, want %v", got, tt.expectFSPendingOnSVC)
+			}
+		})
+	}
+}
+
+// TestClearNodeResizePending verifies that syncPVC clears (or preserves)
+// NodeResizePending in the supervisor PVC's AllocatedResourceStatuses based on
+// the guest PVC state and the supervisor's FileSystemResizePending condition.
+func TestClearNodeResizePending(t *testing.T) {
+	nodeResizePending := map[v1.ResourceName]v1.ClaimResourceStatus{
+		v1.ResourceStorage: v1.PersistentVolumeClaimNodeResizePending,
+	}
+
+	tests := []struct {
+		name                      string
+		guestConditions           []v1.PersistentVolumeClaimCondition
+		guestAllocatedStatuses    map[v1.ResourceName]v1.ClaimResourceStatus
+		supervisorConditions      []v1.PersistentVolumeClaimCondition
+		supervisorAllocatedStatus map[v1.ResourceName]v1.ClaimResourceStatus
+		expectNodeResizePending   bool
+	}{
+		{
+			// Guest is fully clean; supervisor has NodeResizePending but no
+			// FileSystemResizePending — guard passes, NodeResizePending cleared.
+			name:                      "guest clean, supervisor has NodeResizePending only",
+			guestConditions:           nil,
+			guestAllocatedStatuses:    nil,
+			supervisorConditions:      nil,
+			supervisorAllocatedStatus: nodeResizePending,
+			expectNodeResizePending:   false,
+		},
+		{
+			// Guest has cleared NodeResizePending but still has
+			// FileSystemResizePending. Supervisor has both. The
+			// FileSystemResizePending guard blocks premature clearing of
+			// NodeResizePending; it will be cleared in the next reconciliation
+			// once FileSystemResizePending is gone from the guest too.
+			name:                      "guest cleared NodeResizePending but still has FileSystemResizePending",
+			guestConditions:           []v1.PersistentVolumeClaimCondition{createFileSystemResizePendingCondition()},
+			guestAllocatedStatuses:    nil,
+			supervisorConditions:      []v1.PersistentVolumeClaimCondition{createFileSystemResizePendingCondition()},
+			supervisorAllocatedStatus: nodeResizePending,
+			expectNodeResizePending:   true,
+		},
+		{
+			// Guest still has NodeResizePending — reconciler must not clear it
+			// from the supervisor.
+			name:                      "guest still has NodeResizePending",
+			guestConditions:           nil,
+			guestAllocatedStatuses:    nodeResizePending,
+			supervisorConditions:      nil,
+			supervisorAllocatedStatus: nodeResizePending,
+			expectNodeResizePending:   true,
+		},
+		{
+			name:                      "both already clean",
+			guestConditions:           nil,
+			guestAllocatedStatuses:    nil,
+			supervisorConditions:      nil,
+			supervisorAllocatedStatus: nil,
+			expectNodeResizePending:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			guestPVC := createTestPVC("test-pvc", "test-ns", "200Mi", "200Mi",
+				tt.guestConditions, tt.guestAllocatedStatuses)
+			supervisorPVC := createTestPVC("supervisor-pvc-handle", "sv-ns", "200Mi", "200Mi",
+				tt.supervisorConditions, tt.supervisorAllocatedStatus)
+
+			rc, supervisorClient, ctx, teardown := setupSyncPVCTest(t, guestPVC, supervisorPVC)
+			defer teardown()
+
+			if err := rc.syncPVC(ctx, "test-ns/test-pvc"); err != nil {
+				t.Fatalf("syncPVC: %v", err)
+			}
+
+			updated, err := supervisorClient.CoreV1().PersistentVolumeClaims("sv-ns").Get(
+				ctx, "supervisor-pvc-handle", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get supervisor PVC: %v", err)
+			}
+
+			if got := hasNodeResizePending(updated); got != tt.expectNodeResizePending {
+				t.Errorf("NodeResizePending on supervisor PVC = %v, want %v", got, tt.expectNodeResizePending)
+			}
+		})
+	}
+}
+
+// TestResizeReconcilerFlow tests the end-to-end resize reconciler flow.
+func TestResizeReconcilerFlow(t *testing.T) {
+	guestPVC := createTestPVC("test-pvc", "test-ns", "200Mi", "200Mi", nil, nil)
+	supervisorPVC := createTestPVC(
+		"supervisor-pvc-handle", "supervisor-ns", "200Mi", "200Mi",
+		[]v1.PersistentVolumeClaimCondition{createFileSystemResizePendingCondition()},
+		map[v1.ResourceName]v1.ClaimResourceStatus{v1.ResourceStorage: v1.PersistentVolumeClaimNodeResizePending},
+	)
+
+	rc, supervisorClient, ctx, teardown := setupSyncPVCTest(t, guestPVC, supervisorPVC)
+	defer teardown()
+
+	if err := rc.syncPVC(ctx, "test-ns/test-pvc"); err != nil {
+		t.Fatalf("syncPVC failed: %v", err)
+	}
+
+	updatedSVC, err := supervisorClient.CoreV1().PersistentVolumeClaims("supervisor-ns").Get(
+		ctx, "supervisor-pvc-handle", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get updated supervisor PVC: %v", err)
+	}
+
+	if checkFileSystemPendingOnPVC(updatedSVC) {
+		t.Error("FileSystemResizePending should have been cleared from supervisor PVC")
+	}
+	if hasNodeResizePending(updatedSVC) {
+		t.Error("NodeResizePending should have been cleared from supervisor PVC")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When a PVC is resized in a TKG guest cluster, the supervisor cluster's csi-resizer v2.1.0+ (with RecoverVolumeExpansionFailure feature gate enabled) sets allocatedResourceStatuses: storage: NodeResizePending on the supervisor PVC to track node expansion progress.

Node and filesystem expansion are handled entirely within the guest cluster. From the supervisor's perspective, this means NodeResizePending is never cleared by the supervisor's own csi-resizer because it never receives confirmation that node expansion completed — it happened inside the guest, invisibly to the supervisor.

The TKG syncer reconciler, which is responsible for keeping supervisor PVC state in sync with the guest, only handles clearing the legacy FileSystemResizePending condition. It had no logic to clear allocatedResourceStatuses: NodeResizePending, causing the supervisor PVC to remain stuck in a stale NodeResizePending state indefinitely after resize completes.

Fix:
If FileSystemResizePending is gone, it means both operations are complete - this means kubelet has removed NodeResizePending as well as FileSystemResizePending from TKG PVC.
Added logic in syncPVC to detect and clear stale NodeResizePending from the supervisor PVC after the guest resize is complete.

**Testing done**:

Ensured that NodeResizePending is cleared for both online and offline expansions:

```
kubectl --kubeconfig gc_kube.yaml logs vsphere-csi-controller-5979856db6-c462r -n vmware-system-csi -c vsphere-syncer | grep -i "clear"
{"level":"info","time":"2026-06-16T10:33:54.224194058Z","caller":"syncer/resize_reconciler.go:244","msg":"Clearing FileSystemResizePending from supervisor PVC test-gc-e2e-demo-ns/eb056378-87b9-40a2-934e-1a295d6665dd-f03680d3-d8b3-4db1-858b-0cd57359848f - guest completed resize","TraceId":"177bc937-d56c-4580-bf01-b7d05c02102f"}
{"level":"info","time":"2026-06-16T10:33:54.307524325Z","caller":"syncer/resize_reconciler.go:257","msg":"Clearing stale NodeResizePending from supervisor PVC test-gc-e2e-demo-ns/eb056378-87b9-40a2-934e-1a295d6665dd-f03680d3-d8b3-4db1-858b-0cd57359848f - resize complete","TraceId":"177bc937-d56c-4580-bf01-b7d05c02102f"}
{"level":"info","time":"2026-06-16T10:34:54.958595874Z","caller":"syncer/resize_reconciler.go:244","msg":"Clearing FileSystemResizePending from supervisor PVC test-gc-e2e-demo-ns/eb056378-87b9-40a2-934e-1a295d6665dd-f03680d3-d8b3-4db1-858b-0cd57359848f - guest completed resize","TraceId":"e8d1856c-23b2-45e4-9c8e-73357419e60c"}
{"level":"info","time":"2026-06-16T10:34:54.958704219Z","caller":"syncer/resize_reconciler.go:257","msg":"Clearing stale NodeResizePending from supervisor PVC test-gc-e2e-demo-ns/eb056378-87b9-40a2-934e-1a295d6665dd-f03680d3-d8b3-4db1-858b-0cd57359848f - resize complete","TraceId":"e8d1856c-23b2-45e4-9c8e-73357419e60c"}
{"level":"info","time":"2026-06-16T10:36:13.934655831Z","caller":"syncer/resize_reconciler.go:244","msg":"Clearing FileSystemResizePending from supervisor PVC test-gc-e2e-demo-ns/eb056378-87b9-40a2-934e-1a295d6665dd-f03680d3-d8b3-4db1-858b-0cd57359848f - guest completed resize","TraceId":"75e5f8ed-7e39-4b6b-bd3a-84b06df294a9"}
{"level":"info","time":"2026-06-16T10:36:13.934727218Z","caller":"syncer/resize_reconciler.go:257","msg":"Clearing stale NodeResizePending from supervisor PVC test-gc-e2e-demo-ns/eb056378-87b9-40a2-934e-1a295d6665dd-f03680d3-d8b3-4db1-858b-0cd57359848f - resize complete","TraceId":"75e5f8ed-7e39-4b6b-bd3a-84b06df294a9"}
```

Performed back to back expansions successfully.

VKS precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1285/

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1712/