### PR TITLE
Add/remove CBT enablement label on guest cluster PVC, based on same label present on associated supervisor cluster PVC

### DIFF
--- a/manifests/guestcluster/1.34/pvcsi.yaml
+++ b/manifests/guestcluster/1.34/pvcsi.yaml
@@ -51,7 +51,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]

--- a/manifests/guestcluster/1.35/pvcsi.yaml
+++ b/manifests/guestcluster/1.35/pvcsi.yaml
@@ -52,7 +52,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]

--- a/manifests/guestcluster/1.36/pvcsi.yaml
+++ b/manifests/guestcluster/1.36/pvcsi.yaml
@@ -52,7 +52,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]

--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -191,6 +191,12 @@ func PvcsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) er
 		if err != nil {
 			log.Warnf("FullSync: Failed to set change-id annotation on guest cluster snapshot. Err: %v", err)
 		}
+
+		// Mirror the cns.vmware.com/cbt-active label from each Supervisor PVC onto the
+		// corresponding guest cluster PVC, keeping CBT visibility in sync across both clusters.
+		if err1 := syncGuestPvcCBTLabel(ctx, metadataSyncer, supervisorNamespace); err1 != nil {
+			log.Warnf("FullSync: Failed to mirror CBT label to guest PVCs. Err: %v", err1)
+		}
 	}
 	log.Infof("FullSync: End")
 	return nil
@@ -836,6 +842,129 @@ func reconcileGuestSnapshotAnnotation(
 			common.VolumeSnapshotChangeIDKey, supervisorChangeID)
 		return nil
 	}
