### PR TITLE
Upgrade CSI sidecars to latest releases for vsphere csi vanilla k8s driver deployment

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -242,7 +242,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -261,7 +261,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v2.0.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -334,7 +334,7 @@ spec:
             periodSeconds: 180
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -402,7 +402,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -454,7 +454,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -535,7 +535,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -603,7 +603,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
           command:
             - "csi-node-driver-registrar.exe"
           args:
@@ -673,7 +673,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
           command:
             - "livenessprobe.exe"
           args:


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR bumps up sidecar containers to their latest available versions:

```
        - name: csi-attacher
          image: registry.k8s.io/sig-storage/csi-attacher:v4.12.0

        - name: csi-resizer
          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1

        - name: liveness-probe
          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0

        - name: csi-snapshotter
          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0

        - name: node-driver-registrar
          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
```
The PR doesn't include provisioner as the latest provisioner version enables the topology deployments by default, there needs to be an equivalent change in CSI driver which is still being assessed. 


**Testing done**:
```
<br> PR 4111<br>
Ran 64 of 2361 Specs
SUCCESS! -- 64 Passed | 0 Failed | 3 Pending | 1082 Skipped | 0 Flaked
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade CSI sidecars to latest releases for vsphere csi vanilla k8s driver deployment
```
