### PR TITLE
Main - Fix WFFC PVC failure on non-topology GC with csi-provisioner 6.1

### DIFF
--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -180,6 +180,10 @@ type GCConfig struct {
 	ClusterAPIVersion string `gcfg:"cluster-api-version"`
 	// ClusterKind refers to the kind of object guest cluster is created from.
 	ClusterKind string `gcfg:"cluster-kind"`
+	// TopologyEnabled indicates whether this Guest Cluster is topology-aware
+	// (stretched Supervisor or WorkloadDomainIsolation enabled).
+	// Populated from vspherePVCSI.zone via cns-csi.conf topology-enabled field.
+	TopologyEnabled bool `gcfg:"topology-enabled"`
 }
 
 // SnapshotConfig contains snapshot configuration.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -153,6 +153,7 @@ type controller struct {
 	tanzukubernetesClusterUID  string
 	tanzukubernetesClusterName string
 	guestClusterDist           string
+	topologyEnabled            bool
 }
 
 // New creates a CNS controller
@@ -173,6 +174,7 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 	c.tanzukubernetesClusterUID = config.GC.TanzuKubernetesClusterUID
 	c.tanzukubernetesClusterName = config.GC.TanzuKubernetesClusterName
 	c.guestClusterDist = config.GC.ClusterDistribution
