### PR TITLE
Detect VM attachment in BYOK PVC controller from PVC-local signals

### DIFF
--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -74,7 +74,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
   - apiGroups: ["vmware.com"]
     resources: ["virtualnetworks"]
     verbs: ["get"]

--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -74,7 +74,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
   - apiGroups: ["vmware.com"]
     resources: ["virtualnetworks"]
     verbs: ["get"]

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -80,7 +80,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
   - apiGroups: ["vmware.com"]
     resources: ["virtualnetworks"]
     verbs: ["get"]

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -80,7 +80,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["vmoperator.vmware.com"]
     resources: ["virtualmachines"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
   - apiGroups: ["vmware.com"]
     resources: ["virtualnetworks"]
     verbs: ["get"]

--- a/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller.go
+++ b/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller.go
@@ -29,15 +29,22 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/crypto"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	ctrlcommoon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/common"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
+
+// usedByVMAnnotationPrefix is the prefix of the annotation that the
+// CnsNodeVMBatchAttachment controller writes on a PVC when it is attached to a VM
+// (as "cns.vmware.com/usedby-vm-<vm-instance-uuid>"). It mirrors vmServiceVMAnnotationPrefix
+// in cbtsync.go and attachedVmPrefix in the attachment controllers.
+const usedByVMAnnotationPrefix = "cns.vmware.com/usedby-vm-"
 
 func AddToManager(ctx context.Context, mgr manager.Manager, opts ctrlcommoon.Options) error {
 	var (
@@ -100,19 +107,13 @@ func (r *reconciler) reconcileNormal(ctx context.Context, pvc *corev1.Persistent
 		return nil
 	}
 
-	// Check if PVC is referenced in a VM
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
-	if err != nil {
-		r.logger.Errorf("Failed to check PVC attachment status for PVC %s/%s: %v", pvc.Namespace, pvc.Name, err)
-		return err
-	}
-
-	if isAttached {
-		// PVC is referenced in a VM - skip encryption and defer to VM Operator
-		r.logger.Infof("Skipping encryption for PVC %s/%s as it is referenced in VirtualMachine %s. "+
+	// Check if PVC is attached to a VM using PVC-local signals (annotation/finalizer).
+	if isAttached, detail := r.isPVCAttachedToVM(pvc); isAttached {
+		// PVC is attached to a VM - skip encryption and defer to VM Operator
+		r.logger.Infof("Skipping encryption for PVC %s/%s as it is attached to a VirtualMachine %s. "+
 			"Deferring to VM Operator which will aggregate all PVCs and VM encryption changes "+
 			"and issue atomic reconfig API call to vCenter. EncryptionClass: %s, KeyProvider: %s, KeyID: %s",
-			pvc.Namespace, pvc.Name, vmName, encClass.Name, encClass.Spec.KeyProvider, encClass.Spec.KeyID)
+			pvc.Namespace, pvc.Name, detail, encClass.Name, encClass.Spec.KeyProvider, encClass.Spec.KeyID)
 		return nil
 	}
 
@@ -205,37 +206,30 @@ func (r *reconciler) findVolume(ctx context.Context, pvc *corev1.PersistentVolum
 	return volumeID, nil
 }
 
-// isPVCAttachedToVM checks if the PVC is referenced in any VirtualMachine spec in the same namespace.
-// Returns (isAttached, vmName, error) where vmName is the name of the VM using this PVC.
+// isPVCAttachedToVM reports whether the PVC is attached to a VM (and thus encryption must be
+// deferred to VM Operator). It relies on two CSI-maintained signals already present on the
+// PVC object, so it needs no VirtualMachine API access (no listing, no informer):
 //
-// This function uses the v1alpha2 VM Operator API client which can list VirtualMachines created
-// with any API version (v1alpha1, v1alpha2, v1alpha3, v1alpha4, v1alpha5) due to Kubernetes
-// API machinery's automatic version conversion.
-func (r *reconciler) isPVCAttachedToVM(ctx context.Context, pvc *corev1.PersistentVolumeClaim) (bool, string, error) {
-	log := r.logger.With("pvc", pvc.Name, "namespace", pvc.Namespace)
-
-	// List all VirtualMachines in the PVC's namespace
-	vmList, err := utils.ListVirtualMachines(ctx, r.Client, pvc.Namespace)
-	if err != nil {
-		// If VM CRD is not installed or we can't list VMs, proceed with encryption
-		// (don't block encryption if VM Operator is not present)
-		log.Infof("Unable to list VirtualMachines in namespace %s: %v. Proceeding with encryption.",
-			pvc.Namespace, err)
-		return false, "", nil
-	}
-
-	// Check if this PVC is referenced in any VM's spec
-	for _, vm := range vmList.Items {
-		for _, vmVol := range vm.Spec.Volumes {
-			if vmVol.PersistentVolumeClaim != nil &&
-				vmVol.PersistentVolumeClaim.ClaimName == pvc.Name {
-				log.Infof("Found VirtualMachine %s in namespace %s referencing PVC %s",
-					vm.Name, pvc.Namespace, pvc.Name)
-				return true, vm.Name, nil
-			}
+//   - the cns.vmware.com/usedby-vm-<uuid> annotation, written by the CnsNodeVMBatchAttachment
+//     controller on attach and removed on detach; and
+//   - the cns.vmware.com/pvc-protection finalizer (CNSPvcFinalizer), added by both the batch
+//     and the legacy single CnsNodeVMAttachment attach paths (and by cnsfileaccessconfig for
+//     file volumes, which are not encryptable anyway) and removed on detach.
+//
+// The annotation is only written when SharedDiskFss/batch attach is enabled; the finalizer
+// covers the legacy attach path and any pre-upgrade attachments that lack the annotation.
+//
+// Returns (isAttached, detail) where detail is a short human-readable identifier for logging.
+func (r *reconciler) isPVCAttachedToVM(pvc *corev1.PersistentVolumeClaim) (bool, string) {
+	for key := range pvc.Annotations {
+		if strings.HasPrefix(key, usedByVMAnnotationPrefix) {
+			return true, "(VM instance UUID " + strings.TrimPrefix(key, usedByVMAnnotationPrefix) + ")"
 		}
 	}
 
-	log.Infof("PVC %s/%s is not referenced in any VirtualMachine", pvc.Namespace, pvc.Name)
-	return false, "", nil
+	if controllerutil.ContainsFinalizer(pvc, cnsoperatortypes.CNSPvcFinalizer) {
+		return true, "(per " + cnsoperatortypes.CNSPvcFinalizer + " finalizer)"
+	}
+
+	return false, ""
 }

--- a/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller.go
+++ b/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller.go
@@ -40,12 +40,6 @@ import (
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
 
-// usedByVMAnnotationPrefix is the prefix of the annotation that the
-// CnsNodeVMBatchAttachment controller writes on a PVC when it is attached to a VM
-// (as "cns.vmware.com/usedby-vm-<vm-instance-uuid>"). It mirrors vmServiceVMAnnotationPrefix
-// in cbtsync.go and attachedVmPrefix in the attachment controllers.
-const usedByVMAnnotationPrefix = "cns.vmware.com/usedby-vm-"
-
 func AddToManager(ctx context.Context, mgr manager.Manager, opts ctrlcommoon.Options) error {
 	var (
 		controlledType     = &corev1.PersistentVolumeClaim{}
@@ -210,8 +204,8 @@ func (r *reconciler) findVolume(ctx context.Context, pvc *corev1.PersistentVolum
 // deferred to VM Operator). It relies on two CSI-maintained signals already present on the
 // PVC object, so it needs no VirtualMachine API access (no listing, no informer):
 //
-//   - the cns.vmware.com/usedby-vm-<uuid> annotation, written by the CnsNodeVMBatchAttachment
-//     controller on attach and removed on detach; and
+//   - the cnsoperatortypes.UsedByVMAnnotationPrefix annotation (cns.vmware.com/usedby-vm-<uuid>),
+//     written by the CnsNodeVMBatchAttachment controller on attach and removed on detach; and
 //   - the cns.vmware.com/pvc-protection finalizer (CNSPvcFinalizer), added by both the batch
 //     and the legacy single CnsNodeVMAttachment attach paths (and by cnsfileaccessconfig for
 //     file volumes, which are not encryptable anyway) and removed on detach.
@@ -222,8 +216,8 @@ func (r *reconciler) findVolume(ctx context.Context, pvc *corev1.PersistentVolum
 // Returns (isAttached, detail) where detail is a short human-readable identifier for logging.
 func (r *reconciler) isPVCAttachedToVM(pvc *corev1.PersistentVolumeClaim) (bool, string) {
 	for key := range pvc.Annotations {
-		if strings.HasPrefix(key, usedByVMAnnotationPrefix) {
-			return true, "(VM instance UUID " + strings.TrimPrefix(key, usedByVMAnnotationPrefix) + ")"
+		if strings.HasPrefix(key, cnsoperatortypes.UsedByVMAnnotationPrefix) {
+			return true, "(VM instance UUID " + strings.TrimPrefix(key, cnsoperatortypes.UsedByVMAnnotationPrefix) + ")"
 		}
 	}
 

--- a/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
+++ b/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
@@ -187,8 +187,8 @@ func TestIsPVCAttachedToVM_Annotation(t *testing.T) {
 			Name:      "test-pvc",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"csi.vsphere.encryption-class":         "my-encryption-class",
-				usedByVMAnnotationPrefix + "vm-uuid-1": "",
+				"csi.vsphere.encryption-class":                          "my-encryption-class",
+				cnsoperatortypes.UsedByVMAnnotationPrefix + "vm-uuid-1": "",
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -231,7 +231,7 @@ func TestIsPVCAttachedToVM_AnnotationTakesPrecedence(t *testing.T) {
 			Name:      "test-pvc",
 			Namespace: "default",
 			Annotations: map[string]string{
-				usedByVMAnnotationPrefix + "vm-uuid-2": "",
+				cnsoperatortypes.UsedByVMAnnotationPrefix + "vm-uuid-2": "",
 			},
 			Finalizers: []string{cnsoperatortypes.CNSPvcFinalizer},
 		},

--- a/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
+++ b/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
 
 // createTestScheme creates a scheme with all required types for testing
@@ -147,480 +148,17 @@ func TestFindVolume(t *testing.T) {
 	})
 }
 
-// TestIsPVCAttachedToVM_NotAttached tests the case where a PVC is not referenced in any VM
+// newReconciler returns a reconciler suitable for isPVCAttachedToVM tests. The function
+// only inspects PVC-local fields, so no Kubernetes client is required.
+func newReconciler() *reconciler {
+	return &reconciler{
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+	}
+}
+
+// TestIsPVCAttachedToVM_NotAttached verifies that a PVC carrying neither the usedby-vm
+// annotation nor the CNSPvcFinalizer is reported as not attached (encryption proceeds).
 func TestIsPVCAttachedToVM_NotAttached(t *testing.T) {
-	ctx := context.Background()
-	scheme := createTestScheme()
-
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "default",
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "pv-test",
-		},
-	}
-
-	// Create a VM that doesn't reference this PVC
-	vm := &vmoperatortypes.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vm",
-			Namespace: "default",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{
-				{
-					Name: "other-volume",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "other-pvc",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pvc, vm).
-		Build()
-
-	r := &reconciler{
-		Client: fakeClient,
-		logger: logger.GetLoggerWithNoContext().Named("test"),
-	}
-
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
-
-	assert.NoError(t, err)
-	assert.False(t, isAttached, "PVC should not be attached")
-	assert.Empty(t, vmName, "VM name should be empty when not attached")
-}
-
-// TestIsPVCAttachedToVM_Attached tests the case where a PVC is referenced in a VM
-func TestIsPVCAttachedToVM_Attached(t *testing.T) {
-	ctx := context.Background()
-	scheme := createTestScheme()
-
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "default",
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "pv-test",
-		},
-	}
-
-	// Create a VM that references this PVC
-	vm := &vmoperatortypes.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vm",
-			Namespace: "default",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{
-				{
-					Name: "my-disk",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "test-pvc",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pvc, vm).
-		Build()
-
-	r := &reconciler{
-		Client: fakeClient,
-		logger: logger.GetLoggerWithNoContext().Named("test"),
-	}
-
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
-
-	assert.NoError(t, err)
-	assert.True(t, isAttached, "PVC should be attached")
-	assert.Equal(t, "test-vm", vmName, "VM name should match")
-}
-
-// TestIsPVCAttachedToVM_NoVMs tests the case where no VMs exist in the namespace
-func TestIsPVCAttachedToVM_NoVMs(t *testing.T) {
-	ctx := context.Background()
-	scheme := createTestScheme()
-
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "default",
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "pv-test",
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pvc).
-		Build()
-
-	r := &reconciler{
-		Client: fakeClient,
-		logger: logger.GetLoggerWithNoContext().Named("test"),
-	}
-
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
-
-	assert.NoError(t, err)
-	assert.False(t, isAttached, "PVC should not be attached when no VMs exist")
-	assert.Empty(t, vmName, "VM name should be empty")
-}
-
-// TestIsPVCAttachedToVM_MultipleVMs tests the case where multiple VMs exist and one references the PVC
-func TestIsPVCAttachedToVM_MultipleVMs(t *testing.T) {
-	ctx := context.Background()
-	scheme := createTestScheme()
-
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "default",
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "pv-test",
-		},
-	}
-
-	// VM 1 - doesn't reference the PVC
-	vm1 := &vmoperatortypes.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vm-1",
-			Namespace: "default",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{
-				{
-					Name: "other-volume",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "other-pvc",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// VM 2 - references the PVC
-	vm2 := &vmoperatortypes.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vm-2",
-			Namespace: "default",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{
-				{
-					Name: "my-disk",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "test-pvc",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// VM 3 - doesn't reference the PVC
-	vm3 := &vmoperatortypes.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vm-3",
-			Namespace: "default",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pvc, vm1, vm2, vm3).
-		Build()
-
-	r := &reconciler{
-		Client: fakeClient,
-		logger: logger.GetLoggerWithNoContext().Named("test"),
-	}
-
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
-
-	assert.NoError(t, err)
-	assert.True(t, isAttached, "PVC should be attached")
-	assert.Equal(t, "vm-2", vmName, "VM name should match the VM that references the PVC")
-}
-
-// TestIsPVCAttachedToVM_VMWithMultipleVolumes tests a VM with multiple volumes including the target PVC
-func TestIsPVCAttachedToVM_VMWithMultipleVolumes(t *testing.T) {
-	ctx := context.Background()
-	scheme := createTestScheme()
-
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "default",
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "pv-test",
-		},
-	}
-
-	// VM with multiple volumes
-	vm := &vmoperatortypes.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vm",
-			Namespace: "default",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{
-				{
-					Name: "disk-1",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "pvc-1",
-							},
-						},
-					},
-				},
-				{
-					Name: "disk-2",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "test-pvc",
-							},
-						},
-					},
-				},
-				{
-					Name: "disk-3",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "pvc-3",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pvc, vm).
-		Build()
-
-	r := &reconciler{
-		Client: fakeClient,
-		logger: logger.GetLoggerWithNoContext().Named("test"),
-	}
-
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
-
-	assert.NoError(t, err)
-	assert.True(t, isAttached, "PVC should be attached")
-	assert.Equal(t, "test-vm", vmName, "VM name should match")
-}
-
-// TestIsPVCAttachedToVM_DifferentNamespace tests that VMs in different namespaces are not considered
-func TestIsPVCAttachedToVM_DifferentNamespace(t *testing.T) {
-	ctx := context.Background()
-	scheme := createTestScheme()
-
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "namespace-1",
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "pv-test",
-		},
-	}
-
-	// VM in a different namespace that references a PVC with the same name
-	vm := &vmoperatortypes.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vm",
-			Namespace: "namespace-2",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{
-				{
-					Name: "my-disk",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "test-pvc",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pvc, vm).
-		Build()
-
-	r := &reconciler{
-		Client: fakeClient,
-		logger: logger.GetLoggerWithNoContext().Named("test"),
-	}
-
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
-
-	assert.NoError(t, err)
-	assert.False(t, isAttached, "PVC should not be attached (VM is in different namespace)")
-	assert.Empty(t, vmName, "VM name should be empty")
-}
-
-// TestIsPVCAttachedToVM_VMWithNoPVCVolumes tests a VM that has no PVC volumes
-func TestIsPVCAttachedToVM_VMWithNoPVCVolumes(t *testing.T) {
-	ctx := context.Background()
-	scheme := createTestScheme()
-
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "default",
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "pv-test",
-		},
-	}
-
-	// VM with a non-PVC volume (e.g., ConfigMap)
-	vm := &vmoperatortypes.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vm",
-			Namespace: "default",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{
-				{
-					Name: "config-volume",
-					// PersistentVolumeClaim is nil - could be a ConfigMap or other volume type
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{},
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pvc, vm).
-		Build()
-
-	r := &reconciler{
-		Client: fakeClient,
-		logger: logger.GetLoggerWithNoContext().Named("test"),
-	}
-
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
-
-	assert.NoError(t, err)
-	assert.False(t, isAttached, "PVC should not be attached")
-	assert.Empty(t, vmName, "VM name should be empty")
-}
-
-// TestIsPVCAttachedToVM_PVCAnnotationChanged_AttachedToVM tests the scenario where
-// a PVC's csi.vsphere.encryption-class annotation is changed while the PVC is attached to a VM.
-// The isPVCAttachedToVM function should detect the attachment and return true.
-func TestIsPVCAttachedToVM_PVCAnnotationChanged_AttachedToVM(t *testing.T) {
-	ctx := context.Background()
-	scheme := createTestScheme()
-
-	// Create PVC with NEW encryption class annotation (simulating annotation change from old-class to new-class)
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"csi.vsphere.encryption-class": "new-encryption-class", // Changed annotation
-			},
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "pv-test-123",
-		},
-	}
-
-	// Create VM that references this PVC
-	vm := &vmoperatortypes.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vm",
-			Namespace: "default",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{
-				{
-					Name: "my-disk",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "test-pvc",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pvc, vm).
-		Build()
-
-	r := &reconciler{
-		Client: fakeClient,
-		logger: logger.GetLoggerWithNoContext().Named("test"),
-	}
-
-	// Execute - this simulates the reconciliation triggered by PVC annotation change
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
-
-	// Verify - should detect attachment and return true
-	assert.NoError(t, err)
-	assert.True(t, isAttached, "PVC should be detected as attached when annotation changes while attached to VM")
-	assert.Equal(t, "test-vm", vmName, "VM name should be returned")
-}
-
-// TestIsPVCAttachedToVM_EncryptionClassUpdated_PVCAttachedToVM tests the scenario where
-// an EncryptionClass is updated (e.g., KeyID or KeyProvider changed) and a PVC referencing
-// it is attached to a VM. The isPVCAttachedToVM function should detect the attachment.
-func TestIsPVCAttachedToVM_EncryptionClassUpdated_PVCAttachedToVM(t *testing.T) {
-	ctx := context.Background()
-	scheme := createTestScheme()
-
-	// Create PVC that references an EncryptionClass (which will be updated externally)
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pvc",
@@ -630,49 +168,103 @@ func TestIsPVCAttachedToVM_EncryptionClassUpdated_PVCAttachedToVM(t *testing.T) 
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "pv-test-456",
+			VolumeName: "pv-test",
 		},
 	}
 
