### PR TITLE
Fix WFFC PVC failure on non-topology GC with csi-provisioner 6.1

### DIFF
--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -179,6 +179,10 @@ type GCConfig struct {
 	ClusterAPIVersion string `gcfg:"cluster-api-version"`
 	// ClusterKind refers to the kind of object guest cluster is created from.
 	ClusterKind string `gcfg:"cluster-kind"`
+	// TopologyEnabled indicates whether this Guest Cluster is topology-aware
+	// (stretched Supervisor or WorkloadDomainIsolation enabled).
+	// Populated from vspherePVCSI.zone via cns-csi.conf topology-enabled field.
+	TopologyEnabled bool `gcfg:"topology-enabled"`
 }
 
 // SnapshotConfig contains snapshot configuration.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -151,6 +151,7 @@ type controller struct {
 	tanzukubernetesClusterUID  string
 	tanzukubernetesClusterName string
 	guestClusterDist           string
+	topologyEnabled            bool
 	csi.UnimplementedControllerServer
 	csi.UnimplementedSnapshotMetadataServer
 }
@@ -173,6 +174,7 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 	c.tanzukubernetesClusterUID = config.GC.TanzuKubernetesClusterUID
 	c.tanzukubernetesClusterName = config.GC.TanzuKubernetesClusterName
 	c.guestClusterDist = config.GC.ClusterDistribution
