### PR TITLE
Add property collector for datastore, host and cluster

### DIFF
--- a/pkg/syncer/cnsoperator/vsphereinfra/cache.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/cache.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphereinfra
+
+import "sync"
+
+// StoragePolicyInfoCache is a shared in-memory cache used by the
+// PropertyCollector watcher and the storage-policy-info
+// controllers.
+type StoragePolicyInfoCache struct {
+	mu sync.RWMutex
+
+	// DsToHosts tracks the last-known set of hosts mounting each datastore.
+	// Written by the PropertyCollector on Datastore.host changes.
+	DsToHosts map[string]map[string]struct{}
+
+	// TODO: not yet written or read by anything. Intended for the
+	// clusterstoragepolicyinfo/storagepolicyinfo controllers to record which
+	// storage policies a datastore is compatible with (after a PBM query), so
+	// EventDatastoreHostChanged/EventHostClusterChanged handlers can look up
+	// affected policies without a separate vCenter round trip. Wire this up
+	// (and add real accessors) once those controllers consume this cache.
+	DsToPolicy map[string][]string
+
+	// HostToVersion tracks the last-known ESXi version string per host
+	// (e.g. "9.2.0"). key: host moref.
+	// Written by the PropertyCollector on HostSystem.summary.config.product.version
+	// changes. Needed because vCenter can re-publish this property with an
+	// unchanged value during unrelated churn.
+	HostToVersion map[string]string
+
+	// ClusterToHosts tracks the last-known set of hosts per cluster.
+	// key: cluster moref; inner key: host moref.
+	// Written by the PropertyCollector on ClusterComputeResource.host changes.
+	// Diffing this (rather than watching HostSystem.parent per host) gives the
+	// full added/removed host set for a cluster from a single Modify, and
+	// matches how InfraSPI itself queries hosts (GetHostsByCluster, per known
+	// zone-registered cluster).
+	ClusterToHosts map[string]map[string]struct{}
+}
+
+var (
+	defaultCache *StoragePolicyInfoCache
+	cacheOnce    sync.Once
+)
+
+// GetCache returns the process-wide singleton StoragePolicyInfoCache.
+// Safe to call from multiple goroutines; initialised exactly once.
+func GetCache() *StoragePolicyInfoCache {
+	cacheOnce.Do(func() {
+		defaultCache = &StoragePolicyInfoCache{
+			DsToHosts:      make(map[string]map[string]struct{}),
+			DsToPolicy:     make(map[string][]string),
+			HostToVersion:  make(map[string]string),
+			ClusterToHosts: make(map[string]map[string]struct{}),
+		}
+	})
+	return defaultCache
+}
+
+// InvalidateDatastore removes all cache entries associated with a deleted datastore.
+func (c *StoragePolicyInfoCache) InvalidateDatastore(dsID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.DsToHosts, dsID)
+	delete(c.DsToPolicy, dsID)
+}
+
+// UpdateDsHosts compares newHosts (the current set of host morefs mounting
+// this datastore) against the cached state.  Returns true if the set of hosts
+// changed, and updates the cache.  Returns false for identical
+// re-publications (e.g. from DRS rebalancing or HA reconfiguration) so
+// callers can suppress spurious events.  A nil newHosts (e.g. extractHostSet
+// hitting an unexpected PropertyCollector type) is treated as an invalid
+// update: the cache is left unchanged and false is returned, rather than
+// caching the nil and causing a spurious "changed" event on the next valid
+// update.
+func (c *StoragePolicyInfoCache) UpdateDsHosts(dsID string, newHosts map[string]struct{}) bool {
+	if newHosts == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	prev, ok := c.DsToHosts[dsID]
+	if ok && hostSetsEqual(prev, newHosts) {
+		return false
+	}
+	c.DsToHosts[dsID] = newHosts
+	return true
+}
+
+// GetDsHosts returns a copy of the cached host set for a datastore and
+// whether the entry exists. A copy is returned (rather than the cache's
+// internal map) so a caller mutating the result can't race with the cache's
+// own locked reads/writes on that same map, and can't mistake a retained
+// reference for a live view that updates as the cache does.
+func (c *StoragePolicyInfoCache) GetDsHosts(dsID string) (map[string]struct{}, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	hosts, ok := c.DsToHosts[dsID]
+	if !ok {
+		return nil, false
+	}
+	cp := make(map[string]struct{}, len(hosts))
+	for h := range hosts {
+		cp[h] = struct{}{}
+	}
+	return cp, true
+}
+
+// UpdateHostVersion compares newVersion against the cached ESXi version for a
+// host. Returns the previous value and whether it changed. On the first
+// sighting for a host (no previous entry) changed is false — there is nothing
+// yet to compare against.
+func (c *StoragePolicyInfoCache) UpdateHostVersion(hostID, newVersion string) (oldVersion string, changed bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	prev, ok := c.HostToVersion[hostID]
+	c.HostToVersion[hostID] = newVersion
+	if !ok || prev == newVersion {
+		return prev, false
+	}
+	return prev, true
+}
+
+// InvalidateHostVersion removes cached version info for a host that has left
+// the inventory, so a moref reused later doesn't compare against stale data.
+func (c *StoragePolicyInfoCache) InvalidateHostVersion(hostID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.HostToVersion, hostID)
+}
+
+// UpdateClusterHosts compares newHosts (the current set of host morefs in
+// this cluster) against the cached state, and updates the cache. Returns the
+// host morefs added and removed since the last known state. Returns nil, nil
+// on the first sighting for a cluster (no previous entry) — that's the
+// baseline, not a change — and also when the set is unchanged (e.g. a DRS/HA
+// re-publication of the same host list). A nil newHosts (e.g. extractHostRefSet
+// hitting an unexpected PropertyCollector type) is treated as an invalid
+// update: the cache is left unchanged and nil, nil is returned, rather than
+// clobbering the cached host list and reporting every previously-known host
+// as removed.
+func (c *StoragePolicyInfoCache) UpdateClusterHosts(
+	clusterID string, newHosts map[string]struct{}) (added, removed []string) {
+	if newHosts == nil {
+		return nil, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	prev, ok := c.ClusterToHosts[clusterID]
+	c.ClusterToHosts[clusterID] = newHosts
+	if !ok {
+		return nil, nil
+	}
+	for h := range newHosts {
+		if _, existed := prev[h]; !existed {
+			added = append(added, h)
+		}
+	}
+	for h := range prev {
+		if _, still := newHosts[h]; !still {
+			removed = append(removed, h)
+		}
+	}
+	return added, removed
+}
+
+// InvalidateCluster removes cached host-list state for a cluster that has
+// been deleted or moved out of scope, returning the host morefs it last
+// contained so callers can treat each as having left its cluster.
+func (c *StoragePolicyInfoCache) InvalidateCluster(clusterID string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	hosts := c.ClusterToHosts[clusterID]
+	delete(c.ClusterToHosts, clusterID)
+	result := make([]string, 0, len(hosts))
+	for h := range hosts {
+		result = append(result, h)
+	}
+	return result
+}
+
+// hostSetsEqual returns true if both sets contain the same host morefs.
+func hostSetsEqual(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/syncer/cnsoperator/vsphereinfra/cache_test.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/cache_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphereinfra
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestCache returns a fresh, independent StoragePolicyInfoCache instead of
+// the process-wide GetCache() singleton, so cache_test.go cases never share
+// state with each other or with collector_test.go.
+func newTestCache() *StoragePolicyInfoCache {
+	return &StoragePolicyInfoCache{
+		DsToHosts:      make(map[string]map[string]struct{}),
+		DsToPolicy:     make(map[string][]string),
+		HostToVersion:  make(map[string]string),
+		ClusterToHosts: make(map[string]map[string]struct{}),
+	}
+}
+
+func hostSet(hosts ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(hosts))
+	for _, h := range hosts {
+		set[h] = struct{}{}
+	}
+	return set
+}
+
+func TestUpdateDsHosts(t *testing.T) {
+	t.Run("first sighting reports changed", func(t *testing.T) {
+		c := newTestCache()
+		// Note: unlike UpdateHostVersion/UpdateClusterHosts, UpdateDsHosts
+		// reports changed=true on first sighting. This is harmless in
+		// practice: collectEvents only checks the return value on Modify,
+		// and Enter (which always precedes Modify for a newly-viewed object)
+		// discards it.
+		changed := c.UpdateDsHosts("ds-1", hostSet("host-1"))
+		assert.True(t, changed)
+	})
+
+	t.Run("identical host set reports unchanged", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateDsHosts("ds-1", hostSet("host-1", "host-2"))
+		changed := c.UpdateDsHosts("ds-1", hostSet("host-1", "host-2"))
+		assert.False(t, changed)
+	})
+
+	t.Run("host added reports changed", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateDsHosts("ds-1", hostSet("host-1"))
+		changed := c.UpdateDsHosts("ds-1", hostSet("host-1", "host-2"))
+		assert.True(t, changed)
+	})
+
+	t.Run("host removed reports changed", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateDsHosts("ds-1", hostSet("host-1", "host-2"))
+		changed := c.UpdateDsHosts("ds-1", hostSet("host-1"))
+		assert.True(t, changed)
+	})
+
+	t.Run("same size different members reports changed", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateDsHosts("ds-1", hostSet("host-1"))
+		changed := c.UpdateDsHosts("ds-1", hostSet("host-2"))
+		assert.True(t, changed)
+	})
+
+	t.Run("nil host set is an invalid update and leaves an unpopulated entry absent", func(t *testing.T) {
+		c := newTestCache()
+		changed := c.UpdateDsHosts("ds-1", nil)
+		assert.False(t, changed)
+		_, ok := c.GetDsHosts("ds-1")
+		assert.False(t, ok, "a nil update must not fabricate a cache entry")
+	})
+
+	t.Run("nil host set is an invalid update and leaves a populated entry untouched", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateDsHosts("ds-1", hostSet("host-1", "host-2"))
+		changed := c.UpdateDsHosts("ds-1", nil)
+		assert.False(t, changed)
+		hosts, ok := c.GetDsHosts("ds-1")
+		assert.True(t, ok)
+		assert.Equal(t, hostSet("host-1", "host-2"), hosts)
+	})
+}
+
+func TestGetDsHosts(t *testing.T) {
+	c := newTestCache()
+
+	_, ok := c.GetDsHosts("ds-1")
+	assert.False(t, ok, "unpopulated datastore should not be found")
+
+	c.UpdateDsHosts("ds-1", hostSet("host-1"))
+	hosts, ok := c.GetDsHosts("ds-1")
+	assert.True(t, ok)
+	assert.Equal(t, hostSet("host-1"), hosts)
+
+	// The returned map must be a copy: mutating it must not affect the cache's
+	// internal state.
+	hosts["host-2"] = struct{}{}
+	internal, _ := c.GetDsHosts("ds-1")
+	assert.Equal(t, hostSet("host-1"), internal, "mutating the returned map must not leak into the cache")
+}
+
+func TestInvalidateDatastore(t *testing.T) {
+	c := newTestCache()
+	c.UpdateDsHosts("ds-1", hostSet("host-1"))
+	c.DsToPolicy["ds-1"] = []string{"policy-1"}
+
+	c.InvalidateDatastore("ds-1")
+
+	_, ok := c.GetDsHosts("ds-1")
+	assert.False(t, ok)
+	_, ok = c.DsToPolicy["ds-1"]
+	assert.False(t, ok)
+}
+
+func TestUpdateHostVersion(t *testing.T) {
+	t.Run("first sighting is baseline, not a change", func(t *testing.T) {
+		c := newTestCache()
+		old, changed := c.UpdateHostVersion("host-1", "9.2.0")
+		assert.False(t, changed)
+		assert.Equal(t, "", old)
+	})
+
+	t.Run("identical version reports unchanged", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateHostVersion("host-1", "9.2.0")
+		_, changed := c.UpdateHostVersion("host-1", "9.2.0")
+		assert.False(t, changed)
+	})
+
+	t.Run("different version reports changed with old value", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateHostVersion("host-1", "9.0.0")
+		old, changed := c.UpdateHostVersion("host-1", "9.1.0")
+		assert.True(t, changed)
+		assert.Equal(t, "9.0.0", old)
+	})
+}
+
+func TestInvalidateHostVersion(t *testing.T) {
+	c := newTestCache()
+	c.UpdateHostVersion("host-1", "9.2.0")
+
+	c.InvalidateHostVersion("host-1")
+
+	_, changed := c.UpdateHostVersion("host-1", "9.9.9")
+	assert.False(t, changed, "host should be treated as never-seen after invalidation")
+}
+
+func TestUpdateClusterHosts(t *testing.T) {
+	t.Run("first sighting is baseline, not a change", func(t *testing.T) {
+		c := newTestCache()
+		added, removed := c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-2"))
+		assert.Nil(t, added)
+		assert.Nil(t, removed)
+	})
+
+	t.Run("identical host set reports no added or removed hosts", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-2"))
+		added, removed := c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-2"))
+		assert.Empty(t, added)
+		assert.Empty(t, removed)
+	})
+
+	t.Run("host added to cluster", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateClusterHosts("cluster-1", hostSet("host-1"))
+		added, removed := c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-2"))
+		assert.ElementsMatch(t, []string{"host-2"}, added)
+		assert.Empty(t, removed)
+	})
+
+	t.Run("host removed from cluster", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-2"))
+		added, removed := c.UpdateClusterHosts("cluster-1", hostSet("host-1"))
+		assert.Empty(t, added)
+		assert.ElementsMatch(t, []string{"host-2"}, removed)
+	})
+
+	t.Run("host swap reports both added and removed", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-2"))
+		added, removed := c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-3"))
+		assert.ElementsMatch(t, []string{"host-3"}, added)
+		assert.ElementsMatch(t, []string{"host-2"}, removed)
+	})
+
+	t.Run("nil host set is an invalid update and leaves an unpopulated entry absent", func(t *testing.T) {
+		c := newTestCache()
+		added, removed := c.UpdateClusterHosts("cluster-1", nil)
+		assert.Nil(t, added)
+		assert.Nil(t, removed)
+		_, ok := c.ClusterToHosts["cluster-1"]
+		assert.False(t, ok, "a nil update must not fabricate a cache entry")
+	})
+
+	t.Run("nil host set is an invalid update and does not report every prior host as removed", func(t *testing.T) {
+		c := newTestCache()
+		c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-2"))
+		added, removed := c.UpdateClusterHosts("cluster-1", nil)
+		assert.Nil(t, added)
+		assert.Nil(t, removed)
+		assert.Equal(t, hostSet("host-1", "host-2"), c.ClusterToHosts["cluster-1"],
+			"cached host list must be untouched by an invalid update")
+	})
+}
+
+func TestInvalidateCluster(t *testing.T) {
+	c := newTestCache()
+	c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-2"))
+
+	lastHosts := c.InvalidateCluster("cluster-1")
+
+	assert.ElementsMatch(t, []string{"host-1", "host-2"}, lastHosts)
+
+	added, _ := c.UpdateClusterHosts("cluster-1", hostSet("host-1"))
+	assert.Nil(t, added, "cluster should be treated as never-seen after invalidation")
+}
+
+func TestInvalidateCluster_UnknownCluster(t *testing.T) {
+	c := newTestCache()
+	lastHosts := c.InvalidateCluster("cluster-never-seen")
+	assert.Empty(t, lastHosts)
+}
+
+func TestHostSetsEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     map[string]struct{}
+		expected bool
+	}{
+		{"both empty", hostSet(), hostSet(), true},
+		{"identical single", hostSet("host-1"), hostSet("host-1"), true},
+		{"identical multiple", hostSet("host-1", "host-2"), hostSet("host-2", "host-1"), true},
+		{"different sizes", hostSet("host-1"), hostSet("host-1", "host-2"), false},
+		{"same size different members", hostSet("host-1"), hostSet("host-2"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hostSetsEqual(tt.a, tt.b))
+		})
+	}
+}

