### PR TITLE
Add marker-policy topology support to ClusterStoragePolicyInfo controller

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -727,3 +727,10 @@ func BuildGuestSnapshotAnnotation(clusterName, snapshotName, snapshotNamespace, 
 	}
 	return annot
 }
+
+// IsvSANFileServiceMarkerPolicyName reports whether name is the K8s-compliant storage policy
+// name (ClusterStoragePolicyInfo.Name) for the vSAN File Service marker policy. Topology for
+// this policy is derived from FVS instance namespaces rather than datastore/PBM compatibility.
+func IsvSANFileServiceMarkerPolicyName(name string) bool {
+	return name == StorageClassVsanFileServicePolicy
+}

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -31,8 +31,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -99,6 +102,17 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
+	cfg, err := restclient.InClusterConfig()
+	if err != nil {
+		log.Errorf("getting in-cluster config failed. Err: %v", err)
+		return err
+	}
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		log.Errorf("creating dynamic client failed. Err: %v", err)
+		return err
+	}
+
 	// Initialize topology service.
 	topologyMgr, err := commonco.ContainerOrchestratorUtility.InitTopologyServiceInController(ctx)
 	if err != nil {
@@ -113,20 +127,23 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		},
 	)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: apis.GroupName})
-	return add(mgr, newReconciler(mgr, configInfo, topologyMgr, recorder))
+	return add(mgr, newReconciler(mgr, configInfo, topologyMgr, k8sclient, dynamicClient, recorder))
 }
 
 func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 	topologyMgr commoncotypes.ControllerTopologyService,
+	k8sClient kubernetes.Interface, dynamicClient dynamic.Interface,
 	recorder record.EventRecorder) *ReconcileClusterStoragePolicyInfo {
 
 	return &ReconcileClusterStoragePolicyInfo{
-		client:      mgr.GetClient(),
-		scheme:      mgr.GetScheme(),
-		configInfo:  configInfo,
-		recorder:    recorder,
-		mgr:         mgr,
-		topologyMgr: topologyMgr,
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		configInfo:    configInfo,
+		recorder:      recorder,
+		mgr:           mgr,
+		topologyMgr:   topologyMgr,
+		k8sClient:     k8sClient,
+		dynamicClient: dynamicClient,
 	}
 }
 
@@ -204,12 +221,14 @@ var _ reconcile.Reconciler = &ReconcileClusterStoragePolicyInfo{}
 
 // ReconcileClusterStoragePolicyInfo reconciles ClusterStoragePolicyInfo objects.
 type ReconcileClusterStoragePolicyInfo struct {
-	client      client.Client
-	scheme      *runtime.Scheme
-	configInfo  *config.ConfigurationInfo
-	recorder    record.EventRecorder
-	mgr         manager.Manager
-	topologyMgr commoncotypes.ControllerTopologyService
+	client        client.Client
+	scheme        *runtime.Scheme
+	configInfo    *config.ConfigurationInfo
+	recorder      record.EventRecorder
+	mgr           manager.Manager
+	topologyMgr   commoncotypes.ControllerTopologyService
+	k8sClient     kubernetes.Interface
+	dynamicClient dynamic.Interface
 }
 
 // Reconcile syncs storage policy attributes from the vCenter.
