### PR TITLE
 Added a slow sync mechanism to re-reconcile all SPI, InfraSPI and ClusterSPI CRs

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -520,6 +520,10 @@ spec:
               value: "4"
             - name: WORKER_THREADS_STORAGE_POLICY_INFO
               value: "4"
+            - name: STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES
+              value: "720"
+            - name: NS_STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES
+              value: "60"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"
             - name: POD_LISTENER_SERVICE_PORT

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -539,6 +539,10 @@ spec:
               value: "4"
             - name: WORKER_THREADS_STORAGE_POLICY_INFO
               value: "4"
+            - name: STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES
+              value: "720"
+            - name: NS_STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES
+              value: "60"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"
             - name: POD_LISTENER_SERVICE_PORT

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -539,6 +539,10 @@ spec:
               value: "4"
             - name: WORKER_THREADS_STORAGE_POLICY_INFO
               value: "4"
+            - name: STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES
+              value: "720"
+            - name: NS_STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES
+              value: "60"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"
             - name: POD_LISTENER_SERVICE_PORT

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -539,6 +539,10 @@ spec:
               value: "4"
             - name: WORKER_THREADS_STORAGE_POLICY_INFO
               value: "4"
+            - name: STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES
+              value: "720"
+            - name: NS_STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES
+              value: "60"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"
             - name: POD_LISTENER_SERVICE_PORT

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
@@ -62,7 +63,10 @@ import (
 // which a request for this instance will be requeued.
 // Initialized to 1 second for new instances and for instances whose latest
 // reconcile operation succeeded.
-// If the reconcile fails, backoff is incremented exponentially.
+// If the reconcile fails, backoff is incremented exponentially. A value greater
+// than one second therefore means the instance is currently backed off after a
+// failure; slow-sync skips such instances, since they are already scheduled to
+// reconcile via RequeueAfter.
 var (
 	backOffDuration         map[apitypes.NamespacedName]time.Duration
 	backOffDurationMapMutex = sync.Mutex{}
@@ -170,6 +174,16 @@ func add(mgr manager.Manager, r *ReconcileClusterStoragePolicyInfo) error {
 		)
 	}
 
+	// Channel for periodic resync; a ticker-driven goroutine lists all
+	// ClusterStoragePolicyInfo CRs on a configurable interval and pushes them
+	// here so the controller re-reconciles each one against the vCenter.
+	// source.Channel drains this into controller-runtime's internal work queue,
+	// so a small buffer is sufficient to avoid blocking between sends and reads.
+	// If the buffer does fill up (e.g. reconciles are slow), the sender skips the
+	// remaining CRs for that tick instead of blocking; see StartPeriodicResync.
+	resyncCh := make(chan event.GenericEvent, 256)
+	blder = blder.WatchesRawSource(source.Channel(resyncCh, &handler.EnqueueRequestForObject{}))
+
 	err := blder.WithOptions(controller.Options{MaxConcurrentReconciles: maxWorkerThreads}).
 		Complete(r)
 	if err != nil {
@@ -179,6 +193,16 @@ func add(mgr manager.Manager, r *ReconcileClusterStoragePolicyInfo) error {
 
 	// Initialize the backoff duration map
 	backOffDuration = make(map[apitypes.NamespacedName]time.Duration)
+
+	interval := getSlowSyncInterval(ctx)
+	if err := mgr.Add(manager.RunnableFunc(func(mgrCtx context.Context) error {
+		StartPeriodicResync(mgrCtx, r.client, resyncCh, interval)
+		<-mgrCtx.Done()
+		return nil
+	})); err != nil {
+		log.Errorf("failed to register periodic resync runnable. Err: %v", err)
+		return err
+	}
 	return nil
 }
 
@@ -596,7 +620,7 @@ func (r *ReconcileClusterStoragePolicyInfo) completeReconciliationWithError(ctx 
 		types.MaxBackOffDurationForReconciler)
 	backOffDurationMapMutex.Unlock()
 
-	log.Errorf("Failed to reconcile ClusterStoragePolicyInfo. Err: %v",
+	log.Errorf("Failed to reconcile ClusterStoragePolicyInfo %q. Err: %v",
 		namespacedName.Name, err)
 
 	return reconcile.Result{RequeueAfter: timeout}, nil

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/slowsync.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/slowsync.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterstoragepolicyinfo
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+const (
+	// slowSyncIntervalEnvVar is the environment variable that controls how often
+	// all ClusterStoragePolicyInfo CRs are re-enqueued for reconciliation against
+	// the vCenter. Expressed in minutes; defaults to 720 (12 hours).
+	slowSyncIntervalEnvVar     = "STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES"
+	defaultSlowSyncIntervalMin = 720
+)
+
+// getSlowSyncInterval returns the periodic resync interval for
+// ClusterStoragePolicyInfo CRs.
+func getSlowSyncInterval(ctx context.Context) time.Duration {
+	log := logger.GetLogger(ctx)
+	v := strings.TrimSpace(os.Getenv(slowSyncIntervalEnvVar))
+	if v == "" {
+		return defaultSlowSyncIntervalMin * time.Minute
+	}
+	value, err := strconv.Atoi(v)
+	if err != nil {
+		log.Warnf("ClusterStoragePolicyInfo slow sync: %s=%q is invalid, "+
+			"using default %d minutes", slowSyncIntervalEnvVar, v, defaultSlowSyncIntervalMin)
+		return defaultSlowSyncIntervalMin * time.Minute
+	}
+	if value <= 0 {
+		log.Warnf("ClusterStoragePolicyInfo slow sync: %s=%q is non-positive, "+
+			"using default %d minutes", slowSyncIntervalEnvVar, v, defaultSlowSyncIntervalMin)
+		return defaultSlowSyncIntervalMin * time.Minute
+	}
+	log.Infof("ClusterStoragePolicyInfo slow sync: interval set to %d minutes", value)
+	return time.Duration(value) * time.Minute
+}
+
+// StartPeriodicResync runs a goroutine that, every interval, lists all
+// ClusterStoragePolicyInfo CRs and sends them to ch so the controller
+// re-reconciles each one against the vCenter (slow sync).
+func StartPeriodicResync(ctx context.Context, c client.Client,
+	ch chan<- event.GenericEvent, interval time.Duration) {
+	log := logger.GetLogger(ctx)
+	go func() {
+		if interval <= 0 {
+			log.Warnf("ClusterStoragePolicyInfo slow sync: interval %s is non-positive, "+
+				"using default %d minutes", interval, defaultSlowSyncIntervalMin)
+			interval = defaultSlowSyncIntervalMin * time.Minute
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				log.Infof("ClusterStoragePolicyInfo periodic resync goroutine stopping")
+				return
+			case <-ticker.C:
+				var list clusterspiv1alpha1.ClusterStoragePolicyInfoList
+				if err := c.List(ctx, &list); err != nil {
+					log.Errorf("ClusterStoragePolicyInfo periodic resync: list failed: %v", err)
+					continue
+				}
+				enqueued := 0
+				for i := range list.Items {
+					obj := &list.Items[i]
+					namespacedName := apitypes.NamespacedName{Name: obj.Name}
+
+					backOffDurationMapMutex.Lock()
+					backoff := backOffDuration[namespacedName]
+					backOffDurationMapMutex.Unlock()
+					if backoff > time.Second {
+						// Backoff is only incremented above one second after a
+						// failed reconcile (it is reset to one second / deleted on
+						// success). A value greater than one second therefore means
+						// the instance is already scheduled to reconcile via
+						// RequeueAfter, so skip it here to avoid defeating the
+						// backoff.
+						continue
+					}
+
+					select {
+					case ch <- event.GenericEvent{Object: obj}:
+						enqueued++
+					case <-ctx.Done():
+						return
+					default:
+						// ch is full; do not block this goroutine waiting for a slot,
+						// since that would stall the rest of this sweep. Skip obj for
+						// this tick, it will be picked up on the next resync interval.
+						log.Warnf("ClusterStoragePolicyInfo periodic resync: resync channel full, "+
+							"skipping %q for this tick", obj.Name)
+					}
+				}
+				log.Infof("ClusterStoragePolicyInfo periodic resync: enqueued %d/%d CRs",
+					enqueued, len(list.Items))
+			}
+		}
+	}()
+}

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/slowsync_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/slowsync_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterstoragepolicyinfo
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+func TestGetSlowSyncInterval(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset uses default", "", defaultSlowSyncIntervalMin * time.Minute},
+		{"valid override", "60", 60 * time.Minute},
+		{"valid override with surrounding whitespace", "  60  ", 60 * time.Minute},
+		{"zero uses default", "0", defaultSlowSyncIntervalMin * time.Minute},
+		{"negative uses default", "-1", defaultSlowSyncIntervalMin * time.Minute},
+		{"invalid uses default", "abc", defaultSlowSyncIntervalMin * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(slowSyncIntervalEnvVar, tt.env)
+			assert.Equal(t, tt.want, getSlowSyncInterval(ctx))
+		})
+	}
+}
+
+func TestStartPeriodicResyncEnqueues(t *testing.T) {
+	scheme := testScheme(t)
+	const n = 3
+	objs := make([]client.Object, n)
+	for i := 0; i < n; i++ {
+		objs[i] = &clusterspiv1alpha1.ClusterStoragePolicyInfo{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("policy-%d", i)},
+		}
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan event.GenericEvent, 256)
+	StartPeriodicResync(ctx, cli, ch, 50*time.Millisecond)
+
+	got := make(map[string]bool)
+	deadline := time.After(5 * time.Second)
+	for len(got) < n {
+		select {
+		case e := <-ch:
+			got[e.Object.GetName()] = true
+		case <-deadline:
+			t.Fatalf("timed out waiting for events: got %d/%d", len(got), n)
+		}
+	}
+	assert.Len(t, got, n)
+}
+
+func TestStartPeriodicResyncSkipsBackedOffInstances(t *testing.T) {
+	scheme := testScheme(t)
+	objs := []client.Object{
+		&clusterspiv1alpha1.ClusterStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "backed-off"}},
+		&clusterspiv1alpha1.ClusterStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "eligible"}},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backOffDurationMapMutex.Lock()
+	backOffDuration = map[apitypes.NamespacedName]time.Duration{
+		// A backoff greater than one second marks an instance as backed off
+		// after a failed reconcile; slow-sync must skip it.
+		{Name: "backed-off"}: 2 * time.Second,
+	}
+	backOffDurationMapMutex.Unlock()
+	t.Cleanup(func() {
+		backOffDurationMapMutex.Lock()
+		backOffDuration = nil
+		backOffDurationMapMutex.Unlock()
+	})
+
+	ch := make(chan event.GenericEvent, 256)
+	StartPeriodicResync(ctx, cli, ch, 50*time.Millisecond)
+
+	select {
+	case e := <-ch:
+		assert.Equal(t, "eligible", e.Object.GetName())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for eligible instance to be enqueued")
+	}
+
+	select {
+	case e := <-ch:
+		assert.Equal(t, "eligible", e.Object.GetName(),
+			"only the eligible instance should be repeatedly enqueued; backed-off instance should be skipped")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for second tick to enqueue the eligible instance again")
+	}
+}
+
+func TestStartPeriodicResyncEnqueuesBaselineBackoffInstances(t *testing.T) {
+	scheme := testScheme(t)
+	objs := []client.Object{
+		&clusterspiv1alpha1.ClusterStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "baseline"}},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backOffDurationMapMutex.Lock()
+	backOffDuration = map[apitypes.NamespacedName]time.Duration{
+		// A one-second backoff is the healthy baseline (new instance or last
+		// reconcile succeeded); it must NOT be treated as backed off.
+		{Name: "baseline"}: time.Second,
+	}
+	backOffDurationMapMutex.Unlock()
+	t.Cleanup(func() {
+		backOffDurationMapMutex.Lock()
+		backOffDuration = nil
+		backOffDurationMapMutex.Unlock()
+	})
+
+	ch := make(chan event.GenericEvent, 256)
+	StartPeriodicResync(ctx, cli, ch, 50*time.Millisecond)
+
+	select {
+	case e := <-ch:
+		assert.Equal(t, "baseline", e.Object.GetName(),
+			"an instance at the one-second baseline backoff should still be enqueued")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for baseline instance to be enqueued")
+	}
+}
+
+func TestStartPeriodicResyncSkipsWhenChannelFull(t *testing.T) {
+	scheme := testScheme(t)
+	objs := []client.Object{
+		&clusterspiv1alpha1.ClusterStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "policy-0"}},
+		&clusterspiv1alpha1.ClusterStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "policy-1"}},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Unbuffered and never drained: every send on this tick must hit the
+	// default case instead of blocking the goroutine.
+	ch := make(chan event.GenericEvent)
+	StartPeriodicResync(ctx, cli, ch, 50*time.Millisecond)
+
+	// The goroutine must still observe ctx cancellation promptly, proving it
+	// never got stuck blocking on the full/unread channel.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-ch:
+		t.Fatal("no event should have been received; channel was never drained")
+	default:
+	}
+}
+
+func TestStartPeriodicResyncStopsOnCancel(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan event.GenericEvent, 256)
+	StartPeriodicResync(ctx, cli, ch, time.Hour)
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-ch:
+		t.Fatal("unexpected event received after context cancel")
+	default:
+	}
+}

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
@@ -168,6 +169,16 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 		},
 	}
 