-	// Create VM that references this PVC
-	vm := &vmoperatortypes.VirtualMachine{
+	isAttached, detail := newReconciler().isPVCAttachedToVM(pvc)
+
+	assert.False(t, isAttached, "PVC should not be attached without usedby-vm annotation or CNS finalizer")
+	assert.Empty(t, detail, "detail should be empty when not attached")
+}
+
+// TestIsPVCAttachedToVM_Annotation verifies that a PVC carrying the cns.vmware.com/usedby-vm-
+// annotation (written by CnsNodeVMBatchAttachment) is reported as attached, and the VM
+// instance UUID suffix is surfaced in the detail string for logging.
+func TestIsPVCAttachedToVM_Annotation(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "prod-vm",
+			Name:      "test-pvc",
 			Namespace: "default",
-		},
-		Spec: vmoperatortypes.VirtualMachineSpec{
-			Volumes: []vmoperatortypes.VirtualMachineVolume{
-				{
-					Name: "data-disk",
-					VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "test-pvc",
-							},
-						},
-					},
-				},
+			Annotations: map[string]string{
+				"csi.vsphere.encryption-class":         "my-encryption-class",
+				usedByVMAnnotationPrefix + "vm-uuid-1": "",
 			},
 		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pvc, vm).
-		Build()
+	isAttached, detail := newReconciler().isPVCAttachedToVM(pvc)
 
