### PR TITLE
Report retained PVs in Released state to CNS as a label

### DIFF
--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -102,6 +102,14 @@ const (
 	// PrometheusPVMissingLabelKey when the K8s PV is missing.
 	PrometheusPVMissingLabelValue = "true"
 
+	// PrometheusPVRetainedLabelKey is the CNS metadata label key set on a CNS
+	// volume whose Kubernetes PV has ReclaimPolicy=Retain and is in Released or
+	// Available phase (no active PVC binding, PodVM, or VMService VM consumer).
+	PrometheusPVRetainedLabelKey = "pv_retained"
+	// PrometheusPVRetainedLabelValue is the value associated with
+	// PrometheusPVRetainedLabelKey when the PV is retained without a consumer.
+	PrometheusPVRetainedLabelValue = "true"
+
 	// PrometheusPassStatus represents a successful API run.
 	PrometheusPassStatus = "pass"
 	// PrometheusFailStatus represents an unsuccessful API run.
@@ -188,5 +196,16 @@ var (
 	CnsVolumePVMissingGaugeVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "vsphere_cns_volume_pv_missing",
 		Help: "Number of CNS volumes whose corresponding Kubernetes PV was not found during the last full sync, per vCenter.",
+	}, []string{"vc"})
+
+	// CnsVolumePVRetainedGaugeVec is a gauge metric that tracks, per vCenter,
+	// the number of CNS volumes whose Kubernetes PV has ReclaimPolicy=Retain
+	// and is in Released or Available phase (no active consumer) in the most
+	// recent full-sync cycle. A non-zero value indicates volumes that have been
+	// labeled with pv_retained=true on the CNS side and may need VI Admin
+	// attention (e.g., data cleanup or manual reclamation).
+	CnsVolumePVRetainedGaugeVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "vsphere_cns_volume_pv_retained",
+		Help: "Number of CNS volumes with ReclaimPolicy=Retain PVs in Released/Available phase, per vCenter.",
 	}, []string{"vc"})
 )

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -64,6 +64,11 @@ import (
 const (
 	allowedRetriesToPatchCNSVolumeInfo    = 5
 	annCSIvSphereVolumeAccessibleTopology = "csi.vsphere.volume-accessible-topology"
+
+	// querySelectionNameTypeVolumeMetadata is the CNS query selection name for
+	// volume metadata. The vendored cnstypes package does not define this
+	// constant, so it is declared here.
+	querySelectionNameTypeVolumeMetadata = cnstypes.QuerySelectionNameType("VOLUME_METADATA")
 )
 
 // queryVolumeByIDFn is the function used to query a CNS volume by its ID.
@@ -335,7 +340,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 				volumeIDsWithOldClusterID = append(volumeIDsWithOldClusterID, volume.VolumeId)
 			}
 			queryAllResult, err := fullSyncGetQueryResults(ctx, volumeIDsWithOldClusterID,
-				metadataSyncer.configInfo.Cfg.Global.ClusterID, volManager, metadataSyncer)
+				metadataSyncer.configInfo.Cfg.Global.ClusterID, volManager, metadataSyncer, nil)
 			if err != nil {
 				log.Errorf("FullSync for VC %s: fullSyncGetQueryResults failed to query volume metadata from vc. Err: %v", vc, err)
 				return err
@@ -470,6 +475,34 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 		volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, volumeClusterDistributionMap,
 		containerCluster, migrationFeatureStateForFullSync, vc)
 
+	// Re-query the same volume set with VOLUME_METADATA included so that
+	// getMissingPVVolumeUpdateSpecs and getRetainedPVVolumeUpdateSpecs can
+	// read vol.Metadata.EntityMetadata. The main queryAllResult intentionally
+	// omits VOLUME_METADATA to keep the payload small; this secondary query
+	// fetches only what the labeling path needs.
+	var volumeIDsForLabelQuery []cnstypes.CnsVolumeId
+	for _, vol := range queryAllResult.Volumes {
+		volumeIDsForLabelQuery = append(volumeIDsForLabelQuery, vol.VolumeId)
+	}
+	labelQuerySelection := &cnstypes.CnsQuerySelection{
+		Names: []string{
+			string(cnstypes.QuerySelectionNameTypeVolumeType),
+			string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
+			string(cnstypes.QuerySelectionNameTypeVolumeName),
+			string(querySelectionNameTypeVolumeMetadata),
+		},
+	}
+	labelQueryResults, err := fullSyncGetQueryResults(ctx, volumeIDsForLabelQuery,
+		clusterIDforVolumeMetadata, volManager, metadataSyncer, labelQuerySelection)
+	if err != nil {
+		log.Errorf("FullSync for VC %s: fullSyncGetQueryResults for label query failed with err %+v", vc, err)
+		return err
+	}
+	var volumesWithMetadata []cnstypes.CnsVolume
+	for _, qr := range labelQueryResults {
+		volumesWithMetadata = append(volumesWithMetadata, qr.Volumes...)
+	}
+
 	// Per the cns-health-initiative design (docs/mermaid/cns-health-initiative/
 	// 03-syncer-no-unregister.mmd), CNS volumes whose matching K8s PV cannot
 	// be found are no longer unregistered (the legacy fullSyncDeleteVolumes