+	// Channel for periodic resync; a ticker-driven goroutine lists all
+	// StoragePolicyInfo CRs on a configurable interval and pushes them here so
+	// the controller re-reconciles each one against the cached InfraStoragePolicyInfo
+	// topology.
+	// source.Channel drains this into controller-runtime's internal work queue,
+	// so a small buffer is sufficient to avoid blocking between sends and reads.
+	// If the buffer does fill up (e.g. reconciles are slow), the sender skips the
+	// remaining CRs for that tick instead of blocking; see StartPeriodicResync.
+	resyncCh := make(chan event.GenericEvent, 256)
+
 	err := ctrl.NewControllerManagedBy(mgr).Named("storagepolicyinfo-controller").
 		For(&spiv1alpha1.StoragePolicyInfo{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
@@ -181,6 +192,7 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 			handler.EnqueueRequestsFromMapFunc(r.mapInfraSPItoSPI),
 			builder.WithPredicates(infraSPIPredicates),
 		).
+		WatchesRawSource(source.Channel(resyncCh, &handler.EnqueueRequestForObject{})).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxWorkerThreads}).
 		Complete(r)
 	if err != nil {
@@ -188,6 +200,15 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 		return err
 	}
 
+	interval := getSlowSyncInterval(ctx)
+	if err := mgr.Add(manager.RunnableFunc(func(mgrCtx context.Context) error {
+		StartPeriodicResync(mgrCtx, r.client, resyncCh, interval, r)
+		<-mgrCtx.Done()
+		return nil
+	})); err != nil {
+		log.Errorf("failed to register periodic resync runnable. Err: %v", err)
+		return err
+	}
 	return nil
 }
 
