### PR TITLE
Parse FCD faults correctly to return appropriate error for CBT APIs

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -4291,6 +4292,17 @@ func runQueryChangedDiskAreasViaVslm(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create VSLM client: %v", err)
 	}
+	// The VSLM endpoint (/vslm/sdk) uses fully-qualified VMODL type names in xsi:type
+	// (e.g. "vmodl.fault.InvalidArgument") whereas govmomi's type registry only contains
+	// short names (e.g. "InvalidArgument"). Extend the client's TypeFunc to strip the
+	// "vmodl.fault." prefix before the second lookup so fault details decode correctly.
+	existing := vslmClient.Types
+	vslmClient.Types = func(name string) (reflect.Type, bool) {
+		if t, ok := existing(name); ok {
+			return t, ok
+		}
+		return existing(strings.TrimPrefix(name, "vmodl.fault."))
+	}
 	globalObjectManager := vslm.NewGlobalObjectManager(vslmClient)
 	return globalObjectManager.QueryChangedDiskAreas(ctx, volumeID, snapshotID, startingOffset, changeID)
 }
@@ -4415,6 +4427,17 @@ func (m *defaultManager) QueryFCDChangedBlocks(ctx context.Context, volumeID, ta
 
 // TranslateVslmError maps VSLM and VADP error codes to standard CSI gRPC error codes.
 func TranslateVslmError(ctx context.Context, err error) error {
+	const (
+		cbtFaultNoTrack         = "vim.hostd.vmsvc.cbt.noTrack"
+		cbtFaultNoEpoch         = "vim.hostd.vmsvc.cbt.noEpoch"
+		cbtFaultCannotGetChange = "vim.hostd.vmsvc.cbt.cannotGetChanges"
+
+		propStartOffset = "startOffset"
+		propSnapshotID  = "snapshotId"
+		propChangeID    = "changeId"
+		propDeviceKey   = "deviceKey"
+	)
+
 	log := logger.GetLogger(ctx)
 	if err == nil {
 		return nil
@@ -4422,71 +4445,73 @@ func TranslateVslmError(ctx context.Context, err error) error {
 
 	errMsg := err.Error()
 
-	if soap.IsSoapFault(err) {
-		fault := soap.ToSoapFault(err).VimFault()
-
-		switch f := fault.(type) {
-		case *vim25types.FileFault:
-			msgID := ""
-			if len(f.FaultMessage) > 0 {
-				msgID = f.FaultMessage[0].Key
-			} else {
-				if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.noTrack") {
-					msgID = "vim.hostd.vmsvc.cbt.noTrack"
-				} else if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.noEpoch") {
-					msgID = "vim.hostd.vmsvc.cbt.noEpoch"
-				} else if strings.Contains(errMsg, "vim.hostd.vmsvc.cbt.cannotGetChanges") {
-					msgID = "vim.hostd.vmsvc.cbt.cannotGetChanges"
-				}
+	if !soap.IsSoapFault(err) {
+		return logger.LogNewErrorCodef(log, codes.Internal, "failed with error 1: %v", err)
+	}
+	fault := soap.ToSoapFault(err).VimFault()
+	if fault == nil {
+		return logger.LogNewErrorCodef(log, codes.Internal, "failed with error: %v", err)
+	}
+	switch f := fault.(type) {
+	case vim25types.FileFault:
+		msgID := ""
+		if len(f.FaultMessage) > 0 {
+			msgID = f.FaultMessage[0].Key
+		} else {
+			if strings.Contains(errMsg, cbtFaultNoTrack) {
+				msgID = cbtFaultNoTrack
+			} else if strings.Contains(errMsg, cbtFaultNoEpoch) {
+				msgID = cbtFaultNoEpoch
+			} else if strings.Contains(errMsg, cbtFaultCannotGetChange) {
+				msgID = cbtFaultCannotGetChange
 			}
-
-			switch msgID {
-			case "vim.hostd.vmsvc.cbt.noTrack":
+		}
+		switch msgID {
+		case cbtFaultNoTrack:
+			return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+				"CBT disabled or not enabled. The caller should perform a full backup instead: %v", err)
+		case cbtFaultNoEpoch:
+			return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+				"Cannot get current epoch when changeId=*. The caller should perform a full backup instead: %v", err)
+		case cbtFaultCannotGetChange:
+			if strings.Contains(strings.ToLower(errMsg), "corrupt") {
 				return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
-					"CBT disabled or not enabled. The caller should perform a full backup instead: %v", err)
-			case "vim.hostd.vmsvc.cbt.noEpoch":
-				return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
-					"Cannot get current epoch when changeId=*. The caller should perform a full backup instead: %v", err)
-			case "vim.hostd.vmsvc.cbt.cannotGetChanges":
-				if strings.Contains(strings.ToLower(errMsg), "corrupt") {
-					return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
-						"ctk file corrupted. The caller should perform a full backup instead: %v", err)
-				}
-				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
-					"changeID mismatch. The caller should correct the error and resubmit the call: %v", err)
-			default:
-				return logger.LogNewErrorCodef(log, codes.Internal,
-					"Internal errors such ctk disk open fails, FCD disk locked, disk missing, etc. "+
-						"CSI driver should retry the operation: %v", err)
-			}
-		case *vim25types.SystemError:
-			return logger.LogNewErrorCodef(log, codes.Internal,
-				"Internal system error. CSI driver should retry the operation: %v", err)
-		case *vim25types.InvalidArgument:
-			if f.InvalidProperty == "startOffset" || strings.Contains(errMsg, "startOffset") {
-				return logger.LogNewErrorCodef(log, codes.OutOfRange,
-					"start offset specified beyond volume size. The caller should specify a valid offset: %v", err)
-			}
-			if f.InvalidProperty == "snapshotId" || strings.Contains(errMsg, "snapshotId") {
-				return logger.LogNewErrorCodef(log, codes.NotFound,
-					"snapshot ID not found for FCD. The caller should re-check that these objects exist: %v", err)
-			}
-			if f.InvalidProperty == "changeId" || strings.Contains(errMsg, "changeId") {
-				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
-					"invalid format for changeID. The caller should correct the error and resubmit the call: %v", err)
-			}
-			if f.InvalidProperty == "deviceKey" || strings.Contains(errMsg, "deviceKey") {
-				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
-					"Device key doesn't exist, Disk has no backing, or Disk backing "+
-						"type doesn't support CBT. The caller should correct the "+
-						"error and resubmit the call: %v", err)
+					"ctk file corrupted. The caller should perform a full backup instead: %v", err)
 			}
 			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