--- a/pkg/syncer/cnsoperator/vsphereinfra/collector.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/collector.go
@@ -1,0 +1,385 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vsphereinfra provides a shared PropertyCollector watcher for the
+// vSphere inventory.  It fires events when hosts or datastores are deleted from
+// vCenter or when their topology relationships change (host leaves a cluster,
+// datastore host list changes), allowing higher-level controllers to react
+// without individually polling vCenter.
+package vsphereinfra
+
+import (
+	"context"
+	"time"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25/types"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// restartDelay is how long manageWatcher waits before restarting the watcher
+// after the session goroutine exits, to avoid tight reconnect loops against a
+// temporarily unhealthy vCenter.
+const restartDelay = time.Minute
+
+// StartInventoryWatcher starts a long-running PropertyCollector listener that
+// watches HostSystem, Datastore, and ClusterComputeResource objects across the
+// entire vCenter inventory. It returns immediately; the watcher runs in the
+// background.
+func StartInventoryWatcher(ctx context.Context, vc *cnsvsphere.VirtualCenter) {
+	go manageWatcher(ctx, vc)
+}
+
+// manageWatcher is the single long-lived goroutine that owns the watcher
+// lifecycle.  It loops: run a session to completion, then either stop
+// (ctx cancelled) or wait restartDelay and try again.
+func manageWatcher(ctx context.Context, vc *cnsvsphere.VirtualCenter) {
+	log := logger.GetLogger(ctx)
+	for {
+		runWatcherSession(ctx, vc)
+
+		select {
+		case <-ctx.Done():
+			log.Infof("vsphereinfra: context cancelled, stopping inventory watcher")
+			return
+		case <-time.After(restartDelay):
+			log.Infof("vsphereinfra: restarting inventory watcher after session exit")
+		}
+	}
+}
+
+// runWatcherSession runs the PropertyCollector session loop.  On each
+// WaitForUpdatesEx error it immediately attempts to reconnect; only when the
+// reconnect itself fails (or ctx is cancelled) does it return so manageWatcher
+// can decide whether to restart.
+func runWatcherSession(ctx context.Context, vc *cnsvsphere.VirtualCenter) {
+	log := logger.GetLogger(ctx)
+	// This runs in its own goroutine (see StartInventoryWatcher), so an
+	// unrecovered panic here — e.g. from unexpected vCenter data — would crash
+	// the entire syncer process instead of just this watcher. Recovering lets
+	// manageWatcher's loop restart the session on the next iteration.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Infof("vsphereinfra: recovered panic in inventory watcher: %v", r)
+		}
+	}()
+
+	if err := vc.Connect(ctx); err != nil {
+		log.Errorf("vsphereinfra: cannot connect to vCenter: %v", err)
+		return
+	}
+
+	log.Infof("vsphereinfra: starting PropertyCollector inventory watcher")
+
+	for {
+		// runPCSession blocks for the entire life of one WaitForUpdatesEx
+		// long-poll session — it only returns when that session itself ends
+		// (e.g. vCenter session expiry, network blip), not after each batch
+		// of updates. So the reconnect below runs once per session teardown,
+		// not once per callback fire.
+		err := runPCSession(ctx, vc)
+
+		if ctx.Err() != nil {
+			log.Infof("vsphereinfra: context cancelled, stopping inventory watcher")
+			return
+		}
+
+		if err != nil {
+			log.Infof("vsphereinfra: PropertyCollector session ended (%v); reconnecting to vCenter", err)
+		} else {
+			log.Infof("vsphereinfra: PropertyCollector session ended cleanly; reconnecting to vCenter")
+		}
+
+		// Connect() no-ops if the existing session is still valid (checks
+		// sessionMgr.UserSession first), so this is cheap even if the
+		// session didn't actually need re-establishing.
+		if connErr := vc.Connect(ctx); connErr != nil {
+			log.Errorf("vsphereinfra: cannot reconnect to vCenter (%v); stopping watcher", connErr)
+			return
+		}
+		log.Infof("vsphereinfra: reconnected to vCenter; resuming inventory watcher")
+	}
+}
+
+// runPCSession creates a PropertyCollector, runs WaitForUpdatesEx until the
+// session ends, and cleans up.
+func runPCSession(ctx context.Context, vc *cnsvsphere.VirtualCenter) error {
+	log := logger.GetLogger(ctx)
+
+	pc, err := property.DefaultCollector(vc.Client.Client).Create(ctx)
+	if err != nil {
+		log.Errorf("vsphereinfra: cannot create PropertyCollector: %v", err)
+		return err
+	}
+	// Use context.Background() instead of ctx: by the time this runs (e.g. on
+	// shutdown), ctx may already be cancelled, which would make the Destroy
+	// call fail before it ever reaches vCenter, leaking the PropertyCollector
+	// session server-side. Same reasoning as storagepool/listener.go.
+	defer func() { _ = pc.Destroy(context.Background()) }()
+
+	filter, cv, err := buildWaitFilter(ctx, vc)
+	if err != nil {
+		log.Errorf("vsphereinfra: cannot build wait filter: %v", err)
+		return err
+	}
+	defer func() { _ = cv.Destroy(context.Background()) }()
+
+	return property.WaitForUpdatesEx(ctx, pc, filter, func(updates []types.ObjectUpdate) bool {
+		events := collectEvents(ctx, updates)
+		if len(events) > 0 {
+			OnInventoryChange(ctx, events)
+		}
+		return false
+	})
+}
+
+// buildWaitFilter creates a ContainerView over the entire vCenter inventory and
+// returns a WaitFilter that tracks Datastore, HostSystem, and
+// ClusterComputeResource objects.
+func buildWaitFilter(
+	ctx context.Context, vc *cnsvsphere.VirtualCenter) (*property.WaitFilter, *view.ContainerView, error) {
+	log := logger.GetLogger(ctx)
+	client := vc.Client.Client
+
+	rootFolder := client.ServiceContent.RootFolder
+	log.Infof("vsphereinfra: creating ContainerView rooted at %s", rootFolder.Value)
+
+	viewMgr := view.NewManager(client)
+	cv, err := viewMgr.CreateContainerView(ctx, rootFolder,
+		[]string{"Datastore", "HostSystem", "ClusterComputeResource"},
+		true,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	filter := new(property.WaitFilter)
+	filter.Add(cv.Reference(), "ContainerView", nil,
+		&types.TraversalSpec{
+			Type: "ContainerView",
+			Path: "view",
+			Skip: types.NewBool(false),
+		},
+	)
+
+	// Datastore.host — detect a host being added to or removed from a
+	// datastore's mount list.
+	// HostSystem — Leave (deletion or moving out of scope) is always tracked
+	// implicitly regardless of PathSet. summary.config.product.version detects
+	// ESXi version changes.
+	// ClusterComputeResource.host — detect a host being added to or removed
+	// from a cluster (see collectEvents doc for why this is watched instead
+	// of HostSystem.parent).
+	filter.Spec.PropSet = append(filter.Spec.PropSet,
+		types.PropertySpec{Type: "Datastore", PathSet: []string{"host"}},
+		types.PropertySpec{Type: "HostSystem", PathSet: []string{"summary.config.product.version"}},
+		types.PropertySpec{Type: "ClusterComputeResource", PathSet: []string{"host"}},
+	)
+
+	log.Infof("vsphereinfra: ContainerView created, watching Datastore.host, " +
+		"HostSystem version, and ClusterComputeResource.host")
+	return filter, cv, nil
+}
+
+// collectEvents translates a batch of ObjectUpdates from WaitForUpdatesEx into
+// InventoryEvents.
+//
+// Datastore updates:
+//   - Enter: populates DsToHosts baseline (no event).
+//   - Leave: emits EventDatastoreRemoved and clears cached state.
+//   - Modify on host: emits EventDatastoreHostChanged only when the set of
+//     mounting hosts actually changed (added/removed), matching how InfraSPI
+//     itself determines datastore accessibility — it checks HostSystem.datastore
+//     list membership, not the per-host Mounted/Accessible flags, so a mount
+//     flipping accessible without being added/removed isn't tracked as a
+//     change here either. This also suppresses no-op re-publications from
+//     DRS/HA.
+//
+// HostSystem updates:
+//   - Leave: cleans up HostToVersion for the departed host. Cluster-membership
+//     changes (including a host leaving visibility entirely) are detected via
+//     ClusterComputeResource.host instead — see below — so Leave here doesn't
+//     emit EventHostClusterChanged itself anymore.
+//   - Enter/Modify on version: emits EventHostVersionChanged only when it
+//     actually differs from the cached one; vCenter can re-publish this
+//     property unchanged during unrelated churn (observed in practice), so
+//     update.Kind alone isn't sufficient here.
+//
+// ClusterComputeResource updates:
+//   - Enter: populates ClusterToHosts baseline (no event).
+//   - Leave: the cluster is gone (deleted or moved out of scope). Every host
+//     it last contained is treated as having left its cluster — emits
+//     EventHostClusterChanged for each.
+//   - Modify on host: diffs the new host array against the cached one and
+//     emits EventHostClusterChanged for each host added or removed. This is
+//     watched instead of HostSystem.parent because a host moving between two
+//     clusters both visible to this session doesn't reliably fire any
+//     particular update on the host's own parent — vCenter delivers that
+//     non-deterministically depending on move direction. Watching the
+//     cluster's own host array instead also gives the complete added/removed
+//     set from a single Modify, rather than inferring it from scattered
+//     per-host updates.
+func collectEvents(ctx context.Context, updates []types.ObjectUpdate) []InventoryEvent {
+	log := logger.GetLogger(ctx)
+	cache := GetCache()
+	var events []InventoryEvent
+
+	for _, update := range updates {
+		moref := update.Obj.Value
+
+		switch update.Obj.Type {
+		case "Datastore":
+			switch update.Kind {
+			case types.ObjectUpdateKindEnter:
+				for _, change := range update.ChangeSet {
+					if change.Name == "host" && isAssignOp(ctx, update.Obj.Type, moref, change) {
+						cache.UpdateDsHosts(moref, extractHostSet(ctx, change.Val))
+					}
+				}
+
+			case types.ObjectUpdateKindLeave:
+				log.Infof("vsphereinfra: datastore %s removed from vCenter inventory", moref)
+				cache.InvalidateDatastore(moref)
+				events = append(events, InventoryEvent{Kind: EventDatastoreRemoved, MoRef: moref})
+
+			case types.ObjectUpdateKindModify:
+				for _, change := range update.ChangeSet {
+					if change.Name == "host" && isAssignOp(ctx, update.Obj.Type, moref, change) {
+						newHosts := extractHostSet(ctx, change.Val)
+						if cache.UpdateDsHosts(moref, newHosts) {
+							log.Infof("vsphereinfra: datastore %s host list changed", moref)
+							events = append(events, InventoryEvent{Kind: EventDatastoreHostChanged, MoRef: moref})
+						} else {
+							log.Debugf("vsphereinfra: datastore %s host list re-published without change (DRS/HA noise), skipping", moref)
+						}
+					}
+				}
+			}
+
+		case "HostSystem":
+			switch update.Kind {
+			case types.ObjectUpdateKindLeave:
+				log.Infof("vsphereinfra: host %s removed from inventory or moved out of scope", moref)
+				cache.InvalidateHostVersion(moref)
+
+			case types.ObjectUpdateKindEnter, types.ObjectUpdateKindModify:
+				for _, change := range update.ChangeSet {
+					if change.Name != "summary.config.product.version" {
+						continue
+					}
+					newVersion, ok := change.Val.(string)
+					if !ok {
+						log.Errorf("vsphereinfra: HostSystem.summary.config.product.version has unexpected type %T, want string",
+							change.Val)
+						continue
+					}
+					if _, changed := cache.UpdateHostVersion(moref, newVersion); changed {
+						log.Infof("vsphereinfra: host %s ESXi version changed", moref)
+						events = append(events, InventoryEvent{Kind: EventHostVersionChanged, MoRef: moref})
+					}
+				}
+			}
+
+		case "ClusterComputeResource":
+			switch update.Kind {
+			case types.ObjectUpdateKindEnter:
+				for _, change := range update.ChangeSet {
+					if change.Name == "host" && isAssignOp(ctx, update.Obj.Type, moref, change) {
+						cache.UpdateClusterHosts(moref, extractHostRefSet(ctx, change.Val))
+					}
+				}
+
+			case types.ObjectUpdateKindLeave:
+				log.Infof("vsphereinfra: cluster %s removed from vCenter inventory or moved out of scope", moref)
+				for _, hostID := range cache.InvalidateCluster(moref) {
+					events = append(events, InventoryEvent{Kind: EventHostClusterChanged, MoRef: hostID})
+				}
+
+			case types.ObjectUpdateKindModify:
+				for _, change := range update.ChangeSet {
+					if change.Name != "host" || !isAssignOp(ctx, update.Obj.Type, moref, change) {
+						continue
+					}
+					newHosts := extractHostRefSet(ctx, change.Val)
+					added, removed := cache.UpdateClusterHosts(moref, newHosts)
+					for _, hostID := range added {
+						log.Infof("vsphereinfra: host %s added to cluster %s", hostID, moref)
+						events = append(events, InventoryEvent{Kind: EventHostClusterChanged, MoRef: hostID})
+					}
+					for _, hostID := range removed {
+						log.Infof("vsphereinfra: host %s removed from cluster %s", hostID, moref)
+						events = append(events, InventoryEvent{Kind: EventHostClusterChanged, MoRef: hostID})
+					}
+					if len(added) == 0 && len(removed) == 0 {
+						log.Debugf("vsphereinfra: cluster %s host list re-published without change (DRS/HA noise), skipping", moref)
+					}
+				}
+			}
+		}
+	}
+
+	return events
+}
+
+// isAssignOp reports whether change.Op is "assign".
+func isAssignOp(ctx context.Context, objType, moref string, change types.PropertyChange) bool {
+	log := logger.GetLogger(ctx)
+	if change.Op != types.PropertyChangeOpAssign {
+		log.Errorf("vsphereinfra: %s %s property %q change has unexpected op %q, want assign",
+			objType, moref, change.Name, change.Op)
+		return false
+	}
+	return true
+}
+
+// extractHostSet converts a Datastore.host PropertyChange value into the set
+// of host morefs mounting it. The per-host Mounted/Accessible flags are
+// deliberately ignored — InfraSPI's own accessible-datastore algorithm only
+// checks HostSystem.datastore list membership, not those flags, so a mount
+// flipping accessible without being added or removed isn't a change worth
+// reporting here.
+func extractHostSet(ctx context.Context, val types.AnyType) map[string]struct{} {
+	log := logger.GetLogger(ctx)
+	arr, ok := val.(types.ArrayOfDatastoreHostMount)
+	if !ok {
+		log.Errorf("vsphereinfra: Datastore.host value has unexpected type %T, want types.ArrayOfDatastoreHostMount", val)
+		return nil
+	}
+	hosts := make(map[string]struct{}, len(arr.DatastoreHostMount))
+	for _, m := range arr.DatastoreHostMount {
+		hosts[m.Key.Value] = struct{}{}
+	}
+	return hosts
+}
+
+// extractHostRefSet converts a ClusterComputeResource.host PropertyChange
+// value into the set of host morefs in that cluster.
+func extractHostRefSet(ctx context.Context, val types.AnyType) map[string]struct{} {
+	log := logger.GetLogger(ctx)
+	arr, ok := val.(types.ArrayOfManagedObjectReference)
+	if !ok {
+		log.Errorf("vsphereinfra: ClusterComputeResource.host value has unexpected type %T, "+
+			"want types.ArrayOfManagedObjectReference", val)
+		return nil
+	}
+	hosts := make(map[string]struct{}, len(arr.ManagedObjectReference))
+	for _, ref := range arr.ManagedObjectReference {
+		hosts[ref.Value] = struct{}{}
+	}
+	return hosts
+}

--- a/pkg/syncer/cnsoperator/vsphereinfra/collector_test.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/collector_test.go
@@ -1,0 +1,435 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphereinfra
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// collectEvents reads/writes the process-wide GetCache() singleton, so tests
+// in this file use morefs unique to the calling test (via uniqueID) to avoid
+// cross-test state collisions when run in the same binary.
+func uniqueID(t *testing.T, base string) string {
+	t.Helper()
+	return fmt.Sprintf("%s-%s", base, strings.NewReplacer("/", "_", " ", "_").Replace(t.Name()))
+}
+
+func datastoreHostMountVal(hosts map[string]bool) types.ArrayOfDatastoreHostMount {
+	mounts := make([]types.DatastoreHostMount, 0, len(hosts))
+	for host, accessible := range hosts {
+		accessible := accessible
+		mounts = append(mounts, types.DatastoreHostMount{
+			Key: types.ManagedObjectReference{Type: "HostSystem", Value: host},
+			MountInfo: types.HostMountInfo{
+				AccessMode: "readWrite",
+				Mounted:    &accessible,
+				Accessible: &accessible,
+			},
+		})
+	}
+	return types.ArrayOfDatastoreHostMount{DatastoreHostMount: mounts}
+}
+
+func clusterHostRefsVal(hosts ...string) types.ArrayOfManagedObjectReference {
+	refs := make([]types.ManagedObjectReference, 0, len(hosts))
+	for _, h := range hosts {
+		refs = append(refs, types.ManagedObjectReference{Type: "HostSystem", Value: h})
+	}
+	return types.ArrayOfManagedObjectReference{ManagedObjectReference: refs}
+}
+
+func datastoreUpdate(moref string, kind types.ObjectUpdateKind, hosts map[string]bool) types.ObjectUpdate {
+	return types.ObjectUpdate{
+		Obj:  types.ManagedObjectReference{Type: "Datastore", Value: moref},
+		Kind: kind,
+		ChangeSet: []types.PropertyChange{
+			// Op: assign matches real vCenter behavior for Datastore.host,
+			// confirmed against live vCenter 9.2.0 — see isAssignOp.
+			{Name: "host", Op: types.PropertyChangeOpAssign, Val: datastoreHostMountVal(hosts)},
+		},
+	}
+}
+
+func clusterUpdate(moref string, kind types.ObjectUpdateKind, hosts ...string) types.ObjectUpdate {
+	return types.ObjectUpdate{
+		Obj:  types.ManagedObjectReference{Type: "ClusterComputeResource", Value: moref},
+		Kind: kind,
+		ChangeSet: []types.PropertyChange{
+			// Op: assign matches real vCenter behavior for
+			// ClusterComputeResource.host, confirmed against live vCenter
+			// 9.2.0 — see isAssignOp.
+			{Name: "host", Op: types.PropertyChangeOpAssign, Val: clusterHostRefsVal(hosts...)},
+		},
+	}
+}
+
+func clusterLeaveUpdate(moref string) types.ObjectUpdate {
+	return types.ObjectUpdate{
+		Obj:  types.ManagedObjectReference{Type: "ClusterComputeResource", Value: moref},
+		Kind: types.ObjectUpdateKindLeave,
+	}
+}
+
+func hostVersionUpdate(moref string, kind types.ObjectUpdateKind, version string) types.ObjectUpdate {
+	return types.ObjectUpdate{
+		Obj:  types.ManagedObjectReference{Type: "HostSystem", Value: moref},
+		Kind: kind,
+		ChangeSet: []types.PropertyChange{
+			{Name: "summary.config.product.version", Val: version},
+		},
+	}
+}
+
+func TestCollectEvents_DatastoreModify_NonAssignOp_Ignored(t *testing.T) {
+	ds := uniqueID(t, "ds")
+	// Establish a valid baseline via Enter (Op: assign).
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindEnter, map[string]bool{"host-1": true}),
+	})
+
+	// A Modify with a non-assign Op must not be treated as the complete host
+	// set — the cache must stay untouched and no event should fire.
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		{
+			Obj:  types.ManagedObjectReference{Type: "Datastore", Value: ds},
+			Kind: types.ObjectUpdateKindModify,
+			ChangeSet: []types.PropertyChange{
+				{Name: "host", Op: types.PropertyChangeOpRemove, Val: datastoreHostMountVal(map[string]bool{"host-2": true})},
+			},
+		},
+	})
+	assert.Empty(t, events)
+
+	hosts, ok := GetCache().GetDsHosts(ds)
+	assert.True(t, ok)
+	assert.Equal(t, hostSet("host-1"), hosts, "cache must be untouched by a non-assign op")
+}
+
+func TestCollectEvents_ClusterModify_NonAssignOp_Ignored(t *testing.T) {
+	cluster := uniqueID(t, "cluster")
+	// Establish a valid baseline via Enter (Op: assign).
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindEnter, "host-1", "host-2"),
+	})
+
+	// A Modify with a non-assign Op must not be treated as the complete host
+	// set — the cache must stay untouched and no event should fire (in
+	// particular, it must not report host-1/host-2 as removed).
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		{
+			Obj:  types.ManagedObjectReference{Type: "ClusterComputeResource", Value: cluster},
+			Kind: types.ObjectUpdateKindModify,
+			ChangeSet: []types.PropertyChange{
+				{Name: "host", Op: types.PropertyChangeOpAdd, Val: clusterHostRefsVal("host-3")},
+			},
+		},
+	})
+	assert.Empty(t, events)
+	assert.Equal(t, hostSet("host-1", "host-2"), GetCache().ClusterToHosts[cluster],
+		"cache must be untouched by a non-assign op")
+}
+
+func TestCollectEvents_DatastoreEnter_NoEvent(t *testing.T) {
+	ds := uniqueID(t, "ds")
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindEnter, map[string]bool{"host-1": true}),
+	})
+	assert.Empty(t, events)
+
+	hosts, ok := GetCache().GetDsHosts(ds)
+	assert.True(t, ok)
+	assert.Equal(t, hostSet("host-1"), hosts)
+}
+
+func TestCollectEvents_DatastoreModify_HostAdded(t *testing.T) {
+	ds := uniqueID(t, "ds")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindEnter, map[string]bool{"host-1": true}),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindModify, map[string]bool{"host-1": true, "host-2": true}),
+	})
+
+	assert.Equal(t, []InventoryEvent{{Kind: EventDatastoreHostChanged, MoRef: ds}}, events)
+}
+
+func TestCollectEvents_DatastoreModify_AccessibleFlagOnly_NoEvent(t *testing.T) {
+	// Regression test: unmounting a datastore from a host flips
+	// Mounted/Accessible without removing it from the host list. InfraSPI's
+	// own algorithm never looks at those flags, so this must not fire
+	// EventDatastoreHostChanged.
+	ds := uniqueID(t, "ds")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindEnter, map[string]bool{"host-1": true}),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindModify, map[string]bool{"host-1": false}),
+	})
+
+	assert.Empty(t, events)
+}
+
+func TestCollectEvents_DatastoreModify_NoChange_DRSNoise(t *testing.T) {
+	ds := uniqueID(t, "ds")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindEnter, map[string]bool{"host-1": true}),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindModify, map[string]bool{"host-1": true}),
+	})
+
+	assert.Empty(t, events)
+}
+
+func TestCollectEvents_DatastoreLeave(t *testing.T) {
+	ds := uniqueID(t, "ds")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindEnter, map[string]bool{"host-1": true}),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		{Obj: types.ManagedObjectReference{Type: "Datastore", Value: ds}, Kind: types.ObjectUpdateKindLeave},
+	})
+
+	assert.Equal(t, []InventoryEvent{{Kind: EventDatastoreRemoved, MoRef: ds}}, events)
+	_, ok := GetCache().GetDsHosts(ds)
+	assert.False(t, ok)
+}
+
+func TestCollectEvents_HostVersion_Changed(t *testing.T) {
+	host := uniqueID(t, "host")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		hostVersionUpdate(host, types.ObjectUpdateKindEnter, "9.0.0"),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		hostVersionUpdate(host, types.ObjectUpdateKindModify, "9.1.0"),
+	})
+
+	assert.Equal(t, []InventoryEvent{{Kind: EventHostVersionChanged, MoRef: host}}, events)
+}
+
+func TestCollectEvents_HostVersion_Unchanged_NoEvent(t *testing.T) {
+	// Regression test: vCenter can re-publish summary.config.product.version
+	// unchanged during unrelated churn (observed: multiple sibling hosts
+	// firing Modify with identical old/new version at the same instant).
+	host := uniqueID(t, "host")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		hostVersionUpdate(host, types.ObjectUpdateKindEnter, "9.2.0"),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		hostVersionUpdate(host, types.ObjectUpdateKindModify, "9.2.0"),
+	})
+
+	assert.Empty(t, events)
+}
+
+func TestCollectEvents_HostVersion_UnexpectedType_NoEventNoPanic(t *testing.T) {
+	host := uniqueID(t, "host")
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		{
+			Obj:  types.ManagedObjectReference{Type: "HostSystem", Value: host},
+			Kind: types.ObjectUpdateKindEnter,
+			ChangeSet: []types.PropertyChange{
+				{Name: "summary.config.product.version", Val: 42}, // wrong type: int, not string
+			},
+		},
+	})
+	assert.Empty(t, events)
+}
+
+func TestCollectEvents_HostSystemModify_IgnoresUnrelatedChangeSetEntry(t *testing.T) {
+	host := uniqueID(t, "host")
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		{
+			Obj:  types.ManagedObjectReference{Type: "HostSystem", Value: host},
+			Kind: types.ObjectUpdateKindModify,
+			ChangeSet: []types.PropertyChange{
+				{Name: "runtime.connectionState", Val: "connected"},
+			},
+		},
+	})
+	assert.Empty(t, events)
+}
+
+func TestCollectEvents_ClusterModify_IgnoresUnrelatedChangeSetEntry(t *testing.T) {
+	cluster := uniqueID(t, "cluster")
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		{
+			Obj:  types.ManagedObjectReference{Type: "ClusterComputeResource", Value: cluster},
+			Kind: types.ObjectUpdateKindModify,
+			ChangeSet: []types.PropertyChange{
+				{Name: "name", Val: "some-cluster-name"},
+			},
+		},
+	})
+	assert.Empty(t, events)
+}
+
+func TestCollectEvents_HostSystemLeave_NoLongerEmitsClusterEvent(t *testing.T) {
+	// HostSystem Leave used to emit EventHostClusterChanged directly; cluster
+	// membership is now tracked via ClusterComputeResource.host instead, so
+	// Leave should only clean up HostToVersion and emit nothing.
+	host := uniqueID(t, "host")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		hostVersionUpdate(host, types.ObjectUpdateKindEnter, "9.2.0"),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		{Obj: types.ManagedObjectReference{Type: "HostSystem", Value: host}, Kind: types.ObjectUpdateKindLeave},
+	})
+
+	assert.Empty(t, events)
+
+	// version cache was cleared, so a re-appearance with any version is
+	// treated as a fresh baseline (no event), not a "change" from "9.2.0".
+	events = collectEvents(context.Background(), []types.ObjectUpdate{
+		hostVersionUpdate(host, types.ObjectUpdateKindModify, "1.0.0"),
+	})
+	assert.Empty(t, events)
+}
+
+func TestCollectEvents_ClusterEnter_NoEvent(t *testing.T) {
+	cluster := uniqueID(t, "cluster")
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindEnter, "host-1", "host-2"),
+	})
+	assert.Empty(t, events)
+}
+
+func TestCollectEvents_ClusterModify_HostAdded(t *testing.T) {
+	cluster := uniqueID(t, "cluster")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindEnter, "host-1"),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindModify, "host-1", "host-2"),
+	})
+
+	assert.Equal(t, []InventoryEvent{{Kind: EventHostClusterChanged, MoRef: "host-2"}}, events)
+}
+
+func TestCollectEvents_ClusterModify_HostRemoved(t *testing.T) {
+	cluster := uniqueID(t, "cluster")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindEnter, "host-1", "host-2"),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindModify, "host-1"),
+	})
+
+	assert.Equal(t, []InventoryEvent{{Kind: EventHostClusterChanged, MoRef: "host-2"}}, events)
+}
+
+func TestCollectEvents_ClusterModify_HostSwap_EmitsBoth(t *testing.T) {
+	cluster := uniqueID(t, "cluster")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindEnter, "host-1", "host-2"),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindModify, "host-1", "host-3"),
+	})
+
+	morefs := make([]string, 0, len(events))
+	for _, e := range events {
+		assert.Equal(t, EventHostClusterChanged, e.Kind)
+		morefs = append(morefs, e.MoRef)
+	}
+	assert.ElementsMatch(t, []string{"host-2", "host-3"}, morefs)
+}
+
+func TestCollectEvents_ClusterModify_NoChange_DRSNoise(t *testing.T) {
+	cluster := uniqueID(t, "cluster")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindEnter, "host-1", "host-2"),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindModify, "host-1", "host-2"),
+	})
+
+	assert.Empty(t, events)
+}
+
+func TestCollectEvents_ClusterLeave_EmitsForEveryLastKnownHost(t *testing.T) {
+	cluster := uniqueID(t, "cluster")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterUpdate(cluster, types.ObjectUpdateKindEnter, "host-1", "host-2"),
+	})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterLeaveUpdate(cluster),
+	})
+
+	morefs := make([]string, 0, len(events))
+	for _, e := range events {
+		assert.Equal(t, EventHostClusterChanged, e.Kind)
+		morefs = append(morefs, e.MoRef)
+	}
+	assert.ElementsMatch(t, []string{"host-1", "host-2"}, morefs)
+}
+
+func TestCollectEvents_ClusterLeave_UnknownCluster_NoEvent(t *testing.T) {
+	cluster := uniqueID(t, "cluster")
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		clusterLeaveUpdate(cluster),
+	})
+	assert.Empty(t, events)
+}
+
+func TestExtractHostSet(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("valid type", func(t *testing.T) {
+		val := datastoreHostMountVal(map[string]bool{"host-1": true, "host-2": false})
+		hosts := extractHostSet(ctx, val)
+		assert.Equal(t, hostSet("host-1", "host-2"), hosts)
+	})
+
+	t.Run("unexpected type returns nil", func(t *testing.T) {
+		hosts := extractHostSet(ctx, "not-the-right-type")
+		assert.Nil(t, hosts)
+	})
+}
+
+func TestExtractHostRefSet(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("valid type", func(t *testing.T) {
+		val := clusterHostRefsVal("host-1", "host-2")
+		hosts := extractHostRefSet(ctx, val)
+		assert.Equal(t, hostSet("host-1", "host-2"), hosts)
+	})
+
+	t.Run("unexpected type returns nil", func(t *testing.T) {
+		hosts := extractHostRefSet(ctx, "not-the-right-type")
+		assert.Nil(t, hosts)
+	})
+}