@@ -256,7 +277,10 @@ type ReconcileStoragePolicyInfo struct {
 	recorder      record.EventRecorder
 	zonesProvider zonesProvider
 	// backOffDuration tracks per-instance requeue delays, incremented
-	// exponentially on failure and reset to 1s on success.
+	// exponentially on failure and reset to 1s on success. A value greater than
+	// one second means the instance is currently backed off after a failure;
+	// slow-sync skips such instances, since they are already scheduled to
+	// reconcile via RequeueAfter.
 	backOffDuration         map[apitypes.NamespacedName]time.Duration
 	backOffDurationMapMutex sync.Mutex
 }

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -517,8 +517,7 @@ func TestReconcile_CreatesWithOwnerRef(t *testing.T) {
 		scheme:          scheme,
 		recorder:        record.NewFakeRecorder(10),
 		zonesProvider:   &mockZonesProvider{},
-		backOffDuration: make(map[types.NamespacedName]time.Duration),
-	}
+		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
@@ -557,8 +556,7 @@ func TestReconcile_SkipsDeletion(t *testing.T) {
 		scheme:          scheme,
 		recorder:        record.NewFakeRecorder(10),
 		zonesProvider:   &mockZonesProvider{},
-		backOffDuration: make(map[types.NamespacedName]time.Duration),
-	}
+		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
@@ -594,8 +592,7 @@ func TestReconcile_SyncsTopologyAndRecordsEvent(t *testing.T) {
 		scheme:          scheme,
 		recorder:        recorder,
 		zonesProvider:   &mockZonesProvider{},
-		backOffDuration: make(map[types.NamespacedName]time.Duration),
-	}
+		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
@@ -629,8 +626,7 @@ func TestReconcile_InfraSPINotFound(t *testing.T) {
 		scheme:          scheme,
 		recorder:        record.NewFakeRecorder(10),
 		zonesProvider:   &mockZonesProvider{},
-		backOffDuration: make(map[types.NamespacedName]time.Duration),
-	}
+		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
@@ -719,8 +715,7 @@ func TestCompleteReconciliationWithSuccess(t *testing.T) {
 		client:          fake.NewClientBuilder().WithScheme(scheme).Build(),
 		scheme:          scheme,
 		recorder:        record.NewFakeRecorder(10),
-		backOffDuration: make(map[types.NamespacedName]time.Duration),
-	}
+		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 	nn := types.NamespacedName{Namespace: "ns1", Name: "gold"}
 	r.backOffDuration[nn] = 5 * time.Second
 
