### PR TITLE
Add marker-policy topology support to namespace level StoragePolicyInfo controller

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -729,8 +729,10 @@ func BuildGuestSnapshotAnnotation(clusterName, snapshotName, snapshotNamespace, 
 }
 
 // IsvSANFileServiceMarkerPolicyName reports whether name is the K8s-compliant storage policy
-// name (ClusterStoragePolicyInfo.Name) for the vSAN File Service marker policy. Topology for
-// this policy is derived from FVS instance namespaces rather than datastore/PBM compatibility.
+// name for the vSAN File Service marker policy. Both ClusterStoragePolicyInfo.Name and
+// StoragePolicyInfo.Name are K8s-compliant name, so obj.GetName() on either CR is a
+// valid argument. Topology for this policy is derived from FVS instance namespaces rather
+// than datastore/PBM compatibility.
 func IsvSANFileServiceMarkerPolicyName(name string) bool {
 	return name == StorageClassVsanFileServicePolicy
 }

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -30,6 +30,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
@@ -78,6 +80,9 @@ const (
 	// spiNameIndexField is the field index key used to look up StoragePolicyInfo
 	// objects by name, enabling efficient cross-namespace lookups in mapInfraSPItoSPI.
 	spiNameIndexField = ".metadata.name"
+	// spiMarkerIndexField is the field index key used to list only marker-policy
+	// StoragePolicyInfo objects in mapFVSNamespaceToMarkerSPIs.
+	spiMarkerIndexField = "isMarkerPolicy"
 )
 
 // Add registers the StoragePolicyInfo controller with the Manager (WCP / Workload only).
@@ -100,6 +105,17 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
+	cfg, err := restclient.InClusterConfig()
+	if err != nil {
+		log.Errorf("getting in-cluster config failed. Err: %v", err)
+		return err
+	}
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		log.Errorf("creating dynamic client failed. Err: %v", err)
+		return err
+	}
+
 	if err := commonco.ContainerOrchestratorUtility.StartZonesInformer(
 		ctx, nil, metav1.NamespaceAll); err != nil {
 		return logger.LogNewErrorf(log, "failed to start zone informer for StoragePolicyInfo controller. Err: %v", err)
@@ -112,19 +128,37 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		},
 	)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: apis.GroupName})
-	return add(mgr, newReconciler(mgr, configInfo, recorder, commonco.ContainerOrchestratorUtility))
+
+	// Marker-policy topology support (the marker field index, the FVS-namespace
+	// watch, and the syncMarkerPolicyTopology branch) is a distinct feature gated
+	// by the VsanFileVolumeService capability. Regular policy topology reconciles
+	// regardless of this flag.
+	markerPolicyEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VsanFileVolumeService)
+	if !markerPolicyEnabled {
+		log.Infof("StoragePolicyInfo Controller: capability %q is not activated; "+
+			"marker-policy topology support is disabled", common.VsanFileVolumeService)
+	}
+
+	return add(mgr, newReconciler(mgr, configInfo, recorder,
+		commonco.ContainerOrchestratorUtility,
+		k8sclient, dynamicClient, markerPolicyEnabled))
 }
 
 func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
-	recorder record.EventRecorder, zp zonesProvider) *ReconcileStoragePolicyInfo {
+	recorder record.EventRecorder, zp zonesProvider,
+	k8sClient kubernetes.Interface, dynamicClient dynamic.Interface,
+	markerPolicyEnabled bool) *ReconcileStoragePolicyInfo {
 
 	return &ReconcileStoragePolicyInfo{
-		client:          mgr.GetClient(),
-		scheme:          mgr.GetScheme(),
-		configInfo:      configInfo,
-		recorder:        recorder,
-		zonesProvider:   zp,
-		backOffDuration: make(map[apitypes.NamespacedName]time.Duration),
+		client:              mgr.GetClient(),
+		scheme:              mgr.GetScheme(),
+		configInfo:          configInfo,
+		recorder:            recorder,
+		zonesProvider:       zp,
+		k8sClient:           k8sClient,
+		dynamicClient:       dynamicClient,
+		markerPolicyEnabled: markerPolicyEnabled,
+		backOffDuration:     make(map[apitypes.NamespacedName]time.Duration),
 	}
 }
 
@@ -140,6 +174,23 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 		}); err != nil {
 		log.Errorf("failed to add field index for StoragePolicyInfo name: %v", err)
 		return err
+	}
+
+	// Index StoragePolicyInfo by marker-policy membership so mapFVSNamespaceToMarkerSPIs
+	// can list only marker SPIs without a full cross-namespace scan. Only registered
+	// when marker-policy support is enabled; the index and the FVS-namespace watch
+	// below are wired together since the watch's map func lists by this index.
+	if r.markerPolicyEnabled {
+		if err := mgr.GetFieldIndexer().IndexField(ctx, &spiv1alpha1.StoragePolicyInfo{},
+			spiMarkerIndexField, func(obj client.Object) []string {
+				if common.IsvSANFileServiceMarkerPolicyName(obj.GetName()) {
+					return []string{"true"}
+				}
+				return nil
+			}); err != nil {
+			log.Errorf("failed to add field index for marker StoragePolicyInfo: %v", err)
+			return err
+		}
 	}
 
 	// Only reconcile on StoragePolicyQuota CREATE events. Updates to the quota
@@ -179,7 +230,35 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 	// remaining CRs for that tick instead of blocking; see StartPeriodicResync.
 	resyncCh := make(chan event.GenericEvent, 256)
 