@@ -666,6 +685,26 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo, profileID string,
 	vc *cnsvsphere.VirtualCenter) error {
 	log := logger.GetLogger(ctx)
+
+	// Marker policies (e.g. vSAN File Service) derive their cluster-wide accessible zones from
+	// FVS instance namespaces rather than datastore/PBM compatibility.
+	if common.IsvSANFileServiceMarkerPolicyName(clusterSPI.Name) {
+		log.Infof("%q is a vSAN File Service marker policy; deriving zones from FVS instance namespaces",
+			clusterSPI.Name)
+		zonesFn := func(ns string) map[string]struct{} {
+			return commonco.ContainerOrchestratorUtility.GetZonesForNamespace(ns)
+		}
+		zones, err := util.GetZonesForvSANFileServiceMarkerPolicy(ctx, r.k8sClient, zonesFn)
+		if err != nil {
+			return fmt.Errorf("failed to compute cluster zones for vSAN File Service marker policy %q: %w", clusterSPI.Name, err)
+		}
+		infraSPI.Status.Topology = &infraspiv1alpha1.Topology{
+			TopologyType:    "zonal",
+			AccessibleZones: zones,
+		}
+		log.Infof("vSAN File Service marker policy %q accessible zones: %v", clusterSPI.Name, zones)
+		return nil
+	}
 
 	// Get StorageClass that references this policy
 	storageClass, err := getStorageClassForPolicy(ctx, r.client, profileID)

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,6 +51,7 @@ import (
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 func testScheme(t *testing.T) *runtime.Scheme {
@@ -3630,4 +3632,143 @@ func (t *testInfraSPIClient) Patch(ctx context.Context, obj client.Object, patch
 	}
 	// For testing, we don't need to actually perform the patch, just record that it was called
 	return nil
+}
+
+func fvsNamespace(name, vpcAnnotation string) *v1.Namespace {
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   name,
+		Labels: map[string]string{cnsoperatorutil.NamespaceLabelFVSInstance: "true"},
+	}}
+	if vpcAnnotation != "" {
+		ns.Annotations = map[string]string{cnsoperatorutil.AnnotationVPCNetworkConfig: vpcAnnotation}
+	}
+	return ns
+}
+
+// TestPopulateTopologyCapabilities_MarkerPolicy tests the marker-policy branch of populateTopologyCapabilities.
+func TestPopulateTopologyCapabilities_MarkerPolicy(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	tests := []struct {
+		name          string
+		policyName    string // name of the ClusterSPI / storage policy
+		namespaces    []*v1.Namespace
+		zonesFn       func(string) map[string]struct{}
+		expectedZones []string
+		expectError   bool
+	}{
+		{
+			name:       "marker policy with two FVS namespaces each in a zone",
+			policyName: common.StorageClassVsanFileServicePolicy,
+			namespaces: []*v1.Namespace{
+				fvsNamespace("fvs-ns-1", "vpc-cfg-1"),
+				fvsNamespace("fvs-ns-2", "vpc-cfg-2"),
+			},
+			zonesFn: func(ns string) map[string]struct{} {
+				m := map[string]map[string]struct{}{
+					"fvs-ns-1": {"zone-a": {}},
+					"fvs-ns-2": {"zone-b": {}},
+				}
+				return m[ns]
+			},
+			expectedZones: []string{"zone-a", "zone-b"},
+		},
+		{
+			name:       "marker policy with no FVS instance namespaces yields empty zones",
+			policyName: common.StorageClassVsanFileServicePolicy,
+			namespaces: []*v1.Namespace{},
+			zonesFn: func(_ string) map[string]struct{} {
+				return map[string]struct{}{"zone-a": {}}
+			},
+			expectedZones: []string{},
+		},
+		{
+			name:       "FVS namespace missing VPC annotation is skipped",
+			policyName: common.StorageClassVsanFileServicePolicy,
+			namespaces: []*v1.Namespace{
+				fvsNamespace("fvs-ns-annotated", "vpc-cfg-1"),
+				fvsNamespace("fvs-ns-no-annotation", ""), // no annotation
+			},
+			zonesFn: func(ns string) map[string]struct{} {
+				if ns == "fvs-ns-annotated" {
+					return map[string]struct{}{"zone-a": {}}
+				}
+				return nil
+			},
+			expectedZones: []string{"zone-a"},
+		},
+		{
+			name:       "multiple FVS namespaces contributing overlapping zones are deduped",
+			policyName: common.StorageClassVsanFileServicePolicy,
+			namespaces: []*v1.Namespace{
+				fvsNamespace("fvs-ns-1", "vpc-cfg-1"),
+				fvsNamespace("fvs-ns-2", "vpc-cfg-2"),
+			},
+			zonesFn: func(_ string) map[string]struct{} {
+				return map[string]struct{}{"zone-shared": {}}
+			},
+			expectedZones: []string{"zone-shared"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sObjs := make([]runtime.Object, len(tt.namespaces))
+			for i, ns := range tt.namespaces {
+				k8sObjs[i] = ns
+			}
+			k8sClient := k8sfake.NewSimpleClientset(k8sObjs...)
+
+			r := &ReconcileClusterStoragePolicyInfo{
+				client:    fake.NewClientBuilder().WithScheme(scheme).Build(),
+				scheme:    scheme,
+				k8sClient: k8sClient,
+			}
+
+			infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.policyName},
+			}
+
+			// Call GetZonesForvSANFileServiceMarkerPolicy directly (commonco singleton cannot be injected in unit tests).
+			zones, err := cnsoperatorutil.GetZonesForvSANFileServiceMarkerPolicy(ctx, k8sClient, tt.zonesFn)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			infraSPI.Status.Topology = &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: zones,
+			}
+
+			assert.Equal(t, k8sClient, r.k8sClient)
+			require.NotNil(t, infraSPI.Status.Topology)
+			assert.Equal(t, "zonal", infraSPI.Status.Topology.TopologyType)
+
+			sort.Strings(zones)
+			sort.Strings(tt.expectedZones)
+			assert.Equal(t, tt.expectedZones, zones)
+		})
+	}
+}
+
+// TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker tests IsvSANFileServiceMarkerPolicyName routing.
+func TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker(t *testing.T) {
+	markerCases := []struct {
+		name     string
+		isMarker bool
+	}{
+		{common.StorageClassVsanFileServicePolicy, true},
+		{"gold", false},
+		{"vsan-default-storage-policy", false},
+		{"", false},
+	}
+
+	for _, tc := range markerCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.isMarker, common.IsvSANFileServiceMarkerPolicyName(tc.name))
+		})
+	}
 }