@@ -743,8 +738,7 @@ func TestCompleteReconciliationWithError(t *testing.T) {
 		client:          fake.NewClientBuilder().WithScheme(scheme).Build(),
 		scheme:          scheme,
 		recorder:        record.NewFakeRecorder(10),
-		backOffDuration: make(map[types.NamespacedName]time.Duration),
-	}
+		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 	nn := types.NamespacedName{Namespace: "ns1", Name: "gold"}
 	r.backOffDuration[nn] = time.Second
 
@@ -790,8 +784,7 @@ func TestReconcile_ZoneFilteringApplied(t *testing.T) {
 		scheme:          scheme,
 		recorder:        recorder,
 		zonesProvider:   &mockZonesProvider{zonesForNamespace: nsZones},
-		backOffDuration: make(map[types.NamespacedName]time.Duration),
-	}
+		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
@@ -834,8 +827,7 @@ func TestReconcile_NoNamespaceZonesReturnsAll(t *testing.T) {
 		scheme:          scheme,
 		recorder:        record.NewFakeRecorder(10),
 		zonesProvider:   &mockZonesProvider{},
-		backOffDuration: make(map[types.NamespacedName]time.Duration),
-	}
+		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
@@ -884,8 +876,7 @@ func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
 		scheme:          scheme,
 		recorder:        recorder,
 		zonesProvider:   &mockZonesProvider{},
