### PR TITLE
Add some validation checks for CBT API inputs

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -734,3 +734,13 @@ func BuildGuestSnapshotAnnotation(clusterName, snapshotName, snapshotNamespace, 
 func IsvSANFileServiceMarkerPolicyName(name string) bool {
 	return name == StorageClassVsanFileServicePolicy
 }
+
+// changeIDPattern matches a well-formed vSphere CBT change-id: <change-epic-uuid>/<epoch-number>.
+// Example: "52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d/5"
+var changeIDPattern = regexp.MustCompile(`^[0-9a-f]{2}(?: [0-9a-f]{2}){7}-[0-9a-f]{2}(?: [0-9a-f]{2}){7}/\d+$`)
+
+// IsValidChangeId reports whether changeID is a well-formed vSphere CBT
+// change-id in the form <change-epic-uuid>/<epoch-number> expected at the CSI API boundary.
+func IsValidChangeId(changeID string) bool {
+	return changeIDPattern.MatchString(changeID)
+}

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -1127,3 +1127,34 @@ func TestBuildGuestSnapshotAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidChangeId(t *testing.T) {
+	tests := []struct {
+		name     string
+		changeID string
+		want     bool
+	}{
+		{name: "valid change-id", changeID: "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/0", want: true},
+		{name: "empty string", changeID: "", want: false},
+		{name: "wildcard only", changeID: "*", want: false},
+		{name: "wildcard with epoch", changeID: "*/123", want: false},
+		{name: "no slash (no epoch)", changeID: "52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d", want: false},
+		{name: "empty UUID", changeID: "/123", want: false},
+		{name: "empty epoch", changeID: "52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d/", want: false},
+		{name: "non-digit epoch", changeID: "52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d/abc", want: false},
+		{name: "changeid with parent chain", changeID: "52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d/123/p0", want: false},
+		{name: "changeid with parent chain without epoch", changeID: "52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d/p1",
+			want: false},
+		{name: "UUID with upper case", changeID: "52 05 A2 CE 6D 6D C9 59-D3 2E AD 19 E3 96 73 6D/5", want: false},
+		{name: "plain text not valid UUID format", changeID: "diskuuid/0", want: false},
+		{name: "UUID with length more than default", changeID: "52 05 a2 ce 6d 6d c9 59-d3 2e ad 19 e3 96 73 6d0/5",
+			want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidChangeId(tt.changeID); got != tt.want {
+				t.Errorf("IsValidChangeId(%q) = %v, want %v", tt.changeID, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/csi/service/wcp/controller_cbt.go
+++ b/pkg/csi/service/wcp/controller_cbt.go
@@ -419,15 +419,19 @@ func validateGetMetadataAllocatedRequest(ctx context.Context, req *csi.GetMetada
 		return fmt.Errorf("snapshot ID is required")
 	}
 
+	if req.StartingOffset < 0 {
+		return fmt.Errorf("starting_offset must be non-negative value")
+	}
+
+	if req.MaxResults < 0 {
+		return fmt.Errorf("max_results must be non-negative value")
+	}
+
 	log.Debugf("GetMetadataAllocated request validation passed")
 	return nil
 }
 
 // validateGetMetadataDeltaRequest validates the GetMetadataDelta request.
-//
-// base_snapshot_id is the vSphere CBT change-id (opaque string) — we only check that it is
-// non-empty. target_snapshot_id is a CSI snapshot handle that the caller is responsible for
-// keeping valid (the target snapshot must still exist in vSphere).
 func validateGetMetadataDeltaRequest(ctx context.Context, req *csi.GetMetadataDeltaRequest) error {
 	log := logger.GetLogger(ctx)
 
@@ -439,8 +443,21 @@ func validateGetMetadataDeltaRequest(ctx context.Context, req *csi.GetMetadataDe
 		return fmt.Errorf("base snapshot ID (vSphere change-id) is required")
 	}
 
+	if !common.IsValidChangeId(req.BaseSnapshotId) {
+		return fmt.Errorf("base_snapshot_id %q has invalid format; provide a valid vSphere changeID",
+			req.BaseSnapshotId)
+	}
+
 	if req.TargetSnapshotId == "" {
 		return fmt.Errorf("target snapshot ID is required")
+	}
+
+	if req.StartingOffset < 0 {
+		return fmt.Errorf("starting_offset must be non-negative value")
+	}
+
+	if req.MaxResults < 0 {
+		return fmt.Errorf("max_results must be non-negative value")
 	}
 
 	log.Debugf("GetMetadataDelta request validation passed")

--- a/pkg/csi/service/wcp/controller_cbt_test.go
+++ b/pkg/csi/service/wcp/controller_cbt_test.go
@@ -37,6 +37,12 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
+const (
+	testValidChangeID    = "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/12"
+	testInvalidChangeID1 = "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/12/p0"
+	testInvalidChangeID2 = "*/p0"
+)
+
 type mockAllocatedServer struct {
 	grpc.ServerStream
 	ctx       context.Context
@@ -121,6 +127,22 @@ func TestValidateGetMetadataAllocatedRequest(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "negative starting_offset",
+			req: &csi.GetMetadataAllocatedRequest{
+				SnapshotId:     "volume-123+snapshot-456",
+				StartingOffset: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative max_results",
+			req: &csi.GetMetadataAllocatedRequest{
+				SnapshotId: "volume-123+snapshot-456",
+				MaxResults: -1,
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid request",
 			req: &csi.GetMetadataAllocatedRequest{
 				SnapshotId:     "volume-123+snapshot-456",
@@ -167,15 +189,57 @@ func TestValidateGetMetadataDeltaRequest(t *testing.T) {
 		{
 			name: "empty target snapshot ID",
 			req: &csi.GetMetadataDeltaRequest{
-				BaseSnapshotId:   "some-change-id",
+				BaseSnapshotId:   testValidChangeID,
 				TargetSnapshotId: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "base_snapshot_id is reserved '*'",
+			req: &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   "*",
+				TargetSnapshotId: "volume-123+snapshot-456",
+			},
+			wantErr: true,
+		},
+		{
+			name: "base_snapshot_id has invalid format - 1",
+			req: &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   testInvalidChangeID1,
+				TargetSnapshotId: "volume-123+snapshot-456",
+			},
+			wantErr: true,
+		},
+		{
+			name: "base_snapshot_id has invalid format - 2",
+			req: &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   testInvalidChangeID2,
+				TargetSnapshotId: "volume-123+snapshot-456",
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative starting_offset",
+			req: &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   testValidChangeID,
+				TargetSnapshotId: "volume-123+snapshot-456",
+				StartingOffset:   -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative max_results",
+			req: &csi.GetMetadataDeltaRequest{
+				BaseSnapshotId:   testValidChangeID,
+				TargetSnapshotId: "volume-123+snapshot-456",
+				MaxResults:       -1,
 			},
 			wantErr: true,
 		},
 		{
 			name: "valid request (BaseSnapshotId is the vSphere change-id)",
 			req: &csi.GetMetadataDeltaRequest{
-				BaseSnapshotId:   "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/123",
+				BaseSnapshotId:   testValidChangeID,
 				TargetSnapshotId: "volume-123+snapshot-456",
 				StartingOffset:   0,
 				MaxResults:       1000,
@@ -253,7 +317,7 @@ func TestGetMetadataDelta_VolumeNotFound(t *testing.T) {
 	_ = fakeOrchestrator.EnableFSS(ctx, common.CSI_Backup_API)
 
 	req := &csi.GetMetadataDeltaRequest{
-		BaseSnapshotId:   "some-change-id",
+		BaseSnapshotId:   testValidChangeID,
 		TargetSnapshotId: "nonexistent-volume+snapshot-456",
 	}
 
@@ -514,7 +578,7 @@ func TestGetMetadataDelta_Success(t *testing.T) {
 	// `csi.vsphere.volume/change-id` annotation when the base snapshot was first created).
 	// for this mock.
 	req := &csi.GetMetadataDeltaRequest{
-		BaseSnapshotId:   "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/123",
+		BaseSnapshotId:   testValidChangeID,
 		TargetSnapshotId: volID + "+snapshot-456",
 		MaxResults:       1,
 	}
@@ -607,7 +671,7 @@ func runVSLMErrorPropagationCase(t *testing.T, name string, vimFault vim25types.
 
 		if isDelta {
 			req := &csi.GetMetadataDeltaRequest{
-				BaseSnapshotId:   "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/123",
+				BaseSnapshotId:   testValidChangeID,
 				TargetSnapshotId: volID + "+snapshot-456",
 				MaxResults:       1,
 			}
@@ -862,7 +926,7 @@ func TestGetMetadataDelta_Pagination(t *testing.T) {
 
 	srv := &mockDeltaServer{ctx: ctx, t: t}
 	req := &csi.GetMetadataDeltaRequest{
-		BaseSnapshotId:   "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/123",
+		BaseSnapshotId:   testValidChangeID,
 		TargetSnapshotId: volID + "+snapshot-pagination",
 		MaxResults:       1, // force one area per Send() call
 	}

--- a/pkg/csi/service/wcpguest/controller_cbt.go
+++ b/pkg/csi/service/wcpguest/controller_cbt.go
@@ -41,6 +41,7 @@ import (
 //  2. Builds an external-proto request carrying the security token and the resolved
 //     (namespace, snapshot_name).
 //  3. Streams responses back, translating them into CSI GetMetadataAllocatedResponse messages.
+
 func (c *controller) GetMetadataAllocated(
 	req *csi.GetMetadataAllocatedRequest,
 	server csi.SnapshotMetadata_GetMetadataAllocatedServer) error {
@@ -66,6 +67,14 @@ func (c *controller) GetMetadataAllocated(
 		}
 		if req.SnapshotId == "" {
 			return logger.LogNewErrorCode(log, codes.InvalidArgument, "snapshot ID is required")
+		}
+		if req.StartingOffset < 0 {
+			return logger.LogNewErrorCode(log, codes.InvalidArgument,
+				"starting_offset must be non-negative value")
+		}
+		if req.MaxResults < 0 {
+			return logger.LogNewErrorCode(log, codes.InvalidArgument,
+				"max_results must be non-negative value")
 		}
 
 		svNamespace, svName, err := c.findSupervisorSnapshotByHandle(ctx, req.SnapshotId)
@@ -175,8 +184,21 @@ func (c *controller) GetMetadataDelta(
 			return logger.LogNewErrorCode(log, codes.InvalidArgument,
 				"base snapshot ID (vSphere change-id) is required")
 		}
+		if !common.IsValidChangeId(req.BaseSnapshotId) {
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"base_snapshot_id %q has invalid format; provide a valid vSphere changeID",
+				req.BaseSnapshotId)
+		}
 		if req.TargetSnapshotId == "" {
 			return logger.LogNewErrorCode(log, codes.InvalidArgument, "target snapshot ID is required")
+		}
+		if req.StartingOffset < 0 {
+			return logger.LogNewErrorCode(log, codes.InvalidArgument,
+				"starting_offset must be non-negative value")
+		}
+		if req.MaxResults < 0 {
+			return logger.LogNewErrorCode(log, codes.InvalidArgument,
+				"max_results must be non-negative value")
 		}
 
 		svNamespace, svTargetName, err := c.findSupervisorSnapshotByHandle(ctx, req.TargetSnapshotId)

--- a/pkg/csi/service/wcpguest/controller_cbt_test.go
+++ b/pkg/csi/service/wcpguest/controller_cbt_test.go
@@ -59,6 +59,12 @@ import (
 // sidecar as-is.
 const testSupervisorSnapshotNamespace = "test-sv-ns"
 
+const (
+	testValidChangeID    = "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/12"
+	testInvalidChangeID1 = "52 21 4f 8a 5e 47 9c bd-3b ff e0 12 a3 4c 56 78/12/p0"
+	testInvalidChangeID2 = "*/p0"
+)
+
 // seedSupervisorVolumeSnapshots installs a fake snapshotter client on the controller with a
 // VolumeSnapshot named after every CSI snapshot handle in handles. The guest pvCSI uses a
 // namespace-scoped VolumeSnapshot Get on the Supervisor to translate the target snapshot
@@ -451,6 +457,30 @@ func TestGetMetadataAllocated(t *testing.T) {
 		assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
 
+	t.Run("negative starting_offset", func(t *testing.T) {
+		req := &csi.GetMetadataAllocatedRequest{
+			SnapshotId:     "snap-1",
+			StartingOffset: -1,
+			MaxResults:     10,
+		}
+		mockStream := &mockAllocatedStreamServer{ctx: ctx}
+		err := ct.controller.GetMetadataAllocated(req, mockStream)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("negative max_results", func(t *testing.T) {
+		req := &csi.GetMetadataAllocatedRequest{
+			SnapshotId:     "snap-1",
+			StartingOffset: 0,
+			MaxResults:     -1,
+		}
+		mockStream := &mockAllocatedStreamServer{ctx: ctx}
+		err := ct.controller.GetMetadataAllocated(req, mockStream)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
 	t.Run("supervisor server error", func(t *testing.T) {
 		mockServer.errToReturn = status.Error(codes.NotFound, "snapshot not found")
 
@@ -775,7 +805,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		}
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId:   "snap-1",
+			BaseSnapshotId:   testValidChangeID,
 			TargetSnapshotId: "snap-2",
 			StartingOffset:   0,
 			MaxResults:       10,
@@ -796,7 +826,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		//   - translated only the target CSI handle to the Supervisor VolumeSnapshot
 		//     (namespace, name) using a namespace-scoped Get.
 		require.NotNil(t, mockServer.lastDeltaReq)
-		assert.Equal(t, "snap-1", mockServer.lastDeltaReq.BaseSnapshotId)
+		assert.Equal(t, testValidChangeID, mockServer.lastDeltaReq.BaseSnapshotId)
 		assert.Equal(t, "snap-2", mockServer.lastDeltaReq.TargetSnapshotName)
 		assert.Equal(t, testSupervisorSnapshotNamespace, mockServer.lastDeltaReq.Namespace)
 	})
@@ -819,7 +849,7 @@ func TestGetMetadataDelta(t *testing.T) {
 
 	t.Run("missing target snapshot id", func(t *testing.T) {
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId: "snap-1",
+			BaseSnapshotId: testValidChangeID,
 			StartingOffset: 0,
 			MaxResults:     10,
 		}
@@ -833,11 +863,37 @@ func TestGetMetadataDelta(t *testing.T) {
 		assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
 
+	t.Run("negative starting_offset", func(t *testing.T) {
+		req := &csi.GetMetadataDeltaRequest{
+			BaseSnapshotId:   testValidChangeID,
+			TargetSnapshotId: "snap-2",
+			StartingOffset:   -1,
+			MaxResults:       10,
+		}
+		mockStream := &mockDeltaStreamServer{ctx: ctx}
+		err := ct.controller.GetMetadataDelta(req, mockStream)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("negative max_results", func(t *testing.T) {
+		req := &csi.GetMetadataDeltaRequest{
+			BaseSnapshotId:   testValidChangeID,
+			TargetSnapshotId: "snap-2",
+			StartingOffset:   0,
+			MaxResults:       -1,
+		}
+		mockStream := &mockDeltaStreamServer{ctx: ctx}
+		err := ct.controller.GetMetadataDelta(req, mockStream)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
 	t.Run("supervisor server error", func(t *testing.T) {
 		mockServer.errToReturn = status.Error(codes.Internal, "internal error")
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId:   "snap-1",
+			BaseSnapshotId:   testValidChangeID,
 			TargetSnapshotId: "snap-invalid",
 			StartingOffset:   0,
 			MaxResults:       10,
@@ -852,12 +908,63 @@ func TestGetMetadataDelta(t *testing.T) {
 		assert.Equal(t, codes.Internal, status.Code(err))
 	})
 
+	t.Run("base_snapshot_id is reserved '*'", func(t *testing.T) {
+		mockServer.errToReturn = nil
+
+		req := &csi.GetMetadataDeltaRequest{
+			BaseSnapshotId:   "*",
+			TargetSnapshotId: "snap-2",
+			StartingOffset:   0,
+			MaxResults:       10,
+		}
+
+		mockStream := &mockDeltaStreamServer{ctx: ctx}
+		err := ct.controller.GetMetadataDelta(req, mockStream)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		assert.Contains(t, err.Error(), "*")
+	})
+
+	t.Run("base_snapshot_id has invalid format - 1", func(t *testing.T) {
+		mockServer.errToReturn = nil
+
+		req := &csi.GetMetadataDeltaRequest{
+			BaseSnapshotId:   testInvalidChangeID1,
+			TargetSnapshotId: "snap-2",
+			StartingOffset:   0,
+			MaxResults:       10,
+		}
+
+		mockStream := &mockDeltaStreamServer{ctx: ctx}
+		err := ct.controller.GetMetadataDelta(req, mockStream)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		assert.Contains(t, err.Error(), "invalid format")
+	})
+
+	t.Run("base_snapshot_id has invalid format - 2", func(t *testing.T) {
+		mockServer.errToReturn = nil
+
+		req := &csi.GetMetadataDeltaRequest{
+			BaseSnapshotId:   testInvalidChangeID2,
+			TargetSnapshotId: "snap-2",
+			StartingOffset:   0,
+			MaxResults:       10,
+		}
+
+		mockStream := &mockDeltaStreamServer{ctx: ctx}
+		err := ct.controller.GetMetadataDelta(req, mockStream)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		assert.Contains(t, err.Error(), "invalid format")
+	})
+
 	t.Run("minted token rejected by supervisor", func(t *testing.T) {
 		mockServer.errToReturn = nil
 		installFakeTokenMinterForTest(t, "wrong-token", nil)
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId:   "snap-1",
+			BaseSnapshotId:   testValidChangeID,
 			TargetSnapshotId: "snap-2",
 			StartingOffset:   0,
 			MaxResults:       10,
@@ -877,7 +984,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		installFakeTokenMinterForTest(t, "", fmt.Errorf("simulated TokenRequest failure"))
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId:   "snap-1",
+			BaseSnapshotId:   testValidChangeID,
 			TargetSnapshotId: "snap-2",
 			StartingOffset:   0,
 			MaxResults:       10,
@@ -907,7 +1014,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		mockServer.blockAfterSendsUntilCtxDone = false
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId: "snap-1", TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
+			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
 		}
 		mockStream := &mockDeltaStreamServer{ctx: ctx}
 		err := ct.controller.GetMetadataDelta(req, mockStream)
@@ -939,7 +1046,7 @@ func TestGetMetadataDelta(t *testing.T) {
 			WithScheme(runtime.NewScheme()).WithObjects(smsCR).Build()
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId: "snap-1", TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
+			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
 		}
 		mockStream := &mockDeltaStreamServer{ctx: ctx}
 		err := ct.controller.GetMetadataDelta(req, mockStream)
@@ -954,7 +1061,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		mockServer.blockAfterSendsUntilCtxDone = false
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId: "snap-1", TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
+			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
 		}
 		mockStream := &mockDeltaStreamServer{ctx: ctx}
 		err := ct.controller.GetMetadataDelta(req, mockStream)
@@ -969,7 +1076,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		mockServer.blockAfterSendsUntilCtxDone = false
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId: "snap-1", TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
+			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
 		}
 		mockStream := &mockDeltaStreamServer{ctx: ctx}
 		err := ct.controller.GetMetadataDelta(req, mockStream)
@@ -984,7 +1091,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		mockServer.blockAfterSendsUntilCtxDone = false
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId: "snap-1", TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
+			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
 		}
 		mockStream := &mockDeltaStreamServer{ctx: ctx}
 		err := ct.controller.GetMetadataDelta(req, mockStream)
@@ -1001,7 +1108,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		}
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId: "snap-1", TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
+			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
 		}
 		mockStream := &mockDeltaStreamServer{ctx: ctx, failOutgoingAfterN: 1}
 		err := ct.controller.GetMetadataDelta(req, mockStream)
@@ -1017,7 +1124,7 @@ func TestGetMetadataDelta(t *testing.T) {
 
 		ctx2, cancel := context.WithCancel(ctx)
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId: "snap-1", TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
+			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
 		}
 		mockStream := &mockDeltaStreamServer{ctx: ctx2}
 		errCh := make(chan error, 1)


### PR DESCRIPTION
**What this PR does / why we need it**:
Validates the input values such as baseSnapshotId/ChangeId, maxresults, startoffsets against negative value check or reserved values check.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* Tested fix by running input validation testcase on setup with image replaced with this fix.
* WCP precheckin passed -https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1730/
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```
* VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1304/
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```