@@ -477,7 +510,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 	// Instead we label them with `pv_missing=true` on their existing PV-type
 	// CnsKubernetesEntityMetadata, after a two-cycle grace period to absorb
 	// transient races between PV deletion and full-sync execution.
-	missingPVUpdateSpecs, missingPVCount, err := getMissingPVVolumeUpdateSpecs(ctx, queryAllResult.Volumes,
+	missingPVUpdateSpecs, missingPVCount, err := getMissingPVVolumeUpdateSpecs(ctx, volumesWithMetadata,
 		k8sPVMap, metadataSyncer, migrationFeatureStateForFullSync, containerCluster, vc)
 	if err != nil {
 		log.Errorf("FullSync for VC %s: failed to compute pv_missing update specs with err %+v", vc, err)
@@ -488,6 +521,25 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 		log.Infof("FullSync for VC %s: applying pv_missing label to %d volume(s)",
 			vc, len(missingPVUpdateSpecs))
 		updateSpecArray = append(updateSpecArray, missingPVUpdateSpecs...)
+	}
+
+	// On Supervisor clusters, label CNS volumes whose Kubernetes PV has
+	// ReclaimPolicy=Retain and is in Released or Available phase (no active
+	// PVC binding, PodVM, or VMService VM consumer). These volumes are safe
+	// to mark as pv_retained=true for VI Admin visibility.
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		retainedPVUpdateSpecs, retainedPVCount, err := getRetainedPVVolumeUpdateSpecs(ctx,
+			volumesWithMetadata, k8sPVs, containerCluster, vc)
+		if err != nil {
+			log.Errorf("FullSync for VC %s: failed to compute pv_retained update specs with err %+v", vc, err)
+			return err
+		}
+		prometheus.CnsVolumePVRetainedGaugeVec.WithLabelValues(vc).Set(float64(retainedPVCount))
+		if len(retainedPVUpdateSpecs) > 0 {
+			log.Infof("FullSync for VC %s: applying pv_retained label to %d volume(s)",
+				vc, len(retainedPVUpdateSpecs))
+			updateSpecArray = append(updateSpecArray, retainedPVUpdateSpecs...)
+		}
 	}
 
 	wg := sync.WaitGroup{}