+	return nil
+}
+
+// syncGuestPvcCBTLabel mirrors cns.vmware.com/cbt-active label from each Supervisor PVC onto the
+// corresponding guest cluster PVC so that data-protection consumers on the guest can use the same
+// label selector to discover CBT-eligible volumes without additional CNS queries.
+//
+// For every bound vSphere block-volume PV in the guest cluster the function:
+//  1. Reads all Supervisor PVCs for the guest namespace with a single List call (N API-server
+//     round-trips → 1) and indexes them by name.
+//  2. Compares the cns.vmware.com/cbt-active label on the supervisor PVC with the guest PVC (read
+//     from the informer cache).
+//  3. Applies a JSON merge-patch to add or remove the label when they differ.
+//
+// Failures per PVC are logged at Warn and skipped; the next fullsync tick re-converges.
+func syncGuestPvcCBTLabel(ctx context.Context, metadataSyncer *metadataSyncInformer,
+	supervisorNamespace string) error {
+	log := logger.GetLogger(ctx)
+	log.Debugf("syncGuestPvcCBTLabel: starting CBT label mirror for supervisor namespace %q", supervisorNamespace)
+
+	pvList, err := getPVsInBoundAvailableOrReleased(ctx, metadataSyncer)
+	if err != nil {
+		return fmt.Errorf("syncGuestPvcCBTLabel: failed to list guest PVs: %w", err)
+	}
+
+	// Pre-filter to the PVs that actually need CBT processing.
+	type guestPVs struct {
+		svPVCName      string
+		guestNamespace string
+		guestPVCName   string
+	}
+	var filteredGuestPVs []guestPVs
+	for _, pv := range pvList {
+		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != common.VSphereCSIDriverName ||
+			pv.Spec.CSI.VolumeHandle == "" {
+			continue
+		}
+		if pv.Spec.CSI.VolumeAttributes == nil ||
+			pv.Spec.CSI.VolumeAttributes[common.AttributeDiskType] != common.DiskTypeBlockVolume {
+			continue
+		}
+		if pv.Status.Phase != v1.VolumeBound || pv.Spec.ClaimRef == nil {
+			continue
+		}
+		filteredGuestPVs = append(filteredGuestPVs, guestPVs{
+			svPVCName:      pv.Spec.CSI.VolumeHandle,
+			guestNamespace: pv.Spec.ClaimRef.Namespace,
+			guestPVCName:   pv.Spec.ClaimRef.Name,
+		})
+	}
+
+	if len(filteredGuestPVs) == 0 {
+		log.Debugf("syncGuestPvcCBTLabel: no filteredGuestPVs block PVs found; nothing to do")
+		return nil
+	}
+
+	// Fetch all supervisor PVCs for the guest namespace in a single List call and index them by name
+	// so the per-PV loop below is O(1) with no additional round-trips to the API server.
+	svPVCList, err := metadataSyncer.supervisorClient.CoreV1().
+		PersistentVolumeClaims(supervisorNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("syncGuestPvcCBTLabel: failed to list supervisor PVCs in namespace %q: %w",
+			supervisorNamespace, err)
+	}
+	svPVCByName := make(map[string]*v1.PersistentVolumeClaim, len(svPVCList.Items))
+	for i := range svPVCList.Items {
+		svPVCByName[svPVCList.Items[i].Name] = &svPVCList.Items[i]
+	}
+
+	guestKubeClient, err := k8sNewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("syncGuestPvcCBTLabel: failed to create guest kube client: %w", err)
+	}
+
+	patched, skipped := 0, 0
+	for _, e := range filteredGuestPVs {
+		svPVC, ok := svPVCByName[e.svPVCName]
+		if !ok {
+			log.Warnf("syncGuestPvcCBTLabel: supervisor PVC %q not found in namespace %q; skipping",
+				e.svPVCName, supervisorNamespace)
+			skipped++
+			continue
+		}
+
+		svHasLabel := svPVC.Labels[isCBTActiveLabel] == isCBTActiveLabelVal
+
+		guestPVC, err := metadataSyncer.pvcLister.
+			PersistentVolumeClaims(e.guestNamespace).Get(e.guestPVCName)
+		if err != nil {
+			log.Warnf("syncGuestPvcCBTLabel: failed to get guest PVC %s/%s: %v; skipping",
+				e.guestNamespace, e.guestPVCName, err)
+			skipped++
+			continue
+		}
+
+		if (guestPVC.Labels[isCBTActiveLabel] == isCBTActiveLabelVal) == svHasLabel {
+			continue // already in sync
+		}
+
+		patchBytes, err := buildCBTLabelPatch(svHasLabel)
+		if err != nil {
+			log.Warnf("syncGuestPvcCBTLabel: failed to build patch for guest PVC %s/%s: %v",
+				e.guestNamespace, e.guestPVCName, err)
+			skipped++
+			continue
+		}
+		if _, err = guestKubeClient.CoreV1().PersistentVolumeClaims(e.guestNamespace).
+			Patch(ctx, e.guestPVCName, types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+			log.Warnf("syncGuestPvcCBTLabel: failed to patch guest PVC %s/%s: %v",
+				e.guestNamespace, e.guestPVCName, err)
+			skipped++
+			continue
+		}
+		patched++
+		if svHasLabel {
+			log.Infof("syncGuestPvcCBTLabel: added %s on guest PVC %s/%s (supervisor PVC %s)",
+				isCBTActiveLabel, e.guestNamespace, e.guestPVCName, e.svPVCName)
+		} else {
+			log.Infof("syncGuestPvcCBTLabel: removed %s from guest PVC %s/%s (supervisor PVC %s)",
+				isCBTActiveLabel, e.guestNamespace, e.guestPVCName, e.svPVCName)
+		}
+	}
+	log.Infof("syncGuestPvcCBTLabel: completed — %d PVC(s) patched, %d skipped", patched, skipped)
 	return nil
 }
 

--- a/pkg/syncer/pvcsi_fullsync_test.go
+++ b/pkg/syncer/pvcsi_fullsync_test.go
@@ -39,6 +39,7 @@ import (
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
@@ -1446,6 +1447,380 @@ func TestSetGuestClusterDetailsOnSupervisorSnapshot_AnnotationBackfill(t *testin
 		assert.Equal(t, existing, annots[common.AnnKeyGuestClusterSnapshot],
 			"pre-existing annotation must not be overwritten")
 	})