-	err := ctrl.NewControllerManagedBy(mgr).Named("storagepolicyinfo-controller").
+	// Trigger re-reconcile of marker-policy SPIs when an FVS instance namespace is
+	// created/deleted or its vpc_network_config annotation / fvs_instance_namespace
+	// label changes.
+	nsFVSPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			if e.Object == nil {
+				return false
+			}
+			return e.Object.GetLabels()[util.NamespaceLabelFVSInstance] == "true"
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			oldAnnotation := e.ObjectOld.GetAnnotations()[util.AnnotationVPCNetworkConfig]
+			newAnnotation := e.ObjectNew.GetAnnotations()[util.AnnotationVPCNetworkConfig]
+			oldLabel := e.ObjectOld.GetLabels()[util.NamespaceLabelFVSInstance]
+			newLabel := e.ObjectNew.GetLabels()[util.NamespaceLabelFVSInstance]
+			return oldAnnotation != newAnnotation || oldLabel != newLabel
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if e.Object == nil {
+				return false
+			}
+			return e.Object.GetLabels()[util.NamespaceLabelFVSInstance] == "true"
+		},
+	}
+
+	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).Named("storagepolicyinfo-controller").
 		For(&spiv1alpha1.StoragePolicyInfo{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
@@ -192,7 +271,20 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 			handler.EnqueueRequestsFromMapFunc(r.mapInfraSPItoSPI),
 			builder.WithPredicates(infraSPIPredicates),
 		).
-		WatchesRawSource(source.Channel(resyncCh, &handler.EnqueueRequestForObject{})).
+		WatchesRawSource(source.Channel(resyncCh, &handler.EnqueueRequestForObject{}))
+
+	// The FVS-namespace watch re-triggers marker-policy SPIs on namespace changes.
+	// Only wired when marker-policy support is enabled, matching the marker index
+	// above (mapFVSNamespaceToMarkerSPIs lists by that index).
+	if r.markerPolicyEnabled {
+		ctrlBuilder = ctrlBuilder.Watches(
+			&v1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.mapFVSNamespaceToMarkerSPIs),
+			builder.WithPredicates(nsFVSPredicate),
+		)
+	}
+
+	err := ctrlBuilder.
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxWorkerThreads}).
 		Complete(r)
 	if err != nil {
@@ -267,6 +359,38 @@ func (r *ReconcileStoragePolicyInfo) mapInfraSPItoSPI(ctx context.Context,
 	return reqs
 }
 
+// mapFVSNamespaceToMarkerSPIs maps an FVS instance namespace event to reconcile
+// requests for all marker-policy StoragePolicyInfo CRs across all namespaces.
+// Marker policy topology depends on FVS instance namespace membership and VPC path,
+// so any relevant namespace change must re-trigger all marker SPI reconciliations.
+// If the list call below fails, the event is dropped, but the periodic slow-sync
+// reconcile independently re-syncs marker-policy topology.
+func (r *ReconcileStoragePolicyInfo) mapFVSNamespaceToMarkerSPIs(ctx context.Context,
+	_ client.Object) []reconcile.Request {
+	log := logger.GetLogger(ctx)
+
+	spiList := &spiv1alpha1.StoragePolicyInfoList{}
+	if err := r.client.List(ctx, spiList,
+		client.MatchingFields{spiMarkerIndexField: "true"}); err != nil {
+		log.Errorf("mapFVSNamespaceToMarkerSPIs: failed to list marker StoragePolicyInfo: %v", err)
+		return nil
+	}
+
+	if len(spiList.Items) == 0 {
+		return nil
+	}
+	reqs := make([]reconcile.Request, len(spiList.Items))
+	for i := range spiList.Items {
+		reqs[i] = reconcile.Request{
+			NamespacedName: apitypes.NamespacedName{
+				Namespace: spiList.Items[i].Namespace,
+				Name:      spiList.Items[i].Name,
+			},
+		}
+	}
+	return reqs
+}
+
 var _ reconcile.Reconciler = &ReconcileStoragePolicyInfo{}
 
 // ReconcileStoragePolicyInfo reconciles StoragePolicyInfo objects.
@@ -276,6 +400,13 @@ type ReconcileStoragePolicyInfo struct {
 	configInfo    *config.ConfigurationInfo
 	recorder      record.EventRecorder
 	zonesProvider zonesProvider
+	k8sClient     kubernetes.Interface
+	dynamicClient dynamic.Interface
+	// markerPolicyEnabled mirrors the VsanFileVolumeService capability read at
+	// controller start. When false, marker-policy topology support (the marker
+	// field index, the FVS-namespace watch, and the syncMarkerPolicyTopology
+	// branch) is disabled and only regular policy topology is reconciled.
+	markerPolicyEnabled bool
 	// backOffDuration tracks per-instance requeue delays, incremented
 	// exponentially on failure and reset to 1s on success. A value greater than
 	// one second means the instance is currently backed off after a failure;
@@ -456,10 +587,20 @@ func (r *ReconcileStoragePolicyInfo) ensureInfraSPIOwnerReference(ctx context.Co
 // syncTopologyFromInfraSPI copies topology information from the cluster-scoped
 // InfraStoragePolicyInfo into the namespace-scoped StoragePolicyInfo status,
 // filtering accessible zones down to only those assigned to the namespace.
+// For marker policies the zone set is derived from FVS instance namespaces that
+// share the consumer namespace's VPC path, bypassing the standard namespace filter.
 func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Context,
 	instance *spiv1alpha1.StoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) error {
 	log := logger.GetLogger(ctx)
+
+	// Marker policies derive namespace-level zones from VPC/FVS instance namespace
+	// topology rather than from InfraSPI zones filtered by namespace Zone CRs. This
+	// path is only taken when marker-policy support is enabled; otherwise a marker
+	// policy falls through to the regular namespace-filtered topology path.
+	if r.markerPolicyEnabled && common.IsvSANFileServiceMarkerPolicyName(instance.Name) {
+		return r.syncMarkerPolicyTopology(ctx, instance, infraSPI)
+	}
 
 	if infraSPI.Status.Topology == nil {
 		log.Debugf("InfraStoragePolicyInfo %q has no topology; clearing StoragePolicyInfo topology",
@@ -479,6 +620,43 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 		instance.Namespace, instance.Name,
 		instance.Status.TopologyInfo.TopologyType,
 		instance.Status.TopologyInfo.AccessibleZones)
+	return nil
+}
+
+// syncMarkerPolicyTopology populates the namespace-scoped StoragePolicyInfo
+// topology for a marker policy by deriving accessible zones from FVS instance
+// namespaces that share the consumer namespace's VPC path, bypassing the
+// standard InfraSPI-zones-filtered-by-namespace-Zone-CRs path used for
+// regular policies.
+func (r *ReconcileStoragePolicyInfo) syncMarkerPolicyTopology(ctx context.Context,
+	instance *spiv1alpha1.StoragePolicyInfo,
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) error {
+	log := logger.GetLogger(ctx)
+
+	log.Infof("syncTopologyFromInfraSPI: %q is a marker policy; deriving zones from FVS instance namespaces",
+		instance.Name)
+	if infraSPI.Status.Topology == nil || infraSPI.Status.Topology.TopologyType == "" {
+		log.Debugf("syncTopologyFromInfraSPI: marker policy %q has no topology type; clearing topology",
+			instance.Name)
+		instance.Status.TopologyInfo = nil
+		return nil
+	}
+
+	zonesFn := func(ns string) map[string]struct{} {
+		return r.zonesProvider.GetZonesForNamespace(ns)
+	}
+	zones, err := util.GetZonesForvSANFileServiceMarkerPolicyByNamespace(ctx, r.dynamicClient, r.k8sClient,
+		instance.Namespace, zonesFn)
+	if err != nil {
+		return fmt.Errorf("failed to compute marker-policy zones for namespace %q: %w",
+			instance.Namespace, err)
+	}
+	instance.Status.TopologyInfo = &spiv1alpha1.Topology{
+		TopologyType:    infraSPI.Status.Topology.TopologyType,
+		AccessibleZones: zones,
+	}
+	log.Infof("syncTopologyFromInfraSPI: marker policy %q namespace %q zones: %v",
+		instance.Name, instance.Namespace, zones)
 	return nil
 }
 

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -133,32 +133,32 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	// watch, and the syncMarkerPolicyTopology branch) is a distinct feature gated
 	// by the VsanFileVolumeService capability. Regular policy topology reconciles
 	// regardless of this flag.
-	markerPolicyEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VsanFileVolumeService)
-	if !markerPolicyEnabled {
+	IsVsanFileVolumeService := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VsanFileVolumeService)
+	if !IsVsanFileVolumeService {
 		log.Infof("StoragePolicyInfo Controller: capability %q is not activated; "+
 			"marker-policy topology support is disabled", common.VsanFileVolumeService)
 	}
 
 	return add(mgr, newReconciler(mgr, configInfo, recorder,
 		commonco.ContainerOrchestratorUtility,
-		k8sclient, dynamicClient, markerPolicyEnabled))
+		k8sclient, dynamicClient, IsVsanFileVolumeService))
 }
 
 func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 	recorder record.EventRecorder, zp zonesProvider,
 	k8sClient kubernetes.Interface, dynamicClient dynamic.Interface,
-	markerPolicyEnabled bool) *ReconcileStoragePolicyInfo {
+	IsVsanFileVolumeService bool) *ReconcileStoragePolicyInfo {
 
 	return &ReconcileStoragePolicyInfo{
-		client:              mgr.GetClient(),
-		scheme:              mgr.GetScheme(),
-		configInfo:          configInfo,
-		recorder:            recorder,
-		zonesProvider:       zp,
-		k8sClient:           k8sClient,
-		dynamicClient:       dynamicClient,
-		markerPolicyEnabled: markerPolicyEnabled,
-		backOffDuration:     make(map[apitypes.NamespacedName]time.Duration),
+		client:                  mgr.GetClient(),
+		scheme:                  mgr.GetScheme(),
+		configInfo:              configInfo,
+		recorder:                recorder,
+		zonesProvider:           zp,
+		k8sClient:               k8sClient,
+		dynamicClient:           dynamicClient,
+		IsVsanFileVolumeService: IsVsanFileVolumeService,
+		backOffDuration:         make(map[apitypes.NamespacedName]time.Duration),
 	}
 }
 
@@ -180,7 +180,7 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 	// can list only marker SPIs without a full cross-namespace scan. Only registered
 	// when marker-policy support is enabled; the index and the FVS-namespace watch
 	// below are wired together since the watch's map func lists by this index.