@@ -1253,7 +1305,7 @@ func fullSyncConstructVolumeMaps(ctx context.Context, pvList []*v1.PersistentVol
 		return volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, volumeClusterDistributionMap, nil
 	}
 	allQueryResults, err := fullSyncGetQueryResults(ctx, queryVolumeIds,
-		clusterIDforVolumeMetadata, volManager, metadataSyncer)
+		clusterIDforVolumeMetadata, volManager, metadataSyncer, nil)
 	if err != nil {
 		log.Errorf("FullSync for VC %s: fullSyncGetQueryResults failed to query volume metadata from vc. Err: %v", vc, err)
 		return nil, nil, nil, err
@@ -1629,6 +1681,129 @@ func buildPVMissingUpdateSpec(ctx context.Context, vol cnstypes.CnsVolume,
 	}
 	log.Infof("FullSync for VC %s: Adding pv_missing label to volume %q "+
 		"(no matching K8s PV after grace period)", vc, vol.VolumeId.Id)
+	return cnstypes.CnsVolumeMetadataUpdateSpec{
+		VolumeId: cnstypes.CnsVolumeId{Id: vol.VolumeId.Id},
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster:      containerCluster,
+			ContainerClusterArray: []cnstypes.CnsContainerCluster{containerCluster},
+			EntityMetadata:        entityMetadata,
+		},
+	}, true
+}
+
+// getRetainedPVVolumeUpdateSpecs returns UpdateSpecs for CNS volumes whose
+// matching Kubernetes PV has ReclaimPolicy=Retain and is in Released or
+// Available phase. A PV in either of these phases has no active PVC binding
+// and therefore no active PodVM or VMService VM consumer — the volume data
+// is retained on the datastore but is no longer serving any workload.
+//
+// The returned count corresponds to what the caller should publish to the
+// pv_retained gauge for this VC.
+func getRetainedPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstypes.CnsVolume,
+	k8sPVs []*v1.PersistentVolume, containerCluster cnstypes.CnsContainerCluster,
+	vc string) ([]cnstypes.CnsVolumeMetadataUpdateSpec, int, error) {
+	log := logger.GetLogger(ctx)
+	var updateSpecArray []cnstypes.CnsVolumeMetadataUpdateSpec
+
+	// Build a set of volume IDs for Retain-policy PVs with no active consumer.
+	// Released = was bound, PVC deleted, PV kept by Retain policy.
+	// Available = never bound (or manually reclaimed), no consumer.
+	retainedVolumeIDs := make(map[string]struct{})
+	for _, pv := range k8sPVs {
+		if pv.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimRetain {
+			continue
+		}
+		if pv.Status.Phase != v1.VolumeReleased && pv.Status.Phase != v1.VolumeAvailable {
+			continue
+		}
+		if pv.Spec.CSI == nil || pv.Spec.CSI.VolumeHandle == "" {
+			continue
+		}
+		retainedVolumeIDs[pv.Spec.CSI.VolumeHandle] = struct{}{}
+		log.Debugf("FullSync for VC %s: PV %q (volume %q) has ReclaimPolicy=Retain and phase=%s",
+			vc, pv.Name, pv.Spec.CSI.VolumeHandle, pv.Status.Phase)
+	}
+
+	if len(retainedVolumeIDs) == 0 {
+		log.Debugf("FullSync for VC %s: no Retain-policy Released/Available PVs found; skipping pv_retained labeling", vc)
+		return nil, 0, nil
+	}
+
+	for _, vol := range cnsVolumeList {
+		if _, isRetained := retainedVolumeIDs[vol.VolumeId.Id]; !isRetained {
+			continue
+		}
+		updateSpec, ok := buildPVRetainedUpdateSpec(ctx, vol, containerCluster, vc)
+		if !ok {
+			continue
+		}
+		updateSpecArray = append(updateSpecArray, updateSpec)
+	}
+	return updateSpecArray, len(updateSpecArray), nil
+}
+
+// buildPVRetainedUpdateSpec returns an UpdateSpec that sets pv_retained=true
+// on the CNS volume's PV-type CnsKubernetesEntityMetadata, preserving any
+// pre-existing labels on those entries.
+//
+// It mirrors buildPVMissingUpdateSpec but applies the pv_retained label to
+// volumes whose K8s PV has ReclaimPolicy=Retain and no active consumer.
+//
+// Returns (spec, false) if there is nothing to update (every PV entity is
+// already labeled, or no candidate entity could be synthesized).
+func buildPVRetainedUpdateSpec(ctx context.Context, vol cnstypes.CnsVolume,
+	containerCluster cnstypes.CnsContainerCluster, vc string) (cnstypes.CnsVolumeMetadataUpdateSpec, bool) {
+	log := logger.GetLogger(ctx)
+	var entityMetadata []cnstypes.BaseCnsEntityMetadata
+	foundInClusterPV := false
+	log.Infof("FullSync for VC %s: buildPVRetainedUpdateSpec: volume %q with name %q has %d entity metadata entries",
+		vc, vol.VolumeId.Id, vol.Name, len(vol.Metadata.EntityMetadata))
+	for _, em := range vol.Metadata.EntityMetadata {
+		k8sEm, ok := em.(*cnstypes.CnsKubernetesEntityMetadata)
+		if !ok {
+			continue
+		}
+		if k8sEm.ClusterID != clusterIDforVolumeMetadata {
+			continue
+		}
+		if k8sEm.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) {
+			continue
+		}
+		foundInClusterPV = true
+		labels := cnsvsphere.GetLabelsMapFromKeyValue(k8sEm.Labels)
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		if labels[prometheus.PrometheusPVRetainedLabelKey] == prometheus.PrometheusPVRetainedLabelValue {
+			log.Infof("FullSync for VC %s: buildPVRetainedUpdateSpec: volume %q PV entity %q"+
+				" already has pv_retained=true label, skipping", vc, vol.VolumeId.Id, k8sEm.EntityName)
+			continue
+		}
+		labels[prometheus.PrometheusPVRetainedLabelKey] = prometheus.PrometheusPVRetainedLabelValue
+		entityMetadata = append(entityMetadata,
+			cnsvsphere.GetCnsKubernetesEntityMetaData(k8sEm.EntityName, labels, false,
+				k8sEm.EntityType, k8sEm.Namespace, k8sEm.ClusterID, k8sEm.ReferredEntity))
+	}
+
+	if !foundInClusterPV && vol.Name != "" {
+		log.Infof("FullSync for VC %s: buildPVRetainedUpdateSpec: volume %q has no in-cluster PV entity;"+
+			" synthesizing one using vol.Name %q", vc, vol.VolumeId.Id, vol.Name)
+		labels := map[string]string{
+			prometheus.PrometheusPVRetainedLabelKey: prometheus.PrometheusPVRetainedLabelValue,
+		}
+		entityMetadata = append(entityMetadata,
+			cnsvsphere.GetCnsKubernetesEntityMetaData(vol.Name, labels, false,
+				string(cnstypes.CnsKubernetesEntityTypePV), "", clusterIDforVolumeMetadata, nil))
+	}
+
+	if len(entityMetadata) == 0 {
+		log.Infof("FullSync for VC %s: buildPVRetainedUpdateSpec: volume %q produced no update specs"+
+			" (foundInClusterPV=%v vol.Name=%q); skipping",
+			vc, vol.VolumeId.Id, foundInClusterPV, vol.Name)
+		return cnstypes.CnsVolumeMetadataUpdateSpec{}, false
+	}
+	log.Infof("FullSync for VC %s: Adding pv_retained label to volume %q "+
+		"(Retain-policy PV with no active consumer)", vc, vol.VolumeId.Id)
 	return cnstypes.CnsVolumeMetadataUpdateSpec{
 		VolumeId: cnstypes.CnsVolumeId{Id: vol.VolumeId.Id},
 		Metadata: cnstypes.CnsVolumeMetadata{

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -1243,6 +1243,67 @@ func buildCnsMetadataList(ctx context.Context, pv *v1.PersistentVolume, pvToPVCM
 	return metadataList
 }
 
+// healthLabelKeys are labels applied to CNS volume PV entity metadata
+// out-of-band by full sync's own health-labeling routines
+// (getMissingPVVolumeUpdateSpecs, getRetainedPVVolumeUpdateSpecs). They have
+// no counterpart on the actual k8s PV object, so k8s-truth metadata built
+// from pv.GetLabels() never carries them. See preserveHealthLabelsOnK8sPVMetadata.
+var healthLabelKeys = []string{
+	prometheus.PrometheusPVMissingLabelKey,
+	prometheus.PrometheusPVRetainedLabelKey,
+}
+
+// preserveHealthLabelsOnK8sPVMetadata copies any healthLabelKeys found on the
+// CNS-side PV entity metadata onto the corresponding k8s-side PV entity
+// metadata, in place.
+//
+// Without this, isUpdateRequired's exact label-map comparison (via
+// CompareKubernetesMetadata) sees a health label present only on the CNS
+// side as a difference and triggers a metadata "updateVolume" that rebuilds
+// CNS entity metadata purely from k8s-truth data, silently stripping the
+// label. getMissingPVVolumeUpdateSpecs/getRetainedPVVolumeUpdateSpecs only
+// re-add the label when it isn't already present, based on a CNS query
+// taken earlier in the same full sync cycle, so they don't observe the
+// strip happening later in that same cycle — the label only reappears on
+// the next cycle. The net effect is the label visibly flipping on/off on
+// alternating full sync cycles.
+func preserveHealthLabelsOnK8sPVMetadata(k8sMetadataList []cnstypes.BaseCnsEntityMetadata,
+	cnsMetadataList []cnstypes.BaseCnsEntityMetadata) {
+	var cnsPV *cnstypes.CnsKubernetesEntityMetadata
+	for _, m := range cnsMetadataList {
+		if km, ok := m.(*cnstypes.CnsKubernetesEntityMetadata); ok &&
+			km.EntityType == string(cnstypes.CnsKubernetesEntityTypePV) {
+			cnsPV = km
+			break
+		}
+	}
+	if cnsPV == nil {
+		return
+	}
+	cnsLabels := cnsvsphere.GetLabelsMapFromKeyValue(cnsPV.Labels)
+	for i, m := range k8sMetadataList {
+		km, ok := m.(*cnstypes.CnsKubernetesEntityMetadata)
+		if !ok || km.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) {
+			continue
+		}
+		k8sLabels := cnsvsphere.GetLabelsMapFromKeyValue(km.Labels)
+		if k8sLabels == nil {
+			k8sLabels = make(map[string]string)
+		}
+		changed := false
+		for _, key := range healthLabelKeys {
+			if val, ok := cnsLabels[key]; ok && k8sLabels[key] != val {
+				k8sLabels[key] = val
+				changed = true
+			}
+		}
+		if changed {
+			k8sMetadataList[i] = cnsvsphere.GetCnsKubernetesEntityMetaData(km.EntityName, k8sLabels,
+				km.Delete, km.EntityType, km.Namespace, km.ClusterID, km.ReferredEntity)
+		}
+	}
+}
+
 // fullSyncConstructVolumeMaps builds and returns map of volume to
 // EntityMetadata in CNS (volumeToCnsEntityMetadataMap), map of volume to
 // EntityMetadata in kubernetes (volumeToK8sEntityMetadataMap) and set of
@@ -1321,6 +1382,7 @@ func fullSyncConstructVolumeMaps(ctx context.Context, pvList []*v1.PersistentVol
 				}
 			}
 			volumeToCnsEntityMetadataMap[volume.VolumeId.Id] = cnsMetadata