+}
+
+// assertSingleSupervisorListCall verifies that the supervisor fake client
+// recorded exactly one API call and that it was a List — not a per-PV Get.
+// This documents and enforces the N-round-trips→1 optimization introduced in
+// syncGuestPvcCBTLabel: rather than calling Get once per eligible PV the
+// implementation fetches all supervisor PVCs with a single List and looks up
+// results in an in-memory map.
+func assertSingleSupervisorListCall(t *testing.T, supervisorClient *k8sfake.Clientset) {
+	t.Helper()
+	actions := supervisorClient.Actions()
+	require.Len(t, actions, 1,
+		"expected exactly one supervisor API call (List); got %d — "+
+			"a per-PV Get would indicate the optimization has regressed", len(actions))
+	assert.Equal(t, "list", actions[0].GetVerb(),
+		"supervisor API call should be List, not Get")
+}
+
+// makeBlockPV builds a bound vSphere block-volume PV whose VolumeHandle is svPVCName and
+// whose ClaimRef points at guestPVCName/guestNS.
+func makeBlockPV(name, svPVCName, guestPVCName, guestNS string) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       common.VSphereCSIDriverName,
+					VolumeHandle: svPVCName,
+					VolumeAttributes: map[string]string{
+						common.AttributeDiskType: common.DiskTypeBlockVolume,
+					},
+				},
+			},
+			ClaimRef: &v1.ObjectReference{
+				Name:      guestPVCName,
+				Namespace: guestNS,
+			},
+		},
+		Status: v1.PersistentVolumeStatus{Phase: v1.VolumeBound},
+	}
+}
+
+// TestSyncGuestPvcCBTLabel_AddLabel verifies that when the supervisor PVC carries
+// cns.vmware.com/cbt-active=true but the guest PVC has no such label, the function
+// adds the label to the guest PVC.
+func TestSyncGuestPvcCBTLabel_AddLabel(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	const (
+		svNS         = "sv-namespace"
+		svPVCName    = "sv-pvc-1"
+		guestPVCNS   = "guest-ns"
+		guestPVCName = "guest-pvc-1"
+	)
+
+	// Supervisor PVC: has the cbt-active label.
+	svPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svPVCName,
+			Namespace: svNS,
+			Labels:    map[string]string{isCBTActiveLabel: isCBTActiveLabelVal},
+		},
+	}
+	// Guest PVC: no cbt-active label yet.
+	guestPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: guestPVCName, Namespace: guestPVCNS},
+	}
+	pv := makeBlockPV("pv-1", svPVCName, guestPVCName, guestPVCNS)
+
+	supervisorClient := k8sfake.NewClientset(svPVC)
+	guestClient := k8sfake.NewClientset(guestPVC)
+	_, pvcLister, _ := newTestListers(t, guestPVC)
+
+	syncer := &metadataSyncInformer{
+		supervisorClient: supervisorClient,
+		pvcLister:        pvcLister,
+	}
+
+	origK8s := k8sNewClient
+	defer func() { k8sNewClient = origK8s }()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) { return guestClient, nil }
+
+	origGetPVs := getPVsInBoundAvailableOrReleased
+	defer func() { getPVsInBoundAvailableOrReleased = origGetPVs }()
+	getPVsInBoundAvailableOrReleased = func(_ context.Context, _ *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+		return []*v1.PersistentVolume{pv}, nil
+	}
+
+	require.NoError(t, syncGuestPvcCBTLabel(ctx, syncer, svNS))
+
+	// Exactly one supervisor API call (List), not one Get per PV.
+	assertSingleSupervisorListCall(t, supervisorClient)
+
+	updated, err := guestClient.CoreV1().PersistentVolumeClaims(guestPVCNS).Get(ctx, guestPVCName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, isCBTActiveLabelVal, updated.Labels[isCBTActiveLabel],
+		"guest PVC should have cbt-active label mirrored from supervisor PVC")
+}
+
+// TestSyncGuestPvcCBTLabel_RemoveLabel verifies that when the supervisor PVC no longer
+// carries cns.vmware.com/cbt-active but the guest PVC still does, the label is removed.
+func TestSyncGuestPvcCBTLabel_RemoveLabel(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	const (
+		svNS         = "sv-namespace"
+		svPVCName    = "sv-pvc-2"
+		guestPVCNS   = "guest-ns"
+		guestPVCName = "guest-pvc-2"
+	)
+
+	// Supervisor PVC: cbt-active label absent.
+	svPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: svPVCName, Namespace: svNS},
+	}
+	// Guest PVC: still has the stale cbt-active label.
+	guestPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      guestPVCName,
+			Namespace: guestPVCNS,
+			Labels:    map[string]string{isCBTActiveLabel: isCBTActiveLabelVal},
+		},
+	}
+	pv := makeBlockPV("pv-2", svPVCName, guestPVCName, guestPVCNS)
+
+	supervisorClient := k8sfake.NewClientset(svPVC)
+	guestClient := k8sfake.NewClientset(guestPVC)
+	_, pvcLister, _ := newTestListers(t, guestPVC)
+
+	syncer := &metadataSyncInformer{
+		supervisorClient: supervisorClient,
+		pvcLister:        pvcLister,
+	}
+
+	origK8s := k8sNewClient
+	defer func() { k8sNewClient = origK8s }()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) { return guestClient, nil }
+
+	origGetPVs := getPVsInBoundAvailableOrReleased
+	defer func() { getPVsInBoundAvailableOrReleased = origGetPVs }()
+	getPVsInBoundAvailableOrReleased = func(_ context.Context, _ *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+		return []*v1.PersistentVolume{pv}, nil
+	}
+
+	require.NoError(t, syncGuestPvcCBTLabel(ctx, syncer, svNS))
+
+	// Exactly one supervisor API call (List), not one Get per PV.
+	assertSingleSupervisorListCall(t, supervisorClient)
+
+	updated, err := guestClient.CoreV1().PersistentVolumeClaims(guestPVCNS).Get(ctx, guestPVCName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, updated.Labels[isCBTActiveLabel],
+		"guest PVC cbt-active label should be removed when supervisor PVC has none")
+}
+
+// TestSyncGuestPvcCBTLabel_AlreadyInSync verifies that no patch is issued when
+// the guest PVC already matches the supervisor PVC's CBT label state.
+func TestSyncGuestPvcCBTLabel_AlreadyInSync(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	const (
+		svNS         = "sv-namespace"
+		svPVCName    = "sv-pvc-3"
+		guestPVCNS   = "guest-ns"
+		guestPVCName = "guest-pvc-3"
+	)
+
+	// Both supervisor and guest PVCs have the label — already in sync.
+	svPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svPVCName,
+			Namespace: svNS,
+			Labels:    map[string]string{isCBTActiveLabel: isCBTActiveLabelVal},
+		},
+	}
+	guestPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      guestPVCName,
+			Namespace: guestPVCNS,
+			Labels:    map[string]string{isCBTActiveLabel: isCBTActiveLabelVal},
+		},
+	}
+	pv := makeBlockPV("pv-3", svPVCName, guestPVCName, guestPVCNS)
+
+	supervisorClient := k8sfake.NewClientset(svPVC)
+	// guestClient initially has the PVC with the label; we detect an unexpected Patch via actions.
+	guestClient := k8sfake.NewClientset(guestPVC)
+	_, pvcLister, _ := newTestListers(t, guestPVC)
+
+	syncer := &metadataSyncInformer{
+		supervisorClient: supervisorClient,
+		pvcLister:        pvcLister,
+	}
+
+	origK8s := k8sNewClient
+	defer func() { k8sNewClient = origK8s }()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) { return guestClient, nil }
+
+	origGetPVs := getPVsInBoundAvailableOrReleased
+	defer func() { getPVsInBoundAvailableOrReleased = origGetPVs }()
+	getPVsInBoundAvailableOrReleased = func(_ context.Context, _ *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+		return []*v1.PersistentVolume{pv}, nil
+	}
+
+	require.NoError(t, syncGuestPvcCBTLabel(ctx, syncer, svNS))
+
+	// Exactly one supervisor API call (List), not one Get per PV.
+	assertSingleSupervisorListCall(t, supervisorClient)
+
+	// No patch action should have been recorded on the guest client.
+	for _, action := range guestClient.Actions() {
+		assert.NotEqual(t, "patch", action.GetVerb(),
+			"no patch should be issued when labels are already in sync")
+	}
+}
+
+// TestSyncGuestPvcCBTLabel_SkipsNonBlockVolumes verifies that file volumes (missing
+// DiskType=block attribute) are skipped without error.
+func TestSyncGuestPvcCBTLabel_SkipsNonBlockVolumes(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	const svNS = "sv-namespace"
+
+	// PV with no VolumeAttributes (i.e. a file volume).
+	fileVolumePV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "file-pv"},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       common.VSphereCSIDriverName,
+					VolumeHandle: "file-sv-pvc",
+				},
+			},
+			ClaimRef: &v1.ObjectReference{Name: "file-guest-pvc", Namespace: "guest-ns"},
+		},
+		Status: v1.PersistentVolumeStatus{Phase: v1.VolumeBound},
+	}
+
+	supervisorClient := k8sfake.NewClientset()
+	guestClient := k8sfake.NewClientset()
+	_, pvcLister, _ := newTestListers(t)
+
+	syncer := &metadataSyncInformer{
+		supervisorClient: supervisorClient,
+		pvcLister:        pvcLister,
+	}
+
+	origK8s := k8sNewClient
+	defer func() { k8sNewClient = origK8s }()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) { return guestClient, nil }
+
+	origGetPVs := getPVsInBoundAvailableOrReleased
+	defer func() { getPVsInBoundAvailableOrReleased = origGetPVs }()
+	getPVsInBoundAvailableOrReleased = func(_ context.Context, _ *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+		return []*v1.PersistentVolume{fileVolumePV}, nil
+	}
+
+	require.NoError(t, syncGuestPvcCBTLabel(ctx, syncer, svNS))
+
+	// No eligible block PVs → early return before the supervisor List call.
+	for _, action := range guestClient.Actions() {
+		assert.NotEqual(t, "patch", action.GetVerb())
+	}
+	assert.Empty(t, supervisorClient.Actions(),
+		"supervisor List should not be issued when there are no eligible block volumes")
+}
+
+// TestSyncGuestPvcCBTLabel_SkipsUnboundPVs verifies that non-Bound PVs are skipped.
+func TestSyncGuestPvcCBTLabel_SkipsUnboundPVs(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	const svNS = "sv-namespace"
+
+	unboundPV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "unbound-pv"},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       common.VSphereCSIDriverName,
+					VolumeHandle: "some-sv-pvc",
+					VolumeAttributes: map[string]string{
+						common.AttributeDiskType: common.DiskTypeBlockVolume,
+					},
+				},
+			},
+			ClaimRef: &v1.ObjectReference{Name: "some-pvc", Namespace: "ns"},
+		},
+		Status: v1.PersistentVolumeStatus{Phase: v1.VolumeAvailable}, // not Bound
+	}
+
+	supervisorClient := k8sfake.NewClientset()
+	guestClient := k8sfake.NewClientset()
+	_, pvcLister, _ := newTestListers(t)
+
+	syncer := &metadataSyncInformer{
+		supervisorClient: supervisorClient,
+		pvcLister:        pvcLister,
+	}
+
+	origK8s := k8sNewClient
+	defer func() { k8sNewClient = origK8s }()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) { return guestClient, nil }
+
+	origGetPVs := getPVsInBoundAvailableOrReleased
+	defer func() { getPVsInBoundAvailableOrReleased = origGetPVs }()
+	getPVsInBoundAvailableOrReleased = func(_ context.Context, _ *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+		return []*v1.PersistentVolume{unboundPV}, nil
+	}
+
+	require.NoError(t, syncGuestPvcCBTLabel(ctx, syncer, svNS))
+
+	assert.Empty(t, supervisorClient.Actions(),
+		"supervisor List should not be issued when there are no eligible (Bound) PVs")
+}
+
+// TestSyncGuestPvcCBTLabel_MultipleVolumes verifies that the function correctly
+// processes multiple PVs in one pass — adding the label to some, removing from others.
+func TestSyncGuestPvcCBTLabel_MultipleVolumes(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	const svNS = "sv-namespace"
+
+	// sv-pvc-a: has cbt-active; guest-pvc-a: no label → label should be added.
+	svPVCA := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sv-pvc-a", Namespace: svNS,
+			Labels: map[string]string{isCBTActiveLabel: isCBTActiveLabelVal},
+		},
+	}
+	guestPVCA := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "guest-pvc-a", Namespace: "guest-ns"},
+	}
+	pvA := makeBlockPV("pv-a", "sv-pvc-a", "guest-pvc-a", "guest-ns")
+
+	// sv-pvc-b: no cbt-active; guest-pvc-b: has label → label should be removed.
+	svPVCB := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "sv-pvc-b", Namespace: svNS},
+	}
+	guestPVCB := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "guest-pvc-b", Namespace: "guest-ns",
+			Labels: map[string]string{isCBTActiveLabel: isCBTActiveLabelVal},
+		},
+	}
+	pvB := makeBlockPV("pv-b", "sv-pvc-b", "guest-pvc-b", "guest-ns")
+
+	supervisorClient := k8sfake.NewClientset(svPVCA, svPVCB)
+	guestClient := k8sfake.NewClientset(guestPVCA, guestPVCB)
+	_, pvcLister, _ := newTestListers(t, guestPVCA, guestPVCB)
+
+	syncer := &metadataSyncInformer{
+		supervisorClient: supervisorClient,
+		pvcLister:        pvcLister,
+	}
+
+	origK8s := k8sNewClient
+	defer func() { k8sNewClient = origK8s }()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) { return guestClient, nil }
+
+	origGetPVs := getPVsInBoundAvailableOrReleased
+	defer func() { getPVsInBoundAvailableOrReleased = origGetPVs }()
+	getPVsInBoundAvailableOrReleased = func(_ context.Context, _ *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+		return []*v1.PersistentVolume{pvA, pvB}, nil
+	}
+
+	require.NoError(t, syncGuestPvcCBTLabel(ctx, syncer, svNS))
+
+	// Two eligible PVs must still produce exactly one supervisor API call (List),
+	// not two individual Gets.  This is the core invariant of the optimization.
+	assertSingleSupervisorListCall(t, supervisorClient)
+
+	gotA, err := guestClient.CoreV1().PersistentVolumeClaims("guest-ns").Get(ctx, "guest-pvc-a", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, isCBTActiveLabelVal, gotA.Labels[isCBTActiveLabel],
+		"guest-pvc-a should have cbt-active label added")
+
+	gotB, err := guestClient.CoreV1().PersistentVolumeClaims("guest-ns").Get(ctx, "guest-pvc-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, gotB.Labels[isCBTActiveLabel],
+		"guest-pvc-b should have cbt-active label removed")
 }
 
 // TestIsReadyVolumeSnapshotContent_NilReadyToUse tests VSC with nil ReadyToUse