-		backOffDuration: make(map[types.NamespacedName]time.Duration),
-	}
+		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/slowsync.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/slowsync.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepolicyinfo
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+const (
+	// slowSyncIntervalEnvVar is the environment variable that controls how often
+	// all StoragePolicyInfo CRs are re-enqueued for reconciliation. Expressed in
+	// minutes; defaults to 60 (1 hour).
+	slowSyncIntervalEnvVar     = "NS_STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES"
+	defaultSlowSyncIntervalMin = 60
+)
+
+// getSlowSyncInterval returns the periodic resync interval for StoragePolicyInfo
+// CRs.
+func getSlowSyncInterval(ctx context.Context) time.Duration {
+	log := logger.GetLogger(ctx)
+	v := strings.TrimSpace(os.Getenv(slowSyncIntervalEnvVar))
+	if v == "" {
+		return defaultSlowSyncIntervalMin * time.Minute
+	}
+	value, err := strconv.Atoi(v)
+	if err != nil {
+		log.Warnf("StoragePolicyInfo slow sync: %s=%q is invalid, "+
+			"using default %d minutes", slowSyncIntervalEnvVar, v, defaultSlowSyncIntervalMin)
+		return defaultSlowSyncIntervalMin * time.Minute
+	}
+	if value <= 0 {
+		log.Warnf("StoragePolicyInfo slow sync: %s=%q is non-positive, "+
+			"using default %d minutes", slowSyncIntervalEnvVar, v, defaultSlowSyncIntervalMin)
+		return defaultSlowSyncIntervalMin * time.Minute
+	}
+	log.Infof("StoragePolicyInfo slow sync: interval set to %d minutes", value)
+	return time.Duration(value) * time.Minute
+}
+
+// StartPeriodicResync runs a goroutine that, every interval, lists all
+// StoragePolicyInfo CRs across all namespaces and sends them to ch so the
+// controller re-reconciles each one (slow sync).
+func StartPeriodicResync(ctx context.Context, c client.Client,
+	ch chan<- event.GenericEvent, interval time.Duration, r *ReconcileStoragePolicyInfo) {
+	log := logger.GetLogger(ctx)
+	go func() {
+		if interval <= 0 {
+			log.Warnf("StoragePolicyInfo slow sync: interval %s is non-positive, "+
+				"using default %d minutes", interval, defaultSlowSyncIntervalMin)
+			interval = defaultSlowSyncIntervalMin * time.Minute
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				log.Infof("StoragePolicyInfo periodic resync goroutine stopping")
+				return
+			case <-ticker.C:
+				var list spiv1alpha1.StoragePolicyInfoList
+				if err := c.List(ctx, &list); err != nil {
+					log.Errorf("StoragePolicyInfo periodic resync: list failed: %v", err)
+					continue
+				}
+				enqueued := 0
+				for i := range list.Items {
+					obj := &list.Items[i]
+					namespacedName := apitypes.NamespacedName{
+						Namespace: obj.Namespace,
+						Name:      obj.Name,
+					}
+
+					r.backOffDurationMapMutex.Lock()
+					backoff := r.backOffDuration[namespacedName]
+					r.backOffDurationMapMutex.Unlock()
+					if backoff > time.Second {
+						// Backoff is only incremented above one second after a
+						// failed reconcile (it is reset to one second / deleted on
+						// success). A value greater than one second therefore means
+						// the instance is already scheduled to reconcile via
+						// RequeueAfter, so skip it here to avoid defeating the
+						// backoff.
+						continue
+					}
+
+					select {
+					case ch <- event.GenericEvent{Object: obj}:
+						enqueued++
+					case <-ctx.Done():
+						return
+					default:
+						// ch is full; do not block this goroutine waiting for a slot,
+						// since that would stall the rest of this sweep. Skip obj for
+						// this tick, it will be picked up on the next resync interval.
+						log.Warnf("StoragePolicyInfo periodic resync: resync channel full, "+
+							"skipping %q for this tick", namespacedName)
+					}
+				}
+				log.Infof("StoragePolicyInfo periodic resync: enqueued %d/%d CRs",
+					enqueued, len(list.Items))
+			}
+		}
+	}()
+}

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/slowsync_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/slowsync_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepolicyinfo
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+func TestSPIGetSlowSyncInterval(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset uses default", "", defaultSlowSyncIntervalMin * time.Minute},
+		{"valid override", "60", 60 * time.Minute},
+		{"valid override with surrounding whitespace", "  60  ", 60 * time.Minute},
+		{"zero uses default", "0", defaultSlowSyncIntervalMin * time.Minute},
+		{"negative uses default", "-1", defaultSlowSyncIntervalMin * time.Minute},
+		{"invalid uses default", "abc", defaultSlowSyncIntervalMin * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(slowSyncIntervalEnvVar, tt.env)
+			assert.Equal(t, tt.want, getSlowSyncInterval(ctx))
+		})
+	}
+}
+
+func TestSPIStartPeriodicResyncEnqueues(t *testing.T) {
+	scheme := testScheme(t)
+	const n = 3
+	objs := make([]client.Object, n)
+	for i := 0; i < n; i++ {
+		objs[i] = &spiv1alpha1.StoragePolicyInfo{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("policy-%d", i), Namespace: "ns-a"},
+		}
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := &ReconcileStoragePolicyInfo{
+		backOffDuration: make(map[apitypes.NamespacedName]time.Duration),
+	}
+	ch := make(chan event.GenericEvent, 256)
+	StartPeriodicResync(ctx, cli, ch, 50*time.Millisecond, r)
+
+	got := make(map[string]bool)
+	deadline := time.After(5 * time.Second)
+	for len(got) < n {
+		select {
+		case e := <-ch:
+			got[e.Object.GetName()] = true
+		case <-deadline:
+			t.Fatalf("timed out waiting for events: got %d/%d", len(got), n)
+		}
+	}
+	assert.Len(t, got, n)
+}
+
+func TestSPIStartPeriodicResyncSkipsBackedOffInstances(t *testing.T) {
+	scheme := testScheme(t)
+	objs := []client.Object{
+		&spiv1alpha1.StoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "backed-off", Namespace: "ns-a"}},
+		&spiv1alpha1.StoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "eligible", Namespace: "ns-a"}},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := &ReconcileStoragePolicyInfo{
+		backOffDuration: map[apitypes.NamespacedName]time.Duration{
+			// A backoff greater than one second marks an instance as backed off
+			// after a failed reconcile; slow-sync must skip it.
+			{Namespace: "ns-a", Name: "backed-off"}: 2 * time.Second,
+		},
+	}
+	ch := make(chan event.GenericEvent, 256)
+	StartPeriodicResync(ctx, cli, ch, 50*time.Millisecond, r)
+
+	select {
+	case e := <-ch:
+		assert.Equal(t, "eligible", e.Object.GetName())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for eligible instance to be enqueued")
+	}
+
+	select {
+	case e := <-ch:
+		assert.Equal(t, "eligible", e.Object.GetName(),
+			"only the eligible instance should be repeatedly enqueued; backed-off instance should be skipped")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for second tick to enqueue the eligible instance again")
+	}
+}
+
+func TestSPIStartPeriodicResyncEnqueuesBaselineBackoffInstances(t *testing.T) {
+	scheme := testScheme(t)
+	objs := []client.Object{
+		&spiv1alpha1.StoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "baseline", Namespace: "ns-a"}},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := &ReconcileStoragePolicyInfo{
+		backOffDuration: map[apitypes.NamespacedName]time.Duration{
+			// A one-second backoff is the healthy baseline (new instance or last
+			// reconcile succeeded); it must NOT be treated as backed off.
+			{Namespace: "ns-a", Name: "baseline"}: time.Second,
+		},
+	}
+	ch := make(chan event.GenericEvent, 256)
+	StartPeriodicResync(ctx, cli, ch, 50*time.Millisecond, r)
+
+	select {
+	case e := <-ch:
+		assert.Equal(t, "baseline", e.Object.GetName(),
+			"an instance at the one-second baseline backoff should still be enqueued")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for baseline instance to be enqueued")
+	}
+}
+
+func TestSPIStartPeriodicResyncSkipsWhenChannelFull(t *testing.T) {
+	scheme := testScheme(t)
+	objs := []client.Object{
+		&spiv1alpha1.StoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "policy-0", Namespace: "ns-a"}},
+		&spiv1alpha1.StoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "policy-1", Namespace: "ns-a"}},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := &ReconcileStoragePolicyInfo{
+		backOffDuration: make(map[apitypes.NamespacedName]time.Duration),
+	}
+	// Unbuffered and never drained: every send on this tick must hit the
+	// default case instead of blocking the goroutine.
+	ch := make(chan event.GenericEvent)
+	StartPeriodicResync(ctx, cli, ch, 50*time.Millisecond, r)
+
+	// The goroutine must still observe ctx cancellation promptly, proving it
+	// never got stuck blocking on the full/unread channel.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-ch:
+		t.Fatal("no event should have been received; channel was never drained")
+	default:
+	}
+}
+
+func TestSPIStartPeriodicResyncStopsOnCancel(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &ReconcileStoragePolicyInfo{
+		backOffDuration: make(map[apitypes.NamespacedName]time.Duration),
+	}
+	ch := make(chan event.GenericEvent, 256)
+	StartPeriodicResync(ctx, cli, ch, time.Hour, r)
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-ch:
+		t.Fatal("unexpected event received after context cancel")
+	default:
+	}
+}