+			preserveHealthLabelsOnK8sPVMetadata(volumeToK8sEntityMetadataMap[volume.VolumeId.Id], cnsMetadata)
 
 			volumeClusterDistributionMap[volume.VolumeId.Id] =
 				hasClusterDistributionSet(ctx, volume, clusterIDforVolumeMetadata,
@@ -1557,6 +1619,15 @@ func getMissingPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstypes
 			continue
 		}
 
+		// Already labeled by a previous full sync cycle: skip re-evaluating
+		// this volume's CNS metadata and reissuing UpdateVolumeMetadata. This
+		// short-circuit is purely local (independent of what the current CNS
+		// query returns), so a volume that remains PV-missing indefinitely is
+		// only ever labeled once instead of every cycle.
+		if pvMissingLabeledMap[vc][vol.VolumeId.Id] {
+			continue
+		}
+
 		// PVC is still cached: the PV likely has not surfaced in the lister
 		// yet. Defer to the next full-sync cycle rather than racing the API
 		// server's eventual-consistency.
@@ -1589,6 +1660,15 @@ func getMissingPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstypes
 			continue
 		}
 
+		// The volume may already carry the label from before this process
+		// started (e.g. syncer restart), in which case pvMissingLabeledMap
+		// would not know about it yet. Detect that from the live query so we
+		// don't keep re-deriving an update spec for it every cycle.
+		if isPVEntityLabeled(vol, prometheus.PrometheusPVMissingLabelKey, prometheus.PrometheusPVMissingLabelValue) {
+			pvMissingLabeledMap[vc][vol.VolumeId.Id] = true
+			continue
+		}
+
 		updateSpec, ok := buildPVMissingUpdateSpec(ctx, vol, containerCluster, vc)
 		if !ok {
 			// Either the volume has no in-cluster PV-type entity or it is
@@ -1596,9 +1676,29 @@ func getMissingPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstypes
 			// cycles continue to no-op cheaply.
 			continue
 		}