-	r := &reconciler{
-		Client: fakeClient,
-		logger: logger.GetLoggerWithNoContext().Named("test"),
+	assert.True(t, isAttached, "PVC should be attached when usedby-vm annotation is present")
+	assert.Contains(t, detail, "vm-uuid-1", "detail should contain the VM instance UUID suffix")
+}
+
+// TestIsPVCAttachedToVM_Finalizer verifies that a PVC carrying the CNSPvcFinalizer but no
+// usedby-vm annotation (e.g. attached via the legacy CnsNodeVMAttachment path) is reported
+// as attached.
+func TestIsPVCAttachedToVM_Finalizer(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-pvc",
+			Namespace:  "default",
+			Finalizers: []string{cnsoperatortypes.CNSPvcFinalizer},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
 	}
 
-	// Execute - this simulates the reconciliation triggered by EncryptionClass update
-	// (The EncryptionClassToPersistentVolumeClaimMapper would have triggered reconciliation of this PVC)
-	isAttached, vmName, err := r.isPVCAttachedToVM(ctx, pvc)
+	isAttached, detail := newReconciler().isPVCAttachedToVM(pvc)
 
-	// Verify - should detect attachment and return true
-	assert.NoError(t, err)
-	assert.True(t, isAttached,
-		"PVC should be detected as attached when EncryptionClass is updated and PVC is attached to VM")
-	assert.Equal(t, "prod-vm", vmName, "VM name should be returned")
+	assert.True(t, isAttached, "PVC should be attached when CNSPvcFinalizer is present")
+	assert.Contains(t, detail, cnsoperatortypes.CNSPvcFinalizer, "detail should reference the finalizer")
+}
+
+// TestIsPVCAttachedToVM_AnnotationTakesPrecedence verifies that when both signals are present
+// the annotation path is used (and surfaces the VM UUID).
+func TestIsPVCAttachedToVM_AnnotationTakesPrecedence(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				usedByVMAnnotationPrefix + "vm-uuid-2": "",
+			},
+			Finalizers: []string{cnsoperatortypes.CNSPvcFinalizer},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	isAttached, detail := newReconciler().isPVCAttachedToVM(pvc)
+
+	assert.True(t, isAttached, "PVC should be attached")
+	assert.Contains(t, detail, "vm-uuid-2", "detail should surface the VM instance UUID from the annotation")
+}
+
+// TestIsPVCAttachedToVM_UnrelatedAnnotationAndFinalizer verifies that annotations/finalizers
+// that merely resemble but do not match the markers are not treated as attachment.
+func TestIsPVCAttachedToVM_UnrelatedAnnotationAndFinalizer(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"cns.vmware.com/some-other-annotation": "value",
+			},
+			Finalizers: []string{"kubernetes.io/pvc-protection"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-test",
+		},
+	}
+
+	isAttached, detail := newReconciler().isPVCAttachedToVM(pvc)
+
+	assert.False(t, isAttached, "unrelated annotation/finalizer should not count as VM attachment")
+	assert.Empty(t, detail)
 }