-	if r.markerPolicyEnabled {
+	if r.IsVsanFileVolumeService {
 		if err := mgr.GetFieldIndexer().IndexField(ctx, &spiv1alpha1.StoragePolicyInfo{},
 			spiMarkerIndexField, func(obj client.Object) []string {
 				if common.IsvSANFileServiceMarkerPolicyName(obj.GetName()) {
@@ -276,7 +276,7 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 	// The FVS-namespace watch re-triggers marker-policy SPIs on namespace changes.
 	// Only wired when marker-policy support is enabled, matching the marker index
 	// above (mapFVSNamespaceToMarkerSPIs lists by that index).
-	if r.markerPolicyEnabled {
+	if r.IsVsanFileVolumeService {
 		ctrlBuilder = ctrlBuilder.Watches(
 			&v1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.mapFVSNamespaceToMarkerSPIs),
@@ -402,11 +402,11 @@ type ReconcileStoragePolicyInfo struct {
 	zonesProvider zonesProvider
 	k8sClient     kubernetes.Interface
 	dynamicClient dynamic.Interface
-	// markerPolicyEnabled mirrors the VsanFileVolumeService capability read at
+	// IsVsanFileVolumeService mirrors the VsanFileVolumeService capability read at
 	// controller start. When false, marker-policy topology support (the marker
 	// field index, the FVS-namespace watch, and the syncMarkerPolicyTopology
 	// branch) is disabled and only regular policy topology is reconciled.
-	markerPolicyEnabled bool
+	IsVsanFileVolumeService bool
 	// backOffDuration tracks per-instance requeue delays, incremented
 	// exponentially on failure and reset to 1s on success. A value greater than
 	// one second means the instance is currently backed off after a failure;
@@ -598,7 +598,7 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 	// topology rather than from InfraSPI zones filtered by namespace Zone CRs. This
 	// path is only taken when marker-policy support is enabled; otherwise a marker
 	// policy falls through to the regular namespace-filtered topology path.
-	if r.markerPolicyEnabled && common.IsvSANFileServiceMarkerPolicyName(instance.Name) {
+	if r.IsVsanFileVolumeService && common.IsvSANFileServiceMarkerPolicyName(instance.Name) {
 		return r.syncMarkerPolicyTopology(ctx, instance, infraSPI)
 	}
 

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -1068,12 +1068,12 @@ func TestSyncTopologyFromInfraSPI_MarkerPolicy(t *testing.T) {
 	}
 
 	r := &ReconcileStoragePolicyInfo{
-		client:              fake.NewClientBuilder().WithScheme(scheme).Build(),
-		scheme:              scheme,
-		zonesProvider:       zp,
-		k8sClient:           k8sClient,
-		dynamicClient:       dc,
-		markerPolicyEnabled: true,
+		client:                  fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:                  scheme,
+		zonesProvider:           zp,
+		k8sClient:               k8sClient,
+		dynamicClient:           dc,
+		IsVsanFileVolumeService: true,
 	}
 
 	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
@@ -1114,12 +1114,12 @@ func TestSyncTopologyFromInfraSPI_MarkerPolicy_NoFVSNamespaces(t *testing.T) {
 	}
 
 	r := &ReconcileStoragePolicyInfo{
-		client:              fake.NewClientBuilder().WithScheme(scheme).Build(),
-		scheme:              scheme,
-		zonesProvider:       &mockZonesProvider{},
-		k8sClient:           k8sClient,
-		dynamicClient:       dc,
-		markerPolicyEnabled: true,
+		client:                  fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:                  scheme,
+		zonesProvider:           &mockZonesProvider{},
+		k8sClient:               k8sClient,
+		dynamicClient:           dc,
+		IsVsanFileVolumeService: true,
 	}
 
 	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
@@ -1146,9 +1146,9 @@ func TestSyncTopologyFromInfraSPI_MarkerPolicy_NilTopology(t *testing.T) {
 	}
 
 	r := &ReconcileStoragePolicyInfo{
-		client:              fake.NewClientBuilder().WithScheme(scheme).Build(),
-		scheme:              scheme,
-		markerPolicyEnabled: true,
+		client:                  fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:                  scheme,
+		IsVsanFileVolumeService: true,
 	}
 
 	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
@@ -1191,10 +1191,10 @@ func TestSyncTopologyFromInfraSPI_MarkerPolicy_FSSDisabled(t *testing.T) {
 		},
 	}
 	r := &ReconcileStoragePolicyInfo{
-		client:              fake.NewClientBuilder().WithScheme(scheme).Build(),
-		scheme:              scheme,
-		zonesProvider:       zp,
-		markerPolicyEnabled: false,
+		client:                  fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:                  scheme,
+		zonesProvider:           zp,
+		IsVsanFileVolumeService: false,
 	}
 
 	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -26,8 +26,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,8 +41,10 @@ import (
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
 	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 func testScheme(t *testing.T) *runtime.Scheme {
@@ -898,4 +904,303 @@ func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
 	default:
 		t.Error("expected a Normal StoragePolicyInfoSynced event after topology update")
 	}
+}
+
+// vpcNetworkConfigGVR mirrors the GVR used in markerzones.go.
+var vpcNetworkConfigGVR = schema.GroupVersionResource{
+	Group:    "crd.nsx.vmware.com",
+	Version:  "v1alpha1",
+	Resource: "vpcnetworkconfigurations",
+}
+
+// vpcCRPair holds a VPCNetworkConfiguration CR name and its resolved VPC path.
+type vpcCRPair struct {
+	name    string
+	vpcPath string
+}
+
+// newFakeDynClientWithVPCCRs builds a fake dynamic client pre-populated with one
+// VPCNetworkConfiguration object per pair, each carrying status.vpcs[0].vpcPath.
+func newFakeDynClientWithVPCCRs(pairs ...vpcCRPair) *dynfake.FakeDynamicClient {
+	dynScheme := runtime.NewScheme()
+	dynScheme.AddKnownTypeWithName(
+		vpcNetworkConfigGVR.GroupVersion().WithKind("VPCNetworkConfiguration"),
+		&unstructured.Unstructured{},
+	)
+	dynScheme.AddKnownTypeWithName(
+		vpcNetworkConfigGVR.GroupVersion().WithKind("VPCNetworkConfigurationList"),
+		&unstructured.UnstructuredList{},
+	)
+
+	objs := make([]runtime.Object, 0, len(pairs))
+	for _, p := range pairs {
+		cr := &unstructured.Unstructured{}
+		cr.SetGroupVersionKind(vpcNetworkConfigGVR.GroupVersion().WithKind("VPCNetworkConfiguration"))
+		cr.SetName(p.name)
+		_ = unstructured.SetNestedSlice(cr.Object, []interface{}{
+			map[string]interface{}{"vpcPath": p.vpcPath},
+		}, "status", "vpcs")
+		objs = append(objs, cr)
+	}
+
+	return dynfake.NewSimpleDynamicClient(dynScheme, objs...)
+}
+
+// fvsSPINamespace returns a Namespace labelled as an FVS instance namespace
+// with the given VPC network config annotation.
+func fvsSPINamespace(name, vpcAnnotation string) *v1.Namespace {
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   name,
+		Labels: map[string]string{cnsoperatorutil.NamespaceLabelFVSInstance: "true"},
+	}}
+	if vpcAnnotation != "" {
+		ns.Annotations = map[string]string{cnsoperatorutil.AnnotationVPCNetworkConfig: vpcAnnotation}
+	}
+	return ns
+}
+
+// TestMapFVSNamespaceToMarkerSPIs verifies that mapFVSNamespaceToMarkerSPIs
+// enqueues reconcile requests for every marker-policy StoragePolicyInfo across
+// all namespaces, and ignores non-marker policies.
+func TestMapFVSNamespaceToMarkerSPIs(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	// One marker-policy SPI and one non-marker SPI.
+	spiMarker1 := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.StorageClassVsanFileServicePolicy,
+			Namespace: "ns1",
+		},
+	}
+	spiNonMarker := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(spiMarker1, spiNonMarker).
+		WithIndex(&spiv1alpha1.StoragePolicyInfo{}, spiMarkerIndexField,
+			func(obj client.Object) []string {
+				if common.IsvSANFileServiceMarkerPolicyName(obj.GetName()) {
+					return []string{"true"}
+				}
+				return nil
+			}).
+		Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	reqs := r.mapFVSNamespaceToMarkerSPIs(ctx, nil) // trigger object is unused
+	require.Len(t, reqs, 1, "expected one request per marker-policy SPI")
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: common.StorageClassVsanFileServicePolicy},
+	}, reqs[0])
+}
+
+// TestMapFVSNamespaceToMarkerSPIs_NoMarkerSPIs verifies that when no
+// marker-policy StoragePolicyInfos exist, mapFVSNamespaceToMarkerSPIs returns nil.
+func TestMapFVSNamespaceToMarkerSPIs_NoMarkerSPIs(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	spiNonMarker := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(spiNonMarker).
+		WithIndex(&spiv1alpha1.StoragePolicyInfo{}, spiMarkerIndexField,
+			func(obj client.Object) []string {
+				if common.IsvSANFileServiceMarkerPolicyName(obj.GetName()) {
+					return []string{"true"}
+				}
+				return nil
+			}).
+		Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	reqs := r.mapFVSNamespaceToMarkerSPIs(ctx, nil)
+	assert.Nil(t, reqs)
+}
+
+// TestSyncTopologyFromInfraSPI_MarkerPolicy verifies that for a marker-policy SPI
+// syncTopologyFromInfraSPI derives zones from FVS instance namespaces sharing the
+// consumer namespace's VPC path, rather than using the standard namespace-filter path.
+func TestSyncTopologyFromInfraSPI_MarkerPolicy(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	// Consumer namespace "consumer-ns" uses VPC "vpc-cfg-a" → path "/vpc/a".
+	// FVS instance namespace "fvs-ns-1" also uses "vpc-cfg-a" → matches.
+	// FVS instance namespace "fvs-ns-2" uses "vpc-cfg-b" → different VPC, no match.
+	consumerNS := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:        "consumer-ns",
+		Annotations: map[string]string{cnsoperatorutil.AnnotationVPCNetworkConfig: "vpc-cfg-a"},
+	}}
+	fvsNS1 := fvsSPINamespace("fvs-ns-1", "vpc-cfg-a") // same VPC as consumer
+	fvsNS2 := fvsSPINamespace("fvs-ns-2", "vpc-cfg-b") // different VPC
+
+	k8sClient := k8sfake.NewSimpleClientset(consumerNS, fvsNS1, fvsNS2)
+	// Fake dynamic client: vpc-cfg-a → /vpc/a, vpc-cfg-b → /vpc/b.
+	dc := newFakeDynClientWithVPCCRs(
+		vpcCRPair{"vpc-cfg-a", "/vpc/a"},
+		vpcCRPair{"vpc-cfg-b", "/vpc/b"},
+	)
+
+	// zonesProvider: fvs-ns-1 is in zone-x; fvs-ns-2 is in zone-y (should not appear).
+	zp := &mockZonesProvider{
+		zonesForNamespace: map[string]map[string]struct{}{
+			"fvs-ns-1": {"zone-x": {}},
+			"fvs-ns-2": {"zone-y": {}},
+		},
+	}
+
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: common.StorageClassVsanFileServicePolicy},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{TopologyType: "zonal"},
+		},
+	}
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.StorageClassVsanFileServicePolicy,
+			Namespace: "consumer-ns",
+		},
+	}
+
+	r := &ReconcileStoragePolicyInfo{
+		client:              fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:              scheme,
+		zonesProvider:       zp,
+		k8sClient:           k8sClient,
+		dynamicClient:       dc,
+		markerPolicyEnabled: true,
+	}
+
+	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
+	require.NoError(t, err)
+	require.NotNil(t, instance.Status.TopologyInfo)
+	assert.Equal(t, "zonal", instance.Status.TopologyInfo.TopologyType)
+	assert.Equal(t, []string{"zone-x"}, instance.Status.TopologyInfo.AccessibleZones,
+		"only zones from FVS namespaces sharing the consumer VPC path should be included")
+}
+
+// TestSyncTopologyFromInfraSPI_MarkerPolicy_NoFVSNamespaces verifies that when no
+// FVS instance namespaces share the consumer's VPC path, the zone list is empty.
+func TestSyncTopologyFromInfraSPI_MarkerPolicy_NoFVSNamespaces(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	consumerNS := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:        "consumer-ns",
+		Annotations: map[string]string{cnsoperatorutil.AnnotationVPCNetworkConfig: "vpc-cfg-a"},
+	}}
+	// FVS namespace is on a completely different VPC — no match.
+	fvsNS := fvsSPINamespace("fvs-ns-1", "vpc-cfg-b")
+
+	k8sClient := k8sfake.NewSimpleClientset(consumerNS, fvsNS)
+	dc := newFakeDynClientWithVPCCRs(
+		vpcCRPair{"vpc-cfg-a", "/vpc/a"},
+		vpcCRPair{"vpc-cfg-b", "/vpc/b"},
+	)
+
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: common.StorageClassVsanFileServicePolicy},
+	}
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.StorageClassVsanFileServicePolicy,
+			Namespace: "consumer-ns",
+		},
+	}
+
+	r := &ReconcileStoragePolicyInfo{
+		client:              fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:              scheme,
+		zonesProvider:       &mockZonesProvider{},
+		k8sClient:           k8sClient,
+		dynamicClient:       dc,
+		markerPolicyEnabled: true,
+	}
+
+	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
+	require.NoError(t, err)
+	assert.Nil(t, instance.Status.TopologyInfo,
+		"TopologyInfo should be nil when InfraStoragePolicyInfo has no topology type")
+}
+
+// TestSyncTopologyFromInfraSPI_MarkerPolicy_NilTopology verifies that when
+// InfraStoragePolicyInfo has no topology, the marker branch clears TopologyInfo
+// without attempting any VPC/zone lookup.
+func TestSyncTopologyFromInfraSPI_MarkerPolicy_NilTopology(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: common.StorageClassVsanFileServicePolicy},
+	}
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.StorageClassVsanFileServicePolicy,
+			Namespace: "consumer-ns",
+		},
+	}
+
+	r := &ReconcileStoragePolicyInfo{
+		client:              fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:              scheme,
+		markerPolicyEnabled: true,
+	}
+
+	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
+	require.NoError(t, err)
+	assert.Nil(t, instance.Status.TopologyInfo,
+		"TopologyInfo should be nil when InfraStoragePolicyInfo has no topology")
+}
+
+// TestSyncTopologyFromInfraSPI_MarkerPolicy_FSSDisabled verifies that when the
+// marker-policy FSS (VsanFileVolumeService) is disabled, an SPI whose name matches
+// the marker policy is NOT routed through syncMarkerPolicyTopology and instead
+// takes the regular InfraSPI-zones-filtered-by-namespace path.
+func TestSyncTopologyFromInfraSPI_MarkerPolicy_FSSDisabled(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: common.StorageClassVsanFileServicePolicy},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"zone-a", "zone-b"},
+			},
+		},
+	}
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.StorageClassVsanFileServicePolicy,
+			Namespace: "consumer-ns",
+		},
+	}
+
+	// Namespace consumer-ns is assigned only zone-a, so the regular path must
+	// intersect the InfraSPI cluster zones down to {zone-a}. A dynamicClient/
+	// k8sClient absence here also proves the marker branch (which needs them) is
+	// not taken.
+	zp := &mockZonesProvider{
+		zonesForNamespace: map[string]map[string]struct{}{
+			"consumer-ns": {"zone-a": {}},
+		},
+	}
+	r := &ReconcileStoragePolicyInfo{
+		client:              fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:              scheme,
+		zonesProvider:       zp,
+		markerPolicyEnabled: false,
+	}
+
+	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
+	require.NoError(t, err)
+	require.NotNil(t, instance.Status.TopologyInfo)
+	assert.Equal(t, "zonal", instance.Status.TopologyInfo.TopologyType)
+	assert.Equal(t, []string{"zone-a"}, instance.Status.TopologyInfo.AccessibleZones,
+		"with marker FSS off, the marker SPI must use the regular namespace-filtered zones")
 }