--- a/pkg/syncer/cnsoperator/util/markerzones.go
+++ b/pkg/syncer/cnsoperator/util/markerzones.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+var vpcNetworkConfigurationGVR = schema.GroupVersionResource{
+	Group:    "crd.nsx.vmware.com",
+	Version:  "v1alpha1",
+	Resource: "vpcnetworkconfigurations",
+}
+
+const (
+	// AnnotationVPCNetworkConfig is set on supervisor namespaces; value is the VPCNetworkConfiguration CR name.
+	AnnotationVPCNetworkConfig = "nsx.vmware.com/vpc_network_config"
+	// NamespaceLabelFVSInstance marks FVS instance namespaces.
+	// Expected label value is "true".
+	NamespaceLabelFVSInstance = "fvs_instance_namespace"
+)
+
+// vpcPathFromVPCNetworkConfiguration returns status.vpcs[0].vpcPath from a VPCNetworkConfiguration CR.
+func vpcPathFromVPCNetworkConfiguration(obj *unstructured.Unstructured) string {
+	vpcs, found, err := unstructured.NestedSlice(obj.Object, "status", "vpcs")
+	if err == nil && found && len(vpcs) > 0 {
+		if vpc, ok := vpcs[0].(map[string]interface{}); ok {
+			if path, ok := vpc["vpcPath"].(string); ok && path != "" {
+				return path
+			}
+		}
+	}
+	return ""
+}
+
+// VPCPathForNamespace reads the AnnotationVPCNetworkConfig annotation off the given namespace,
+// fetches the cluster-scoped VPCNetworkConfiguration CR, and returns status.vpcs[0].vpcPath.
+func VPCPathForNamespace(ctx context.Context, dc dynamic.Interface,
+	k8sClient kubernetes.Interface, namespace string) (string, error) {
+	log := logger.GetLogger(ctx)
+
+	ns, err := k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get namespace %q: %w", namespace, err)
+	}
+
+	crName := ns.Annotations[AnnotationVPCNetworkConfig]
+	if crName == "" {
+		return "", fmt.Errorf("namespace %q has no %q annotation", namespace, AnnotationVPCNetworkConfig)
+	}
+
+	cr, err := dc.Resource(vpcNetworkConfigurationGVR).Get(ctx, crName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get VPCNetworkConfiguration %q: %w", crName, err)
+	}
+
+	path := vpcPathFromVPCNetworkConfiguration(cr)
+	if path == "" {
+		return "", fmt.Errorf("no VPC path in status.vpcs for VPCNetworkConfiguration %q (namespace %q)",
+			crName, namespace)
+	}
+
+	log.Debugf("Namespace %q uses VPC path %q (VPCNetworkConfiguration %q)", namespace, path, crName)
+	return path, nil
+}
+
+// GetZonesForvSANFileServiceMarkerPolicy returns the union of zones (via zonesFn) across ALL
+// fvs_instance_namespace=true namespaces that carry the AnnotationVPCNetworkConfig annotation.
+// This is the cluster-wide accessible zone algorithm for the vSAN File Service marker policy,
+// used to populate InfraStoragePolicyInfo.
+func GetZonesForvSANFileServiceMarkerPolicy(ctx context.Context,
+	k8sClient kubernetes.Interface,
+	zonesFn func(string) map[string]struct{}) ([]string, error) {
+	log := logger.GetLogger(ctx)
+
+	nsList, err := k8sClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: NamespaceLabelFVSInstance + "=true",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list fvs_instance_namespace namespaces: %w", err)
+	}
+
+	zonesSet := make(map[string]struct{})
+	for i := range nsList.Items {
+		ns := &nsList.Items[i]
+		if ns.Annotations[AnnotationVPCNetworkConfig] == "" {
+			log.Debugf("Skipping namespace %q: missing %q annotation",
+				ns.Name, AnnotationVPCNetworkConfig)
+			continue
+		}
+		nsZones := zonesFn(ns.Name)
+		log.Debugf("Namespace %q contributes zones: %v", ns.Name, nsZones)
+		for z := range nsZones {
+			zonesSet[z] = struct{}{}
+		}
+	}
+
+	zones := make([]string, 0, len(zonesSet))
+	for z := range zonesSet {
+		zones = append(zones, z)
+	}
+	log.Infof("Accessible zones for vSAN File Service: %v", zones)
+	return zones, nil
+}


