### PR TITLE
Optimizations to delete VM workflow

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -65,6 +65,11 @@ const (
 	// PVCEncryptionClassAnnotationName is a PVC annotation indicating the associated EncryptionClass
 	PVCEncryptionClassAnnotationName = "csi.vsphere.encryption-class"
 	MaxConditionMessageLength        = 32768
+
+	// maxConcurrentPVCFinalizers caps the number of PVCs whose protection
+	// finalizers are removed in parallel during VM deletion. Keeping this below
+	// the total PVC count (255) prevents flooding the API server
+	maxConcurrentPVCFinalizers = 20
 )
 
 // FCDBackingDetails reflects the parameters with which a given FCD is attached to a VM.
@@ -96,6 +101,11 @@ func trimMessage(err error) error {
 // spec and status (see getPvcsFromSpecAndStatus). For each, it calls removePvcFinalizer, which
 // handles missing PVCs (NotFound) and whether cns.vmware.com/pvc-protection is present.
 // Volume status is updated to detached on success or detach-failed on error.
+//
+// PVCs are processed concurrently (up to maxConcurrentPVCFinalizers at a time)
+// because each PVC holds its own VolumeLock and the API calls are independent.
+// All PVCs are attempted even if some fail; the first error is returned so the
+// caller can retry the remaining failures on the next reconcile.
 func removePvcProtectionFinalizersForTrackedPVCs(ctx context.Context,
 	instance *v1alpha1.CnsNodeVMBatchAttachment,
 	c client.Client,
@@ -103,20 +113,48 @@ func removePvcProtectionFinalizersForTrackedPVCs(ctx context.Context,
 	cnsOperatorClient client.Client) error {
 	log := logger.GetLogger(ctx)
 
-	for pvcName, volumeName := range getPvcsFromSpecAndStatus(ctx, instance) {
-		err := removePvcFinalizerFn(ctx, c, k8sClient, cnsOperatorClient,
-			pvcName, instance.Namespace, instance.Spec.InstanceUUID)
-		if err != nil {
-			updateInstanceVolumeStatus(ctx, instance, volumeName, pvcName, "", "", err,
+	type pvcResult struct {
+		pvcName    string
+		volumeName string
+		err        error
+	}
+
+	pvcs := getPvcsFromSpecAndStatus(ctx, instance)
+	results := make(chan pvcResult, len(pvcs))
+	sem := make(chan struct{}, maxConcurrentPVCFinalizers)
+
+	var wg sync.WaitGroup
+	for pvcName, volumeName := range pvcs {
+		pvcName, volumeName := pvcName, volumeName
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			err := removePvcFinalizerFn(ctx, c, k8sClient, cnsOperatorClient,
+				pvcName, instance.Namespace, instance.Spec.InstanceUUID)
+			results <- pvcResult{pvcName, volumeName, err}
+		}()
+	}
+
+	go func() { wg.Wait(); close(results) }()
+
+	var firstErr error
+	for r := range results {
+		if r.err != nil {
+			updateInstanceVolumeStatus(ctx, instance, r.volumeName, r.pvcName, "", "", r.err,
 				v1alpha1.ConditionDetached, v1alpha1.ReasonDetachFailed)
 			log.Errorf("failed to remove protection finalizer from PVC %s before removing batch attachment finalizer: %v",
-				pvcName, err)
-			return err
+				r.pvcName, r.err)
+			if firstErr == nil {
+				firstErr = r.err
+			}
+		} else {
+			updateInstanceVolumeStatus(ctx, instance, r.volumeName, r.pvcName, "", "", nil,
+				v1alpha1.ConditionDetached, "")
 		}
-		updateInstanceVolumeStatus(ctx, instance, volumeName, pvcName, "", "", nil,
-			v1alpha1.ConditionDetached, "")
 	}
-	return nil
+	return firstErr
 }
 
 // removeFinalizerFromCRDInstance will remove the CNS Finalizer, cns.vmware.com,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PR introduces the following Optimizations to delete VM workflow:

Parallelize removePvcProtectionFinalizers function to speed up finalizer removal. Instead of flooding the API server, we can use a semaphore channel (set to a limit of 20) to safely throttle the concurrent Patch calls. Also, the changes in the PR ensures to process every PVC even if a partial failure occurs, & hence no PVCs are left hanging while waiting for the next reconcile. To avoid race conditions, we keep status updates serial by collecting the results through a channel and applying them only after all the background tasks finish.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Perf team test results:

```
Without Fix (Latency measurements in sec):-

| filename                                                | tag | threads | runNumber | optype             | passrate | count |       min |        q1 |      mean |    median |        q3 |       p95 |       p99 |       max |
| wl1_createvm-deletevm_thd01/csibench-1threads-cns.json  |     |         |           | DELETE_VM          |    100.0 |     9 |    73.070 |    76.578 |    87.276 |    95.924 |    96.241 |    96.773 |    96.773 |    97.020 |
| wl1_createvm-deletevm_thd16/csibench-16threads-cns.json |     |         |           | DELETE_VM          |    100.0 |    65 |    68.698 |   101.089 |   114.644 |   118.272 |   123.659 |   145.274 |   153.509 |   153.907 |
| wl1_createvm-deletevm_thd32/csibench-32threads-cns.json |     |         |           | DELETE_VM          |    100.0 |    96 |    75.331 |   105.904 |   154.315 |   151.228 |   197.431 |   219.820 |   274.141 |   293.406 |



 With Fix (Latency measurements in sec):-


| filename                                                | tag | threads | runNumber | optype           | passrate | count |     min |      q1 |    mean |  median |      q3 |     p95 |       p99 |       max |
| wl2_createvm-deletevm_thd01/csibench-1threads-cns.json  |     |         |           | DELETE_VM        |      100 |    11 |  51.540 |  63.055 |  66.313 |  65.820 |  70.338 |  72.367 |    72.367 |    73.735 |
| wl2_createvm-deletevm_thd16/csibench-16threads-cns.json |     |         |           | DELETE_VM        |      100 |    71 |  35.882 |  74.928 |  88.041 |  88.978 | 105.611 | 115.256 |   127.486 |   130.426 |
| wl2_createvm-deletevm_thd32/csibench-32threads-cns.json |     |         |           | DELETE_VM        |      100 |   105 |  30.201 |  67.115 | 117.503 | 130.295 | 151.737 | 182.447 |   188.674 |   193.447 |



csibench logs :-


{"opType":"DELETE_VM","name":"csibench-vm-50811-0-8","clientDuration":65.820070406,"serverDuration":0,"startTime":"2026-07-14T06:05:51.931227807Z","endTime":"2026-07-14T06:06:57.751298213Z","thread":0,"operationID":"","succeeded":true,"err":"","events":null}


vsphere syncer logs :-

vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-07-14T06:06:57.510821611Z stderr F {"level":"info","time":"2026-07-14T06:06:57.510774465Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:178","msg":"Removing \"[cns.vmware.com](http://cns.vmware.com/)\" finalizer from CnsNodeVMBatchAttachment instance with name: \"csibench-vm-50811-0-8\" on namespace: \"ns-perfauto-1\"","TraceId":"cfe65101-7204-47e4-b262-960f1e2769e0"}
>vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-07-14T06:06:57.742477898Z stderr F {"level":"info","time":"2026-07-14T06:06:57.742155274Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:340","msg":"Successfully removed finalizer [cns.vmware.com](http://cns.vmware.com/) from instance ns-perfauto-1/csibench-vm-50811-0-8","TraceId":"cfe65101-7204-47e4-b262-960f1e2769e0"}

```

For around 255 disks now it is just taking 1-2 sec for the cleanup.


<br> PR 4109<br>
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Optimizations to delete VM workflow by parallelizing the remove finalizer operation
```
