### PR TITLE
Optimizations to attach VM workflow

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -544,8 +544,8 @@ func (r *Reconciler) processBatchAttach(ctx context.Context, k8sClient kubernete
 
 	// Validate if the VM is present in the same namespace as the batchattach instance/volumes.
 	// This is to prevent any cross namespace attacks.
-	isPresentInSameNamespace, err := isVmInSameNamespace(ctx, r.vmOperatorClient, instance.Spec.InstanceUUID,
-		instance.Namespace)
+	isPresentInSameNamespace, err := isVmInSameNamespace(ctx, r.vmOperatorClient, instance.Name,
+		instance.Spec.InstanceUUID, instance.Namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,7 +42,6 @@ import (
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
@@ -1149,27 +1149,31 @@ func updateInstanceVolumeStatus(
 		trimmedError, conditionType, reason)
 }
 
-// isVmInSameNamespace checks whether the VM with the given instanceUUID is in the
-// same namespace as the batchattach instance and the PVCs.
+// isVmInSameNamespace checks whether the VM with the given name and instanceUUID
+// exists in the same namespace as the batchattach instance and the PVCs.
+//
+// The CnsNodeVMBatchAttachment name equals the VM CR name by convention, so a
+// targeted Get replaces the previous namespace-wide List + UUID scan. This cuts
+// the API-server load from O(n) (all VMs in namespace) to O(1) per reconcile,
+// which is significant under high thread counts with many VMs per namespace.
 func isVmInSameNamespace(ctx context.Context, vmOperatorClient client.Client,
-	instanceUUID string, namespace string) (bool, error) {
+	vmName string, instanceUUID string, namespace string) (bool, error) {
 	log := logger.GetLogger(ctx)
-	vmList, err := utils.ListVirtualMachines(ctx, vmOperatorClient, namespace)
+	vm := &vmoperatortypes.VirtualMachine{}
+	err := vmOperatorClient.Get(ctx, types.NamespacedName{Name: vmName, Namespace: namespace}, vm)
 	if err != nil {
-		msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
-		log.Error(msg)
+		if apierrors.IsNotFound(err) {
+			log.Infof("VM CR %s not found in namespace %s", vmName, namespace)
+			return false, nil
+		}
+		log.Errorf("failed to get VM CR %s in namespace %s: %+v", vmName, namespace, err)
 		return false, err
 	}
-	for _, vmInstance := range vmList.Items {
-		if vmInstance.Status.InstanceUUID == instanceUUID {
-			msg := fmt.Sprintf("VM CR with instance UUID: %s found in namespace: %s",
-				instanceUUID, namespace)
-			log.Info(msg)
-			return true, nil
-		}
+	if vm.Status.InstanceUUID != instanceUUID {
+		log.Infof("VM CR %s found in namespace %s but InstanceUUID %s does not match expected %s",
+			vmName, namespace, vm.Status.InstanceUUID, instanceUUID)
+		return false, nil
 	}
-	msg := fmt.Sprintf("VM CR with InstanceUUID: %s not found in namespace: %s",
-		instanceUUID, namespace)
-	log.Info(msg)
-	return false, nil
+	log.Infof("VM CR %s with instance UUID %s found in namespace %s", vmName, instanceUUID, namespace)
+	return true, nil
 }

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_test.go
@@ -157,7 +157,7 @@ func setTestEnvironment(testCnsNodeVMBatchAttachment *v1alpha1.CnsNodeVMBatchAtt
 
 	vm1 := &vmoperatortypes.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vm",
+			Name:      testCnsNodeVMBatchAttachmentName,
 			Namespace: testNamespace,
 		},
 		Status: vmoperatortypes.VirtualMachineStatus{
@@ -2197,7 +2197,7 @@ func TestIsVmInSameNamespace_Found(t *testing.T) {
 		WithObjects(vm).
 		Build()
 
-	found, err := isVmInSameNamespace(ctx, vmClient, instanceUUID, namespace)
+	found, err := isVmInSameNamespace(ctx, vmClient, "test-vm", instanceUUID, namespace)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2234,7 +2234,9 @@ func TestIsVmInSameNamespace_NotFound(t *testing.T) {
 		WithObjects(vm).
 		Build()
 
-	found, err := isVmInSameNamespace(ctx, vmClient, instanceUUID, namespace)
+	// "other-vm" exists but its UUID ("different-uuid") does not match
+	// "missing-uuid", so the function must return false.
+	found, err := isVmInSameNamespace(ctx, vmClient, "other-vm", instanceUUID, namespace)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
While running performance benchmarks with 255 PVs per node, a bottleneck was observed that caused latency to grow linearly with disk count and VM density.

Before every batch attach, isVmInSameNamespace was listing all VMs in the namespace and scanning for a UUID match. With 38 VMs in a namespace and 16 concurrent threads all doing this at once, that's 16 simultaneous namespace-wide list calls hitting the API server directly (the client here is not cached). Since the CnsNodeVMBatchAttachment name matches the VM CR name by convention, the code changes in this PR replaces the list-and-scan with a single targeted Get call followed by a UUID check. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Results from Perf team:

```
Without Fix (Latency measurements in sec ) :-

| filename                                                | tag | threads | runNumber | optype             | passrate | count |       min |        q1 |      mean |    median |        q3 |       p95 |       p99 |       max |
| wl3_detachvm-attachvm_thd16/csibench-16threads-cns.json |     |         |           | VM_ATTACH_VOLUME   |    100.0 |   240 |    38.419 |    50.201 |    58.959 |    56.934 |    65.253 |    81.099 |    94.878 |   104.765 |
| wl3_detachvm-attachvm_thd32/csibench-32threads-cns.json |     |         |           | VM_ATTACH_VOLUME   |    100.0 |   301 |    78.832 |    92.704 |   100.361 |    97.727 |   105.927 |   126.108 |   137.660 |   143.032 |




With Fix (Latency Measeurements in sec ) :-


| filename                                                | tag | threads | runNumber | optype           | passrate | count |     min |      q1 |    mean |  median |      q3 |     p95 |       p99 |       max |
| wl4_detachvm-attachvm_thd16/csibench-16threads-cns.json |     |         |           | VM_ATTACH_VOLUME |      100 |   261 |  27.235 |  39.631 |  47.089 |  44.906 |  52.368 |  67.699 |    91.093 |    94.416 |
| wl4_detachvm-attachvm_thd32/csibench-32threads-cns.json |     |         |           | VM_ATTACH_VOLUME |      100 |   288 |  57.880 |  80.726 |  97.097 |  97.747 | 110.077 | 128.691 |   135.470 |   139.908 |



Checked the syncer logs for 16 thread operation

..........
>vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-07-14T08:58:41.508767037Z stderr F {"level":"info","time":"2026-07-14T08:58:41.508696411Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:329","msg":"Obtained volumes to attach map[csibench-vol-82741-9-117:023551e9-b914-4e68-8b6d-fb5175b0bb58 csibench-vol-82741-9-14:6502c554-cb77-4bc4-a6e5-099a6fcb3c6d csibench-vol-82741-9-80:d88d67d9-186d-48cb-a504-2a118b8a9411 csibench-vol-84070-62-123:d064ae84-05af-4e25-b4a1-876e30260d3c csibench-vol-84070-62-3:32b61dcd-6216-4986-b4e5-1770a3b49d1b] for instance csibench-vm-41025-2-0","TraceId":"9f98144e-8935-49d7-9b89-19bd74efb9da"}
>vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-07-14T08:58:42.329982846Z stderr F {"level":"info","time":"2026-07-14T08:58:42.329666553Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:1215","msg":"VM CR csibench-vm-41025-2-0 with instance UUID f0ab2d18-737f-40c5-9106-c4479d74d833 found in namespace ns-perfauto-1","TraceId":"9f98144e-8935-49d7-9b89-19bd74efb9da"}
```

It is taking just around 1 sec now to confirm if the VM CR exists.



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Optimizations to attach VM workflow
```
