### PR TITLE
Fix WFFC volume provision on GC with SC without storageTopologyType (#4085)

### DIFF
--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -179,6 +179,10 @@ type GCConfig struct {
 	ClusterAPIVersion string `gcfg:"cluster-api-version"`
 	// ClusterKind refers to the kind of object guest cluster is created from.
 	ClusterKind string `gcfg:"cluster-kind"`
+	// TopologyEnabled indicates whether this Guest Cluster is topology-aware
+	// (stretched Supervisor or WorkloadDomainIsolation enabled).
+	// Populated from vspherePVCSI.zone via cns-csi.conf topology-enabled field.
+	TopologyEnabled bool `gcfg:"topology-enabled"`
 }
 
 // SnapshotConfig contains snapshot configuration.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -88,6 +88,7 @@ type controller struct {
 	tanzukubernetesClusterUID   string
 	tanzukubernetesClusterName  string
 	guestClusterDist            string
+	topologyEnabled             bool
 	csi.UnimplementedControllerServer
 }
 
@@ -109,6 +110,7 @@ func (c *controller) Init(config *commonconfig.Config, version string) error {
 	c.tanzukubernetesClusterUID = config.GC.TanzuKubernetesClusterUID
 	c.tanzukubernetesClusterName = config.GC.TanzuKubernetesClusterName
 	c.guestClusterDist = config.GC.ClusterDistribution
+	c.topologyEnabled = config.GC.TopologyEnabled
 	c.restClientConfig = k8s.GetRestClientConfigForSupervisor(ctx, config.GC.Endpoint, config.GC.Port)
 	c.supervisorClient, err = k8s.NewSupervisorClient(ctx, c.restClientConfig)
 	if err != nil {
@@ -394,6 +396,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				labels[key] = c.tanzukubernetesClusterUID
 				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 					req.AccessibilityRequirements != nil &&
+					c.topologyEnabled &&
 					!isLinkedCloneRequest && // the cns-csi mutation webhook in supervisor will automatically set it.
 					(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 						!isFileVolumeRequest) {
@@ -519,6 +522,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		var accessibleTopologies []map[string]string
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 			req.AccessibilityRequirements != nil &&
+			c.topologyEnabled &&
 			(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 				!isFileVolumeRequest) {
 			// Retrieve the latest version of the PVC
@@ -1511,7 +1515,8 @@ func (c *controller) GetCapacity(ctx context.Context, req *csi.GetCapacityReques
 	totalcapacity := int64(math.MaxInt64)
 	maxvolumesize := int64(math.MaxInt64)
 
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) {
+	if c.topologyEnabled &&
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) {
 		zonesMap := commonco.ContainerOrchestratorUtility.GetZonesForNamespace(c.supervisorNamespace)
 		if req.AccessibleTopology != nil {
 			if zonesMap == nil {

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -18,6 +18,7 @@ package wcpguest
 
 import (
 	"context"
+	"math"
 	"os"
 	"reflect"
 	"sync"
@@ -40,6 +41,8 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -96,6 +99,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 		c := &controller{
 			supervisorClient:    supervisorClient,
 			supervisorNamespace: supervisorNamespace,
+			topologyEnabled:     true,
 		}
 		commonco.ContainerOrchestratorUtility, err =
 			unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
@@ -442,6 +446,45 @@ func createTestTopologyRequirement() *csi.TopologyRequirement {
 		Preferred: []*csi.Topology{topology},
 	}
 	return topologyRequirement
+}
+
+// TestGetCapacity_TopologyDisabled_ZoneIgnored verifies that GetCapacity returns
+// full capacity (MaxInt64) on a non-topology Guest Cluster even when
+// csi-provisioner 6.1.1 populates AccessibleTopology in the request.
+//
+// Without the c.topologyEnabled guard, the WorkloadDomainIsolationFSS block
+// would execute with a nil zonesMap (fake returns nil for non-topology clusters)
+// and return an error, stalling all capacity-based scheduling.
+func TestGetCapacity_TopologyDisabled_ZoneIgnored(t *testing.T) {
+	tCtx := context.Background()
+
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("failed to get fake container orchestrator: %v", err)
+	}
+
+	oldCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = co
+	defer func() { commonco.ContainerOrchestratorUtility = oldCO }()
+
+	// topologyEnabled=false: simulates a non-topology (single-zone) Guest Cluster.
+	c := &controller{
+		supervisorNamespace: testNamespace,
+		topologyEnabled:     false,
+	}
+
+	// AccessibleTopology populated by csi-provisioner 6.1.1 even for non-topology clusters.
+	resp, err := c.GetCapacity(tCtx, &csi.GetCapacityRequest{
+		AccessibleTopology: &csi.Topology{
+			Segments: map[string]string{"topology.kubernetes.io/zone": "zone-1"},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("GetCapacity must not error when topologyEnabled=false, even with AccessibleTopology set: %v", err)
+	}
+	assert.Equal(t, int64(math.MaxInt64), resp.AvailableCapacity,
+		"capacity must be MaxInt64 (unlimited) when topologyEnabled=false")
 }
 
 // TestGenerateVolumeAccessibleTopologyFromPVCAnnotation helps unit test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry-pick 686a4282bd09dc6dc213a50c90c0a2a124e63c71
Fix WFFC PVC failure on non-topology GC with csi-provisioner 6.1


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix WFFC PVC failure on non-topology GC with csi-provisioner 6.1
```
