### PR TITLE
Update provisioner sidecar version in supervisor to v6.3.0

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -325,7 +325,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.1.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -340,7 +340,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.1.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -340,7 +340,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.1.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -340,7 +340,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.1.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update provisioner sidecar version in supervisor to v6.3.0

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Basic sanity testing has been done with the new provisioner image and things worked fine.

```
# k apply -f pvc.yaml -n svc-cci-ns-91h44 
persistentvolumeclaim/example-vanilla-rwo-pvc created

# k get pvc -n svc-cci-ns-91h44 
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  VOLUMEATTRIBUTESCLASS   AGE
example-vanilla-rwo-pvc   Bound    pvc-5d0791ce-5058-4750-ac2f-c6043d320df5   1Gi        RWO            vsan-default-storage-policy   <unset>                 64s

# k apply -f pod.yaml -n svc-cci-ns-91h44 
pod/example-vanilla-block-pod created

 k get pod -n svc-cci-ns-91h44
NAME                                         READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod                    1/1     Running   0          27m
```

FVT did sanity testing and all tests passed:
```
an 14 of 1279 Specs in 2819.357 seconds
14:36:17  SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 1265 Skipped
14:36:17  PASS
14:36:17    W0625 09:06:17.590484  532830 test_context.go:505] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
14:36:17    I0625 09:06:17.590578  532830 test_context.go:528] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
14:36:17  Running Suite: CNS-CSI-Driver-End-to-End-MultiSvc-Tests - /home/worker/workspace/WCP_VDS_createTestbed_clone/Results/12/vsphere-csi-driver/tests/e2e/multiSvc
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update provisioner sidecar version in supervisor to v6.3.0
```