--- a/pkg/syncer/cnsoperator/vsphereinfra/events.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/events.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphereinfra
+
+import (
+	"context"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// EventKind classifies a vSphere inventory change detected by the PropertyCollector.
+type EventKind int
+
+const (
+	// EventDatastoreRemoved fires when a Datastore is deleted from vCenter entirely.
+	EventDatastoreRemoved EventKind = iota
+
+	// EventDatastoreHostChanged fires when the set of hosts mounting a
+	// datastore changes — a host added or removed from Datastore.host.
+	// Matches InfraSPI's own accessible-datastore algorithm, which checks
+	// HostSystem.datastore list membership only; a mount's Accessible/Mounted
+	// flag flipping without an add/remove isn't a change InfraSPI would
+	// notice, so it isn't tracked as one here either.
+	EventDatastoreHostChanged
+
+	// EventHostClusterChanged fires when a host's cluster association changes
+	// in any way this session can observe: it moved to a different cluster
+	// (also visible to this session), its cluster is no longer visible at all
+	// — deleted from vCenter, or moved out of this session's scope. Detected
+	// via ClusterComputeResource.host (see collectEvents doc), not per-host
+	// HostSystem.parent. The MoRef field carries the host moref; callers can
+	// look up affected datastores via DsToHosts.
+	EventHostClusterChanged
+
+	// EventHostVersionChanged fires when a host's ESXi version changes (e.g.
+	// an upgrade). The MoRef field carries the host moref.
+	EventHostVersionChanged
+)
+
+// InventoryEvent describes a change detected by the PropertyCollector watcher.
+type InventoryEvent struct {
+	Kind  EventKind
+	MoRef string // moref of the changed object — see EventKind docs for which object type
+}
+
+// OnInventoryChange is called whenever the PropertyCollector watcher detects a topology change.
+func OnInventoryChange(ctx context.Context, events []InventoryEvent) {
+	log := logger.GetLogger(ctx)
+	log.Infof("vsphereinfra: OnInventoryChange not yet implemented, received %d event(s)", len(events))
+	// TODO: coalesce events over a short window (e.g. a couple minutes) before
+	// reconciling. A single real-world change (e.g. a host moving clusters) can
+	// cascade into many individual PropertyCollector updates — e.g. several
+	// datastores that host mounts each getting their own Datastore.host update
+	// in the same burst — so without coalescing, the same affected storage
+	// policy gets reconciled once per update instead of once for the whole
+	// burst. Resolve events to affected policies (via DsToPolicy/DsToHosts)
+	// and dedupe by policy ID, not by raw event, since several different
+	// events can resolve to the same policy.
+	// TODO: implement — look up affected datastores via DsToHosts and enqueue for reconciliation.
+}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -84,6 +84,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/featurestates"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/vsphereinfra"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/storagepool"
 )
 