+		// Mark labeled now so subsequent cycles short-circuit above,
+		// regardless of whether this cycle's CNS query reflects the label
+		// yet on a later read.
+		pvMissingLabeledMap[vc][vol.VolumeId.Id] = true
 		updateSpecArray = append(updateSpecArray, updateSpec)
 	}
 	return updateSpecArray, len(updateSpecArray), nil
+}
+
+// isPVEntityLabeled reports whether the volume's PV-type CNS entity
+// metadata, scoped to the current cluster, already carries the given label.
+func isPVEntityLabeled(vol cnstypes.CnsVolume, labelKey, labelValue string) bool {
+	for _, em := range vol.Metadata.EntityMetadata {
+		k8sEm, ok := em.(*cnstypes.CnsKubernetesEntityMetadata)
+		if !ok || k8sEm.ClusterID != clusterIDforVolumeMetadata ||
+			k8sEm.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) {
+			continue
+		}
+		if cnsvsphere.GetLabelsMapFromKeyValue(k8sEm.Labels)[labelKey] == labelValue {
+			return true
+		}
+	}
+	return false
 }
 
 // buildPVMissingUpdateSpec returns an UpdateSpec that sets pv_missing=true on
@@ -1935,6 +2035,15 @@ func cleanupCnsMaps(k8sPVs map[string]string, vc string) {
 		if _, existsInK8s := k8sPVs[volID]; existsInK8s {
 			// PV reappeared — clear the grace flag.
 			delete(cnsDeletionMap[vc], volID)
+		}
+	}
+	// Cleanup pvMissingLabeledMap: if the PV reappeared in K8s, forget that
+	// the volume was labeled so it is re-evaluated (and re-labeled) from
+	// scratch if it goes missing again later.
+	pvMissingLabeledMapForVc := pvMissingLabeledMap[vc]
+	for volID := range pvMissingLabeledMapForVc {
+		if _, existsInK8s := k8sPVs[volID]; existsInK8s {
+			delete(pvMissingLabeledMap[vc], volID)
 		}
 	}
 }

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -1244,12 +1244,22 @@ func buildCnsMetadataList(ctx context.Context, pv *v1.PersistentVolume, pvToPVCM
 }
 
 // healthLabelKeys are labels applied to CNS volume PV entity metadata
-// out-of-band by full sync's own health-labeling routines
-// (getMissingPVVolumeUpdateSpecs, getRetainedPVVolumeUpdateSpecs). They have
-// no counterpart on the actual k8s PV object, so k8s-truth metadata built
-// from pv.GetLabels() never carries them. See preserveHealthLabelsOnK8sPVMetadata.
+// out-of-band by full sync's own health-labeling routines, which have no
+// counterpart on the actual k8s PV object, so k8s-truth metadata built from
+// pv.GetLabels() never carries them. See preserveHealthLabelsOnK8sPVMetadata.
+//
+// pv_missing is deliberately NOT included here. preserveHealthLabelsOnK8sPVMetadata
+// only ever runs for volumes that have a live k8s PV (fullSyncConstructVolumeMaps
+// iterates pvList), so by construction the volume is not missing at that
+// point — any pv_missing label still present in CNS is stale and must be
+// allowed to drop via the normal k8s-truth diff/overwrite. That overwrite is
+// what clears pv_missing when a matching PV reappears (see
+// getMissingPVVolumeUpdateSpecs and tests/e2e/fullsync_pv_missing.go
+// "pv-missing-cleared"). Only pv_retained belongs here, since a volume can
+// remain legitimately retained-and-unconsumed across many cycles while still
+// having a live PV, and getRetainedPVVolumeUpdateSpecs re-derives eligibility
+// independently every cycle.
 var healthLabelKeys = []string{
-	prometheus.PrometheusPVMissingLabelKey,
 	prometheus.PrometheusPVRetainedLabelKey,
 }
 