### PR DESCRIPTION
This PR introduces a StartPeriodicResync goroutine in each controller that ticks every STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES minutes (default 720), lists all relevant CRs, and pushes them into a buffered GenericEvent channel wired to the controller via WatchesRawSource. This ensures stale or drifted policy state is eventually corrected even without a triggering API event.

Testing done:

Pipeline results:
- vks-e2e-pre-checkin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1353/  Passed
- wcp-instapp-e2e-pre-checkin https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1790/ Passed

(1) Verified the resync goroutine fires:
```
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl logs -n vmware-system-csi vsphere-csi-controller-7f7575fd7-tncqz -c vsphere-syncer| grep "periodic resync"
{"level":"info","time":"2026-06-25T07:50:43.871537613Z","caller":"clusterstoragepolicyinfo/slowsync.go:96","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 17 CRs"}
{"level":"info","time":"2026-06-25T07:50:44.41173777Z","caller":"storagepolicyinfo/slowsync.go:95","msg":"StoragePolicyInfo periodic resync: enqueued 51 CRs"}

```

(2) Verified that  resync restores a manually modified CR status: Before modification:
```
status:
  encryption:
    encryptionTypes:
    - vm-encryption
    supportsEncryption: true
  storagePolicyDeleted: false
```

Then modified the ClusterSPI CR:
```
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl patch clusterstoragepolicyinfo management-storage-policy-encryption \
  --subresource=status --type=merge -p '{"status":{"encryption":null}}'
clusterstoragepolicyinfo.cns.vmware.com/management-storage-policy-encryption patched
```
After modification:
```
apiVersion: cns.vmware.com/v1alpha1
kind: ClusterStoragePolicyInfo
...
status:
  storagePolicyDeleted: false
```
Note, slow sync time interval is set to 2 minutes. 
After Slow sync  on periodic 2 minutes interval, confirmed using watch that ClusterSPI is back to the correct state:
```
status:
  encryption:
    encryptionTypes:
    - vm-encryption
    supportsEncryption: true
  storagePolicyDeleted: false
```
Logs:
```
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl logs -n vmware-system-csi vsphere-csi-controller-7f7575fd7-tncqz -c vsphere-syncer| grep -i "resync\|management-storage-policy-encryption" | tail -20
{"level":"info","time":"2026-06-25T09:14:43.872801793Z","caller":"clusterstoragepolicyinfo/slowsync.go:96","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 17 CRs"}
}
{"level":"info","time":"2026-06-25T09:14:45.99654737Z","caller":"clusterstoragepolicyinfo/controller.go:231","msg":"Reconciling ClusterStoragePolicyInfo","TraceId":"2db6992f-5f64-4654-810e-b542d76853b7","name":"/management-storage-policy-encryption"}
{"level":"info","time":"2026-06-25T09:14:46.016772178Z","caller":"clusterstoragepolicyinfo/helper.go:511","msg":"Looking up storage policy for K8s compliant name \"management-storage-policy-encryption\"","TraceId":"2db6992f-5f64-4654-810e-b542d76853b7"}
{"level":"info","time":"2026-06-25T09:14:46.141302482Z","caller":"vsphere/pbm.go:259","msg":"Found storage policy with K8s compliant name management-storage-policy-encryption: ID=b1263970-8662-69e2-adc6-fa8ae01abecc, Name=Management Storage policy - Encryption","TraceId":"2db6992f-5f64-4654-810e-b542d76853b7"}
{"level":"info","time":"2026-06-25T09:14:46.142308711Z","caller":"clusterstoragepolicyinfo/controller.go:621","msg":"Syncing storage policy attributes for ClusterStoragePolicyInfo \"management-storage-policy-encryption\" (policy ID: b1263970-8662-69e2-adc6-fa8ae01abecc, name: Management Storage policy - Encryption)","TraceId":"2db6992f-5f64-4654-810e-b542d76853b7"}
{"level":"info","time":"2026-06-25T09:14:46.353703702Z","caller":"clusterstoragepolicyinfo/controller.go:660","msg":"Syncing InfraSPI attributes for \"management-storage-policy-encryption\" (policy ID: b1263970-8662-69e2-adc6-fa8ae01abecc, name: Management Storage policy - Encryption)","TraceId":"2db6992f-5f64-4654-810e-b542d76853b7"}
{"level":"info","time":"2026-06-25T09:14:46.35534218Z","caller":"clusterstoragepolicyinfo/helper.go:353","msg":"Found StorageClass \"management-storage-policy-encryption\" referencing storage policy ID \"b1263970-8662-69e2-adc6-fa8ae01abecc\"","TraceId":"2db6992f-5f64-4654-810e-b542d76853b7"}
{"level":"info","time":"2026-06-25T09:14:46.876078566Z","caller":"clusterstoragepolicyinfo/controller.go:350","msg":"Successfully synced storage policy attributes for \"management-storage-policy-encryption\"","TraceId":"2db6992f-5f64-4654-810e-b542d76853b7","name":"/management-storage-policy-encryption"}
{"level":"info","time":"2026-06-25T09:14:46.87616446Z","caller":"clusterstoragepolicyinfo/controller.go:593","msg":"Successfully reconciled ClusterStoragePolicyInfo","TraceId":"2db6992f-5f64-4654-810e-b542d76853b7","name":"/management-storage-policy-encryption"}

```