--- a/pkg/syncer/cbtsync.go
+++ b/pkg/syncer/cbtsync.go
@@ -43,14 +43,13 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 const (
 	workerThreadsCBTReconcileOpsEnvVar  = "WORKER_THREADS_CBT_RECONCILE_OPS"
 	defaultWorkerThreadsCBTReconcileOps = 4
-
-	vmServiceVMAnnotationPrefix = "cns.vmware.com/usedby-vm-"
 
 	// isCBTActiveLabel is set to "true" on a PVC whose underlying CNS volume currently
 	// has ChangedBlockTracking enabled, and is absent when CBT is disabled. The label
@@ -587,7 +586,7 @@ func pvcEligibleForCBTChange(ctx context.Context,
 		return false
 	}
 	for key := range pvc.Annotations {
-		if strings.HasPrefix(key, vmServiceVMAnnotationPrefix) {
+		if strings.HasPrefix(key, cnsoperatortypes.UsedByVMAnnotationPrefix) {
 			log.Debugf("pvcEligibleForCBTChange: PVC %s/%s is in use by a VM Service VM; skipping",
 				pvc.Namespace, pvc.Name)
 			return false

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -62,7 +62,6 @@ import (
 const (
 	workerThreadsEnvVar     = "WORKER_THREADS_NODEVM_ATTACH"
 	defaultMaxWorkerThreads = 20
-	attachedVmPrefix        = "cns.vmware.com/usedby-vm-"
 )
 
 // backOffDuration is a map of cnsnodevmattachment name's to the time after
@@ -839,13 +838,13 @@ func pvcHasUsedByAnnotaion(ctx context.Context, pvc *v1.PersistentVolumeClaim) b
 	}
 
 	for key := range pvc.Annotations {
-		if strings.HasPrefix(key, attachedVmPrefix) {
-			log.Infof("Annotation with prefix %s found on PVC %s", attachedVmPrefix, pvc.Name)
+		if strings.HasPrefix(key, cnsoptypes.UsedByVMAnnotationPrefix) {
+			log.Infof("Annotation with prefix %s found on PVC %s", cnsoptypes.UsedByVMAnnotationPrefix, pvc.Name)
 			return true
 		}
 	}
 
-	log.Infof("PVC %s does not contain any annotations with prefix %s", pvc.Name, attachedVmPrefix)
+	log.Infof("PVC %s does not contain any annotations with prefix %s", pvc.Name, cnsoptypes.UsedByVMAnnotationPrefix)
 	return false
 }
 

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -53,7 +53,6 @@ import (
 
 var (
 	GetVMFromVcenter = cnsoperatorutil.GetVMFromVcenter
-	attachedVmPrefix = "cns.vmware.com/usedby-vm-"
 
 	// removePvcFinalizerFn is a package-level function variable so tests can
 	// inject a fake implementation without architecture-specific monkey patching.
@@ -765,7 +764,7 @@ func getVolumesToDetach(ctx context.Context, client client.Client,
 func addPvcAnnotation(ctx context.Context, k8sClient kubernetes.Interface,
 	vmInstanceUUID string, pvc *v1.PersistentVolumeClaim) error {
 
-	return patchPVCAnnotations(ctx, k8sClient, pvc, attachedVmPrefix+vmInstanceUUID, false)
+	return patchPVCAnnotations(ctx, k8sClient, pvc, cnsoperatortypes.UsedByVMAnnotationPrefix+vmInstanceUUID, false)
 }
 
 // removePvcAnnotation removes the given vmInstanceUUID from PVC annotations.
@@ -778,7 +777,7 @@ func removePvcAnnotation(ctx context.Context, k8sClient kubernetes.Interface,
 		return nil
 	}
 
-	return patchPVCAnnotations(ctx, k8sClient, pvc, attachedVmPrefix+vmInstanceUUID, true)
+	return patchPVCAnnotations(ctx, k8sClient, pvc, cnsoperatortypes.UsedByVMAnnotationPrefix+vmInstanceUUID, true)
 }
 
 // patchPVCAnnotations patches the list of annotations on the PVC with the newAnnotations.
@@ -842,13 +841,14 @@ func pvcHasUsedByAnnotaion(ctx context.Context, pvc *v1.PersistentVolumeClaim) b
 	}
 
 	for key := range pvc.Annotations {
-		if strings.HasPrefix(key, attachedVmPrefix) {
-			log.Infof("Annotation with prefix %s found on PVC %s", attachedVmPrefix, pvc.Name)
+		if strings.HasPrefix(key, cnsoperatortypes.UsedByVMAnnotationPrefix) {
+			log.Infof("Annotation with prefix %s found on PVC %s", cnsoperatortypes.UsedByVMAnnotationPrefix, pvc.Name)
 			return true
 		}
 	}
 
-	log.Infof("PVC %s does not contain any annotations with prefix %s", pvc.Name, attachedVmPrefix)
+	log.Infof("PVC %s does not contain any annotations with prefix %s",
+		pvc.Name, cnsoperatortypes.UsedByVMAnnotationPrefix)
 	return false
 }
 

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -456,7 +456,7 @@ func TestReconcileWithoutDeletionTimestampWhenAttachFails(t *testing.T) {
 func TestAddPvcAnnotation(t *testing.T) {
 	ctx := context.TODO()
 	vmUUID := "test-vm-uuid"
-	expectedKey := attachedVmPrefix + vmUUID
+	expectedKey := cnsoperatortypes.UsedByVMAnnotationPrefix + vmUUID
 
 	tests := []struct {
 		name               string
@@ -530,7 +530,7 @@ func TestAddPvcAnnotation(t *testing.T) {
 func TestRemovePvcAnnotation(t *testing.T) {
 	ctx := context.TODO()
 	vmUUID := "test-vm-uuid"
-	annotationKey := attachedVmPrefix + vmUUID
+	annotationKey := cnsoperatortypes.UsedByVMAnnotationPrefix + vmUUID
 
 	tests := []struct {
 		name               string
@@ -640,16 +640,16 @@ func TestPvcHasUsedByAnnotation(t *testing.T) {
 		{
 			name: "Annotations with matching prefix",
 			annotations: map[string]string{
-				attachedVmPrefix + "vm-uuid": "attached",
+				cnsoperatortypes.UsedByVMAnnotationPrefix + "vm-uuid": "attached",
 			},
 			expected: true,
 		},
 		{
 			name: "Multiple annotations, one with matching prefix",
 			annotations: map[string]string{
-				"foo":                           "bar",
-				attachedVmPrefix + "another-vm": "attached",
-				"something.else":                "value",
+				"foo": "bar",
+				cnsoperatortypes.UsedByVMAnnotationPrefix + "another-vm": "attached",
+				"something.else": "value",
 			},
 			expected: true,
 		},

--- a/pkg/syncer/cnsoperator/manager/cleanupcustomresources.go
+++ b/pkg/syncer/cnsoperator/manager/cleanupcustomresources.go
@@ -144,8 +144,6 @@ func cleanupOrphanedBatchAttachPVCs(ctx context.Context, config rest.Config) {
 	// structure of the map follows the logical grouping kubernetes uses.
 	// namespace -> pvc -> struct{}{}
 	orphanPVCs := make(map[string]map[string]struct{})
-	// prefix for the annotation that indicates the PVC is used by a VM.
-	usedByVmAnnotationPrefix := "cns.vmware.com/usedby-vm-"
 	for _, pvc := range pvcList {
 		if pvc.DeletionTimestamp == nil {
 			// PVC is not being deleted. Can be ignored.
@@ -159,7 +157,7 @@ func cleanupOrphanedBatchAttachPVCs(ctx context.Context, config rest.Config) {
 
 		isBatchAttachPVC := false
 		for key := range pvc.GetAnnotations() {
-			if !strings.HasPrefix(key, usedByVmAnnotationPrefix) {
+			if !strings.HasPrefix(key, cnsoperatortypes.UsedByVMAnnotationPrefix) {
 				continue
 			}
 

--- a/pkg/syncer/cnsoperator/types/types.go
+++ b/pkg/syncer/cnsoperator/types/types.go
@@ -26,6 +26,11 @@ const (
 	// to avoid Detach-Delete race which in-turn avoids ResourceInUse errors
 	CNSPvcFinalizer = "cns.vmware.com/pvc-protection"
 
+	// UsedByVMAnnotationPrefix is the prefix of the annotation written on a PVC when it is
+	// attached to a VM Service VM (full key: "cns.vmware.com/usedby-vm-<vm-instance-uuid>").
+	// Written by CnsNodeVMBatchAttachment on attach and removed on detach.
+	UsedByVMAnnotationPrefix = "cns.vmware.com/usedby-vm-"
+
 	// CNSVolumeFinalizer is the finalizer on Supervisor PVC created from Guest cluster
 	// and associated with Guest cluster PVC,
 	// This finalizer is added to avoid deletion of such PVCs directly from Supervisor.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The previous implementation of isPVCAttachedToVM listed all VirtualMachines in the PVC's namespace and scanned every VM's spec.volumes to detect attachment. This required a standing VirtualMachine informer/watch (and the corresponding watch RBAC) and paid a full VM-list + scan cost on every reconcile, worst in the common unattached case.

Replace the VM-listing approach with two PVC-local signals already maintained by the CSI attach controllers:

  1. cns.vmware.com/usedby-vm-<uuid> annotation — written by CnsNodeVMBatchAttachment on batch-attach (SharedDiskFss on); gives the VM instance UUID for logging.

  2. cns.vmware.com/pvc-protection finalizer (CNSPvcFinalizer) — added by both the batch and legacy CnsNodeVMAttachment single-attach paths, and removed on detach. Covers pre-9.1 leftover attachments and any SharedDiskFss-off configuration where the annotation is never written.

Both signals are already present on the PVC (the controller's primary watched object), so the check now needs zero extra API calls, no VirtualMachine informer, and no VM listing.

Also revert the watch verb that commit af6c849 added to the vsphere-csi-controller ClusterRole for virtualmachines in manifests for supervisor cluster versions 1.30–1.33, as it was added solely to back the now-removed cached-client VM List.



**Testing done**:

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1739/

```
11:02:20  Ran 15 of 2361 Specs
11:02:20  SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1307/
```
12:44:18  Summarizing 1 Failure:
12:44:18    [FAIL] [csi-guest] pvCSI metadata syncer tests [It] [cf-vks] Static provisioning across Guest Clusters. [p1, block, tkg, vc70]
12:44:18    /home/worker/workspace/vks-instapp-e2e-pre-checkin/Results/1307/vsphere-csi-driver/tests/e2e/gc_metadata_syncer.go:1445
12:44:18  
12:44:18  Ran 6 of 1279 Specs in 457.319 seconds
12:44:18  FAIL! -- 5 Passed | 1 Failed | 0 Pending | 1273 Skipped
```
Failed test is not related to this PR.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Detect VM attachment in BYOK PVC controller from PVC-local signals
```