@@ -1261,12 +1271,13 @@ var healthLabelKeys = []string{
 // CompareKubernetesMetadata) sees a health label present only on the CNS
 // side as a difference and triggers a metadata "updateVolume" that rebuilds
 // CNS entity metadata purely from k8s-truth data, silently stripping the
-// label. getMissingPVVolumeUpdateSpecs/getRetainedPVVolumeUpdateSpecs only
-// re-add the label when it isn't already present, based on a CNS query
-// taken earlier in the same full sync cycle, so they don't observe the
-// strip happening later in that same cycle — the label only reappears on
-// the next cycle. The net effect is the label visibly flipping on/off on
-// alternating full sync cycles.
+// label. getRetainedPVVolumeUpdateSpecs only re-adds pv_retained when it
+// isn't already present, based on a CNS query taken earlier in the same full
+// sync cycle, so it doesn't observe the strip happening later in that same
+// cycle — the label only reappears on the next cycle. The net effect,
+// without this preservation, is the label visibly flipping on/off on
+// alternating full sync cycles even though the volume's retained/unconsumed
+// state never changed.
 func preserveHealthLabelsOnK8sPVMetadata(k8sMetadataList []cnstypes.BaseCnsEntityMetadata,
 	cnsMetadataList []cnstypes.BaseCnsEntityMetadata) {
 	var cnsPV *cnstypes.CnsKubernetesEntityMetadata

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -2357,3 +2357,63 @@ func TestGetMissingPVVolumeUpdateSpecs_ForeignClusterIgnored(t *testing.T) {
 	assert.Equal(t, 0, count)
 	assert.Len(t, specs, 0)
 }
+
+// TestPreserveHealthLabelsOnK8sPVMetadata_RetainedCarriedForward verifies
+// that pv_retained survives being copied from CNS-side PV entity metadata
+// onto the k8s-truth PV entity metadata, so the regular full-sync diff
+// doesn't treat its absence on the k8s side as a change to overwrite away
+// (see the "flip" bug this guards against).
+func TestPreserveHealthLabelsOnK8sPVMetadata_RetainedCarriedForward(t *testing.T) {
+	k8sMetadataList := []cnstypes.BaseCnsEntityMetadata{
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{EntityName: "pv-1"},
+			EntityType:        string(cnstypes.CnsKubernetesEntityTypePV),
+		},
+	}
+	cnsMetadataList := []cnstypes.BaseCnsEntityMetadata{
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+				EntityName: "pv-1",
+				Labels:     []types.KeyValue{{Key: "pv_retained", Value: "true"}},
+			},
+			EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		},
+	}
+
+	preserveHealthLabelsOnK8sPVMetadata(k8sMetadataList, cnsMetadataList)
+
+	k8sPV := k8sMetadataList[0].(*cnstypes.CnsKubernetesEntityMetadata)
+	labels := cnsvsphere.GetLabelsMapFromKeyValue(k8sPV.Labels)
+	assert.Equal(t, "true", labels["pv_retained"], "pv_retained must be carried forward onto k8s-truth metadata")
+}
+
+// TestPreserveHealthLabelsOnK8sPVMetadata_MissingNotCarriedForward verifies
+// that pv_missing is deliberately NOT copied forward. This function only
+// ever runs for volumes with a live k8s PV, so any pv_missing label still on
+// the CNS side is stale; it must be free to drop via the normal diff/
+// overwrite so that a re-created PV clears the label (see
+// tests/e2e/fullsync_pv_missing.go "pv-missing-cleared").
+func TestPreserveHealthLabelsOnK8sPVMetadata_MissingNotCarriedForward(t *testing.T) {
+	k8sMetadataList := []cnstypes.BaseCnsEntityMetadata{
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{EntityName: "pv-1"},
+			EntityType:        string(cnstypes.CnsKubernetesEntityTypePV),
+		},
+	}
+	cnsMetadataList := []cnstypes.BaseCnsEntityMetadata{
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+				EntityName: "pv-1",
+				Labels:     []types.KeyValue{{Key: "pv_missing", Value: "true"}},
+			},
+			EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		},
+	}
+
+	preserveHealthLabelsOnK8sPVMetadata(k8sMetadataList, cnsMetadataList)
+
+	k8sPV := k8sMetadataList[0].(*cnstypes.CnsKubernetesEntityMetadata)
+	labels := cnsvsphere.GetLabelsMapFromKeyValue(k8sPV.Labels)
+	_, present := labels["pv_missing"]
+	assert.False(t, present, "pv_missing must not be carried forward so it can be dropped when a PV reappears")
+}

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -522,6 +522,8 @@ func setupMetadataSyncerForFullSync(
 	volumeOperationsLock["test-vcenter"] = &sync.Mutex{}
 	cnsDeletionMap = make(map[string]map[string]bool)
 	cnsDeletionMap["test-vcenter"] = make(map[string]bool)
+	pvMissingLabeledMap = make(map[string]map[string]bool)
+	pvMissingLabeledMap["test-vcenter"] = make(map[string]bool)
 	cnsCreationMap = make(map[string]map[string]bool)
 	cnsCreationMap["test-vcenter"] = make(map[string]bool)
 
@@ -2065,6 +2067,7 @@ func TestReconcileKeepAfterDeleteVmFlags(t *testing.T) {
 func pvMissingTestSetup(t *testing.T, vc, clusterID string) *metadataSyncInformer {
 	t.Helper()
 	cnsDeletionMap = map[string]map[string]bool{vc: {}}
+	pvMissingLabeledMap = map[string]map[string]bool{vc: {}}
 	clusterIDforVolumeMetadata = clusterID
 	return &metadataSyncInformer{
 		coCommonInterface: &mockCOCommonForFullSync{},
@@ -2246,6 +2249,44 @@ func TestGetMissingPVVolumeUpdateSpecs_AlreadyLabeled(t *testing.T) {
 		map[string]string{}, ms, false, cc, vc)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, count, "should not re-label an already-labeled volume")
+	assert.Len(t, specs, 0)
+	assert.True(t, pvMissingLabeledMap[vc]["vol-1"],
+		"volume found already labeled via live CNS metadata should be recorded in pvMissingLabeledMap")
+}
+
+// TestGetMissingPVVolumeUpdateSpecs_SkipsOnceLocallyLabeled verifies that
+// once pvMissingLabeledMap records a volume as labeled, subsequent calls
+// short-circuit and never re-issue an update spec for it — even if the CNS
+// query passed in that cycle doesn't reflect the label (e.g. a stale or
+// incomplete read) — so full sync only ever calls UpdateVolumeMetadata once
+// per volume instead of every cycle.
+func TestGetMissingPVVolumeUpdateSpecs_SkipsOnceLocallyLabeled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vc := "test-vc"
+	clusterID := "test-cluster"
+	ms := pvMissingTestSetup(t, vc, clusterID)
+
+	// Simulate a query result that does NOT carry the label (e.g. a stale
+	// read), so the live-metadata check alone would incorrectly conclude
+	// the label still needs to be (re)applied.
+	vol := makeCNSVolume("vol-1", "pv-orphan", clusterID,
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+				EntityName: "pv-orphan",
+				ClusterID:  clusterID,
+			},
+			EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		})
+	cc := cnstypes.CnsContainerCluster{ClusterId: clusterID}
+
+	cnsDeletionMap[vc]["vol-1"] = true
+	pvMissingLabeledMap[vc]["vol-1"] = true
+
+	specs, count, err := getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		map[string]string{}, ms, false, cc, vc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "should not reissue UpdateVolumeMetadata once locally recorded as labeled")
 	assert.Len(t, specs, 0)
 }
 

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -468,6 +468,8 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 
 	// Initialize cnsDeletionMap used by Full Sync.
 	cnsDeletionMap = make(map[string]map[string]bool)