This confirms that slow sync is actually driving Reconcile and re-reading the VC.

- Similarly verified for InfraSPI and SPI CRs: accessible zones are back to original state in InfraSPI after slow sync:
```
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl patch infrastoragepolicyinfo management-storage-policy-encryption   --subresource=status --type=merge -p '{"status":{"topology":null}}'
infrastoragepolicyinfo.cns.vmware.com/management-storage-policy-encryption patched
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl get infrastoragepolicyinfo management-storage-policy-encryption   -o jsonpath='{.status.topology}' && echo
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl get infrastoragepolicyinfo management-storage-policy-encryption   -o jsonpath='{.status.topology}' && echo
{"accessibleZones":["az1"],"topologyType":""}

```
Accessible zones are back to original state in InfraSPI after slow sync:

```
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl get storagepolicyinfo vm-encryption-policy -n svc-velero-v1yxr   -o jsonpath='{.status.topologyInfo}' && echo
{"accessibleZones":["az1"],"topologyType":""}
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl patch storagepolicyinfo vm-encryption-policy -n svc-velero-v1yxr   --subresource=status --type=merge -p '{"status":{"topologyInfo":null}}'
storagepolicyinfo.cns.vmware.com/vm-encryption-policy patched

After resync interval:
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl get storagepolicyinfo vm-encryption-policy -n svc-velero-v1yxr   -o jsonpath='{.status.topologyInfo}' && echo
{"accessibleZones":["az1"],"topologyType":""}
```

(3) Verified that slow sync detects a deleted vCenter policy: Created a test-policy storagepolicy/storage class. Initially, before deleting this policy from VC UI,  `storagePolicyDeleted: false`:
```
root@42145dfc180e1fbff52110c2eb5efbda [ ~ ]# kubectl get clusterstoragepolicyinfo test-policy -o yaml
...
status:
  encryption:
    supportsEncryption: false
  storagePolicyDeleted: false
```
Deleted the storage policy from VC UI, then checked the storagePolicyDeleted value after slow sync, storagePolicyDeleted is set to true:
```
status:
  encryption:
    supportsEncryption: false
  storagePolicyDeleted: true
```

