### PR TITLE
fix: support MoRef datacenter lookup

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -207,7 +207,10 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 	if strings.TrimSpace(cfg.VirtualCenter[host].Datacenters) != "" {
 		vcConfig.DatacenterPaths = strings.Split(cfg.VirtualCenter[host].Datacenters, ",")
 		for idx := range vcConfig.DatacenterPaths {
-			vcConfig.DatacenterPaths[idx] = strings.TrimSpace(vcConfig.DatacenterPaths[idx])
+			entry := strings.TrimSpace(vcConfig.DatacenterPaths[idx])
+			// Strip the "Datacenter:" type prefix to normalise MoRef entries
+			// (e.g. "Datacenter:datacenter-3" → "datacenter-3").
+			vcConfig.DatacenterPaths[idx] = strings.TrimPrefix(entry, "Datacenter:")
 		}
 	}
 
@@ -258,7 +261,10 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 		if strings.TrimSpace(cfg.VirtualCenter[vCenterIP].Datacenters) != "" {
 			vcConfig.DatacenterPaths = strings.Split(cfg.VirtualCenter[vCenterIP].Datacenters, ",")
 			for idx := range vcConfig.DatacenterPaths {
-				vcConfig.DatacenterPaths[idx] = strings.TrimSpace(vcConfig.DatacenterPaths[idx])
+				entry := strings.TrimSpace(vcConfig.DatacenterPaths[idx])
+				// Strip the "Datacenter:" type prefix to normalise MoRef entries
+				// (e.g. "Datacenter:datacenter-3" → "datacenter-3").
+				vcConfig.DatacenterPaths[idx] = strings.TrimPrefix(entry, "Datacenter:")
 			}
 		}
 		VirtualCenterConfigs = append(VirtualCenterConfigs, vcConfig)

--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -6,9 +6,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 )
 
 func TestFilterSuspendedDatastoresWhenDatastoreIsSuspended(t *testing.T) {
@@ -160,4 +163,114 @@ func TestIsInvalidLoginError(t *testing.T) {
 		// Verify
 		assert.False(tt, result)
 	})