--- a/pkg/syncer/cnsoperator/util/markerzones.go
+++ b/pkg/syncer/cnsoperator/util/markerzones.go
@@ -68,30 +68,30 @@ func VPCPathForNamespace(ctx context.Context, dc dynamic.Interface,
 		return "", fmt.Errorf("get namespace %q: %w", namespace, err)
 	}
 
-	crName := ns.Annotations[AnnotationVPCNetworkConfig]
-	if crName == "" {
+	vpcConfigName := ns.Annotations[AnnotationVPCNetworkConfig]
+	if vpcConfigName == "" {
 		return "", fmt.Errorf("namespace %q has no %q annotation", namespace, AnnotationVPCNetworkConfig)
 	}
 
-	cr, err := dc.Resource(vpcNetworkConfigurationGVR).Get(ctx, crName, metav1.GetOptions{})
+	vpcConfig, err := dc.Resource(vpcNetworkConfigurationGVR).Get(ctx, vpcConfigName, metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("get VPCNetworkConfiguration %q: %w", crName, err)
+		return "", fmt.Errorf("get VPCNetworkConfiguration %q: %w", vpcConfigName, err)
 	}
 
-	path := vpcPathFromVPCNetworkConfiguration(cr)
+	path := vpcPathFromVPCNetworkConfiguration(vpcConfig)
 	if path == "" {
 		return "", fmt.Errorf("no VPC path in status.vpcs for VPCNetworkConfiguration %q (namespace %q)",
-			crName, namespace)
+			vpcConfigName, namespace)
 	}
 