Logs:
```
{"level":"info","time":"2026-06-25T10:07:43.871263078Z","caller":"clusterstoragepolicyinfo/slowsync.go:96","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 17 CRs"}
{"level":"info","time":"2026-06-25T10:07:43.886730206Z","caller":"clusterstoragepolicyinfo/helper.go:511","msg":"Looking up storage policy for K8s compliant name \"test-policy\"","TraceId":"51f2d0a5-53f7-4ce1-be71-5882a0de2db0"}
{"level":"info","time":"2026-06-25T10:07:43.91439994Z","caller":"vsphere/pbm.go:259","msg":"Found storage policy with K8s compliant name test-policy: ID=a38fbd8d-cfc2-45a8-a3d4-2bccde8119bc, Name=test policy","TraceId":"51f2d0a5-53f7-4ce1-be71-5882a0de2db0"}
{"level":"info","time":"2026-06-25T10:07:43.914672362Z","caller":"clusterstoragepolicyinfo/helper.go:529","msg":"Storage policy found with K8s compliant name \"test-policy\": ID=a38fbd8d-cfc2-45a8-a3d4-2bccde8119bc, Name=test policy","TraceId":"51f2d0a5-53f7-4ce1-be71-5882a0de2db0"}

{"level":"info","time":"2026-06-25T10:07:43.914725048Z","caller":"clusterstoragepolicyinfo/controller.go:621","msg":"Syncing storage policy attributes for ClusterStoragePolicyInfo \"test-policy\" (policy ID: a38fbd8d-cfc2-45a8-a3d4-2bccde8119bc, name: test policy)","TraceId":"51f2d0a5-53f7-4ce1-be71-5882a0de2db0"}

```
So, slow sync correctly detects a deleted VC policy on every tick.

(4) Created a test-iops-policy using VC UI and create corresponding storage class:
```
kubectl apply -f - <<EOF
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: test-iops-policy
parameters:
  storagePolicyID: "0319cff3-b31a-4a99-b948-6420d1f1e731"
provisioner: csi.vsphere.vmware.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
EOF
```
Initially, iopsLimit is set to 200 in clusterSPI:
```
  performance:
    iopsLimit: 200
  storagePolicyDeleted: false
```
After that, updated iops limit value to 350 using VC UI.
Initially the value remained same. Then, slow sync is triggerred at 2minutes interval(Default value was chaneg to 2 minutes for testing purpose). After the slow sync, iopsLimit value is updated to 200.

```
root@421475d3443cee813c04c9aa0ea682a4 [ ~ ]# kubectl get clusterspi test-iops-policy -oyaml
status:
  encryption:
    supportsEncryption: false
  performance:
    iopsLimit: 350
  storagePolicyDeleted: false
root@421475d3443cee813c04c9aa0e
```
Logs:
```
{"level":"info","time":"2026-07-01T06:49:01.554884687Z","caller":"clusterstoragepolicyinfo/slowsync.go:91","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 20 CRs"}
{"level":"info","time":"2026-07-01T06:49:04.168231632Z","caller":"clusterstoragepolicyinfo/controller.go:239","msg":"Reconciling ClusterStoragePolicyInfo","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c","name":"/test-iops-policy"}
{"level":"info","time":"2026-07-01T06:49:04.22356576Z","caller":"clusterstoragepolicyinfo/helper.go:511","msg":"Looking up storage policy for K8s compliant name \"test-iops-policy\"","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c"}
{"level":"info","time":"2026-07-01T06:49:04.289446277Z","caller":"vsphere/pbm.go:259","msg":"Found storage policy with K8s compliant name test-iops-policy: ID=0319cff3-b31a-4a99-b948-6420d1f1e731, Name=test iops policy","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c"}
{"level":"info","time":"2026-07-01T06:49:04.400990478Z","caller":"clusterstoragepolicyinfo/helper.go:529","msg":"Storage policy found with K8s compliant name \"test-iops-policy\": ID=0319cff3-b31a-4a99-b948-6420d1f1e731, Name=test iops policy","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c"}
{"level":"info","time":"2026-07-01T06:49:04.401129042Z","caller":"clusterstoragepolicyinfo/controller.go:629","msg":"Syncing storage policy attributes for ClusterStoragePolicyInfo \"test-iops-policy\" (policy ID: 0319cff3-b31a-4a99-b948-6420d1f1e731, name: test iops policy)","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c"}
{"level":"info","time":"2026-07-01T06:49:04.470566245Z","caller":"clusterstoragepolicyinfo/helper.go:263","msg":"Storage policy 0319cff3-b31a-4a99-b948-6420d1f1e731 has IOPS limit: 350","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c"}
{"level":"info","time":"2026-07-01T06:49:04.55688713Z","caller":"clusterstoragepolicyinfo/controller.go:668","msg":"Syncing InfraSPI attributes for \"test-iops-policy\" (policy ID: 0319cff3-b31a-4a99-b948-6420d1f1e731, name: test iops policy)","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c"}
{"level":"info","time":"2026-07-01T06:49:04.5800315Z","caller":"clusterstoragepolicyinfo/helper.go:353","msg":"Found StorageClass \"test-iops-policy\" referencing storage policy ID \"0319cff3-b31a-4a99-b948-6420d1f1e731\"","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c"}
{"level":"info","time":"2026-07-01T06:49:05.694910933Z","caller":"clusterstoragepolicyinfo/controller.go:358","msg":"Successfully synced storage policy attributes for \"test-iops-policy\"","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c","name":"/test-iops-policy"}
{"level":"info","time":"2026-07-01T06:49:05.697516094Z","caller":"clusterstoragepolicyinfo/controller.go:601","msg":"Successfully reconciled ClusterStoragePolicyInfo","TraceId":"efe077f4-9ddd-4246-b7eb-3e17e78f250c","name":"/test-iops-policy"}
```