+}
+
+// TestGetVirtualCenterConfigDatacenterPathNormalization verifies that datacenter entries
+// in the config are normalised correctly:
+//   - Inventory paths (starting with "/") are preserved as-is.
+//   - Bare MoRef values (e.g. "datacenter-3") are preserved as-is.
+//   - Entries with the "Datacenter:" type prefix are stripped to a bare MoRef value,
+//     enabling users to copy the identifier verbatim from the vSphere API response while
+//     still producing a value that is resilient to datacenter renames.
+//   - Leading/trailing whitespace is trimmed before prefix stripping.
+func TestGetVirtualCenterConfigDatacenterPathNormalization(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		datacenters string
+		want        []string
+	}{
+		{
+			name:        "inventory path is preserved",
+			datacenters: "/DC1",
+			want:        []string{"/DC1"},
+		},
+		{
+			name:        "bare MoRef value is preserved",
+			datacenters: "datacenter-3",
+			want:        []string{"datacenter-3"},
+		},
+		{
+			name:        "Datacenter: prefix is stripped to bare MoRef",
+			datacenters: "Datacenter:datacenter-3",
+			want:        []string{"datacenter-3"},
+		},
+		{
+			name:        "whitespace is trimmed before prefix stripping",
+			datacenters: "  Datacenter:datacenter-3  ",
+			want:        []string{"datacenter-3"},
+		},
+		{
+			name:        "multiple mixed entries are each normalised",
+			datacenters: "/DC1, Datacenter:datacenter-3, datacenter-5",
+			want:        []string{"/DC1", "datacenter-3", "datacenter-5"},
+		},
+		{
+			name:        "empty datacenters field produces nil DatacenterPaths",
+			datacenters: "",
+			want:        nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				VirtualCenter: map[string]*config.VirtualCenterConfig{
+					"test-vc": {
+						VCenterPort: "443",
+						Datacenters: tc.datacenters,
+					},
+				},
+			}
+			vcConfig, err := GetVirtualCenterConfig(ctx, cfg)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, vcConfig.DatacenterPaths)
+		})
+	}
+}
+
+// TestGetVirtualCenterConfigsDatacenterPathNormalization is the same coverage for
+// GetVirtualCenterConfigs (the multi-VC variant).
+func TestGetVirtualCenterConfigsDatacenterPathNormalization(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		datacenters string
+		want        []string
+	}{
+		{
+			name:        "inventory path is preserved",
+			datacenters: "/DC1",
+			want:        []string{"/DC1"},
+		},
+		{
+			name:        "Datacenter: prefix is stripped to bare MoRef",
+			datacenters: "Datacenter:datacenter-3",
+			want:        []string{"datacenter-3"},
+		},
+		{
+			name:        "multiple mixed entries are each normalised",
+			datacenters: "Datacenter:datacenter-3, /DC2",
+			want:        []string{"datacenter-3", "/DC2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				VirtualCenter: map[string]*config.VirtualCenterConfig{
+					"test-vc": {
+						VCenterPort: "443",
+						Datacenters: tc.datacenters,
+					},
+				},
+			}
+			vcConfigs, err := GetVirtualCenterConfigs(ctx, cfg)
+			require.NoError(t, err)
+			require.Len(t, vcConfigs, 1)
+			assert.Equal(t, tc.want, vcConfigs[0].DatacenterPaths)
+		})
+	}
 }

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -26,6 +26,7 @@ import (
 	neturl "net/url"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -511,19 +512,42 @@ func (vc *VirtualCenter) ListDatacenters(ctx context.Context) (
 	return dcs, nil
 }
 
-// getDatacenters returns Datacenter instances given their paths.
+// getDatacenters returns Datacenter instances given their paths or MoRef values.
+// Entries starting with "/" are treated as inventory paths (e.g. "/DC1").
+// Entries not starting with "/" are treated as MoRef values (e.g. "datacenter-3"),
+// which are resilient to datacenter renames.
 func (vc *VirtualCenter) getDatacenters(ctx context.Context, dcPaths []string) (
 	[]*Datacenter, error) {
 	log := logger.GetLogger(ctx)
 	finder := find.NewFinder(vc.Client.Client, false)
 	var dcs []*Datacenter
 	for _, dcPath := range dcPaths {
-		dcObj, err := finder.Datacenter(ctx, dcPath)
-		if err != nil {
-			log.Errorf("failed to fetch datacenter given dcPath %s with err: %v", dcPath, err)
-			return nil, err
+		var dc *Datacenter
+		if strings.HasPrefix(dcPath, "/") {
+			// Inventory path lookup.
+			dcObj, err := finder.Datacenter(ctx, dcPath)
+			if err != nil {
+				log.Errorf("failed to fetch datacenter given dcPath %s with err: %v", dcPath, err)
+				return nil, err
+			}
+			dc = &Datacenter{Datacenter: dcObj, VirtualCenterHost: vc.Config.Host}
+		} else {
+			// MoRef-based lookup: rename-resilient since MoRefs are stable identifiers.
+			moref := types.ManagedObjectReference{Type: "Datacenter", Value: dcPath}
+			var dcMo mo.Datacenter
+			if err := vc.Client.RetrieveOne(ctx, moref, []string{"name"}, &dcMo); err != nil {
+				log.Errorf("failed to fetch datacenter given MoRef %s with err: %v", dcPath, err)
+				return nil, err
+			}
+			dcObj := object.NewDatacenter(vc.Client.Client, moref)
+			// InventoryPath is not resolved by a MoRef lookup; set it to the datacenter name
+			// so log messages remain meaningful.
+			dcObj.InventoryPath = dcMo.Name
+			dc = &Datacenter{
+				Datacenter:        dcObj,
+				VirtualCenterHost: vc.Config.Host,
+			}
 		}
-		dc := &Datacenter{Datacenter: dcObj, VirtualCenterHost: vc.Config.Host}
 		dcs = append(dcs, dc)
 	}
 	return dcs, nil

--- a/pkg/common/cns-lib/vsphere/virtualcenter_test.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+)
+
+// buildTestVC creates a minimal VirtualCenter backed by a running vcsim server.
+// The returned stop function must be deferred by the caller.
+func buildTestVC(t *testing.T) (
+	ctx context.Context,
+	vc *VirtualCenter,
+	model *simulator.Model,
+	stop func(),
+) {
+	t.Helper()
+	ctx = context.Background()
+	model = simulator.VPX()
+	model.Datacenter = 1
+	if err := model.Create(); err != nil {
+		t.Fatalf("failed to create vcsim model: %v", err)
+	}
+	s := model.Service.NewServer()
+	client, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		s.Close()
+		model.Remove()
+		t.Fatalf("failed to create govmomi client: %v", err)
+	}
+	vc = &VirtualCenter{
+		Config:      &VirtualCenterConfig{Host: s.URL.Hostname()},
+		Client:      client,
+		ClientMutex: &sync.Mutex{},
+	}
+	stop = func() {
+		_ = client.Logout(ctx)
+		s.Close()
+		model.Remove()
+	}
+	return
+}
+
+// TestGetDatacentersWithPathFormat verifies that entries starting with "/" are resolved
+// via the govmomi finder (inventory-path lookup) and the returned Datacenter has its
+// InventoryPath populated.
+func TestGetDatacentersWithPathFormat(t *testing.T) {
+	ctx, vc, _, stop := buildTestVC(t)
+	defer stop()
+
+	dcs, err := vc.getDatacenters(ctx, []string{"/DC0"})
+	require.NoError(t, err)
+	require.Len(t, dcs, 1)
+	assert.Equal(t, "/DC0", dcs[0].InventoryPath)
+	assert.Equal(t, vc.Config.Host, dcs[0].VirtualCenterHost)
+}
+
+// TestGetDatacentersWithMoRefFormat verifies that entries NOT starting with "/" are treated
+// as MoRef values and resolved via RetrieveOne. This lookup is rename-resilient because
+// MoRef identifiers are stable across datacenter renames.
+// It also confirms that resolving via MoRef returns the same datacenter as path-based lookup.
+func TestGetDatacentersWithMoRefFormat(t *testing.T) {
+	ctx, vc, model, stop := buildTestVC(t)
+	defer stop()
+
+	// Obtain the datacenter MoRef from the simulator.
+	morefValue := model.Map().Any("Datacenter").Reference().Value // e.g. "datacenter-2"
+
+	dcs, err := vc.getDatacenters(ctx, []string{morefValue})
+	require.NoError(t, err)
+	require.Len(t, dcs, 1)
+	assert.Equal(t, morefValue, dcs[0].Reference().Value)
+	assert.Equal(t, vc.Config.Host, dcs[0].VirtualCenterHost)
+	// InventoryPath is set to the datacenter name (not a full path) so log messages remain useful.
+	assert.NotEmpty(t, dcs[0].InventoryPath)
+}
+
+// TestGetDatacentersMoRefMatchesPath verifies that path-based and MoRef-based lookups
+// resolve to the same underlying datacenter object (same Reference).
+func TestGetDatacentersMoRefMatchesPath(t *testing.T) {
+	ctx, vc, model, stop := buildTestVC(t)
+	defer stop()
+
+	morefValue := model.Map().Any("Datacenter").Reference().Value
+
+	byPath, err := vc.getDatacenters(ctx, []string{"/DC0"})
+	require.NoError(t, err)
+	require.Len(t, byPath, 1)
+
+	byMoRef, err := vc.getDatacenters(ctx, []string{morefValue})
+	require.NoError(t, err)
+	require.Len(t, byMoRef, 1)
+
+	assert.Equal(t, byPath[0].Reference().Value, byMoRef[0].Reference().Value,
+		"path and MoRef lookup should resolve to the same datacenter")
+}
+
+// TestGetDatacentersWithUnknownPathReturnsError verifies that a non-existent inventory
+// path returns an error.
+func TestGetDatacentersWithUnknownPathReturnsError(t *testing.T) {
+	ctx, vc, _, stop := buildTestVC(t)
+	defer stop()
+
+	_, err := vc.getDatacenters(ctx, []string{"/NoSuchDC"})
+	require.Error(t, err)
+}
+
+// TestGetDatacentersWithInvalidMoRefReturnsError verifies that an unknown MoRef value
+// returns an error.
+func TestGetDatacentersWithInvalidMoRefReturnsError(t *testing.T) {
+	ctx, vc, _, stop := buildTestVC(t)
+	defer stop()
+
+	_, err := vc.getDatacenters(ctx, []string{"datacenter-99999"})
+	require.Error(t, err)
+}


### PR DESCRIPTION
Renaming a datacenter in vCenter breaks CSI node pod startup because getDatacenters() resolved DCs by inventory path, which changes on rename. Fix by detecting MoRef-format entries (no leading "/") and resolving them via RetrieveOne, which is stable across renames. Also strip the optional "Datacenter:" type prefix during config parsing so users can paste MoRef identifiers verbatim from the vSphere API

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3888 

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
