### PR TITLE
Improvements pvcsi security fix

### DIFF
--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -800,7 +800,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["vmware.infrastructure.cluster.x-k8s.io"]
     resources: ["vsphereclusters"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -800,7 +800,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["vmware.infrastructure.cluster.x-k8s.io"]
     resources: ["vsphereclusters"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -800,7 +800,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["vmware.infrastructure.cluster.x-k8s.io"]
     resources: ["vsphereclusters"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -42,6 +42,7 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -915,4 +916,76 @@ func PatchObject(ctx context.Context, k8sClient client.Client, original, modifie
 	log.Debugf("PatchObject: Successfully patched object %s/%s",
 		original.GetNamespace(), original.GetName())
 	return nil
+}
+
+// GetPreferredVersionForCRD uses the discovery API to find the preferred version
+// of a CRD as declared by the API server.
+// Safe for well-behaved CRDs (e.g., VSphereCluster) where all served versions
+// expose the same resources
+func GetPreferredVersionForCRD(
+	ctx context.Context, cfg *restclient.Config, group, resource string) (string, error) {
+	log := logger.GetLogger(ctx)
+	log.Infof("Looking up preferred version for group=%q resource=%q", group, resource)
+
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		log.Errorf("Failed to create discovery client: %+v", err)
+		return "", err
+	}
+	return getPreferredVersionFromDiscovery(ctx, dc, group, resource)
+}
+
+// getPreferredVersionFromDiscovery contains the version-resolution logic and is
+// separated from GetPreferredVersionForCRD to allow unit testing via a mock discovery client.
+func getPreferredVersionFromDiscovery(
+	ctx context.Context, dc discovery.DiscoveryInterface, group, resource string) (string, error) {
+	log := logger.GetLogger(ctx)
+
+	groups, lists, err := dc.ServerGroupsAndResources()
+	if err != nil {
+		if lists == nil {
+			log.Errorf("Discovery returned no data (lists=nil): %+v", err)
+			return "", err
+		}
+		log.Warnf("Partial discovery error (continuing with available data): %+v", err)
+		// If the target group specifically failed discovery, surface that error now
+		// rather than returning a misleading "not found" at the end.
+		if failedGroups, ok := discovery.GroupDiscoveryFailedErrorGroups(err); ok {
+			for gv, groupErr := range failedGroups {
+				if gv.Group == group {
+					return "", fmt.Errorf("discovery failed for group %q: %w", group, groupErr)
+				}
+			}
+		}
+	}
+
+	log.Debugf("Scanning %d API groups for preferred version of group=%q", len(groups), group)
+	for _, g := range groups {
+		if g.Name == group && g.PreferredVersion.Version != "" {
+			log.Debugf("Found preferredVersion=%q for group=%q", g.PreferredVersion.Version, group)
+			return g.PreferredVersion.Version, nil
+		}
+	}
+
+	// Fallback: group not found in groups list — scan lists for any version serving the resource.
+	log.Debugf("Group=%q not in preferred-version list, scanning %d resource lists as fallback",
+		group, len(lists))
+	for _, list := range lists {
+		gv, parseErr := schema.ParseGroupVersion(list.GroupVersion)
+		if parseErr != nil {
+			log.Warnf("Skipping unparseable GroupVersion=%q: %+v", list.GroupVersion, parseErr)
+			continue
+		}
+		if gv.Group != group {
+			continue
+		}
+		for _, r := range list.APIResources {
+			if r.Name == resource {
+				log.Debugf("Found resource=%q in version=%q via fallback scan", resource, gv.Version)
+				return gv.Version, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("group %q resource %q not found in discovery", group, resource)
 }

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -18,11 +18,15 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -98,4 +102,205 @@ func TestGetKubeConfigPath(t *testing.T) {
 		result := getKubeConfigPath(ctx)
 		assert.Equal(t, expectedPath, result)
 	})
+}
+
+const (
+	testGroup    = "vmware.infrastructure.cluster.x-k8s.io"
+	testResource = "vsphereclusters"
+)
+
+// mockDiscovery allows tests to control exactly what ServerGroupsAndResources returns.
+type mockDiscovery struct {
+	discovery.DiscoveryInterface
+	groups []*metav1.APIGroup
+	lists  []*metav1.APIResourceList
+	err    error
+}
+
+func (m *mockDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return m.groups, m.lists, m.err
+}
+
+func apiGroup(name, preferredVersion string) *metav1.APIGroup {
+	return &metav1.APIGroup{
+		Name: name,
+		PreferredVersion: metav1.GroupVersionForDiscovery{
+			Version: preferredVersion,
+		},
+	}
+}
+
+func apiResourceList(groupVersion string, resources ...string) *metav1.APIResourceList {
+	list := &metav1.APIResourceList{GroupVersion: groupVersion}
+	for _, r := range resources {
+		list.APIResources = append(list.APIResources, metav1.APIResource{Name: r})
+	}
+	return list
+}
+
+func TestGetPreferredVersionFromDiscovery_PreferredVersionInGroups(t *testing.T) {
+	dc := &mockDiscovery{
+		groups: []*metav1.APIGroup{
+			apiGroup(testGroup, "v1beta2"),
+		},
+		lists: []*metav1.APIResourceList{
+			apiResourceList(testGroup+"/v1beta2", testResource),
+		},
+	}
+
+	got, err := getPreferredVersionFromDiscovery(context.Background(), dc, testGroup, testResource)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v1beta2" {
+		t.Errorf("expected v1beta2, got %q", got)
+	}
+}
+
+func TestGetPreferredVersionFromDiscovery_FallbackToResourceList(t *testing.T) {
+	// Group has no PreferredVersion set — should fall through to resource list scan.
+	dc := &mockDiscovery{
+		groups: []*metav1.APIGroup{
+			{Name: testGroup, PreferredVersion: metav1.GroupVersionForDiscovery{Version: ""}},
+		},
+		lists: []*metav1.APIResourceList{
+			apiResourceList(testGroup+"/v1beta3", testResource),
+		},
+	}
+
+	got, err := getPreferredVersionFromDiscovery(context.Background(), dc, testGroup, testResource)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v1beta3" {
+		t.Errorf("expected v1beta3, got %q", got)
+	}
+}
+
+func TestGetPreferredVersionFromDiscovery_GroupNotInGroupsList_FoundInResourceList(t *testing.T) {
+	// Target group absent from groups slice entirely — fallback list scan must find it.
+	dc := &mockDiscovery{
+		groups: []*metav1.APIGroup{
+			apiGroup("some.other.group", "v1"),
+		},
+		lists: []*metav1.APIResourceList{
+			apiResourceList(testGroup+"/v1alpha1", testResource),
+		},
+	}
+
+	got, err := getPreferredVersionFromDiscovery(context.Background(), dc, testGroup, testResource)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v1alpha1" {
+		t.Errorf("expected v1alpha1, got %q", got)
+	}
+}
+
+func TestGetPreferredVersionFromDiscovery_TotalFailure_NilLists(t *testing.T) {
+	dc := &mockDiscovery{
+		groups: nil,
+		lists:  nil,
+		err:    errors.New("api server unreachable"),
+	}
+
+	got, err := getPreferredVersionFromDiscovery(context.Background(), dc, testGroup, testResource)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got != "" {
+		t.Errorf("expected empty string on error, got %q", got)
+	}
+}
+
+func TestGetPreferredVersionFromDiscovery_PartialFailure_TargetGroupUnavailable(t *testing.T) {
+	// ErrGroupDiscoveryFailed with the target group in the failed set.
+	// lists is non-nil but does not contain the target group.
+	partialErr := &discovery.ErrGroupDiscoveryFailed{
+		Groups: map[schema.GroupVersion]error{
+			{Group: testGroup, Version: "v1beta2"}: errors.New("timeout"),
+		},
+	}
+	dc := &mockDiscovery{
+		groups: []*metav1.APIGroup{
+			apiGroup("some.other.group", "v1"),
+		},
+		lists: []*metav1.APIResourceList{
+			apiResourceList("some.other.group/v1", "otherobjects"),
+		},
+		err: partialErr,
+	}
+
+	got, err := getPreferredVersionFromDiscovery(context.Background(), dc, testGroup, testResource)
+	if err == nil {
+		t.Fatal("expected error when target group is missing from partial discovery, got nil")
+	}
+	if got != "" {
+		t.Errorf("expected empty string on error, got %q", got)
+	}
+}
+
+func TestGetPreferredVersionFromDiscovery_PartialFailure_TargetGroupStillAvailable(t *testing.T) {
+	// ErrGroupDiscoveryFailed for an unrelated group — target group is still in lists.
+	partialErr := &discovery.ErrGroupDiscoveryFailed{
+		Groups: map[schema.GroupVersion]error{
+			{Group: "unrelated.group", Version: "v1"}: errors.New("timeout"),
+		},
+	}
+	dc := &mockDiscovery{
+		groups: []*metav1.APIGroup{
+			apiGroup(testGroup, "v1beta2"),
+		},
+		lists: []*metav1.APIResourceList{
+			apiResourceList(testGroup+"/v1beta2", testResource),
+		},
+		err: partialErr,
+	}
+
+	got, err := getPreferredVersionFromDiscovery(context.Background(), dc, testGroup, testResource)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v1beta2" {
+		t.Errorf("expected v1beta2 when target group is available despite partial error, got %q", got)
+	}
+}
+
+func TestGetPreferredVersionFromDiscovery_GroupAndResourceNotFound(t *testing.T) {
+	dc := &mockDiscovery{
+		groups: []*metav1.APIGroup{
+			apiGroup("some.other.group", "v1"),
+		},
+		lists: []*metav1.APIResourceList{
+			apiResourceList("some.other.group/v1", "otherobjects"),
+		},
+	}
+
+	got, err := getPreferredVersionFromDiscovery(context.Background(), dc, testGroup, testResource)
+	if err == nil {
+		t.Fatal("expected error when group not found, got nil")
+	}
+	if got != "" {
+		t.Errorf("expected empty string on error, got %q", got)
+	}
+}
+
+func TestGetPreferredVersionFromDiscovery_ResourceNotInMatchingGroup(t *testing.T) {
+	// Group is found but does not serve the requested resource.
+	dc := &mockDiscovery{
+		groups: []*metav1.APIGroup{
+			{Name: testGroup, PreferredVersion: metav1.GroupVersionForDiscovery{Version: ""}},
+		},
+		lists: []*metav1.APIResourceList{
+			apiResourceList(testGroup+"/v1beta2", "otherobjects"),
+		},
+	}
+
+	got, err := getPreferredVersionFromDiscovery(context.Background(), dc, testGroup, testResource)
+	if err == nil {
+		t.Fatal("expected error when resource not in group, got nil")
+	}
+	if got != "" {
+		t.Errorf("expected empty string on error, got %q", got)
+	}
 }

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 
-	_ "crypto/tls/fipsonly"
+	_ "crypto/tls/fipsonly" //nolint:typecheck
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -143,25 +144,56 @@ func startCNSCSIWebhookManager(ctx context.Context, enableWebhookClientCertVerif
 	k8sClient := mgr.GetClient()
 	cryptoClient := crypto.NewClient(ctx, k8sClient)
 
+	vsphereClusterVersion, err := k8s.GetPreferredVersionForCRD(
+		ctx,
+		mgr.GetConfig(),
+		vsphereClusterGroup,
+		vsphereClusterResource,
+	)
+	if err != nil {
+		vsphereClusterVersion = vsphereClusterDefaultVersion
+		log.Warnf("Failed to discover VSphereCluster API version, falling back to %q: %+v",
+			vsphereClusterVersion, err)
+	}
+	log.Infof("Using VSphereCluster API version: %s", vsphereClusterVersion)
+
+	vsphereClusterInformer, err := k8s.GetDynamicInformer(ctx,
+		vsphereClusterGroup, vsphereClusterVersion,
+		vsphereClusterResource,
+		v1.NamespaceAll, mgr.GetConfig(), true)
+	if err != nil {
+		return fmt.Errorf("unable to create VSphereCluster informer: %w", err)
+	}
+	stopCtx := signals.SetupSignalHandler()
+	go func() {
+		vsphereClusterInformer.Informer().Run(stopCtx.Done())
+	}()
+
 	log.Infof("registering validating webhook with the endpoint %v", ValidationWebhookPath)
 
 	webhookServer := mgr.GetWebhookServer()
 
 	webhookServer.Register(ValidationWebhookPath, &webhook.Admission{Handler: &CSISupervisorWebhook{
-		Client:            k8sClient,
-		CryptoClient:      cryptoClient,
-		clientConfig:      mgr.GetConfig(),
-		coCommonInterface: commonInterface,
+		Client:                  k8sClient,
+		CryptoClient:            cryptoClient,
+		clientConfig:            mgr.GetConfig(),
+		coCommonInterface:       commonInterface,
+		vsphereClusterStore:     vsphereClusterInformer.Informer().GetStore(),
+		vsphereClusterHasSynced: vsphereClusterInformer.Informer().HasSynced,
+		vsphereClusterVersion:   vsphereClusterVersion,
 	}})
 
 	log.Infof("registering mutation webhook with the endpoint %v", MutationWebhookPath)
 	webhookServer.Register(MutationWebhookPath, &webhook.Admission{Handler: &CSISupervisorMutationWebhook{
-		Client:            k8sClient,
-		CryptoClient:      cryptoClient,
-		coCommonInterface: commonInterface,
+		Client:                  k8sClient,
+		CryptoClient:            cryptoClient,
+		coCommonInterface:       commonInterface,
+		vsphereClusterStore:     vsphereClusterInformer.Informer().GetStore(),
+		vsphereClusterHasSynced: vsphereClusterInformer.Informer().HasSynced,
+		vsphereClusterVersion:   vsphereClusterVersion,
 	}})
 
-	if err = mgr.Start(signals.SetupSignalHandler()); err != nil {
+	if err = mgr.Start(stopCtx); err != nil {
 		return fmt.Errorf("unable to run the webhook manager: %w", err)
 	}
 
@@ -172,9 +204,12 @@ var _ admission.Handler = &CSISupervisorWebhook{}
 
 type CSISupervisorWebhook struct {
 	client.Client
-	CryptoClient      crypto.Client
-	clientConfig      *rest.Config
-	coCommonInterface commonco.COCommonInterface
+	CryptoClient            crypto.Client
+	clientConfig            *rest.Config
+	coCommonInterface       commonco.COCommonInterface
+	vsphereClusterStore     cache.Store
+	vsphereClusterHasSynced cache.InformerSynced
+	vsphereClusterVersion   string
 }
 
 func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
@@ -208,10 +243,22 @@ func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request
 		if featureFileVolumesWithVmServiceEnabled {
 			switch req.Operation {
 			case admissionv1.Create:
-				admissionResp := validateCreateCnsFileAccessConfig(ctx, h.clientConfig, &req.AdmissionRequest, h.Client)
+				cache := vsphereClusterCache{
+					store:     h.vsphereClusterStore,
+					hasSynced: h.vsphereClusterHasSynced,
+					version:   h.vsphereClusterVersion,
+				}
+				admissionResp := validateCreateCnsFileAccessConfig(ctx, h.clientConfig, &req.AdmissionRequest,
+					h.Client, cache)
 				resp.AdmissionResponse = *admissionResp.DeepCopy()
 			case admissionv1.Delete:
-				admissionResp := validateDeleteCnsFileAccessConfig(ctx, h.clientConfig, &req.AdmissionRequest, h.Client)
+				cache := vsphereClusterCache{
+					store:     h.vsphereClusterStore,
+					hasSynced: h.vsphereClusterHasSynced,
+					version:   h.vsphereClusterVersion,
+				}
+				admissionResp := validateDeleteCnsFileAccessConfig(ctx, h.clientConfig, &req.AdmissionRequest,
+					h.Client, cache)
 				resp.AdmissionResponse = *admissionResp.DeepCopy()
 			}
 		}
@@ -228,8 +275,11 @@ var _ admission.Handler = &CSISupervisorMutationWebhook{}
 
 type CSISupervisorMutationWebhook struct {
 	client.Client
-	CryptoClient      crypto.Client
-	coCommonInterface commonco.COCommonInterface
+	CryptoClient            crypto.Client
+	coCommonInterface       commonco.COCommonInterface
+	vsphereClusterStore     cache.Store
+	vsphereClusterHasSynced cache.InformerSynced
+	vsphereClusterVersion   string
 }
 
 func (h *CSISupervisorMutationWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
@@ -331,7 +381,12 @@ func (h *CSISupervisorMutationWebhook) mutateNewCnsFileAccessConfig(ctx context.
 	}
 
 	// If CR is created by CSI service account, do not add devops label.
-	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username, h.Client)
+	cache := vsphereClusterCache{
+		store:     h.vsphereClusterStore,
+		hasSynced: h.vsphereClusterHasSynced,
+		version:   h.vsphereClusterVersion,
+	}
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username, h.Client, cache)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -29,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 
@@ -39,14 +39,36 @@ import (
 )
 
 const (
-	KubernetesServiceAccount = "system:serviceaccount:kube-system"
-	KubernetesAdmin          = "kubernetes-admin"
+	KubernetesAdmin = "kubernetes-admin"
+
+	vsphereClusterGroup          = "vmware.infrastructure.cluster.x-k8s.io"
+	vsphereClusterResource       = "vsphereclusters"
+	vsphereClusterDefaultVersion = "v1beta2"
 )
+
+// vsphereClusterCache bundles the informer store, sync-state func, and discovered API
+// version for VSphereCluster so they can be threaded through the validation call chain
+// as a single argument.
+type vsphereClusterCache struct {
+	store     cache.Store
+	hasSynced cache.InformerSynced
+	version   string
+}
+
+// allowedKubernetesServiceAccounts is the explicit set of kube-system service accounts
+// permitted to delete CnsFileAccessConfig resources.
+var allowedKubernetesServiceAccounts = map[string]struct{}{
+	"system:serviceaccount:kube-system:generic-garbage-collector":                  {},
+	"system:serviceaccount:kube-system:namespace-controller":                       {},
+	"system:serviceaccount:kube-system:supervisor-authz-service-controller-pkg-sa": {},
+	"system:serviceaccount:kube-system:supervisor-authz-service-controller-sa":     {},
+}
 
 // validateCreateCnsFileAccessConfig validates if a CnsFileAccessConfig CR with the same VM and PVC already exists.
 // If it already exists, do not allow creation of another CR.
 func validateCreateCnsFileAccessConfig(ctx context.Context, clientConfig *rest.Config,
-	req *admissionv1.AdmissionRequest, k8sClient client.Client) *admissionv1.AdmissionResponse {
+	req *admissionv1.AdmissionRequest, k8sClient client.Client,
+	vscc vsphereClusterCache) *admissionv1.AdmissionResponse {
 	log := logger.GetLogger(ctx)
 
 	cnsFileAccessConfig := cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
@@ -63,7 +85,7 @@ func validateCreateCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 	}
 
 	// This validation is not required for PVCSI service account.
-	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username, k8sClient)
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, req.UserInfo.Username, k8sClient, vscc)
 	if err != nil {
 		// return AdmissionResponse result
 		return &admissionv1.AdmissionResponse{
@@ -173,7 +195,8 @@ func cnsFileAccessConfigAlreadyExists(ctx context.Context, clientConfig *rest.Co
 // devops label (indicates that it is a CR being used by guest cluster) if user deleting the instance
 // is a CSI or K8s system user or K8s admin.
 func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.Config,
-	req *admissionv1.AdmissionRequest, k8sClient client.Client) *admissionv1.AdmissionResponse {
+	req *admissionv1.AdmissionRequest, k8sClient client.Client,
+	vscc vsphereClusterCache) *admissionv1.AdmissionResponse {
 	log := logger.GetLogger(ctx)
 
 	cnsFileAccessConfig := cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
@@ -200,7 +223,7 @@ func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 	}
 
 	// Check if user is allowed to delete this CR.
-	allowed, err := isUserAllowedForDeletion(ctx, req.UserInfo.Username, k8sClient)
+	allowed, err := isUserAllowedForDeletion(ctx, req.UserInfo.Username, k8sClient, vscc)
 	if err != nil {
 		return &admissionv1.AdmissionResponse{
 			Allowed: false,
@@ -224,34 +247,27 @@ func validateDeleteCnsFileAccessConfig(ctx context.Context, clientConfig *rest.C
 	}
 }
 
-// isUserAllowedForDeletion returns true if user is either a PVCSI service account or
-// K8s' namespace-controller.
-func isUserAllowedForDeletion(ctx context.Context, username string, k8sClient client.Client) (bool, error) {
-	kubernetesServiceAccount, err := regexp.Compile(KubernetesServiceAccount)
-	if err != nil {
-		return false, err
-	}
-
-	// Check if user is a valid PVCSI service account using the new validation logic
-	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, username, k8sClient)
-	if err != nil {
-		return false, err
-	}
-	if isPvCSIServiceAccount {
-		return true, nil
-	}
+// isUserAllowedForDeletion returns true if the user is either a valid PvCSI service account,
+// An allowlisted kube-system service account, or kubernetes-admin.
+func isUserAllowedForDeletion(ctx context.Context, username string, k8sClient client.Client,
+	vscc vsphereClusterCache) (bool, error) {
 
 	// Allowed users are :
-	// 1. K8s service account (like namespace-controller or generic-garbage-collector)
+	// 1. Specific kube-system service accounts (e.g. namespace-controller, generic-garbage-collector)
 	// 2. K8s admin
-	if kubernetesServiceAccount.MatchString(username) || username == KubernetesAdmin {
+	if _, allowed := allowedKubernetesServiceAccounts[username]; allowed || username == KubernetesAdmin {
 		return true, nil
 	}
-
-	return false, nil
+	// Check if user is a valid PVCSI service account using the new validation logic
+	isPvCSIServiceAccount, err := validatePvCSIServiceAccount(ctx, username, k8sClient, vscc)
+	if err != nil {
+		return false, err
+	}
+	return isPvCSIServiceAccount, nil
 }
 
-func validatePvCSIServiceAccount(ctx context.Context, username string, k8sClient client.Client) (bool, error) {
+func validatePvCSIServiceAccount(ctx context.Context, username string, k8sClient client.Client,
+	vscc vsphereClusterCache) (bool, error) {
 	log := logger.GetLogger(ctx)
 
 	log.Debugf("Validating PvCSI service account: username=%s", username)
@@ -260,7 +276,7 @@ func validatePvCSIServiceAccount(ctx context.Context, username string, k8sClient
 	// Parse the username to extract namespace and service account name
 	const prefix = "system:serviceaccount:"
 	if !strings.HasPrefix(username, prefix) {
-		log.Infof("Username doesn't have service account prefix, returning false")
+		log.Warnf("Username : %s doesn't have service account prefix, returning false", username)
 		return false, nil
 	}
 
@@ -269,7 +285,7 @@ func validatePvCSIServiceAccount(ctx context.Context, username string, k8sClient
 	log.Debugf("Parsed service account parts: %v (count: %d)", parts, len(parts))
 
 	if len(parts) != 2 {
-		log.Errorf("Invalid service account format - expected 2 parts, got %d, returning false", len(parts))
+		log.Warnf("Invalid service account format - expected 2 parts, got %d, returning false", len(parts))
 		return false, nil
 	}
 
@@ -279,21 +295,21 @@ func validatePvCSIServiceAccount(ctx context.Context, username string, k8sClient
 
 	// For any namespace, check if service account follows guest cluster PvCSI pattern
 	// Guest cluster PvCSI service accounts follow the pattern: {cluster-name}-pvcsi
-	if strings.HasSuffix(serviceAccountName, "-pvcsi") {
-		log.Debugf("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
-		return validateProviderServiceAccount(ctx, namespace, serviceAccountName, k8sClient)
+	if !strings.HasSuffix(serviceAccountName, "-pvcsi") {
+		log.Warnf("Service account: %s doesn't match any PvCSI patterns, returning false", serviceAccountName)
+		return false, nil
 	}
 
-	log.Debugf("Service account doesn't match any PvCSI patterns, returning false")
-	return false, nil
+	log.Debugf("Service account ends with -pvcsi, validating as guest cluster PvCSI account")
+	return validateProviderServiceAccount(ctx, namespace, serviceAccountName, k8sClient, vscc)
 }
 
 // validateProviderServiceAccount validates the service account name matches an existing
 // VSphereCluster
 func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccountName string,
-	k8sClient client.Client) (bool, error) {
+	k8sClient client.Client, vscc vsphereClusterCache) (bool, error) {
 	log := logger.GetLogger(ctx)
-	log.Infof("Validating provider service account '%s' in namespace '%s'", serviceAccountName, namespace)
+	log.Debugf("Validating provider service account '%s' in namespace '%s'", serviceAccountName, namespace)
 
 	clusterName := strings.TrimSuffix(serviceAccountName, "-pvcsi")
 	if clusterName == "" {
@@ -301,35 +317,50 @@ func validateProviderServiceAccount(ctx context.Context, namespace, serviceAccou
 		return false, nil
 	}
 
-	log.Infof("Extracted vsphere cluster name '%s' from service account '%s', searching in namespace '%s'",
+	log.Debugf("Extracted vsphere cluster name '%s' from service account '%s', searching in namespace '%s'",
 		clusterName, serviceAccountName, namespace)
 
 	// validate VSphereCluster resource exists
-	found, err := validateVSphereClusterResource(ctx, clusterName, namespace, k8sClient)
+	found, err := validateVSphereClusterResource(ctx, clusterName, namespace, k8sClient, vscc)
 	if err != nil {
 		return false, fmt.Errorf("failed to check VSphereCluster resource: %w", err)
 	}
-	if found {
-		log.Infof("Found VSphereCluster '%s' in namespace '%s', service account '%s' is valid",
+	if !found {
+		log.Warnf("VSphereCluster with name '%s' not found in namespace '%s', service account '%s' is not valid",
 			clusterName, namespace, serviceAccountName)
-		return true, nil
+		return false, nil
 	}
-
-	log.Infof("VSphereCluster with name :'%s' not found in namespace '%s', So service account '%s' is not valid",
+	log.Debugf("Found VSphereCluster '%s' in namespace '%s', service account '%s' is valid",
 		clusterName, namespace, serviceAccountName)
-	return false, nil
+	return true, nil
 }
 
-// validateVSphereClusterResource checks if a VSphereCluster resource exists using dynamic client
+// validateVSphereClusterResource checks if a VSphereCluster resource exists.
+// It queries the informer's local store when synced to avoid API server calls on every
+// webhook request. Falls back to a direct API call during the brief startup sync window
+// to prevent false negatives that would incorrectly reject valid PVCSI requests.
 func validateVSphereClusterResource(ctx context.Context, clusterName, namespace string,
-	k8sClient client.Client) (bool, error) {
+	k8sClient client.Client, vscc vsphereClusterCache) (bool, error) {
 	log := logger.GetLogger(ctx)
 
-	// Use unstructured object to work with the actual VSphereCluster API group/version deployed in the cluster
+	if vscc.store != nil && vscc.hasSynced != nil && vscc.hasSynced() {
+		key := namespace + "/" + clusterName
+		_, exists, err := vscc.store.GetByKey(key)
+		if err != nil {
+			return false, fmt.Errorf("failed to query VSphereCluster store for '%s/%s': %w",
+				namespace, clusterName, err)
+		}
+		log.Debugf("VSphereCluster '%s/%s' store lookup: exists=%v", namespace, clusterName, exists)
+		return exists, nil
+	}
+
+	// Informer not yet synced — fall back to direct API call.
+	log.Warnf("VSphereCluster informer not synced, falling back to API call for '%s/%s'",
+		namespace, clusterName)
 	vsphereCluster := &unstructured.Unstructured{}
 	vsphereCluster.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "vmware.infrastructure.cluster.x-k8s.io",
-		Version: "v1beta2",
+		Group:   vsphereClusterGroup,
+		Version: vscc.version,
 		Kind:    "VSphereCluster",
 	})
 
@@ -339,9 +370,14 @@ func validateVSphereClusterResource(ctx context.Context, clusterName, namespace 
 	}, vsphereCluster)
 
 	if err != nil {
-		return false, fmt.Errorf("failed to get VSphereCluster '%s' in namespace '%s': %w", clusterName, namespace, err)
+		if client.IgnoreNotFound(err) != nil {
+			return false, fmt.Errorf("failed to get VSphereCluster '%s/%s': %w",
+				namespace, clusterName, err)
+		}
+		log.Debugf("VSphereCluster '%s/%s' not found", namespace, clusterName)
+		return false, nil
 	}
 
-	log.Infof("Found VSphereCluster '%s' in namespace '%s'", clusterName, namespace)
+	log.Debugf("Found VSphereCluster '%s/%s' via API call", namespace, clusterName)
 	return true, nil
 }

--- a/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
+++ b/pkg/syncer/admissionhandler/validate_cnsfileaccessconfig_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 	ccV1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -55,8 +56,8 @@ func createTestVSphereClusters() []*unstructured.Unstructured {
 	for _, data := range clusterData {
 		cluster := &unstructured.Unstructured{}
 		cluster.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "vmware.infrastructure.cluster.x-k8s.io",
-			Version: "v1beta2",
+			Group:   vsphereClusterGroup,
+			Version: vsphereClusterDefaultVersion,
 			Kind:    "VSphereCluster",
 		})
 		cluster.SetName(data.name)
@@ -123,11 +124,10 @@ func TestValidatePvCSIServiceAccount(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:           "Invalid namespace for test-cluster VSphereCluster validation",
-			username:       "system:serviceaccount:vmware-system-csi:test-cluster-pvcsi",
-			expected:       false,
-			expectError:    true,
-			errorSubstring: "failed to check VSphereCluster resource", // Namespace mismatch expected
+			name:        "Invalid namespace for test-cluster VSphereCluster validation",
+			username:    "system:serviceaccount:vmware-system-csi:test-cluster-pvcsi",
+			expected:    false,
+			expectError: false,
 		},
 		{
 			name:        "Valid VSphereCluster validation for test-cluster-e2e-script-95jxs",
@@ -142,11 +142,10 @@ func TestValidatePvCSIServiceAccount(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:           "SECURITY FIX: malicious service account in wrong namespace blocked",
-			username:       "system:serviceaccount:malicious-ns:evil-pvcsi",
-			expected:       false,
-			expectError:    true,
-			errorSubstring: "failed to check VSphereCluster resource", // Now properly blocked - wrong namespace
+			name:        "SECURITY FIX: malicious service account in wrong namespace blocked",
+			username:    "system:serviceaccount:malicious-ns:evil-pvcsi",
+			expected:    false,
+			expectError: false,
 		},
 		{
 			name:        "SECURITY FIX: attempt to bypass with multiple colons blocked",
@@ -238,13 +237,12 @@ func TestValidatePvCSIServiceAccount(t *testing.T) {
 			expected:    false, // Empty cluster name blocked by fallback validation
 			expectError: false,
 		},
-		// Note: VSphereCluster validation tests are omitted as they require a real cluster
-		// The dynamic client approach will work with actual deployed API groups
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := validatePvCSIServiceAccount(context.TODO(), tc.username, fakeClient)
+			result, err := validatePvCSIServiceAccount(context.TODO(), tc.username, fakeClient,
+				vsphereClusterCache{version: vsphereClusterDefaultVersion})
 
 			// Check error expectation
 			if tc.expectError {
@@ -290,9 +288,39 @@ func TestIsUserAllowedForDeletion(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "Valid Kubernetes service account",
+			name:     "kube-system invalid SA",
+			username: "system:serviceaccount:kube-system:i-am-invalid",
+			expected: false,
+		},
+		{
+			name:     "kube-system default SA",
+			username: "system:serviceaccount:kube-system:default",
+			expected: false,
+		},
+		{
+			name:     "kube-system generic-garbage-collector",
+			username: "system:serviceaccount:kube-system:generic-garbage-collector",
+			expected: true,
+		},
+		{
+			name:     "kube-system namespace-controller",
 			username: "system:serviceaccount:kube-system:namespace-controller",
 			expected: true,
+		},
+		{
+			name:     "kube-system supervisor-authz-service-controller-pkg-sa",
+			username: "system:serviceaccount:kube-system:supervisor-authz-service-controller-pkg-sa",
+			expected: true,
+		},
+		{
+			name:     "kube-system supervisor-authz-service-controller-sa",
+			username: "system:serviceaccount:kube-system:supervisor-authz-service-controller-sa",
+			expected: true,
+		},
+		{
+			name:     "Bare kube-system prefix is not allowed",
+			username: "system:serviceaccount:kube-system",
+			expected: false,
 		},
 		{
 			name:     "Valid Kubernetes admin",
@@ -313,13 +341,221 @@ func TestIsUserAllowedForDeletion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := isUserAllowedForDeletion(context.TODO(), tc.username, fakeClient)
+			result, err := isUserAllowedForDeletion(context.TODO(), tc.username, fakeClient, vsphereClusterCache{})
 			if err != nil {
 				t.Errorf("isUserAllowedForDeletion() returned error: %v", err)
 				return
 			}
 			if result != tc.expected {
 				t.Errorf("isUserAllowedForDeletion(%q) = %v, want %v", tc.username, result, tc.expected)
+			}
+		})
+	}
+}
+
+// newFakeStore creates a cache.Store populated with the given VSphereCluster objects.
+// The store uses MetaNamespaceKeyFunc so keys are "namespace/name", matching the
+// lookup in validateVSphereClusterResource.
+func newFakeStore(clusters ...*unstructured.Unstructured) cache.Store {
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, c := range clusters {
+		_ = store.Add(c)
+	}
+	return store
+}
+
+// makeVSphereCluster is a test helper that returns an unstructured VSphereCluster.
+func makeVSphereCluster(name, namespace string) *unstructured.Unstructured {
+	c := &unstructured.Unstructured{}
+	c.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   vsphereClusterGroup,
+		Version: vsphereClusterDefaultVersion,
+		Kind:    "VSphereCluster",
+	})
+	c.SetName(name)
+	c.SetNamespace(namespace)
+	return c
+}
+
+func TestValidateVSphereClusterResource(t *testing.T) {
+	synced := func() bool { return true }
+	notSynced := func() bool { return false }
+
+	scheme := setupSchemeForTest()
+	existingCluster := makeVSphereCluster("guest-cluster", "vmware-system-csi")
+
+	clientWithCluster := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existingCluster).
+		Build()
+	emptyClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	testCases := []struct {
+		name        string
+		clusterName string
+		namespace   string
+		store       cache.Store
+		hasSynced   cache.InformerSynced
+		k8sClient   client.Client
+		expected    bool
+	}{
+		{
+			name:        "store synced, cluster present — returns true without hitting API",
+			clusterName: "guest-cluster",
+			namespace:   "vmware-system-csi",
+			store:       newFakeStore(existingCluster),
+			hasSynced:   synced,
+			k8sClient:   emptyClient, // API has nothing — proves the store path is used
+			expected:    true,
+		},
+		{
+			name:        "store synced, cluster absent — returns false even when API has it",
+			clusterName: "guest-cluster",
+			namespace:   "vmware-system-csi",
+			store:       newFakeStore(), // empty store
+			hasSynced:   synced,
+			k8sClient:   clientWithCluster, // API has the cluster — proves store wins
+			expected:    false,
+		},
+		{
+			name:        "store not yet synced, cluster in API — fallback returns true",
+			clusterName: "guest-cluster",
+			namespace:   "vmware-system-csi",
+			store:       newFakeStore(),
+			hasSynced:   notSynced,
+			k8sClient:   clientWithCluster,
+			expected:    true,
+		},
+		{
+			name:        "store not yet synced, cluster missing from API — fallback returns false",
+			clusterName: "nonexistent-cluster",
+			namespace:   "vmware-system-csi",
+			store:       newFakeStore(),
+			hasSynced:   notSynced,
+			k8sClient:   emptyClient,
+			expected:    false,
+		},
+		{
+			name:        "nil store — always falls back to API, cluster present",
+			clusterName: "guest-cluster",
+			namespace:   "vmware-system-csi",
+			store:       nil,
+			hasSynced:   nil, // never called when store is nil
+			k8sClient:   clientWithCluster,
+			expected:    true,
+		},
+		{
+			name:        "store synced, cluster deleted — empty store reflects deletion",
+			clusterName: "deleted-cluster",
+			namespace:   "vmware-system-csi",
+			store:       newFakeStore(), // cluster removed from store on deletion
+			hasSynced:   synced,
+			k8sClient:   emptyClient,
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := validateVSphereClusterResource(context.TODO(), tc.clusterName, tc.namespace,
+				tc.k8sClient, vsphereClusterCache{
+					store:     tc.store,
+					hasSynced: tc.hasSynced,
+					version:   vsphereClusterDefaultVersion,
+				})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("validateVSphereClusterResource(%q, %q) = %v, want %v",
+					tc.namespace, tc.clusterName, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestValidatePvCSIServiceAccountWithStore(t *testing.T) {
+	synced := func() bool { return true }
+	notSynced := func() bool { return false }
+
+	scheme := setupSchemeForTest()
+	// emptyClient: no API objects — proves the store path is taken, not the API
+	emptyClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	guestCluster := makeVSphereCluster("guest-cluster", "vmware-system-csi")
+	e2eCluster := makeVSphereCluster("test-cluster-e2e-script-95jxs", "test-gc-e2e-demo-ns")
+
+	populatedStore := newFakeStore(guestCluster, e2eCluster)
+	emptyStore := newFakeStore()
+
+	testCases := []struct {
+		name      string
+		username  string
+		store     cache.Store
+		hasSynced cache.InformerSynced
+		k8sClient client.Client
+		expected  bool
+	}{
+		{
+			name:      "store synced, cluster present — SA allowed",
+			username:  "system:serviceaccount:vmware-system-csi:guest-cluster-pvcsi",
+			store:     populatedStore,
+			hasSynced: synced,
+			k8sClient: emptyClient,
+			expected:  true,
+		},
+		{
+			name:      "store synced, cluster absent — SA rejected",
+			username:  "system:serviceaccount:vmware-system-csi:nonexistent-cluster-pvcsi",
+			store:     emptyStore,
+			hasSynced: synced,
+			k8sClient: emptyClient,
+			expected:  false,
+		},
+		{
+			name:      "store synced, e2e cluster SA — cluster found",
+			username:  "system:serviceaccount:test-gc-e2e-demo-ns:test-cluster-e2e-script-95jxs-pvcsi",
+			store:     populatedStore,
+			hasSynced: synced,
+			k8sClient: emptyClient,
+			expected:  true,
+		},
+		{
+			name:      "store synced, cluster exists but SA uses wrong namespace",
+			username:  "system:serviceaccount:wrong-ns:guest-cluster-pvcsi",
+			store:     populatedStore, // has guest-cluster in vmware-system-csi, not wrong-ns
+			hasSynced: synced,
+			k8sClient: emptyClient,
+			expected:  false,
+		},
+		{
+			name:      "store not synced, cluster found via API fallback",
+			username:  "system:serviceaccount:vmware-system-csi:guest-cluster-pvcsi",
+			store:     emptyStore, // empty — would return false if consulted
+			hasSynced: notSynced,  // forces the API fallback path
+			k8sClient: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(guestCluster).
+				Build(),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := validatePvCSIServiceAccount(context.TODO(), tc.username, tc.k8sClient,
+				vsphereClusterCache{
+					store:     tc.store,
+					hasSynced: tc.hasSynced,
+					version:   vsphereClusterDefaultVersion,
+				})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("validatePvCSIServiceAccount(%q) = %v, want %v", tc.username, result, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This change has some improvements on top of [PR:4024](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/4024 )suggested by George while cross porting the same to 9.1EP2. 

**Informer Cacher :**
validateVSphereClusterResource() in the CnsFileAccessConfig admission webhook previously called k8sClient.Get() against the API server on every Create/Delete webhook request — a pure existence check that adds API server load proportional to PVC traffic.

This PR replaces that per-request API call with a Kubernetes dynamic informer backed local store. The informer watches vsphereclusters and keeps an in-process cache current via the watch stream. Lookups become pure local map reads with no network hop.

Added "list", "watch" premission on this resource for informer cache

**Security**: Exact match for KubernetesServiceAccount — The username check for system:serviceaccount:kube-system was previously compiled as a regex and matched with MatchString. This is replaced with exact string equality (==), preventing any crafted username from bypassing the check via regex injection (e.g., a username containing system:serviceaccount:kube-system as a substring).

We checked, these are the service account with prefix "system:serviceaccount:kube-system:" have delete permissions on cnsfileaccessconfig.

	"system:serviceaccount:kube-system:generic-garbage-collector"
	"system:serviceaccount:kube-system:namespace-controller"
	"system:serviceaccount:kube-system:supervisor-authz-service-controller-pkg-sa"
	"system:serviceaccount:kube-system:supervisor-authz-service-controller-sa"

This is how I found out these are the SA have permissions:
https://gist.github.com/anuj087/923424df19f2e319f8f02cbeb63c6fcb#file-gistfile1-txt

**Error handling:** Proper not-found handling in validateVSphereClusterResource — client.Get returns a not-found error when a VSphereCluster resource doesn't exist; previously this was propagated as an error, causing valid rejection paths to surface as unexpected errors. Now client.IgnoreNotFound is used to return false, nil for missing resources, reserving actual errors for API/network failures.

**Go conventions:** Early return on invalid path — Functions in isUserAllowedForDeletion, validatePvCSIServiceAccount, and validateProviderServiceAccount are restructured to return the invalid/error case first, with the success path at the end, following standard Go idioms.

**Log level corrections** — Several internal validation messages downgraded from Infof/Warnf/Errorf to Debugf, since they represent expected non-error control flow rather than actionable operational signals.

**Test plan** : 

1. prechecking tests passed
2. vks cluster file volume tests passed
https://gist.github.com/anuj087/923424df19f2e319f8f02cbeb63c6fcb
3. Running vm service+ file volume tests
4. Added required unit tests
