### PR TITLE
Fix CnsFileAccessConfig stuck in deletion when VM is deleted first

### DIFF
--- a/pkg/internalapis/cnsoperator/cnsfilevolumeclient/cnsfilevolumeclient.go
+++ b/pkg/internalapis/cnsoperator/cnsfilevolumeclient/cnsfilevolumeclient.go
@@ -359,6 +359,11 @@ func (f *fileVolumeClient) GetVMIPFromVMName(ctx context.Context,
 	}
 	err = f.client.Get(ctx, instanceKey, instance)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Infof("cnsfilevolumeclient instance %s does not exist on API server, returning empty IP",
+				fileVolumeName)
+			return "", 0, nil
+		}
 		log.Errorf("failed to get cnsfilevolumeclient instance %s with error: %+v", fileVolumeName, err)
 		return "", 0, err
 	}

--- a/pkg/internalapis/cnsoperator/cnsfilevolumeclient/cnsfilevolumeclient_test.go
+++ b/pkg/internalapis/cnsoperator/cnsfilevolumeclient/cnsfilevolumeclient_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnsfilevolumeclient
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	internalapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis"
+	v1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1"
+)
+
+func newTestFileVolumeClient(objs ...v1alpha1.CnsFileVolumeClient) *fileVolumeClient {
+	scheme := runtime.NewScheme()
+	_ = internalapis.SchemeBuilder.AddToScheme(scheme)
+	builder := fakeclient.NewClientBuilder().WithScheme(scheme)
+	for i := range objs {
+		builder = builder.WithObjects(&objs[i])
+	}
+	return &fileVolumeClient{
+		client:     builder.Build(),
+		volumeLock: &sync.Map{},
+	}
+}
+
+// TestGetVMIPFromVMName_InstanceNotFound verifies that when the CnsFileVolumeClient CR does not
+// exist, GetVMIPFromVMName returns an empty IP and no error, allowing callers to treat the
+// absence as "nothing to clean up".
+func TestGetVMIPFromVMName_InstanceNotFound(t *testing.T) {
+	ctx := context.Background()
+	f := newTestFileVolumeClient() // no CR created
+
+	vmIP, count, err := f.GetVMIPFromVMName(ctx, "ns1/pvc1", "vm1")
+
+	assert.NoError(t, err)
+	assert.Empty(t, vmIP)
+	assert.Zero(t, count)
+}
+
+// TestGetVMIPFromVMName_VMNotRegistered verifies that when the CnsFileVolumeClient CR exists but
+// the requested VM name is not in the spec, GetVMIPFromVMName returns an empty IP and no error.
+func TestGetVMIPFromVMName_VMNotRegistered(t *testing.T) {
+	ctx := context.Background()
+	cr := v1alpha1.CnsFileVolumeClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "ns1"},
+		Spec: v1alpha1.CnsFileVolumeClientSpec{
+			ExternalIPtoClientVms: map[string][]string{
+				"10.0.0.1": {"other-vm"},
+			},
+		},
+	}
+	f := newTestFileVolumeClient(cr)
+
+	vmIP, count, err := f.GetVMIPFromVMName(ctx, "ns1/pvc1", "vm1")
+
+	assert.NoError(t, err)
+	assert.Empty(t, vmIP)
+	assert.Zero(t, count)
+}
+
+// TestGetVMIPFromVMName_VMRegistered verifies that when the CnsFileVolumeClient CR exists and
+// the requested VM name is present in the spec, GetVMIPFromVMName returns the correct IP and
+// the number of VMs sharing that IP.
+func TestGetVMIPFromVMName_VMRegistered(t *testing.T) {
+	ctx := context.Background()
+	cr := v1alpha1.CnsFileVolumeClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "ns1"},
+		Spec: v1alpha1.CnsFileVolumeClientSpec{
+			ExternalIPtoClientVms: map[string][]string{
+				"10.0.0.1": {"vm1", "vm2"},
+			},
+		},
+	}
+	f := newTestFileVolumeClient(cr)
+
+	vmIP, count, err := f.GetVMIPFromVMName(ctx, "ns1/pvc1", "vm1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "10.0.0.1", vmIP)
+	assert.Equal(t, 2, count)
+}

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -65,6 +65,10 @@ const (
 	devopsUserLabelKey      = "cns.vmware.com/user-created"
 )
 