+	c.topologyEnabled = config.GC.TopologyEnabled
 	c.restClientConfig = k8s.GetRestClientConfigForSupervisor(ctx, config.GC.Endpoint, config.GC.Port)
 	c.supervisorClient, err = k8s.NewSupervisorClient(ctx, c.restClientConfig)
 	if err != nil {
@@ -520,6 +522,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				if !fvsTopologyOverridden &&
 					commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 					req.AccessibilityRequirements != nil &&
+					c.topologyEnabled &&
 					!isLinkedCloneRequest && // the cns-csi mutation webhook in supervisor will automatically set it.
 					(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 						!isFileVolumeRequest) {
@@ -662,6 +665,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		var accessibleTopologies []map[string]string
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 			req.AccessibilityRequirements != nil &&
+			c.topologyEnabled &&
 			(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 				!isFileVolumeRequest) {
 			// Retrieve the latest version of the PVC
@@ -1730,7 +1734,8 @@ func (c *controller) GetCapacity(ctx context.Context, req *csi.GetCapacityReques
 	totalcapacity := int64(math.MaxInt64)
 	maxvolumesize := int64(math.MaxInt64)
 
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) {
+	if c.topologyEnabled &&
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) {
 		zonesMap := commonco.ContainerOrchestratorUtility.GetZonesForNamespace(c.supervisorNamespace)
 		if req.AccessibleTopology != nil {
 			if zonesMap == nil {

--- a/pkg/csi/service/wcpguest/controller_fvs_create_test.go
+++ b/pkg/csi/service/wcpguest/controller_fvs_create_test.go
@@ -67,6 +67,7 @@ func newFVSCreateController(t *testing.T, guestObjs ...*v1.PersistentVolumeClaim
 		supervisorClient:    supervisorClient,
 		guestClient:         guestClient,
 		supervisorNamespace: fvsCreateSupervisorNS,
+		topologyEnabled:     true,
 	}
 	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
 	if err != nil {

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -19,6 +19,7 @@ package wcpguest
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"os"
 	"reflect"
 	"sync"
@@ -109,6 +110,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 			supervisorClient:            supervisorClient,
 			supervisorSnapshotterClient: fakeSnapshotClient,
 			supervisorNamespace:         supervisorNamespace,
+			topologyEnabled:             true,
 		}
 		commonco.ContainerOrchestratorUtility, err =
 			unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
@@ -455,6 +457,125 @@ func createTestTopologyRequirement() *csi.TopologyRequirement {
 		Preferred: []*csi.Topology{topology},
 	}
 	return topologyRequirement
+}
+
+// TestCreateVolume_TopologyDisabled_ZoneNotForwarded verifies the core fix for
+// WFFC PVC provisioning failures on non-topology Guest Clusters with
+// csi-provisioner 6.1.1.
+//
+// csi-provisioner 6.1.1 enables the Topology feature gate by default, so it
+// populates AccessibilityRequirements even on non-topology clusters. When
+// topologyEnabled=false the controller must NOT forward zone labels to the
+// supervisor — otherwise the supervisor rejects the request with
+// "StorageTopologyType is unset while topology label is present" for
+// StorageClasses that lack storageTopologyType=zonal.
+func TestCreateVolume_TopologyDisabled_ZoneNotForwarded(t *testing.T) {
+	tCtx := context.Background()
+
+	supervisorClient := testclient.NewClientset()
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+
+	oldCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = co
+	defer func() { commonco.ContainerOrchestratorUtility = oldCO }()
+
+	// topologyEnabled=false: simulates a non-topology (single-zone) Guest Cluster.
+	c := &controller{
+		supervisorClient:    supervisorClient,
+		supervisorNamespace: testNamespace,
+		topologyEnabled:     false,
+	}
+
+	// AccessibilityRequirements is populated by csi-provisioner 6.1.1 even for
+	// WFFC volumes on non-topology clusters — this is the failure trigger.
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters: map[string]string{
+			common.AttributeSupervisorStorageClass: testStorageClass,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		}},
+		AccessibilityRequirements: createTestTopologyRequirement(),
+	}
+
+	type cvResult struct {
+		resp *csi.CreateVolumeResponse
+		err  error
+	}
+	resultCh := make(chan cvResult, 1)
+	go func() {
+		resp, err := c.CreateVolume(tCtx, reqCreate)
+		resultCh <- cvResult{resp, err}
+	}()
+
+	// Wait for CreateVolume to create the supervisor PVC and start the Watch.
+	time.Sleep(1 * time.Second)
+
+	pvc, err := supervisorClient.CoreV1().PersistentVolumeClaims(testNamespace).
+		Get(tCtx, testSupervisorPVCName, metav1.GetOptions{})
+	require.NoError(t, err, "supervisor PVC should exist once CreateVolume has started")
+
+	// Zone annotation must NOT have been placed on the supervisor PVC.
+	assert.Empty(t, pvc.Annotations[common.AnnGuestClusterRequestedTopology],
+		"zone topology must not be forwarded to supervisor when topologyEnabled=false")
+
+	// Bind the PVC (no AnnVolumeAccessibleTopology — supervisor won't set it for
+	// non-topology storage classes).
+	pvc.Status.Phase = v1.ClaimBound
+	_, err = supervisorClient.CoreV1().PersistentVolumeClaims(testNamespace).
+		Update(tCtx, pvc, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	r := <-resultCh
+	require.NoError(t, r.err,
+		"CreateVolume must succeed even when AccessibilityRequirements is populated")
+
+	// AccessibleTopology must not appear in the response.
+	assert.Nil(t, r.resp.Volume.AccessibleTopology,
+		"AccessibleTopology must not be set in response when topologyEnabled=false")
+}
+
+// TestGetCapacity_TopologyDisabled_ZoneIgnored verifies that GetCapacity returns
+// full capacity (MaxInt64) on a non-topology Guest Cluster even when
+// csi-provisioner 6.1.1 populates AccessibleTopology in the request.
+//
+// Without the c.topologyEnabled guard, the WorkloadDomainIsolationFSS block
+// would execute with a nil zonesMap (fake returns nil for non-topology clusters)
+// and return an error, stalling all capacity-based scheduling.
+func TestGetCapacity_TopologyDisabled_ZoneIgnored(t *testing.T) {
+	tCtx := context.Background()
+
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+
+	oldCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = co
+	defer func() { commonco.ContainerOrchestratorUtility = oldCO }()
+
+	// topologyEnabled=false: simulates a non-topology (single-zone) Guest Cluster.
+	c := &controller{
+		supervisorNamespace: testNamespace,
+		topologyEnabled:     false,
+	}
+
+	// AccessibleTopology populated by csi-provisioner 6.1.1 even for non-topology clusters.
+	resp, err := c.GetCapacity(tCtx, &csi.GetCapacityRequest{
+		AccessibleTopology: &csi.Topology{
+			Segments: map[string]string{"topology.kubernetes.io/zone": "zone-1"},
+		},
+	})
+
+	require.NoError(t, err,
+		"GetCapacity must not error when topologyEnabled=false, even with AccessibleTopology set")
+	assert.Equal(t, int64(math.MaxInt64), resp.AvailableCapacity,
+		"capacity must be MaxInt64 (unlimited) when topologyEnabled=false")
 }
 
 // TestGenerateVolumeAccessibleTopologyFromPVCAnnotation helps unit test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

VKS 3.7.0 upgraded csi-provisioner to 6.1.1, which enables the Topology feature gate by default (unlike 4.0.0 where it defaulted to false). For
WFFC volumes this causes AccessibilityRequirements to be populated even when the Guest Cluster is not topology-aware, because csi-provisioner
passes the selected node zone label through to CreateVolume.
The Supervisor CSI then rejects the request with: "StorageTopologyType is unset while topology label is present"
if the StorageClass does not carry storageTopologyType=zonal.

Introduce a topologyEnabled bool on the Guest CSI controller populated from a new GCConfig.TopologyEnabled field (gcfg tag: topology-enabled in cns-csi.conf). Gate both the AnnGuestClusterRequestedTopology annotation and the AccessibleTopology response behind c.topologyEnabled.
When false (single-zone or non-WDI cluster): zone topology is never forwarded to the Supervisor; CreateVolume succeeds for any StorageClass.
When true (stretched Supervisor or WDI-enabled): existing behaviour is fully preserved and zone affinity is propagated as before.
The companion aggr-pvcsi change injects topology-enabled from vspherePVCSI.zone into cns-csi.conf at render time.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing:
ref PR: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/4085

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix WFFC PVC failure on non-topology GC with csi-provisioner 6.1
```