@@ -409,6 +410,14 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupportsExposingStoragePolicyAttributes) {
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,
 				common.SupportsExposingStoragePolicyAttributes, "", "")
+		} else {
+			// SupportsExposingStoragePolicyAttributes is enabled — start the shared
+			// vSphere inventory watcher used by ClusterSPI and InfraSPI controllers.
+			vc, vcErr := cnsvsphere.GetVirtualCenterInstance(ctx, configInfo, false)
+			if vcErr != nil {
+				return logger.LogNewErrorf(log, "failed to get vCenter instance for inventory watcher: %v", vcErr)
+			}
+			vsphereinfra.StartInventoryWatcher(ctx, vc)
 		}
 		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.SupportsPerNamespaceNetworkProviders) {
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adds a shared PropertyCollector-based watcher (pkg/syncer/cnsoperator/vsphereinfra) that monitors vCenter inventory for topology changes relevant to storage policy/zone computation, so downstream controllers (e.g. clusterstoragepolicyinfo/storagepolicyinfo) can react to changes.

What it watches, via a single ContainerView + WaitForUpdatesEx long-poll session:

Datastore.host — detects a host being added to or removed from a datastore's mount list. 

ClusterComputeResource.host — detects hosts added to or removed from a cluster, by diffing the full host array against a cached copy.

HostSystem.summary.config.product.version — detects ESXi version changes (e.g. host upgrades).

All three comparisons are diff-based against an in-memory cache rather than trusting Modify/Enter at face value, because vCenter can re-publish these properties with an unchanged value during unrelated churn (observed directly in testing — e.g. sibling hosts re-firing identical values during a cluster move).

Emits typed InventoryEvents (EventDatastoreRemoved, EventDatastoreHostChanged, EventHostClusterChanged, EventHostVersionChanged) to OnInventoryChange, currently a stub — the reconciliation/coalescing logic is left as a TODO.

Notes:

1. After a host moves between clusters, several background tasks run asynchronously:

DRS rebalancing in both source and destination clusters — vCenter re-evaluates workload placement and may trigger storage re-assessments
vSphere HA reconfiguration — HA reconfigures its heartbeat topology in both clusters
Storage I/O control — re-evaluates datastore accessibility across the changed cluster topology
Each of these background tasks causes vCenter to internally re-compute and re-publish Datastore.host on the affected datastores, producing another burst identical to the original.


2. Property Collector's scope is directly restricted to the scope of the CSI driver's service account.


**Testing done**:

Host leaving a cluster:

{"level":"info","time":"2026-07-03T08:21:21.988172576Z","caller":"vsphereinfra/[collector.go:319](http://collector.go:319/)","msg":"vsphereinfra: host host-19 removed from cluster domain-c9","TraceId":"fb2b50d1-4ac2-4d41-b07a-c50573652343"}
{"level":"info","time":"2026-07-03T08:21:21.988230259Z","caller":"vsphereinfra/[events.go:63](http://events.go:63/)","msg":"vsphereinfra: OnInventoryChange not yet implemented, received 1 event(s)","TraceId":"fb2b50d1-4ac2-4d41-b07a-c50573652343"}


Host joining a cluster:

{"level":"info","time":"2026-07-03T08:22:49.983356346Z","caller":"vsphereinfra/[collector.go:315](http://collector.go:315/)","msg":"vsphereinfra: host host-19 added to cluster domain-c9","TraceId":"fb2b50d1-4ac2-4d41-b07a-c50573652343"}
{"level":"info","time":"2026-07-03T08:22:49.983622669Z","caller":"vsphereinfra/[events.go:63](http://events.go:63/)","msg":"vsphereinfra: OnInventoryChange not yet implemented, received 1 event(s)","TraceId":"fb2b50d1-4ac2-4d41-b07a-c50573652343"}

When a datastore's mounted host list changes:

{"level":"info","time":"2026-07-03T08:21:30.87879922Z","caller":"vsphereinfra/[collector.go:260](http://collector.go:260/)","msg":"vsphereinfra: datastore datastore-75 host list changed","TraceId":"fb2b50d1-4ac2-4d41-b07a-c50573652343"}
{"level":"info","time":"2026-07-03T08:21:30.878814361Z","caller":"vsphereinfra/[events.go:63](http://events.go:63/)","msg":"vsphereinfra: OnInventoryChange not yet implemented, received 3 event(s)","TraceId":"fb2b50d1-4ac2-4d41-b07a-c50573652343"}


When session becomes unauthenticated, new PC starts:

```
{"level":"info","time":"2026-07-01T09:05:51.914830039Z","caller":"vsphereinfra/collector.go:103","msg":"vsphereinfra: PropertyCollector session ended (destroy property filter failed with ServerFaultCode: The session is not authenticated. after failing to wait for updates: ServerFaultCode: The task was canceled by a user.); reconnecting to vCenter","TraceId":"a4ac793a-9ac9-489a-b19c-3e32b375e211"}
{"level":"info","time":"2026-07-01T09:05:52.034275527Z","caller":"vsphereinfra/collector.go:112","msg":"vsphereinfra: reconnected to vCenter; resuming inventory watcher","TraceId":"a4ac793a-9ac9-489a-b19c-3e32b375e211"}
{"level":"info","time":"2026-07-01T09:05:52.042327767Z","caller":"vsphereinfra/collector.go:161","msg":"vsphereinfra: creating ContainerView rooted at group-d1","TraceId":"a4ac793a-9ac9-489a-b19c-3e32b375e211"}
{"level":"info","time":"2026-07-01T09:05:52.049308512Z","caller":"vsphereinfra/collector.go:195","msg":"vsphereinfra: ContainerView created, watching Datastore.host","TraceId":"a4ac793a-9ac9-489a-b19c-3e32b375e211"}
{"level":"info","time":"2026-07-01T09:05:52.059876424Z","caller":"vsphereinfra/collector.go:137","msg":"vsphereinfra: WaitForUpdatesEx callback: received 4 object update(s)","TraceId":"a4ac793a-9ac9-489a-b19c-3e32b375e211"}
```

WCP precheckin: 
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1792/ (successful)

VKS precheckin:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1354/ (successful)