-				"invalid argument %s: %v", f.InvalidProperty, err)
-		case *vim25types.NotFound:
-			return logger.LogNewErrorCodef(log, codes.NotFound,
-				"FCD not found in VC inventory. The caller should re-check that these objects exist: %v", err)
+				"changeID mismatch. The caller should correct the error and resubmit the call: %v", err)
+		default:
+			return logger.LogNewErrorCodef(log, codes.Internal,
+				"Internal errors such ctk disk open fails, FCD disk locked, disk missing, etc. "+
+					"CSI driver should retry the operation: %v", err)
 		}
+	case vim25types.SystemError:
+		return logger.LogNewErrorCodef(log, codes.Internal,
+			"Internal system error. CSI driver should retry the operation: %v", err)
+	case vim25types.InvalidArgument:
+		if f.InvalidProperty == propStartOffset || strings.Contains(errMsg, propStartOffset) {
+			return logger.LogNewErrorCodef(log, codes.OutOfRange,
+				"start offset specified beyond volume size. The caller should specify a valid offset: %v", err)
+		}
+		if f.InvalidProperty == propSnapshotID || strings.Contains(errMsg, propSnapshotID) {
+			return logger.LogNewErrorCodef(log, codes.NotFound,
+				"snapshot ID not found for FCD. The caller should re-check that these objects exist: %v", err)
+		}
+		if f.InvalidProperty == propChangeID || strings.Contains(errMsg, propChangeID) {
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"invalid format for changeID. The caller should correct the error and resubmit the call: %v", err)
+		}
+		if f.InvalidProperty == propDeviceKey || strings.Contains(errMsg, propDeviceKey) {
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"Device key doesn't exist, Disk has no backing, or Disk backing "+
+					"type doesn't support CBT. The caller should correct the "+
+					"error and resubmit the call: %v", err)
+		}
+		return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			"invalid argument %s: %v", f.InvalidProperty, err)
+	case vim25types.NotFound:
+		return logger.LogNewErrorCodef(log, codes.NotFound,
+			"FCD not found in VC inventory. The caller should re-check that these objects exist: %v", err)
 	}
 
 	return logger.LogNewErrorCodef(log, codes.Internal, "failed with error: %v", err)