### PR DESCRIPTION
**What this PR does / why we need it**:
For CBT-enabled PVC in supervisor cluster, we add label "cns.vmware.com/cbt-active:true" if underlying FCD has CBT enabled and remove the label if underlying FCD gets CBT disabled later.
This PR propogates the same label on associated guest cluster PVC, based on label present on supervisor PVC.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* Precheckin passed
VKS precheckin https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1288/
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```
WCP precheckin https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1728/
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```

* New unit tests added are passing

```
=== RUN   TestSyncGuestPvcCBTLabel_AddLabel                                                                                                                                                                       {"level":"info","time":"2026-06-12T12:40:47.070423893+05:30","caller":"syncer/pvcsi_fullsync.go:927","msg":"syncGuestPvcCBTLabel: added cns.vmware.com/cbt-active on guest PVC guest-ns/guest-pvc-1 (supervisor PVC sv-pvc-1)","TraceId":"31b3fc25-237b-414e-b359-d1b3ab0b3b6e"}
{"level":"info","time":"2026-06-12T12:40:47.070457567+05:30","caller":"syncer/pvcsi_fullsync.go:934","msg":"syncGuestPvcCBTLabel: completed — 1 PVC(s) patched, 0 skipped","TraceId":"31b3fc25-237b-414e-b359-d1b3ab0b3b6e"}
--- PASS: TestSyncGuestPvcCBTLabel_AddLabel (0.00s)                                                                                                                                                               === RUN   TestSyncGuestPvcCBTLabel_RemoveLabel                                                                                                                                                                    {"level":"info","time":"2026-06-12T12:40:47.071822723+05:30","caller":"syncer/pvcsi_fullsync.go:930","msg":"syncGuestPvcCBTLabel: removed cns.vmware.com/cbt-active from guest PVC guest-ns/guest-pvc-2 (supervisor PVC sv-pvc-2)","TraceId":"f0478caf-c196-49c4-9ba5-49325b9ed4b9"}                                                                                                                                                {"level":"info","time":"2026-06-12T12:40:47.071856519+05:30","caller":"syncer/pvcsi_fullsync.go:934","msg":"syncGuestPvcCBTLabel: completed — 1 PVC(s) patched, 0 skipped","TraceId":"f0478caf-c196-49c4-9ba5-49325b9ed4b9"}                                                                                                                                                                                                        --- PASS: TestSyncGuestPvcCBTLabel_RemoveLabel (0.00s)                                                                                                                                                            === RUN   TestSyncGuestPvcCBTLabel_AlreadyInSync                                                                                                                                                                  {"level":"info","time":"2026-06-12T12:40:47.07193824+05:30","caller":"syncer/pvcsi_fullsync.go:934","msg":"syncGuestPvcCBTLabel: completed — 0 PVC(s) patched, 0 skipped","TraceId":"529cab7d-8a6e-4f5e-988a-c886db79923c"}
--- PASS: TestSyncGuestPvcCBTLabel_AlreadyInSync (0.00s)
=== RUN   TestSyncGuestPvcCBTLabel_SkipsNonBlockVolumes
{"level":"info","time":"2026-06-12T12:40:47.072058015+05:30","caller":"syncer/pvcsi_fullsync.go:934","msg":"syncGuestPvcCBTLabel: completed — 0 PVC(s) patched, 0 skipped","TraceId":"dde61554-4728-40e9-8936-4b9f9ff25b1b"}
--- PASS: TestSyncGuestPvcCBTLabel_SkipsNonBlockVolumes (0.00s)
=== RUN   TestSyncGuestPvcCBTLabel_SkipsUnboundPVs
{"level":"info","time":"2026-06-12T12:40:47.072150963+05:30","caller":"syncer/pvcsi_fullsync.go:934","msg":"syncGuestPvcCBTLabel: completed — 0 PVC(s) patched, 0 skipped","TraceId":"491ac43e-feba-442b-9388-deaba06c98a5"}
--- PASS: TestSyncGuestPvcCBTLabel_SkipsUnboundPVs (0.00s)
=== RUN   TestSyncGuestPvcCBTLabel_MultipleVolumes
{"level":"info","time":"2026-06-12T12:40:47.073343072+05:30","caller":"syncer/pvcsi_fullsync.go:927","msg":"syncGuestPvcCBTLabel: added cns.vmware.com/cbt-active on guest PVC guest-ns/guest-pvc-a (supervisor PVC sv-pvc-a)","TraceId":"aba7e3fd-05b3-4877-a886-b9d81d4b8e92"}
{"level":"info","time":"2026-06-12T12:40:47.07434507+05:30","caller":"syncer/pvcsi_fullsync.go:930","msg":"syncGuestPvcCBTLabel: removed cns.vmware.com/cbt-active from guest PVC guest-ns/guest-pvc-b (supervisor PVC sv-pvc-b)","TraceId":"aba7e3fd-05b3-4877-a886-b9d81d4b8e92"}
{"level":"info","time":"2026-06-12T12:40:47.074371109+05:30","caller":"syncer/pvcsi_fullsync.go:934","msg":"syncGuestPvcCBTLabel: completed — 2 PVC(s) patched, 0 skipped","TraceId":"aba7e3fd-05b3-4877-a886-b9d81d4b8e92"}
--- PASS: TestSyncGuestPvcCBTLabel_MultipleVolumes (0.00s)
```