-	log.Debugf("Namespace %q uses VPC path %q (VPCNetworkConfiguration %q)", namespace, path, crName)
+	log.Debugf("Namespace %q uses VPC path %q (VPCNetworkConfiguration %q)", namespace, path, vpcConfigName)
 	return path, nil
 }
 
-// collectFVSZones iterates over all fvs_instance_namespace=true namespaces and calls zonesFn on
+// GetFVSZones iterates over all fvs_instance_namespace=true namespaces and calls zonesFn on
 // each one whose VPC path satisfies matchVPCPath (empty string means accept all VPC paths).
 // Returns the sorted union of all zone sets returned by zonesFn.
-func collectFVSZones(ctx context.Context, dc dynamic.Interface,
+func GetFVSZones(ctx context.Context, dc dynamic.Interface,
 	k8sClient kubernetes.Interface, matchVPCPath string,
 	zonesFn func(string) map[string]struct{}) ([]string, error) {
 	log := logger.GetLogger(ctx)
@@ -106,24 +106,24 @@ func collectFVSZones(ctx context.Context, dc dynamic.Interface,
 	zonesSet := make(map[string]struct{})
 	for i := range nsList.Items {
 		ns := &nsList.Items[i]
-		crName := ns.Annotations[AnnotationVPCNetworkConfig]
-		if crName == "" {
+		vpcConfigName := ns.Annotations[AnnotationVPCNetworkConfig]
+		if vpcConfigName == "" {
 			log.Debugf("Skipping namespace %q: missing %q annotation", ns.Name, AnnotationVPCNetworkConfig)
 			continue
 		}
 
 		if matchVPCPath != "" {
-			cr, err := dc.Resource(vpcNetworkConfigurationGVR).Get(ctx, crName, metav1.GetOptions{})
+			vpcConfig, err := dc.Resource(vpcNetworkConfigurationGVR).Get(ctx, vpcConfigName, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					log.Debugf("VPCNetworkConfiguration %q for namespace %q not found; skipping",
-						crName, ns.Name)
+						vpcConfigName, ns.Name)
 					continue
 				}
 				return nil, fmt.Errorf("get VPCNetworkConfiguration %q for namespace %q: %w",
-					crName, ns.Name, err)
+					vpcConfigName, ns.Name, err)
 			}
-			if vpcPathFromVPCNetworkConfiguration(cr) != matchVPCPath {
+			if vpcPathFromVPCNetworkConfiguration(vpcConfig) != matchVPCPath {
 				continue
 			}
 		}
@@ -151,7 +151,7 @@ func GetZonesForvSANFileServiceMarkerPolicy(ctx context.Context,
 	zonesFn func(string) map[string]struct{}) ([]string, error) {
 	log := logger.GetLogger(ctx)
 
-	zones, err := collectFVSZones(ctx, nil, k8sClient, "", zonesFn)
+	zones, err := GetFVSZones(ctx, nil, k8sClient, "", zonesFn)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func GetZonesForvSANFileServiceMarkerPolicyByNamespace(ctx context.Context, dc d
 	}
 	log.Infof("Namespace %q has VPC path %q", namespace, consumerVPCPath)
 
-	zones, err := collectFVSZones(ctx, dc, k8sClient, consumerVPCPath, zonesFn)
+	zones, err := GetFVSZones(ctx, dc, k8sClient, consumerVPCPath, zonesFn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/syncer/cnsoperator/util/markerzones.go
+++ b/pkg/syncer/cnsoperator/util/markerzones.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,7 +39,7 @@ var vpcNetworkConfigurationGVR = schema.GroupVersionResource{
 const (
 	// AnnotationVPCNetworkConfig is set on supervisor namespaces; value is the VPCNetworkConfiguration CR name.
 	AnnotationVPCNetworkConfig = "nsx.vmware.com/vpc_network_config"
-	// NamespaceLabelFVSInstance marks FVS instance namespaces.
+	// NamespaceLabelFVSInstance marks FVS instance namespaces (supervisor namespaces that host FileVolume CRs).
 	// Expected label value is "true".
 	NamespaceLabelFVSInstance = "fvs_instance_namespace"
 )
@@ -87,12 +88,11 @@ func VPCPathForNamespace(ctx context.Context, dc dynamic.Interface,
 	return path, nil
 }
 
-// GetZonesForvSANFileServiceMarkerPolicy returns the union of zones (via zonesFn) across ALL
-// fvs_instance_namespace=true namespaces that carry the AnnotationVPCNetworkConfig annotation.
-// This is the cluster-wide accessible zone algorithm for the vSAN File Service marker policy,
-// used to populate InfraStoragePolicyInfo.
-func GetZonesForvSANFileServiceMarkerPolicy(ctx context.Context,
-	k8sClient kubernetes.Interface,
+// collectFVSZones iterates over all fvs_instance_namespace=true namespaces and calls zonesFn on
+// each one whose VPC path satisfies matchVPCPath (empty string means accept all VPC paths).
+// Returns the sorted union of all zone sets returned by zonesFn.
+func collectFVSZones(ctx context.Context, dc dynamic.Interface,
+	k8sClient kubernetes.Interface, matchVPCPath string,
 	zonesFn func(string) map[string]struct{}) ([]string, error) {
 	log := logger.GetLogger(ctx)
 
@@ -106,11 +106,28 @@ func GetZonesForvSANFileServiceMarkerPolicy(ctx context.Context,
 	zonesSet := make(map[string]struct{})
 	for i := range nsList.Items {
 		ns := &nsList.Items[i]
-		if ns.Annotations[AnnotationVPCNetworkConfig] == "" {
-			log.Debugf("Skipping namespace %q: missing %q annotation",
-				ns.Name, AnnotationVPCNetworkConfig)
+		crName := ns.Annotations[AnnotationVPCNetworkConfig]
+		if crName == "" {
+			log.Debugf("Skipping namespace %q: missing %q annotation", ns.Name, AnnotationVPCNetworkConfig)
 			continue
 		}
+
+		if matchVPCPath != "" {
+			cr, err := dc.Resource(vpcNetworkConfigurationGVR).Get(ctx, crName, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					log.Debugf("VPCNetworkConfiguration %q for namespace %q not found; skipping",
+						crName, ns.Name)
+					continue
+				}
+				return nil, fmt.Errorf("get VPCNetworkConfiguration %q for namespace %q: %w",
+					crName, ns.Name, err)
+			}
+			if vpcPathFromVPCNetworkConfiguration(cr) != matchVPCPath {
+				continue
+			}
+		}
+
 		nsZones := zonesFn(ns.Name)
 		log.Debugf("Namespace %q contributes zones: %v", ns.Name, nsZones)
 		for z := range nsZones {
@@ -122,6 +139,46 @@ func GetZonesForvSANFileServiceMarkerPolicy(ctx context.Context,
 	for z := range zonesSet {
 		zones = append(zones, z)
 	}
+	return zones, nil
+}
+
+// GetZonesForvSANFileServiceMarkerPolicy returns the union of zones (via zonesFn) across ALL
+// fvs_instance_namespace=true namespaces that carry the AnnotationVPCNetworkConfig annotation.
+// This is the cluster-wide accessible zone algorithm for the vSAN File Service marker policy,
+// used to populate InfraStoragePolicyInfo.
+func GetZonesForvSANFileServiceMarkerPolicy(ctx context.Context,
+	k8sClient kubernetes.Interface,
+	zonesFn func(string) map[string]struct{}) ([]string, error) {
+	log := logger.GetLogger(ctx)
+
+	zones, err := collectFVSZones(ctx, nil, k8sClient, "", zonesFn)
+	if err != nil {
+		return nil, err
+	}
 	log.Infof("Accessible zones for vSAN File Service: %v", zones)
+	return zones, nil
+}
+
+// GetZonesForvSANFileServiceMarkerPolicyByNamespace returns the union of zones (via zonesFn)
+// across all fvs_instance_namespace=true namespaces whose VPC path matches the consumer
+// namespace's VPC path.
+// This is the per-namespace accessible zone algorithm for the vSAN File Service marker policy,
+// used to populate namespace-level StoragePolicyInfo.
+func GetZonesForvSANFileServiceMarkerPolicyByNamespace(ctx context.Context, dc dynamic.Interface,
+	k8sClient kubernetes.Interface, namespace string,
+	zonesFn func(string) map[string]struct{}) ([]string, error) {
+	log := logger.GetLogger(ctx)
+
+	consumerVPCPath, err := VPCPathForNamespace(ctx, dc, k8sClient, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("resolve VPC path for namespace %q: %w", namespace, err)
+	}
+	log.Infof("Namespace %q has VPC path %q", namespace, consumerVPCPath)
+
+	zones, err := collectFVSZones(ctx, dc, k8sClient, consumerVPCPath, zonesFn)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("Namespace %q marker-policy accessible zones: %v", namespace, zones)
 	return zones, nil
 }

--- a/pkg/syncer/cnsoperator/util/markerzones_test.go
+++ b/pkg/syncer/cnsoperator/util/markerzones_test.go
@@ -1,0 +1,362 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// vpcCRPair holds a VPCNetworkConfiguration CR name and its resolved VPC path.
+type vpcCRPair struct {
+	name    string
+	vpcPath string
+}
+
+// newFakeDynClientWithVPCCRs builds a fake dynamic client pre-populated with one
+// VPCNetworkConfiguration object per pair, each carrying status.vpcs[0].vpcPath.
+func newFakeDynClientWithVPCCRs(pairs ...vpcCRPair) *dynfake.FakeDynamicClient {
+	dynScheme := runtime.NewScheme()
+	dynScheme.AddKnownTypeWithName(
+		vpcNetworkConfigurationGVR.GroupVersion().WithKind("VPCNetworkConfiguration"),
+		&unstructured.Unstructured{},
+	)
+	dynScheme.AddKnownTypeWithName(
+		vpcNetworkConfigurationGVR.GroupVersion().WithKind("VPCNetworkConfigurationList"),
+		&unstructured.UnstructuredList{},
+	)
+
+	objs := make([]runtime.Object, 0, len(pairs))
+	for _, p := range pairs {
+		cr := &unstructured.Unstructured{}
+		cr.SetGroupVersionKind(vpcNetworkConfigurationGVR.GroupVersion().WithKind("VPCNetworkConfiguration"))
+		cr.SetName(p.name)
+		_ = unstructured.SetNestedSlice(cr.Object, []interface{}{
+			map[string]interface{}{"vpcPath": p.vpcPath},
+		}, "status", "vpcs")
+		objs = append(objs, cr)
+	}
+
+	return dynfake.NewSimpleDynamicClient(dynScheme, objs...)
+}
+
+// fvsNamespace returns a Namespace labelled as an FVS instance namespace with
+// the given VPC network config annotation. An empty vpcAnnotation omits the
+// annotation entirely.
+func fvsNamespace(name, vpcAnnotation string) *v1.Namespace {
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   name,
+		Labels: map[string]string{NamespaceLabelFVSInstance: "true"},
+	}}
+	if vpcAnnotation != "" {
+		ns.Annotations = map[string]string{AnnotationVPCNetworkConfig: vpcAnnotation}
+	}
+	return ns
+}
+
+// zonesFnFromMap returns a zonesFn that looks up the given namespace's zones in m.
+func zonesFnFromMap(m map[string][]string) func(string) map[string]struct{} {
+	return func(ns string) map[string]struct{} {
+		out := make(map[string]struct{})
+		for _, z := range m[ns] {
+			out[z] = struct{}{}
+		}
+		return out
+	}
+}
+
+// TestVPCPathForNamespace tests the VPCPathForNamespace function.
+func TestVPCPathForNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		namespace   *v1.Namespace
+		vpcCRs      []vpcCRPair
+		lookupNS    string
+		expectedVPC string
+		expectError bool
+	}{
+		{
+			name:        "happy path",
+			namespace:   fvsNamespace("ns1", "vpc-cfg-a"),
+			vpcCRs:      []vpcCRPair{{name: "vpc-cfg-a", vpcPath: "/org/proj/vpc-a"}},
+			lookupNS:    "ns1",
+			expectedVPC: "/org/proj/vpc-a",
+		},
+		{
+			name:        "namespace not found",
+			namespace:   nil,
+			lookupNS:    "missing-ns",
+			expectError: true,
+		},
+		{
+			name:        "missing VPC network config annotation",
+			namespace:   fvsNamespace("ns1", ""),
+			lookupNS:    "ns1",
+			expectError: true,
+		},
+		{
+			name:        "VPCNetworkConfiguration CR not found",
+			namespace:   fvsNamespace("ns1", "vpc-cfg-missing"),
+			lookupNS:    "ns1",
+			expectError: true,
+		},
+		{
+			name:        "CR has no vpcPath in status",
+			namespace:   fvsNamespace("ns1", "vpc-cfg-a"),
+			vpcCRs:      []vpcCRPair{{name: "vpc-cfg-a", vpcPath: ""}},
+			lookupNS:    "ns1",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var k8sObjs []runtime.Object
+			if tt.namespace != nil {
+				k8sObjs = append(k8sObjs, tt.namespace)
+			}
+			k8sClient := k8sfake.NewClientset(k8sObjs...)
+			dc := newFakeDynClientWithVPCCRs(tt.vpcCRs...)
+
+			path, err := VPCPathForNamespace(ctx, dc, k8sClient, tt.lookupNS)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedVPC, path)
+		})
+	}
+}
+
+// TestGetFVSZones tests the GetFVSZones function.
+func TestGetFVSZones(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		namespaces    []*v1.Namespace
+		vpcCRs        []vpcCRPair
+		matchVPCPath  string
+		zonesByNS     map[string][]string
+		expectedZones []string
+	}{
+		{
+			name:          "no FVS namespaces",
+			expectedZones: []string{},
+		},
+		{
+			name: "union of zones across namespaces, no VPC filter",
+			namespaces: []*v1.Namespace{
+				fvsNamespace("ns-a", "vpc-cfg-a"),
+				fvsNamespace("ns-b", "vpc-cfg-b"),
+				{ObjectMeta: metav1.ObjectMeta{Name: "regular-ns"}},
+			},
+			vpcCRs: []vpcCRPair{
+				{name: "vpc-cfg-a", vpcPath: "/org/proj/vpc-a"},
+				{name: "vpc-cfg-b", vpcPath: "/org/proj/vpc-b"},
+			},
+			zonesByNS: map[string][]string{
+				"ns-a": {"zone-1", "zone-2"},
+				"ns-b": {"zone-2", "zone-3"},
+			},
+			expectedZones: []string{"zone-1", "zone-2", "zone-3"},
+		},
+		{
+			name: "filters namespaces by matchVPCPath",
+			namespaces: []*v1.Namespace{
+				fvsNamespace("ns-a", "vpc-cfg-a"),
+				fvsNamespace("ns-b", "vpc-cfg-b"),
+			},
+			vpcCRs: []vpcCRPair{
+				{name: "vpc-cfg-a", vpcPath: "/org/proj/vpc-a"},
+				{name: "vpc-cfg-b", vpcPath: "/org/proj/vpc-b"},
+			},
+			matchVPCPath: "/org/proj/vpc-a",
+			zonesByNS: map[string][]string{
+				"ns-a": {"zone-1"},
+				"ns-b": {"zone-2"},
+			},
+			expectedZones: []string{"zone-1"},
+		},
+		{
+			name: "skips namespace missing the VPC network config annotation",
+			namespaces: []*v1.Namespace{
+				fvsNamespace("ns-no-annot", ""),
+			},
+			zonesByNS:     map[string][]string{"ns-no-annot": {"zone-1"}},
+			expectedZones: []string{},
+		},
+		{
+			name: "skips namespace whose VPCNetworkConfiguration CR is not found when filtering",
+			namespaces: []*v1.Namespace{
+				fvsNamespace("ns-dangling", "vpc-cfg-missing"),
+			},
+			matchVPCPath:  "/org/proj/vpc-a",
+			zonesByNS:     map[string][]string{"ns-dangling": {"zone-1"}},
+			expectedZones: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sObjs := make([]runtime.Object, len(tt.namespaces))
+			for i, ns := range tt.namespaces {
+				k8sObjs[i] = ns
+			}
+			k8sClient := k8sfake.NewClientset(k8sObjs...)
+			dc := newFakeDynClientWithVPCCRs(tt.vpcCRs...)
+
+			zones, err := GetFVSZones(ctx, dc, k8sClient, tt.matchVPCPath, zonesFnFromMap(tt.zonesByNS))
+			require.NoError(t, err)
+			sort.Strings(zones)
+			sort.Strings(tt.expectedZones)
+			assert.Equal(t, tt.expectedZones, zones)
+		})
+	}
+}
+
+// TestGetZonesForvSANFileServiceMarkerPolicy tests the GetZonesForvSANFileServiceMarkerPolicy function.
+func TestGetZonesForvSANFileServiceMarkerPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		namespaces    []*v1.Namespace
+		zonesByNS     map[string][]string
+		expectedZones []string
+	}{
+		{
+			name: "aggregates zones across all FVS namespaces regardless of VPC",
+			namespaces: []*v1.Namespace{
+				fvsNamespace("ns-a", "vpc-cfg-a"),
+				fvsNamespace("ns-b", "vpc-cfg-b"),
+			},
+			zonesByNS: map[string][]string{
+				"ns-a": {"zone-1"},
+				"ns-b": {"zone-2"},
+			},
+			expectedZones: []string{"zone-1", "zone-2"},
+		},
+		{
+			name:          "no FVS namespaces returns empty zones",
+			expectedZones: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sObjs := make([]runtime.Object, len(tt.namespaces))
+			for i, ns := range tt.namespaces {
+				k8sObjs[i] = ns
+			}
+			k8sClient := k8sfake.NewClientset(k8sObjs...)
+
+			zones, err := GetZonesForvSANFileServiceMarkerPolicy(ctx, k8sClient, zonesFnFromMap(tt.zonesByNS))
+			require.NoError(t, err)
+			sort.Strings(zones)
+			sort.Strings(tt.expectedZones)
+			assert.Equal(t, tt.expectedZones, zones)
+		})
+	}
+}
+
+// TestGetZonesForvSANFileServiceMarkerPolicyByNamespace tests the
+// GetZonesForvSANFileServiceMarkerPolicyByNamespace function.
+func TestGetZonesForvSANFileServiceMarkerPolicyByNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	consumerNSWithVPC := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:        "consumer-ns",
+		Annotations: map[string]string{AnnotationVPCNetworkConfig: "vpc-cfg-a"},
+	}}
+	consumerNSNoVPC := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "consumer-ns"}}
+
+	tests := []struct {
+		name          string
+		namespaces    []*v1.Namespace
+		vpcCRs        []vpcCRPair
+		lookupNS      string
+		zonesByNS     map[string][]string
+		expectedZones []string
+		expectError   bool
+	}{
+		{
+			name: "only zones from FVS namespaces sharing the consumer's VPC path",
+			namespaces: []*v1.Namespace{
+				consumerNSWithVPC,
+				fvsNamespace("fvs-same-vpc", "vpc-cfg-a"),
+				fvsNamespace("fvs-other-vpc", "vpc-cfg-b"),
+			},
+			vpcCRs: []vpcCRPair{
+				{name: "vpc-cfg-a", vpcPath: "/org/proj/vpc-a"},
+				{name: "vpc-cfg-b", vpcPath: "/org/proj/vpc-b"},
+			},
+			lookupNS: "consumer-ns",
+			zonesByNS: map[string][]string{
+				"fvs-same-vpc":  {"zone-1"},
+				"fvs-other-vpc": {"zone-2"},
+			},
+			expectedZones: []string{"zone-1"},
+		},
+		{
+			name:        "consumer namespace missing VPC annotation returns error",
+			namespaces:  []*v1.Namespace{consumerNSNoVPC},
+			lookupNS:    "consumer-ns",
+			expectError: true,
+		},
+		{
+			name:        "consumer namespace not found returns error",
+			lookupNS:    "missing-ns",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sObjs := make([]runtime.Object, len(tt.namespaces))
+			for i, ns := range tt.namespaces {
+				k8sObjs[i] = ns
+			}
+			k8sClient := k8sfake.NewClientset(k8sObjs...)
+			dc := newFakeDynClientWithVPCCRs(tt.vpcCRs...)
+
+			zones, err := GetZonesForvSANFileServiceMarkerPolicyByNamespace(
+				ctx, dc, k8sClient, tt.lookupNS, zonesFnFromMap(tt.zonesByNS))
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			sort.Strings(zones)
+			sort.Strings(tt.expectedZones)
+			assert.Equal(t, tt.expectedZones, zones)
+		})
+	}
+}