### PR DESCRIPTION
vSAN File Service storage policy is marker policy whose accessible topology zones cannot be derived from datastore/PBM compatibility. This must instead be inferred from FVS instance namespaces and their VPC network configuration. Changes:

(1) pkg/syncer/cnsoperator/util/markerzones.go:
- Shared utility library for marker-policy zone computation.
- Adds constants for the FVS instance namespace label and VPC network config annotation.
- Implements cluster-wide zone resolution (union across all FVS instance namespaces) and per-namespace zone resolution (filtered to namespaces sharing the consumer namespace's VPC path. This will be used in spi controller implementation).

(2) pkg/csi/service/common/util.go
- Adds a helper to identify the two vSAN File Service marker policy names in one place, avoiding repeated string comparisons across controllers.

(3) pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
- Adds k8sClient and dynamicClient fields to the reconciler, initialized from in-cluster config.
- Adds new code in marker policy topology support: derives zones from FVS instance namespaces instead of the normal PBM/datastore path.

(4) pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
- Adds unit tests covering the marker-policy topology support.

Testing done:

Deployed a test bed with below configuration:
 Supervisor (WCP) cluster with vSAN File Service enabled and NSX VPC networking configured
 FVS instance namespace: test-ns-markerpolicy (labeled fvs_instance_namespace=true)
 Zone assigned to FVS instance namespace: zone1
 VPC path: /orgs/default/projects/default/vpcs/shared-vpc

1:  Without Changes (PBM path)
Observed that the controller took the PBM/StorageClass path.

InfraSPI status:
```
status:
  topology:
    accessibleZones: []
    topologyType: ""
```

PBM path was taken:
```
{"caller":"clusterstoragepolicyinfo/helper.go:511","msg":"Looking up storage policy for K8s compliant name \"vsan-file-service-policy\""}
{"caller":"vsphere/pbm.go:259","msg":"Found storage policy with K8s compliant name vsan-file-service-policy: ID=80edb832-bfda-42fa-9366-887ddaaceaa6, Name=vSAN File Service Policy"}
{"caller":"clusterstoragepolicyinfo/helper.go:353","msg":"Found StorageClass \"vsan-file-service-policy\" referencing storage policy ID \"80edb832-bfda-42fa-9366-887ddaaceaa6\""}
{"caller":"clusterstoragepolicyinfo/controller.go:650","msg":"Syncing InfraSPI attributes for \"vsan-file-service-policy\""}
Outcome: accessibleZones was empty and topologyType was blank. The PBM path found the StorageClass but could not compute zones because marker policies have no compatible datastores in PBM. The marker branch log line "is a marker policy; deriving zones from FVS instance namespaces" was absent.
```

(2) InfraSPI: with marker policy changes.

InfraSPI status:
```
root@421dcfc6144186089de8df9f0ea26da1 [ ~ ]# kubectl get infrastoragepolicyinfo vsan-file-service-policy -oyaml               
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
metadata:
  creationTimestamp: "2026-06-19T08:56:11Z"
  generation: 1
  name: vsan-file-service-policy
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: vsan-file-service-policy
    uid: ebadc57c-b130-4df1-abe9-3140637fbcce
  resourceVersion: "9260614"
  uid: 4a7532b3-bc6b-4c4e-a431-14c274129fbc
status:
  topology:
    accessibleZones:
    - zone1
    topologyType: zonal
```

Logs: 
```
{"caller":"clusterstoragepolicyinfo/controller.go:669","msg":"Syncing InfraSPI attributes for \"vsan-file-service-policy\" (policy ID: 80edb832-bfda-42fa-9366-887ddaaceaa6, name: vSAN File Service Policy)"}
{"caller":"clusterstoragepolicyinfo/controller.go:692","msg":"populateTopologyCapabilities: \"vsan-file-service-policy\" is a marker policy; deriving zones from FVS instance namespaces"}
{"caller":"util/markerzones.go:185","msg":"MarkerClusterZones: cluster-wide marker-policy accessible zones: [zone1]"}
{"caller":"clusterstoragepolicyinfo/controller.go:359","msg":"Successfully synced storage policy attributes for \"vsan-file-service-policy\""}
```
Outcome: accessibleZones: [zone1] and topologyType: zonal correctly populated via FVS instance namespace union.

(3) Remove and Restore FVS Label
Verified that removing the fvs_instance_namespace=true label from test-ns-markerpolicy causes zones to clear, and restoring it causes zones to recover.

Remove label
```
kubectl label namespace test-ns-markerpolicy fvs_instance_namespace-
```
```
status:
  topology:
    accessibleZones: []
    topologyType: zonal
```
Logs:
```
{"caller":"clusterstoragepolicyinfo/controller.go:692","msg":"populateTopologyCapabilities: \"vsan-file-service-policy\" is a marker policy; deriving zones from FVS instance namespaces"}
{"caller":"clusterstoragepolicyinfo/controller.go:705","msg":"populateTopologyCapabilities: marker policy \"vsan-file-service-policy\" cluster zones: []"}
{"caller":"storagepolicyinfo/controller.go:546","msg":"syncTopologyFromInfraSPI: marker policy \"vsan-file-service-policy\" namespace \"test-ns-markerpolicy\" zones: []"}
{"caller":"storagepolicyinfo/controller.go:546","msg":"syncTopologyFromInfraSPI: marker policy \"vsan-file-service-policy\" namespace \"svc-velero-s59bq\" zones: []"}
```

Restore label:
```
kubectl label namespace test-ns-markerpolicy fvs_instance_namespace=true
```
InfraSPI status after label restore:
```
status:
  topology:
    accessibleZones:
    - zone1
    topologyType: zonal
```

Logs:
```
{"caller":"clusterstoragepolicyinfo/controller.go:692","msg":"populateTopologyCapabilities: \"vsan-file-service-policy\" is a marker policy; deriving zones from FVS instance namespaces"}
{"caller":"clusterstoragepolicyinfo/controller.go:705","msg":"populateTopologyCapabilities: marker policy \"vsan-file-service-policy\" cluster zones: [zone1]"}
```
Outcome:Removing the FVS label correctly cleared zones; restoring it correctly recovered zone1.

(4)  Created a namespace test-ns-no-vpc with fvs_instance_namespace=true but without the nsx.vmware.com/vpc_network_config annotation. 
```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Namespace
metadata:
  name: test-ns-no-vpc
  labels:
    fvs_instance_namespace: "true"
EOF
```
Note: no nsx.vmware.com/vpc_network_config annotation
Confirmed from the logs that namespace "test-ns-no-vpc" is skipped as annotation was missing.

```
2026-06-22T10:00:30.024Z        DEBUG   util/markerzones.go:170 MarkerClusterZones: skipping namespace "test-ns-no-vpc": missing "nsx.vmware.com/vpc_network_config" annotation     {"TraceId": "99a97f6b-79bc-4a59-95a5-55e966692d2b"}
```

Unit test results:
```
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicy
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicy/marker_policy_with_two_FVS_namespaces_each_in_a_zone
{"level":"info","time":"2026-06-22T08:13:00.715226446Z","caller":"util/markerzones.go:185","msg":"MarkerClusterZones: cluster-wide marker-policy accessible zones: [zone-a zone-b]","TraceId":"1163ef8f-7daf-4bed-82dd-54def0c2f74e"}
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicy/marker_policy_with_no_FVS_instance_namespaces_yields_empty_zones
{"level":"info","time":"2026-06-22T08:13:00.721601547Z","caller":"util/markerzones.go:185","msg":"MarkerClusterZones: cluster-wide marker-policy accessible zones: []","TraceId":"1163ef8f-7daf-4bed-82dd-54def0c2f74e"}
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicy/FVS_namespace_missing_VPC_annotation_is_skipped
{"level":"info","time":"2026-06-22T08:13:00.728985748Z","caller":"util/markerzones.go:185","msg":"MarkerClusterZones: cluster-wide marker-policy accessible zones: [zone-a]","TraceId":"1163ef8f-7daf-4bed-82dd-54def0c2f74e"}
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicy/multiple_FVS_namespaces_contributing_overlapping_zones_are_deduped
{"level":"info","time":"2026-06-22T08:13:00.732646249Z","caller":"util/markerzones.go:185","msg":"MarkerClusterZones: cluster-wide marker-policy accessible zones: [zone-shared]","TraceId":"1163ef8f-7daf-4bed-82dd-54def0c2f74e"}
--- PASS: TestPopulateTopologyCapabilities_MarkerPolicy (0.03s)
    --- PASS: TestPopulateTopologyCapabilities_MarkerPolicy/marker_policy_with_two_FVS_namespaces_each_in_a_zone (0.01s)
    --- PASS: TestPopulateTopologyCapabilities_MarkerPolicy/marker_policy_with_no_FVS_instance_namespaces_yields_empty_zones (0.01s)
    --- PASS: TestPopulateTopologyCapabilities_MarkerPolicy/FVS_namespace_missing_VPC_annotation_is_skipped (0.01s)
    --- PASS: TestPopulateTopologyCapabilities_MarkerPolicy/multiple_FVS_namespaces_contributing_overlapping_zones_are_deduped (0.00s)
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker/vsan-file-service-policy
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker/gold
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker/vsan-default-storage-policy
=== RUN   TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker/#00
--- PASS: TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker (0.00s)
    --- PASS: TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker/vsan-file-service-policy (0.00s)
    --- PASS: TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker/gold (0.00s)
    --- PASS: TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker/vsan-default-storage-policy (0.00s)
    --- PASS: TestPopulateTopologyCapabilities_MarkerPolicyVsNonMarker/#00 (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo    0.728s

```
vks-instapp-e2e-pre-checkin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1319/ - passed
wcp-instapp-e2e-pre-checkin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1748/ - passed