+	// Initialize pvMissingLabeledMap used by Full Sync.
+	pvMissingLabeledMap = make(map[string]map[string]bool)
 	// Initialize cnsCreationMap used by Full Sync.
 	cnsCreationMap = make(map[string]map[string]bool)
 	// Initialize volumeOperationsLock map
@@ -507,6 +509,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		metadataSyncer.host = vCenter.Config.Host
 
 		cnsDeletionMap[metadataSyncer.host] = make(map[string]bool)
+		pvMissingLabeledMap[metadataSyncer.host] = make(map[string]bool)
 		cnsCreationMap[metadataSyncer.host] = make(map[string]bool)
 		volumeInfoCrDeletionMap[metadataSyncer.host] = make(map[string]bool)
 		volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
@@ -607,6 +610,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 
 			metadataSyncer.volumeManagers[vcconfig.Host] = volumeManager
 			cnsDeletionMap[vcconfig.Host] = make(map[string]bool)
+			pvMissingLabeledMap[vcconfig.Host] = make(map[string]bool)
 			cnsCreationMap[vcconfig.Host] = make(map[string]bool)
 			volumeInfoCrDeletionMap[vcconfig.Host] = make(map[string]bool)
 			volumeOperationsLock[vcconfig.Host] = &sync.Mutex{}

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -656,6 +656,8 @@ func runTestFullSyncWorkflows(t *testing.T) {
 	}
 	cnsDeletionMap = make(map[string]map[string]bool)
 	cnsDeletionMap[csiConfig.Global.VCenterIP] = make(map[string]bool)