--- a/pkg/common/cns-lib/volume/manager_test.go
+++ b/pkg/common/cns-lib/volume/manager_test.go
@@ -569,7 +569,7 @@ func TestTranslateVslmError(t *testing.T) {
 		},
 		{
 			name: "SOAP FileFault with noTrack",
-			err: createFCDSoapFault(&vim25types.FileFault{
+			err: createFCDSoapFault(vim25types.FileFault{
 				VimFault: vim25types.VimFault{
 					MethodFault: vim25types.MethodFault{
 						FaultMessage: []vim25types.LocalizableMessage{
@@ -582,7 +582,7 @@ func TestTranslateVslmError(t *testing.T) {
 		},
 		{
 			name: "SOAP FileFault with noEpoch",
-			err: createFCDSoapFault(&vim25types.FileFault{
+			err: createFCDSoapFault(vim25types.FileFault{
 				VimFault: vim25types.VimFault{
 					MethodFault: vim25types.MethodFault{
 						FaultMessage: []vim25types.LocalizableMessage{
@@ -595,7 +595,7 @@ func TestTranslateVslmError(t *testing.T) {
 		},
 		{
 			name: "SOAP FileFault with corrupt cannotGetChanges",
-			err: createFCDSoapFault(&vim25types.FileFault{
+			err: createFCDSoapFault(vim25types.FileFault{
 				VimFault: vim25types.VimFault{
 					MethodFault: vim25types.MethodFault{
 						FaultMessage: []vim25types.LocalizableMessage{
@@ -608,7 +608,7 @@ func TestTranslateVslmError(t *testing.T) {
 		},
 		{
 			name: "SOAP FileFault with mismatched cannotGetChanges",
-			err: createFCDSoapFault(&vim25types.FileFault{
+			err: createFCDSoapFault(vim25types.FileFault{
 				VimFault: vim25types.VimFault{
 					MethodFault: vim25types.MethodFault{
 						FaultMessage: []vim25types.LocalizableMessage{
@@ -621,45 +621,45 @@ func TestTranslateVslmError(t *testing.T) {
 		},
 		{
 			name:     "SOAP FileFault generic",
-			err:      createFCDSoapFault(&vim25types.FileFault{}, ""),
+			err:      createFCDSoapFault(vim25types.FileFault{}, ""),
 			wantCode: codes.Internal,
 		},
 		{
 			name:     "SOAP SystemError",
-			err:      createFCDSoapFault(&vim25types.SystemError{}, ""),
+			err:      createFCDSoapFault(vim25types.SystemError{}, ""),
 			wantCode: codes.Internal,
 		},
 		{
 			name: "SOAP InvalidArgument startOffset",
-			err: createFCDSoapFault(&vim25types.InvalidArgument{
+			err: createFCDSoapFault(vim25types.InvalidArgument{
 				InvalidProperty: "startOffset",
 			}, ""),
 			wantCode: codes.OutOfRange,
 		},
 		{
 			name: "SOAP InvalidArgument snapshotId",
-			err: createFCDSoapFault(&vim25types.InvalidArgument{
+			err: createFCDSoapFault(vim25types.InvalidArgument{
 				InvalidProperty: "snapshotId",
 			}, ""),
 			wantCode: codes.NotFound,
 		},
 		{
 			name: "SOAP InvalidArgument changeId",
-			err: createFCDSoapFault(&vim25types.InvalidArgument{
+			err: createFCDSoapFault(vim25types.InvalidArgument{
 				InvalidProperty: "changeId",
 			}, ""),
 			wantCode: codes.InvalidArgument,
 		},
 		{
 			name: "SOAP InvalidArgument deviceKey",
-			err: createFCDSoapFault(&vim25types.InvalidArgument{
+			err: createFCDSoapFault(vim25types.InvalidArgument{
 				InvalidProperty: "deviceKey",
 			}, ""),
 			wantCode: codes.InvalidArgument,
 		},
 		{
 			name:     "SOAP NotFound",
-			err:      createFCDSoapFault(&vim25types.NotFound{}, ""),
+			err:      createFCDSoapFault(vim25types.NotFound{}, ""),
 			wantCode: codes.NotFound,
 		},
 		{
@@ -679,35 +679,35 @@ func TestTranslateVslmError(t *testing.T) {
 		},
 		{
 			name: "SOAP FileFault noTrack via error message substring",
-			err: createFCDSoapFault(&vim25types.FileFault{
+			err: createFCDSoapFault(vim25types.FileFault{
 				VimFault: vim25types.VimFault{MethodFault: vim25types.MethodFault{}},
 			}, "vim.hostd.vmsvc.cbt.noTrack"),
 			wantCode: codes.FailedPrecondition,
 		},
 		{
 			name: "SOAP FileFault noEpoch via error message substring",
-			err: createFCDSoapFault(&vim25types.FileFault{
+			err: createFCDSoapFault(vim25types.FileFault{
 				VimFault: vim25types.VimFault{MethodFault: vim25types.MethodFault{}},
 			}, "vim.hostd.vmsvc.cbt.noEpoch"),
 			wantCode: codes.FailedPrecondition,
 		},
 		{
 			name: "SOAP FileFault cannotGetChanges via error message substring",
-			err: createFCDSoapFault(&vim25types.FileFault{
+			err: createFCDSoapFault(vim25types.FileFault{
 				VimFault: vim25types.VimFault{MethodFault: vim25types.MethodFault{}},
 			}, "vim.hostd.vmsvc.cbt.cannotGetChanges"),
 			wantCode: codes.InvalidArgument,
 		},
 		{
 			name: "SOAP InvalidArgument unknown property",
-			err: createFCDSoapFault(&vim25types.InvalidArgument{
+			err: createFCDSoapFault(vim25types.InvalidArgument{
 				InvalidProperty: "otherProperty",
 			}, ""),
 			wantCode: codes.InvalidArgument,
 		},
 		{
 			name:     "SOAP fault type not specially handled",
-			err:      createFCDSoapFault(&vim25types.AlreadyExists{}, "exists"),
+			err:      createFCDSoapFault(vim25types.AlreadyExists{}, "exists"),
 			wantCode: codes.Internal,
 		},
 	}

--- a/pkg/csi/service/wcp/controller_cbt_test.go
+++ b/pkg/csi/service/wcp/controller_cbt_test.go
@@ -635,7 +635,7 @@ func runVSLMErrorPropagationCase(t *testing.T, name string, vimFault vim25types.
 func TestGetMetadataAllocated_PreservesVSLMErrorCode(t *testing.T) {
 	// noTrack -> CBT not enabled -> FailedPrecondition.
 	runVSLMErrorPropagationCase(t, "FailedPrecondition_noTrack",
-		&vim25types.FileFault{
+		vim25types.FileFault{
 			VimFault: vim25types.VimFault{
 				MethodFault: vim25types.MethodFault{
 					FaultMessage: []vim25types.LocalizableMessage{{Key: "vim.hostd.vmsvc.cbt.noTrack"}},
@@ -645,22 +645,22 @@ func TestGetMetadataAllocated_PreservesVSLMErrorCode(t *testing.T) {
 
 	// startOffset out of range -> OutOfRange.
 	runVSLMErrorPropagationCase(t, "OutOfRange_startOffset",
-		&vim25types.InvalidArgument{InvalidProperty: "startOffset"}, "",
+		vim25types.InvalidArgument{InvalidProperty: "startOffset"}, "",
 		false, codes.OutOfRange)
 
 	// snapshotId not found -> NotFound.
 	runVSLMErrorPropagationCase(t, "NotFound_snapshotId",
-		&vim25types.InvalidArgument{InvalidProperty: "snapshotId"}, "",
+		vim25types.InvalidArgument{InvalidProperty: "snapshotId"}, "",
 		false, codes.NotFound)
 
 	// changeId malformed -> InvalidArgument.
 	runVSLMErrorPropagationCase(t, "InvalidArgument_changeId",
-		&vim25types.InvalidArgument{InvalidProperty: "changeId"}, "",
+		vim25types.InvalidArgument{InvalidProperty: "changeId"}, "",
 		false, codes.InvalidArgument)
 
 	// Generic VSLM SystemError -> Internal (already-wrapped case still works).
 	runVSLMErrorPropagationCase(t, "Internal_systemError",
-		&vim25types.SystemError{}, "", false, codes.Internal)
+		vim25types.SystemError{}, "", false, codes.Internal)
 }
 
 // TestGetMetadataDelta_PreservesVSLMErrorCode is the same end-to-end
@@ -668,7 +668,7 @@ func TestGetMetadataAllocated_PreservesVSLMErrorCode(t *testing.T) {
 // QueryFCDChangedBlocks under the hood).
 func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
 	runVSLMErrorPropagationCase(t, "FailedPrecondition_noEpoch",
-		&vim25types.FileFault{
+		vim25types.FileFault{
 			VimFault: vim25types.VimFault{
 				MethodFault: vim25types.MethodFault{
 					FaultMessage: []vim25types.LocalizableMessage{{Key: "vim.hostd.vmsvc.cbt.noEpoch"}},
@@ -677,7 +677,7 @@ func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
 		}, "", true, codes.FailedPrecondition)
 
 	runVSLMErrorPropagationCase(t, "FailedPrecondition_corruptCTK",
-		&vim25types.FileFault{
+		vim25types.FileFault{
 			VimFault: vim25types.VimFault{
 				MethodFault: vim25types.MethodFault{
 					FaultMessage: []vim25types.LocalizableMessage{
@@ -688,7 +688,7 @@ func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
 		}, "file is corrupted", true, codes.FailedPrecondition)
 
 	runVSLMErrorPropagationCase(t, "InvalidArgument_changeIDMismatch",
-		&vim25types.FileFault{
+		vim25types.FileFault{
 			VimFault: vim25types.VimFault{
 				MethodFault: vim25types.MethodFault{
 					FaultMessage: []vim25types.LocalizableMessage{
@@ -699,7 +699,7 @@ func TestGetMetadataDelta_PreservesVSLMErrorCode(t *testing.T) {
 		}, "", true, codes.InvalidArgument)
 
 	runVSLMErrorPropagationCase(t, "NotFound_FCD",
-		&vim25types.NotFound{}, "", true, codes.NotFound)
+		vim25types.NotFound{}, "", true, codes.NotFound)
 }
 
 // TestGetMetadataAllocated_Pagination verifies that GetMetadataAllocated streams


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds changes to correctly parse FCD faults returned for CBT VADP calls, so that in TranslateVslmError(), they can be converted to right CSI gRPC errorcodes to be returned for CSI CBT API calls from caller.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified the fix by replacing the image locally on setup and running CBT FVT unit tests, failing earlier while validating various API inputs, that passed successfully with the changes now

WCP precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1752/
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```
VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1320/
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Parse FCD faults correctly to return appropriate error for CBT APIs
```