+// getFileVolumeClientInstanceFn is a variable so that tests can substitute a fake implementation
+// without needing gomonkey.
+var getFileVolumeClientInstanceFn = cnsfilevolumeclient.GetFileVolumeClientInstance
+
 // backOffDuration is a map of cnsfileaccessconfig name's to the time after
 // which a request for this instance will be requeued. Initialized to 1 second
 // for new instances and for instances whose latest reconcile operation
@@ -556,7 +560,7 @@ func isPvcInUse(ctx context.Context, pvcName string,
 	instance *v1a1.CnsFileAccessConfig) (bool, error) {
 	log := logger.GetLogger(ctx)
 
-	cnsFileVolumeClientInstance, err := cnsfilevolumeclient.GetFileVolumeClientInstance(ctx)
+	cnsFileVolumeClientInstance, err := getFileVolumeClientInstanceFn(ctx)
 	if err != nil {
 		return true, logger.LogNewErrorf(log, "Failed to get CNSFileVolumeClient instance. Error: %+v", err)
 	}
@@ -634,7 +638,7 @@ func (r *ReconcileCnsFileAccessConfig) removePermissionsForFileVolume(ctx contex
 	instanceLock, _ := volumePermissionLock.(*sync.Mutex)
 	instanceLock.Lock()
 	defer instanceLock.Unlock()
-	cnsFileVolumeClientInstance, err := cnsfilevolumeclient.GetFileVolumeClientInstance(ctx)
+	cnsFileVolumeClientInstance, err := getFileVolumeClientInstanceFn(ctx)
 	if err != nil {
 		return logger.LogNewErrorf(log, "Failed to get CNSFileVolumeClient instance. Error: %+v", err)
 	}
@@ -644,6 +648,13 @@ func (r *ReconcileCnsFileAccessConfig) removePermissionsForFileVolume(ctx contex
 	if err != nil {
 		return logger.LogNewErrorf(log, "Failed to get VM IP from VM name in CNSFileVolumeClient instance. "+
 			"Error: %+v", err)
+	}
+	// CnsFileVolumeClient does not exist or VM was never registered — nothing left to clean up.
+	if vmIP == "" {
+		log.Infof("No VM IP entry found for VM %q in CnsFileVolumeClient; "+
+			"skipping ACL and IPList removal for CnsFileAccessConfig %q",
+			instance.Spec.VMName, instance.Name)
+		return nil
 	}
 	// If PVC is not found, then skipConfigureVolumeACL will be true.
 	// There is no need to configure volume ACL on volume if PVC is already deleted.
@@ -685,7 +696,7 @@ func (r *ReconcileCnsFileAccessConfig) configureNetPermissionsForFileVolume(ctx 
 		return logger.LogNewErrorf(log, "Failed to get external facing IP address for VM: %s/%s instance. Error: %+v",
 			vm.Namespace, vm.Name, err)
 	}
-	cnsFileVolumeClientInstance, err := cnsfilevolumeclient.GetFileVolumeClientInstance(ctx)
+	cnsFileVolumeClientInstance, err := getFileVolumeClientInstanceFn(ctx)
 	if err != nil {
 		return logger.LogNewErrorf(log, "Failed to get CNSFileVolumeClient instance. Error: %+v", err)
 	}

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller_test.go
@@ -2,6 +2,7 @@ package cnsfileaccessconfig
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -28,33 +29,126 @@ import (
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
 
-// fakeFileVolumeClient is a no-op implementation of cnsfilevolumeclient.FileVolumeClient
-// used to avoid the real singleton's dependency on an in-cluster kube client.
-type fakeFileVolumeClient struct{}
+// fakeFileVolumeClient is a test double for cnsfilevolumeclient.FileVolumeClient.
+// Its zero value ("", 0, nil everywhere) behaves like a fully no-op implementation.
+// The *Calls counters let tests assert that no-op downstream calls are skipped
+// once GetVMIPFromVMName reports there is nothing to clean up (empty vmIP).
+type fakeFileVolumeClient struct {
+	vmIP              string
+	vmsAssociatedWith int
+	vmIPErr           error
 
-func (f *fakeFileVolumeClient) GetClientVMsFromIPList(ctx context.Context, fileVolumeName string,
-	clientVMIP string) ([]string, error) {
+	getClientVMsFromIPListCalls   int
+	removeClientVMFromIPListCalls int
+}
+
+func (f *fakeFileVolumeClient) GetClientVMsFromIPList(_ context.Context, _, _ string) ([]string, error) {
+	f.getClientVMsFromIPListCalls++
 	return nil, nil
 }
 
-func (f *fakeFileVolumeClient) AddClientVMToIPList(ctx context.Context,
-	fileVolumeName, clientVMName, clientVMIP string) error {
+func (f *fakeFileVolumeClient) AddClientVMToIPList(_ context.Context, _, _, _ string) error {
 	return nil
 }
 
-func (f *fakeFileVolumeClient) RemoveClientVMFromIPList(ctx context.Context,
-	fileVolumeName, clientVMName, clientVMIP string) error {
+func (f *fakeFileVolumeClient) RemoveClientVMFromIPList(_ context.Context, _, _, _ string) error {
+	f.removeClientVMFromIPListCalls++
 	return nil
 }
 
-func (f *fakeFileVolumeClient) GetVMIPFromVMName(ctx context.Context, fileVolumeName string,
-	clientVMName string) (string, int, error) {
-	return "", 0, nil
+func (f *fakeFileVolumeClient) GetVMIPFromVMName(_ context.Context, _, _ string) (string, int, error) {
+	return f.vmIP, f.vmsAssociatedWith, f.vmIPErr
 }
 
-func (f *fakeFileVolumeClient) CnsFileVolumeClientExistsForPvc(ctx context.Context,
-	fileVolumeName string) (bool, error) {
+func (f *fakeFileVolumeClient) CnsFileVolumeClientExistsForPvc(_ context.Context, _ string) (bool, error) {
 	return false, nil
+}
+
+// initTestPackageState initializes package-level state that is normally set up by Add().
+// Must be called at the start of tests that exercise controller methods directly.
+func initTestPackageState() {
+	volumePermissionLockMap = &sync.Map{}
+}
+
+// TestRemovePermissionsForFileVolume_EmptyVMIP verifies that when GetVMIPFromVMName returns an
+// empty IP (CnsFileVolumeClient absent or VM not registered), removePermissionsForFileVolume
+// returns nil immediately without making any further no-op calls (e.g. RemoveClientVMFromIPList),
+// so the caller can proceed to remove the finalizer.
+func TestRemovePermissionsForFileVolume_EmptyVMIP(t *testing.T) {
+	ctx := context.Background()
+	initTestPackageState()
+
+	fake := &fakeFileVolumeClient{vmIP: "", vmsAssociatedWith: 0, vmIPErr: nil}
+	orig := getFileVolumeClientInstanceFn
+	getFileVolumeClientInstanceFn = func(_ context.Context) (cnsfilevolumeclient.FileVolumeClient, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { getFileVolumeClientInstanceFn = orig })
+
+	r := &ReconcileCnsFileAccessConfig{}
+	instance := &v1a1.CnsFileAccessConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cfg", Namespace: "ns1"},
+		Spec:       v1a1.CnsFileAccessConfigSpec{PvcName: "pvc1", VMName: "vm1"},
+	}
+
+	err := r.removePermissionsForFileVolume(ctx, "vol-1", instance, false)
+
+	assert.NoError(t, err)
+	assert.Zero(t, fake.removeClientVMFromIPListCalls,
+		"RemoveClientVMFromIPList should be skipped once vmIP is reported empty")
+}
+
+// TestRemovePermissionsForFileVolume_EmptyVMIP_SkipsACLRemoval verifies that the empty-vmIP
+// guard short-circuits before the ACL-removal branch is even evaluated. r.volumeManager is left
+// nil here, so if the guard were removed and configureVolumeACLs were reached, this test would
+// panic on a nil volumeManager instead of passing.
+func TestRemovePermissionsForFileVolume_EmptyVMIP_SkipsACLRemoval(t *testing.T) {
+	ctx := context.Background()
+	initTestPackageState()
+
+	// vmsAssociatedWith is set to 1 to match the condition that would otherwise trigger
+	// ACL removal (vmsAssociatedWithIP == 1); the empty vmIP must still take precedence.
+	fake := &fakeFileVolumeClient{vmIP: "", vmsAssociatedWith: 1, vmIPErr: nil}
+	orig := getFileVolumeClientInstanceFn
+	getFileVolumeClientInstanceFn = func(_ context.Context) (cnsfilevolumeclient.FileVolumeClient, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { getFileVolumeClientInstanceFn = orig })
+
+	r := &ReconcileCnsFileAccessConfig{} // volumeManager intentionally left nil
+	instance := &v1a1.CnsFileAccessConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cfg", Namespace: "ns1"},
+		Spec:       v1a1.CnsFileAccessConfigSpec{PvcName: "pvc1", VMName: "vm1"},
+	}
+
+	err := r.removePermissionsForFileVolume(ctx, "vol-1", instance, false /* skipConfigureVolumeACL */)
+
+	assert.NoError(t, err)
+	assert.Zero(t, fake.removeClientVMFromIPListCalls)
+}
+
+// TestRemovePermissionsForFileVolume_GetInstanceError verifies that when GetFileVolumeClientInstance
+// itself fails, removePermissionsForFileVolume propagates the error.
+func TestRemovePermissionsForFileVolume_GetInstanceError(t *testing.T) {
+	ctx := context.Background()
+	initTestPackageState()
+
+	orig := getFileVolumeClientInstanceFn
+	getFileVolumeClientInstanceFn = func(_ context.Context) (cnsfilevolumeclient.FileVolumeClient, error) {
+		return nil, fmt.Errorf("kubeconfig unavailable")
+	}
+	t.Cleanup(func() { getFileVolumeClientInstanceFn = orig })
+
+	r := &ReconcileCnsFileAccessConfig{}
+	instance := &v1a1.CnsFileAccessConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cfg", Namespace: "ns1"},
+		Spec:       v1a1.CnsFileAccessConfigSpec{PvcName: "pvc1", VMName: "vm1"},
+	}
+
+	err := r.removePermissionsForFileVolume(ctx, "vol-1", instance, false)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to get CNSFileVolumeClient instance")
 }
 
 func TestValidateVmAndPvc_NoLabels(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When a VM is deleted before its CnsFileAccessConfig CR, the controller enters the VM-not-found deletion path and calls removePermissionsForFileVolume(). That function calls GetVMIPFromVMName() to look up the VM's IP from the CnsFileVolumeClient CR, but if the CnsFileVolumeClient has already been cleaned up as part of VM teardown, the lookup fails with "not found" and propagates the error, blocking finalizer removal and leaving the CnsFileAccessConfig CR permanently stuck with a DeletionTimestamp.

Fix GetVMIPFromVMName() to treat IsNotFound as a clean "nothing here" response (returning "", 0, nil) rather than an error, matching its own documented contract. Add an early-return guard in
removePermissionsForFileVolume() for the empty-vmIP case so that when the CnsFileVolumeClient records are already gone, the function returns nil and allows the finalizer and CR deletion to complete.

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3151 fix made the VM-deleted path work, but left GetVMIPFromVMName / removePermissionsForFileVolume unable to tolerate an already-deleted CnsFileVolumeClient. Once https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3186 made cleanup run unconditionally and https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3348 added a requeue point after it, idempotency became a hard requirement. Our commits (2d099dd2 + 0bd39011) supply exactly that — treating a missing CnsFileVolumeClient as "already cleaned up" (return "", 0, nil) and skipping ACL/IP-list removal when vmIP == "".


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1762/
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1326/
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix CnsFileAccessConfig stuck in deletion when VM is deleted first
```