+	pvMissingLabeledMap = make(map[string]map[string]bool)
+	pvMissingLabeledMap[csiConfig.Global.VCenterIP] = make(map[string]bool)
 	// PV does not exist in K8S, but volume exists in CNS cache.
 	// Per the cns-health-initiative design, fullsync no longer unregisters
 	// such volumes; instead it labels them with pv_missing=true on their

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -80,6 +80,15 @@ var (
 	// and tests.
 	cnsDeletionMap map[string]map[string]bool
 
+	// pvMissingLabeledMap tracks, per VC, the CNS volume IDs that full sync
+	// has already labeled pv_missing=true. Once a volume is recorded here,
+	// getMissingPVVolumeUpdateSpecs skips it without re-evaluating its CNS
+	// metadata or reissuing UpdateVolumeMetadata, so a volume that remains
+	// PV-missing across many cycles is only ever labeled once. Cleared when
+	// the volume's PV reappears in K8s (see cleanupCnsMaps), so it is
+	// re-evaluated and re-labeled if it goes missing again later.
+	pvMissingLabeledMap map[string]map[string]bool
+
 	// cnsCreationMap tracks volumes that exist in K8s but not in CNS
 	// If a volume exists in this map across two fullsync cycles,
 	// the volume is created in CNS

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -178,7 +178,8 @@ func IsValidVolume(ctx context.Context, volume v1.Volume, pod *v1.Pod,
 // if volumeIds is empty, then all volumes from CNS will be retrieved by
 // pagination.
 func fullSyncGetQueryResults(ctx context.Context, volumeIds []cnstypes.CnsVolumeId, clusterID string,
-	volumeManager volumes.Manager, metadataSyncer *metadataSyncInformer) ([]*cnstypes.CnsQueryResult, error) {
+	volumeManager volumes.Manager, metadataSyncer *metadataSyncInformer,
+	querySelection *cnstypes.CnsQuerySelection) ([]*cnstypes.CnsQueryResult, error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("FullSync: fullSyncGetQueryResults is called with volumeIds %v for clusterID %s",
 		volumeIds, clusterID)
@@ -199,7 +200,7 @@ func fullSyncGetQueryResults(ctx context.Context, volumeIds []cnstypes.CnsVolume
 		if clusterID != "" {
 			queryFilter.ContainerClusterIds = []string{clusterID}
 		}
-		queryResult, err := utils.QueryVolumeUtil(ctx, volumeManager, queryFilter, nil)
+		queryResult, err := utils.QueryVolumeUtil(ctx, volumeManager, queryFilter, querySelection)
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"queryVolumeUtil failed with err=%+v", err.Error())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Report retained PVs with no consumers/pods to CNS as a label

**Testing done**:
Supervisor cluster has the following state for the volumes:
- 2 PVs exist in the cluster.
- 1 PV is bound to a PVC, used an application
- 1 PV is in Released state as the Deletion Policy was updated to Retain. And is not bound to a PVC. The PVC is/may be deleted by the user or backup solution, after a successful backup.
- Orphaned CNS volume exist in the back-end, but the PV has been deleted/cleaned up


For the above scenario, the expectations in the CNS UI in vCenter are:
- The PV bound to the PVC should show in the CNS volumes table
- The PV in released & Retained state should show up as pv_retained in the CNS volumes table
- The CNS volume which doesn't have a PV in Supervisor Cluster show up as pv_missing in the CNS volumes table


Supervisor k8s:

```
root@423939f29105dc036ca06b6dda0c79e4 [ /tmp ]# kubectl get pvc -n test-r7zlw
NAME                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  VOLUMEATTRIBUTESCLASS   AGE
volume-claim-36j9   Bound    pvc-a2c0276e-f4c8-43b5-9026-677b1130cb0d   1Gi        RWO            vsan-default-storage-policy   <unset>                 4d4h
root@423939f29105dc036ca06b6dda0c79e4 [ /tmp ]# kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS     CLAIM                          STORAGECLASS                  VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-405532d6-a05f-4e09-9649-92ce958cd284   1Gi        RWO            Retain           Released   test-r7zlw/volume-claim-ld3d   vsan-default-storage-policy   <unset>                          8m41s
pvc-a2c0276e-f4c8-43b5-9026-677b1130cb0d   1Gi        RWO            Delete           Bound      test-r7zlw/volume-claim-36j9   vsan-default-storage-policy   <unset>                          4d4h
```

<img width="1530" height="483" alt="Screenshot 2026-07-01 at 12 58 09 PM" src="https://github.com/user-attachments/assets/f886cd60-f91c-4484-9f4a-f5b2dd5fad86" />


e2e pipeline result:
TBA

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Report retained PVs with no consumers to CNS as a label
```