* Manually verified label added on setup with CBT enabled on underlying disk

Before pvCSI fullsync: 

Guest cluster:
```
root@4220aa9517848144d8ab950faadceb07 [ ~ ]# export KUBECONFIG=gc_kubeconfig.yaml
root@4220aa9517848144d8ab950faadceb07 [ ~ ]#
root@4220aa9517848144d8ab950faadceb07 [ ~ ]# k get pvc -A -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"cbt-test-pvc","namespace":"default"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"wcpglobal-storage-profile"}}
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Mon Jun  8 09:42:52 UTC
        2026
    creationTimestamp: "2026-06-08T09:36:48Z"
    finalizers:
    - kubernetes.io/pvc-protection
    name: cbt-test-pvc                                                      <<<<<< no label present
    namespace: default
    resourceVersion: "1659997"
    uid: e4dbe2b6-2bd8-4744-9c77-1f54a81b38d7
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: wcpglobal-storage-profile
    volumeMode: Filesystem
    volumeName: pvc-e4dbe2b6-2bd8-4744-9c77-1f54a81b38d7
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
root@4220aa9517848144d8ab950faadceb07 [ ~ ]#
```

Supervisor cluster:
```
root@4220aa9517848144d8ab950faadceb07 [ ~ ]# export KUBECONFIG=
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"domain-c52"}]'
      csi.vsphere.volume-requested-topology: '[{"topology.kubernetes.io/zone":"domain-c52"}]'
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Mon Jun  8 09:42:52 UTC
        2026
    creationTimestamp: "2026-06-08T09:38:57Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      cns.vmware.com/cbt-active: "true"                                      <<<<< CBT label present
      vks-cluster-01/TKGService: 06c5ed24-5c3c-436a-81fc-fb2827a95d8a
    name: 06c5ed24-5c3c-436a-81fc-fb2827a95d8a-e4dbe2b6-2bd8-4744-9c77-1f54a81b38d7
    namespace: test-vadp-supervisor-ns
    resourceVersion: "7358767"
    uid: abcbbbd3-995d-47d8-825a-e5834aad7388
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: wcpglobal-storage-profile
    volumeMode: Filesystem
    volumeName: pvc-abcbbbd3-995d-47d8-825a-e5834aad7388
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
```