+	c.topologyEnabled = config.GC.TopologyEnabled
 	c.restClientConfig = k8s.GetRestClientConfigForSupervisor(ctx, config.GC.Endpoint, config.GC.Port)
 	c.supervisorClient, err = k8s.NewSupervisorClient(ctx, c.restClientConfig)
 	if err != nil {
@@ -467,6 +469,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				labels[key] = c.tanzukubernetesClusterUID
 				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 					req.AccessibilityRequirements != nil &&
+					c.topologyEnabled &&
 					!isLinkedCloneRequest && // the cns-csi mutation webhook in supervisor will automatically set it.
 					(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 						!isFileVolumeRequest) {
@@ -592,6 +595,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		var accessibleTopologies []map[string]string
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 			req.AccessibilityRequirements != nil &&
+			c.topologyEnabled &&
 			(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 				!isFileVolumeRequest) {
 			// Retrieve the latest version of the PVC
@@ -1660,7 +1664,8 @@ func (c *controller) GetCapacity(ctx context.Context, req *csi.GetCapacityReques
 	totalcapacity := int64(math.MaxInt64)
 	maxvolumesize := int64(math.MaxInt64)
 
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) {
+	if c.topologyEnabled &&
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) {
 		zonesMap := commonco.ContainerOrchestratorUtility.GetZonesForNamespace(c.supervisorNamespace)
 		if req.AccessibleTopology != nil {
 			if zonesMap == nil {

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -18,6 +18,7 @@ package wcpguest
 
 import (
 	"context"
+	"math"
 	"os"
 	"reflect"
 	"sync"
@@ -101,6 +102,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 		c := &controller{
 			supervisorClient:    supervisorClient,
 			supervisorNamespace: supervisorNamespace,
+			topologyEnabled:     true,
 		}
 		commonco.ContainerOrchestratorUtility, err =
 			unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
@@ -447,6 +449,42 @@ func createTestTopologyRequirement() *csi.TopologyRequirement {
 		Preferred: []*csi.Topology{topology},
 	}
 	return topologyRequirement
+}
+
+// TestGetCapacity_TopologyDisabled_ZoneIgnored verifies that GetCapacity returns
+// full capacity (MaxInt64) on a non-topology Guest Cluster even when
+// csi-provisioner 6.1.1 populates AccessibleTopology in the request.
+//
+// Without the c.topologyEnabled guard, the WorkloadDomainIsolationFSS block
+// would execute with a nil zonesMap (fake returns nil for non-topology clusters)
+// and return an error, stalling all capacity-based scheduling.
+func TestGetCapacity_TopologyDisabled_ZoneIgnored(t *testing.T) {
+	tCtx := context.Background()
+
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+
+	oldCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = co
+	defer func() { commonco.ContainerOrchestratorUtility = oldCO }()
+
+	// topologyEnabled=false: simulates a non-topology (single-zone) Guest Cluster.
+	c := &controller{
+		supervisorNamespace: testNamespace,
+		topologyEnabled:     false,
+	}
+
+	// AccessibleTopology populated by csi-provisioner 6.1.1 even for non-topology clusters.
+	resp, err := c.GetCapacity(tCtx, &csi.GetCapacityRequest{
+		AccessibleTopology: &csi.Topology{
+			Segments: map[string]string{"topology.kubernetes.io/zone": "zone-1"},
+		},
+	})
+
+	require.NoError(t, err,
+		"GetCapacity must not error when topologyEnabled=false, even with AccessibleTopology set")
+	assert.Equal(t, int64(math.MaxInt64), resp.AvailableCapacity,
+		"capacity must be MaxInt64 (unlimited) when topologyEnabled=false")
 }
 
 // TestGenerateVolumeAccessibleTopologyFromPVCAnnotation helps unit test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:


VKS 3.7.0 upgraded csi-provisioner to 6.1.1, which enables the Topology feature gate by default (unlike 4.0.0 where it defaulted to false). For
WFFC volumes this causes AccessibilityRequirements to be populated even when the Guest Cluster is not topology-aware, because csi-provisioner
passes the selected node zone label through to CreateVolume. 
The Supervisor CSI then rejects the request with: "StorageTopologyType is unset while topology label is present"
if the StorageClass does not carry storageTopologyType=zonal.

Introduce a topologyEnabled bool on the Guest CSI controller populated from a new GCConfig.TopologyEnabled field (gcfg tag: topology-enabled in cns-csi.conf). Gate both the AnnGuestClusterRequestedTopology annotation and the AccessibleTopology response behind c.topologyEnabled.
When false (single-zone or non-WDI cluster): zone topology is never forwarded to the Supervisor; CreateVolume succeeds for any StorageClass.
When true (stretched Supervisor or WDI-enabled): existing behaviour is fully preserved and zone affinity is propagated as before.
The companion aggr-pvcsi change injects topology-enabled from vspherePVCSI.zone into cns-csi.conf at render time.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing 

**Non Topology Setup**
```
root@4202db91225ef78121440cbd06d265ac [ ~ ]# kubectl -n vmware-system-csi get cm pvcsi-config -o jsonpath='{.data.cns-csi\.conf}'
[GC]
endpoint = supervisor.default.svc
port = 6443
tanzukubernetescluster-uid = 3e6aa718-c7a4-4859-aeff-489679a6bd0d
tanzukubernetescluster-name = wl-antrea
cluster-api-version = cluster.x-k8s.io/v1beta2
cluster-kind = Cluster
cluster-distribution = "TKGService"
topology-enabled = false <---------------- Non topology Setup
root@4202db91225ef78121440cbd06d265ac [ ~ ]# 
root@4202db91225ef78121440cbd06d265ac [ ~ ]# 
root@4202db91225ef78121440cbd06d265ac [ ~ ]# kubectl -n vmware-system-csi get deployment vsphere-csi-controller -o jsonpath='{.spec.template.spec.containers[?(@.name=="csi-provisioner")].args}' | tr ',' '\n'
["--v=4"
"--timeout=300s"
...
"--extra-create-metadata"
"--immediate-topology=false"] <---------------- provisioner has immediate-topology false
root@4202db91225ef78121440cbd06d265ac [ ~ ]# 
root@4202db91225ef78121440cbd06d265ac [ ~ ]# 
root@4202db91225ef78121440cbd06d265ac [ ~ ]# kubectl get csinode -o yaml | grep -A5 "topology.kubernetes.io/zone"
      - topology.kubernetes.io/zone
- apiVersion: storage.k8s.io/v1
  kind: CSINode
  metadata:
    annotations:
      storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd,kubernetes.io/portworx-volume,kubernetes.io/vsphere-volume
--
      - topology.kubernetes.io/zone
...
root@4202db91225ef78121440cbd06d265ac [ ~ ]# kubectl get nodes -L topology.kubernetes.io/zone
NAME                                      STATUS   ROLES           AGE   VERSION            ZONE
wl-antrea-ls9kk-ktl9r                     Ready    control-plane   49m   v1.36.1+vmware.4   vmware-system-legacy
wl-antrea-node-pool-1-whgrn-bflt6-7qmkh   Ready    <none>          46m   v1.36.1+vmware.4   vmware-system-legacy
root@4202db91225ef78121440cbd06d265ac [ ~ ]# k get sc
NAME                                  PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
wcpglobalstorageprofile               csi.vsphere.vmware.com   Delete          Immediate              true                   53m
wcpglobalstorageprofile-latebinding   csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   53m
worker-storagepolicy                  csi.vsphere.vmware.com   Delete          Immediate              true                   53m
worker-storagepolicy-latebinding      csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   53m
root@4202db91225ef78121440cbd06d265ac [ ~ ]# k get sc wcpglobalstorageprofile-latebinding  -o yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2026-06-15T15:56:36Z"
  labels:
    isSyncedFromSupervisor: "yes"
  name: wcpglobalstorageprofile-latebinding
  resourceVersion: "367"
  uid: afece50e-b451-4ad3-8621-75e3f24d79fe
parameters:
  svStorageClass: wcpglobalstorageprofile
provisioner: csi.vsphere.vmware.com
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
root@4202db91225ef78121440cbd06d265ac [ ~ ]# cat pvc_wffc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: example-raw-block-pvc-wffc
spec:
  volumeMode: Block
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: wcpglobalstorageprofile-latebinding
root@4202db91225ef78121440cbd06d265ac [ ~ ]# cat pod_wffc.yaml 
apiVersion: v1
kind: Pod
metadata:
  name: example-raw-block-pod
spec:
  containers:
    - name: test-container
      image: wcp-docker-local.packages.vcfd.broadcom.net/busybox/busybox:1.35
      command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
      volumeDevices:
        - devicePath: /dev/xvda
          name: data
  restartPolicy: Never
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: example-raw-block-pvc-wffc
root@4202db91225ef78121440cbd06d265ac [ ~ ]# kubectl apply -f pvc_wffc.yaml
persistentvolumeclaim/example-raw-block-pvc-wffc created
root@4202db91225ef78121440cbd06d265ac [ ~ ]# k get pvc
NAME                         STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS                          VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc-wffc   Pending                                      wcpglobalstorageprofile-latebinding   <unset>                 11s
root@4202db91225ef78121440cbd06d265ac [ ~ ]# kubectl apply -f pod_wffc.yaml
pod/example-raw-block-pod created
root@4202db91225ef78121440cbd06d265ac [ ~ ]# k get pod 
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   0/1     Pending   0          5s
root@4202db91225ef78121440cbd06d265ac [ ~ ]# k get pvc
NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                          VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc-wffc   Bound    pvc-8802b108-bb1f-4c24-87df-2232afa72701   5Gi        RWO            wcpglobalstorageprofile-latebinding   <unset>                 3m21s
root@4202db91225ef78121440cbd06d265ac [ ~ ]# k get pod
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          3m4s

---- immediate volume provisioning---

root@4202db91225ef78121440cbd06d265ac [ ~ ]# k apply -f pvc_immediate.yaml 
persistentvolumeclaim/example-raw-block-pvc created
root@4202db91225ef78121440cbd06d265ac [ ~ ]# k get pvc
NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                          VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc        Bound    pvc-cb747806-db31-4490-8082-e28537ecbcdf   5Gi        RWO            wcpglobalstorageprofile               <unset>                 4s
example-raw-block-pvc-wffc   Bound    pvc-8802b108-bb1f-4c24-87df-2232afa72701   5Gi        RWO            wcpglobalstorageprofile-latebinding   <unset>                 10m
root@4202db91225ef78121440cbd06d265ac [ ~ ]# k get pod
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          10m
root@4202db91225ef78121440cbd06d265ac [ ~ ]# cat > pod_immediate.yaml 
apiVersion: v1
kind: Pod
metadata:
  name: example-raw-block-pod-immediate
spec:
  containers:
    - name: test-container
      image: wcp-docker-local.packages.vcfd.broadcom.net/busybox/busybox:1.35
      command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
      volumeDevices:
        - devicePath: /dev/xvda
          name: data
  restartPolicy: Never
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: example-raw-block-pvc
root@4202db91225ef78121440cbd06d265ac [ ~ ]# k apply -f pod_immediate.yaml 
pod/example-raw-block-pod-immediate created
^Croot@4202db91225ef78121440cbd06d265ac [ ~ ]# k get pod
NAME                              READY   STATUS    RESTARTS   AGE
example-raw-block-pod             1/1     Running   0          11m
example-raw-block-pod-immediate   1/1     Running   0          13s

```
**Topology Enabled Setup**
```
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# kubectl -n vmware-system-csi get cm pvcsi-config -o jsonpath='{.data.cns-csi\.conf}'
[GC]
endpoint = supervisor.default.svc
port = 6443
tanzukubernetescluster-uid = 9147f853-c235-463c-af18-a88b87f864f3
tanzukubernetescluster-name = wl-antrea
cluster-api-version = cluster.x-k8s.io/v1beta2
cluster-kind = Cluster
cluster-distribution = "TKGService"
topology-enabled = true <-------------- topology enabled for GC
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# 
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# 
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# kubectl -n vmware-system-csi get deployment vsphere-csi-controller -o jsonpath='{.spec.template.spec.containers[?(@.name=="csi-provisioner")].args}' | tr ',' '\n'
["--v=4"
"--timeout=300s"
"--csi-address=$(ADDRESS)"
"--leader-election"
"--default-fstype=ext4"
"--kube-api-qps=100"
"--kube-api-burst=100"
"--leader-election-lease-duration=120s"
"--leader-election-renew-deadline=60s"
"--leader-election-retry-period=30s"
"--enable-capacity=true"
"--capacity-ownerref-level=-1"
"--extra-create-metadata"
"--strict-topology" <-------------- provisioner flags with topology enabled
"--immediate-topology=true" <-------------- provisioner flags with topology enabled
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# 
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# 
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# kubectl get csinode -o yaml | grep -A5 "topology.kubernetes.io/zone"
      - topology.kubernetes.io/zone
- apiVersion: storage.k8s.io/v1
  kind: CSINode
  metadata:
    annotations:
      storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd,kubernetes.io/portworx-volume,kubernetes.io/vsphere-volume
--
      - topology.kubernetes.io/zone
- apiVersion: storage.k8s.io/v1
  kind: CSINode
  metadata:
    annotations:
      storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd,kubernetes.io/portworx-volume,kubernetes.io/vsphere-volume
--
      - topology.kubernetes.io/zone
- apiVersion: storage.k8s.io/v1
  kind: CSINode
  metadata:
    annotations:
      storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd,kubernetes.io/portworx-volume,kubernetes.io/vsphere-volume
--
      - topology.kubernetes.io/zone
- apiVersion: storage.k8s.io/v1
  kind: CSINode
  metadata:
    annotations:
      storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd,kubernetes.io/portworx-volume,kubernetes.io/vsphere-volume
--
      - topology.kubernetes.io/zone
- apiVersion: storage.k8s.io/v1
  kind: CSINode
  metadata:
    annotations:
      storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd,kubernetes.io/portworx-volume,kubernetes.io/vsphere-volume
--
      - topology.kubernetes.io/zone
kind: List
metadata:
  resourceVersion: ""
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# kubectl get nodes -L topology.kubernetes.io/zone
NAME                                      STATUS   ROLES           AGE     VERSION            ZONE
wl-antrea-node-pool-1-vbh8d-qhvzx-fk4ft   Ready    <none>          5h1m    v1.36.1+vmware.4   domain-c52
wl-antrea-node-pool-1-vbh8d-qhvzx-kntk6   Ready    <none>          5h1m    v1.36.1+vmware.4   domain-c52
wl-antrea-node-pool-1-vbh8d-qhvzx-mblgx   Ready    <none>          5h1m    v1.36.1+vmware.4   domain-c52
wl-antrea-w6w78-76bdl                     Ready    control-plane   5h3m    v1.36.1+vmware.4   domain-c52
wl-antrea-w6w78-7gw66                     Ready    control-plane   5h      v1.36.1+vmware.4   domain-c52
wl-antrea-w6w78-kx77p                     Ready    control-plane   4h58m   v1.36.1+vmware.4   domain-c52
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# cat pvc_wffc.yaml 
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: example-raw-block-pvc-wffc
spec:
  volumeMode: Block
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: wcpglobal-storage-profile-latebinding
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# k apply -f pvc_wffc.yaml 
persistentvolumeclaim/example-raw-block-pvc-wffc created
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# k get pvc
NAME                         STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS                            VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc-wffc   Pending                                      wcpglobal-storage-profile-latebinding   <unset>                 4s
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# cat > pod_wffc.yaml 
apiVersion: v1
kind: Pod
metadata:
  name: example-raw-block-pod-wffc
spec:
  containers:
    - name: test-container
      image: wcp-docker-local.packages.vcfd.broadcom.net/busybox/busybox:1.35
      command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
      volumeDevices:
        - devicePath: /dev/xvda
          name: data
  restartPolicy: Never
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: example-raw-block-pvc-wffc
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# k apply -f pod_wffc.yaml 
pod/example-raw-block-pod-wffc created
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# k get pod 
NAME                         READY   STATUS              RESTARTS   AGE
example-raw-block-pod-wffc   0/1     ContainerCreating   0          4s
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# k get pod 
NAME                         READY   STATUS    RESTARTS   AGE
example-raw-block-pod-wffc   1/1     Running   0          87s
root@4220594568cdc101dbfd027a25c93288 [ ~ ]# k get pvc
NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                            VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc-wffc   Bound    pvc-a3c3a8b9-9b18-428f-bca3-0785a78d2bcd   5Gi        RWO            wcpglobal-storage-profile-latebinding   <unset>                 4m58s

```

logs:

Non topology setup logs:
[vks-3.70-vc8.x-manual-testing.log](https://github.com/user-attachments/files/28966236/vks-3.70-vc8.x-manual-testing.log)
[vks-3.70-vc8.x_csi-syncer.log](https://github.com/user-attachments/files/28966237/vks-3.70-vc8.x_csi-syncer.log)
[vks-3.70-vc8.x_csi-controller.log](https://github.com/user-attachments/files/28966238/vks-3.70-vc8.x_csi-controller.log)

Topology enabled setup logs:
[vks-3.70-vc9.1_GC_csi-controller.log](https://github.com/user-attachments/files/28969532/vks-3.70-vc9.1_GC_csi-controller.log)
[vks-3.70-vc9.1_GC_csi-syncer.log](https://github.com/user-attachments/files/28969533/vks-3.70-vc9.1_GC_csi-syncer.log)
[vks-3.70-vc9.1-manual-testing.log](https://github.com/user-attachments/files/28969534/vks-3.70-vc9.1-manual-testing.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix WFFC PVC failure on non-topology GC with csi-provisioner 6.1
```