### PR DESCRIPTION
StoragePolicyInfo (SPI) tracks per-namespace topology capabilities for vSphere storage policies. For most policies, accessible zones are derived from the cluster-wide InfraStoragePolicyInfo and filtered to only those zones assigned to the namespace via Zone CRs. Marker policies differ: their accessible zones for a given namespace must be computed from FVS instance namespaces that share the consumer namespace's VPC network path, not from datastore/PBM zones. This PR completes the marker-policy implementation with the namespace-scoped SPI controller logic Changes:

(1) pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go:
- Adds k8sClient and dynamicClient fields to the reconciler, initialized from in-cluster config.
- Adds a reactive Namespace watch with nsFVSPredicate: on create/update/delete of FVS instance namespaces (or changes to their VPC config), automatically re-triggers reconciliation of all marker-policy SPIs across all namespaces (reactive event-driven pattern, no polling).
- Adds mapFVSNamespaceToMarkerSPIs: when a relevant namespace event fires, lists all StoragePolicyInfo objects and returns reconcile requests for only the marker-policy ones.
- Adds an early-exit branch in syncTopologyFromInfraSPI() for marker policies: derives namespace-level accessible zones via MarkerNamespaceZonesForNamespace()(zones from FVS instance namespaces sharing the consumer namespace's VPC path), bypassing the normal Zone CR filter logic.

(2) pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
- Adds unit tests covering the marker-policy topology support.

(3) pkg/syncer/cnsoperator/util/markerzones.go:
- MarkerNamespaceZonesForNamespace() — returns zones for FVS instance namespaces sharing the consumer namespace's VPC path; reserved for the follow-up SPI PR.

Testing done:

Pipeline results:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1349/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1787/ - Passed

Deployed a test bed with below configuration:
 Supervisor (WCP) cluster with vSAN File Service enabled and NSX VPC networking configured
 FVS instance namespace: test-ns-markerpolicy (labeled fvs_instance_namespace=true)
 Zone assigned to FVS instance namespace: zone1
 VPC path: /orgs/default/projects/default/vpcs/shared-vpc

1: SPI: with marker policy changes.

SPI status:
```
 kubectl get storagepolicyinfo -n test-ns-markerpolicy  vsan-file-service-policy -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyInfo
metadata:
  creationTimestamp: "2026-06-19T12:03:14Z"
  generation: 1
  name: vsan-file-service-policy
  namespace: test-ns-markerpolicy
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: InfraStoragePolicyInfo
    name: vsan-file-service-policy
    uid: 4a7532b3-bc6b-4c4e-a431-14c274129fbc
  resourceVersion: "7418744"
  uid: ff95c203-9ee6-4e25-860c-609c031fc7db
status:
  topologyInfo:
    accessibleZones:
    - zone1
    topologyType: zonal
```

Logs: Confirmed that marker zone implementation is called:

For test-ns-markerpolicy (same VPC as FVS instance namespace → zones expected):
```
{"caller":"storagepolicyinfo/controller.go:354","msg":"Reconciling StoragePolicyInfo","name":"test-ns-markerpolicy/vsan-file-service-policy"}
{"caller":"util/markerzones.go:102","msg":"MarkerNamespaceZonesForNamespace: namespace \"test-ns-markerpolicy\" has VPC path \"/orgs/default/projects/default/vpcs/shared-vpc\""}
{"caller":"util/markerzones.go:145","msg":"MarkerNamespaceZonesForNamespace: namespace \"test-ns-markerpolicy\" marker-policy accessible zones: [zone1]"}
{"caller":"storagepolicyinfo/controller.go:546","msg":"syncTopologyFromInfraSPI: marker policy \"vsan-file-service-policy\" namespace \"test-ns-markerpolicy\" zones: [zone1]"}
{"caller":"storagepolicyinfo/controller.go:425","msg":"Successfully reconciled StoragePolicyInfo \"test-ns-markerpolicy/vsan-file-service-policy\""}
```

For svc-file-volume-service-lmsoo (different VPC → zones expected to be empty):
```
{"caller":"util/markerzones.go:145","msg":"MarkerNamespaceZonesForNamespace: namespace \"svc-file-volume-service-lmsoo\" marker-policy accessible zones: []"}
{"caller":"storagepolicyinfo/controller.go:546","msg":"syncTopologyFromInfraSPI: marker policy \"vsan-file-service-policy\" namespace \"svc-file-volume-service-lmsoo\" zones: []"}
{"caller":"storagepolicyinfo/controller.go:425","msg":"Successfully reconciled StoragePolicyInfo \"svc-file-volume-service-lmsoo/vsan-file-service-policy\""}
Outcome: VPC path matching worked correctly. test-ns-markerpolicy got zone1 because it shares the same VPC as the FVS instance namespace. svc-file-volume-service-lmsoo got [] because it is on a different VPC — correct behavior.
```
Outcome: accessibleZones: [zone1] and topologyType: zonal correctly populated via FVS instance namespace.

(2) Created a namespace test-ns-no-vpc with fvs_instance_namespace=true but without the nsx.vmware.com/vpc_network_config annotation.

cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Namespace
metadata:
  name: test-ns-no-vpc
  labels:
    fvs_instance_namespace: "true"
EOF
Note: no nsx.vmware.com/vpc_network_config annotation Confirmed from the logs that namespace "test-ns-no-vpc" is skipped as annotation was missing.
```
2026-06-21T13:06:45.859Z        DEBUG   util/markerzones.go:116 MarkerNamespaceZonesForNamespace: skipping namespace "test-ns-no-vpc": missing "nsx.vmware.com/vpc_network_config" annotation       {"TraceId": "56b82966-caf2-4260-8d72-01f2fcc5d972"}
2026-06-21T13:06:45.865Z        DEBUG   util/markerzones.go:116 MarkerNamespaceZonesForNamespace: skipping namespace "test-ns-no-vpc": missing "nsx.vmware.com/vpc_network_config" annotation       {"TraceId": "a3d7ec60-96e3-4d8b-88dd-cac75d06f3a6"}
2026-06-21T13:06:45.857Z        DEBUG   util/markerzones.go:116 MarkerNamespaceZonesForNamespace: skipping namespace "test-ns-no-vpc": missing "nsx.vmware.com/vpc_network_config" annotation       {"TraceId": "a734982e-6b38-4f89-97b9-d8dda09826ab"}
```

Unit test results:
```

=== RUN   TestMapFVSNamespaceToMarkerSPIs
--- PASS: TestMapFVSNamespaceToMarkerSPIs (0.01s)
=== RUN   TestMapFVSNamespaceToMarkerSPIs_NoMarkerSPIs
--- PASS: TestMapFVSNamespaceToMarkerSPIs_NoMarkerSPIs (0.01s)
=== RUN   TestSyncTopologyFromInfraSPI_MarkerPolicy
{"level":"info","time":"2026-06-24T10:04:08.374865703Z","caller":"storagepolicyinfo/controller.go:526","msg":"syncTopologyFromInfraSPI: \"vsan-file-service-policy\" is a marker policy; deriving zones from FVS instance namespaces","TraceId":"4991ec80-ac77-45de-b642-335f7010f8e4"}
{"level":"info","time":"2026-06-24T10:04:08.375160803Z","caller":"util/markerzones.go:102","msg":"MarkerNamespaceZonesForNamespace: namespace \"consumer-ns\" has VPC path \"/vpc/a\"","TraceId":"4991ec80-ac77-45de-b642-335f7010f8e4"}
{"level":"info","time":"2026-06-24T10:04:08.375531603Z","caller":"util/markerzones.go:145","msg":"MarkerNamespaceZonesForNamespace: namespace \"consumer-ns\" marker-policy accessible zones: [zone-x]","TraceId":"4991ec80-ac77-45de-b642-335f7010f8e4"}
{"level":"info","time":"2026-06-24T10:04:08.375623703Z","caller":"storagepolicyinfo/controller.go:545","msg":"syncTopologyFromInfraSPI: marker policy \"vsan-file-service-policy\" namespace \"consumer-ns\" zones: [zone-x]","TraceId":"4991ec80-ac77-45de-b642-335f7010f8e4"}
--- PASS: TestSyncTopologyFromInfraSPI_MarkerPolicy (0.00s)
=== RUN   TestSyncTopologyFromInfraSPI_MarkerPolicy_NoFVSNamespaces
{"level":"info","time":"2026-06-24T10:04:08.378841003Z","caller":"storagepolicyinfo/controller.go:526","msg":"syncTopologyFromInfraSPI: \"vsan-file-service-policy\" is a marker policy; deriving zones from FVS instance namespaces","TraceId":"168bfabc-1a69-4309-bbc3-e0a91ce4c1fa"}
{"level":"info","time":"2026-06-24T10:04:08.378944603Z","caller":"util/markerzones.go:102","msg":"MarkerNamespaceZonesForNamespace: namespace \"consumer-ns\" has VPC path \"/vpc/a\"","TraceId":"168bfabc-1a69-4309-bbc3-e0a91ce4c1fa"}
{"level":"info","time":"2026-06-24T10:04:08.379065703Z","caller":"util/markerzones.go:145","msg":"MarkerNamespaceZonesForNamespace: namespace \"consumer-ns\" marker-policy accessible zones: []","TraceId":"168bfabc-1a69-4309-bbc3-e0a91ce4c1fa"}
{"level":"info","time":"2026-06-24T10:04:08.379131303Z","caller":"storagepolicyinfo/controller.go:545","msg":"syncTopologyFromInfraSPI: marker policy \"vsan-file-service-policy\" namespace \"consumer-ns\" zones: []","TraceId":"168bfabc-1a69-4309-bbc3-e0a91ce4c1fa"}
--- PASS: TestSyncTopologyFromInfraSPI_MarkerPolicy_NoFVSNamespaces (0.00s)
=== RUN   TestSyncTopologyFromInfraSPI_MarkerPolicy_TopologyTypeFromInfraSPI
{"level":"info","time":"2026-06-24T10:04:08.385087402Z","caller":"storagepolicyinfo/controller.go:526","msg":"syncTopologyFromInfraSPI: \"vsan-file-service-policy\" is a marker policy; deriving zones from FVS instance namespaces","TraceId":"13d7a83d-d852-46d1-ab7e-f52bbc6b1611"}
{"level":"info","time":"2026-06-24T10:04:08.385260301Z","caller":"util/markerzones.go:102","msg":"MarkerNamespaceZonesForNamespace: namespace \"consumer-ns\" has VPC path \"/vpc/a\"","TraceId":"13d7a83d-d852-46d1-ab7e-f52bbc6b1611"}
{"level":"info","time":"2026-06-24T10:04:08.385441201Z","caller":"util/markerzones.go:145","msg":"MarkerNamespaceZonesForNamespace: namespace \"consumer-ns\" marker-policy accessible zones: []","TraceId":"13d7a83d-d852-46d1-ab7e-f52bbc6b1611"}
{"level":"info","time":"2026-06-24T10:04:08.385579801Z","caller":"storagepolicyinfo/controller.go:545","msg":"syncTopologyFromInfraSPI: marker policy \"vsan-file-service-policy\" namespace \"consumer-ns\" zones: []","TraceId":"13d7a83d-d852-46d1-ab7e-f52bbc6b1611"}
```