After pvCSI fullsync:

Guest cluster:
```
root@4220aa9517848144d8ab950faadceb07 [ ~ ]# export KUBECONFIG=gc_kubeconfig.yaml
root@4220aa9517848144d8ab950faadceb07 [ ~ ]# k get pvc -A -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"cbt-test-pvc","namespace":"default"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"wcpglobal-storage-profile"}}
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Mon Jun  8 09:42:52 UTC
        2026
    creationTimestamp: "2026-06-08T09:36:48Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      cns.vmware.com/cbt-active: "true"             <<<< CBT label added
    name: cbt-test-pvc
    namespace: default
    resourceVersion: "2373713"
    uid: e4dbe2b6-2bd8-4744-9c77-1f54a81b38d7
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: wcpglobal-storage-profile
    volumeMode: Filesystem
    volumeName: pvc-e4dbe2b6-2bd8-4744-9c77-1f54a81b38d7
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
```

pvCSI syncer logs:

```
{"level":"info","time":"2026-06-11T11:06:58.803053249Z","caller":"syncer/pvcsi_fullsync.go:927","msg":"syncGuestPvcCBTLabel: added cns.vmware.com/cbt-active on guest PVC default/cbt-test-pvc (supervisor PVC 06c5ed24-5c3c-436a-81fc-fb2827a95d8a-e4dbe2b6-2bd8-4744-9c77-1f54a81b38d7)","TraceId":"25f9b71a-52ea-4373-97a0-dd7a3c4e44ca"}
{"level":"info","time":"2026-06-11T11:06:58.803775608Z","caller":"syncer/pvcsi_fullsync.go:934","msg":"syncGuestPvcCBTLabel: completed — 1 PVC(s) patched, 0 skipped","TraceId":"25f9b71a-52ea-4373-97a0-dd7a3c4e44ca"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
