### PR TITLE
Support mutable_parameters in CreateVolumeRequest

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -399,6 +399,13 @@ const (
 	// AttributeSupervisorVolumeSnapshotClass represents name of VolumeSnapshotClass
 	AttributeSupervisorVolumeSnapshotClass = "svvolumesnapshotclass"
 
+	// AttributeSupervisorVolumeAttributesClass represents the name of the supervisor-side
+	// VolumeAttributesClass to use when creating a volume. It is passed in the
+	// mutable_parameters field of the CSI CreateVolumeRequest (sourced from the guest
+	// VolumeAttributesClass parameters), consistent with the CSI spec which requires that
+	// mutable_parameters take precedence over parameters.
+	AttributeSupervisorVolumeAttributesClass = "svvolumeattributesclass"
+
 	// VolumeSnapshotApiGroup represents the VolumeSnapshot API Group name
 	VolumeSnapshotApiGroup = "snapshot.storage.k8s.io"
 

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -728,6 +728,19 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 	}
 
+	// If VM_PVC_STORAGE_POLICY_MUTABILITY is enabled and mutable_parameters contains a
+	// storagePolicyID (sourced from the VolumeAttributesClass), use it in place of the
+	// StorageClass storagePolicyID. Per the CSI spec, mutable_parameters take precedence
+	// over parameters.
+	if isVMPVCStoragePolicyMutabilityEnabled {
+		for paramName := range req.GetMutableParameters() {
+			if strings.ToLower(paramName) == common.AttributeStoragePolicyID {
+				storagePolicyID = req.GetMutableParameters()[paramName]
+			}
+		}
+	}
+	log.Infof("createBlockVolume: using StoragePolicyID %q for volume %s", storagePolicyID, req.Name)
+
 	// Get VC instance.
 	vc, err := common.GetVCenter(ctx, c.manager)
 	// TODO: Need to extract fault from err returned by GetVirtualCenter.
@@ -1566,6 +1579,14 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 			}
 		}
 	}
+
+	// VolumeAttributesClass is not yet supported for file volumes. Reject any request that
+	// carries mutable_parameters (which the external-provisioner populates from the VAC).
+	if isVMPVCStoragePolicyMutabilityEnabled && len(req.GetMutableParameters()) > 0 {
+		return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCode(log,
+			codes.Unimplemented, "VolumeAttributesClass is not supported for file volumes")
+	}
+	log.Infof("createFileVolume: using StoragePolicyID %q for volume %s", storagePolicyID, req.Name)
 
 	var createVolumeSpec = common.CreateVolumeSpec{
 		CapacityMB:      volSizeMB,

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -2358,3 +2358,136 @@ func TestSnapshotLockManager(t *testing.T) {
 		}
 	})
 }
+
+// TestCreateFileVolumeVACMutableParams tests the early-return in createFileVolume
+// that rejects requests carrying mutable_parameters when the
+// isVMPVCStoragePolicyMutabilityEnabled flag is set.
+func TestCreateFileVolumeVACMutableParams(t *testing.T) {
+	tests := []struct {
+		name              string
+		fssEnabled        bool
+		mutableParams     map[string]string
+		wantUnimplemented bool
+	}{
+		{
+			name:              "FSS enabled with mutable_parameters rejects file volume",
+			fssEnabled:        true,
+			mutableParams:     map[string]string{"x": "y"},
+			wantUnimplemented: true,
+		},
+		{
+			name:              "FSS enabled with empty mutable_parameters does not reject",
+			fssEnabled:        true,
+			mutableParams:     map[string]string{},
+			wantUnimplemented: false,
+		},
+		{
+			name:              "FSS disabled with mutable_parameters does not reject",
+			fssEnabled:        false,
+			mutableParams:     map[string]string{"x": "y"},
+			wantUnimplemented: false,
+		},
+	}
+
+	ct := getControllerTest(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := isVMPVCStoragePolicyMutabilityEnabled
+			isVMPVCStoragePolicyMutabilityEnabled = tt.fssEnabled
+			defer func() { isVMPVCStoragePolicyMutabilityEnabled = orig }()
+
+			req := &csi.CreateVolumeRequest{
+				Name:              "test-file-vac-" + uuid.New().String(),
+				CapacityRange:     &csi.CapacityRange{RequiredBytes: 1 * common.GbInBytes},
+				Parameters:        map[string]string{},
+				MutableParameters: tt.mutableParams,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+					}},
+				},
+			}
+
+			// Pass isWorkloadDomainIsolationEnabled=true so that, for the
+			// non-early-return cases, the function exits via the topology path
+			// (codes.FailedPrecondition) rather than reaching the nil authMgr.
+			_, _, err := ct.controller.createFileVolume(ctx, req, true)
+
+			gotUnimplemented := err != nil && status.Code(err) == codes.Unimplemented
+			if gotUnimplemented != tt.wantUnimplemented {
+				t.Fatalf("wantUnimplemented=%v but gotUnimplemented=%v (code=%v, err=%v)",
+					tt.wantUnimplemented, gotUnimplemented, status.Code(err), err)
+			}
+		})
+	}
+}
+
+// TestCreateBlockVolumeVACPolicyOverride tests that when
+// isVMPVCStoragePolicyMutabilityEnabled is true the storagePolicyID from
+// mutable_parameters overrides the one from parameters, so the CNS volume is
+// provisioned under the VAC's storage policy, not the StorageClass's.
+func TestCreateBlockVolumeVACPolicyOverride(t *testing.T) {
+	ct := getControllerTest(t)
+
+	orig := isVMPVCStoragePolicyMutabilityEnabled
+	isVMPVCStoragePolicyMutabilityEnabled = true
+	defer func() { isVMPVCStoragePolicyMutabilityEnabled = orig }()
+
+	pc, err := pbm.NewClient(ctx, ct.vcenter.Client.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vacPolicyID, err := pc.ProfileIDByName(ctx, "vSAN Default Storage Policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parameters carries a fake SC policy; mutable_parameters carries the real
+	// VAC policy. With FSS enabled the mutable policy must win, so the volume
+	// is created under vacPolicyID.
+	reqCreate := &csi.CreateVolumeRequest{
+		Name:          testVolumeName + "-block-vac-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 1 * common.GbInBytes},
+		Parameters: map[string]string{
+			common.AttributeStoragePolicyID: "sc-storage-policy-id",
+		},
+		MutableParameters: map[string]string{
+			common.AttributeStoragePolicyID: vacPolicyID,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			}},
+		},
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Requisite: []*csi.Topology{},
+			Preferred: []*csi.Topology{},
+		},
+	}
+
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatalf("expected success with mutable policy override; got: %v", err)
+	}
+	defer func() {
+		_, _ = ct.controller.DeleteVolume(ctx, &csi.DeleteVolumeRequest{
+			VolumeId: respCreate.Volume.VolumeId,
+		})
+	}()
+
+	queryFilter := cnstypes.CnsQueryFilter{
+		VolumeIds: []cnstypes.CnsVolumeId{{Id: respCreate.Volume.VolumeId}},
+	}
+	queryResult, err := ct.vcenter.CnsClient.QueryVolume(ctx, &queryFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(queryResult.Volumes) != 1 {
+		t.Fatalf("expected 1 volume in query result, got %d", len(queryResult.Volumes))
+	}
+	if queryResult.Volumes[0].StoragePolicyId != vacPolicyID {
+		t.Fatalf("expected storage policy %q (VAC policy from mutable_parameters), got %q",
+			vacPolicyID, queryResult.Volumes[0].StoragePolicyId)
+	}
+}

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -437,6 +437,27 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			}
 		}
 
+		// If the VM_PVC_STORAGE_POLICY_MUTABILITY FSS is enabled, read the supervisor
+		// VolumeAttributesClass name from mutable_parameters. Per the CSI spec, mutable_parameters
+		// take precedence over parameters and are sourced from the VolumeAttributesClass (not
+		// the StorageClass), so they are separate from the supervisorStorageClass above.
+		var supervisorVACName string
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VMPVCStoragePolicyMutabilityFSS) {
+			for param := range req.GetMutableParameters() {
+				if strings.ToLower(param) == common.AttributeSupervisorVolumeAttributesClass {
+					supervisorVACName = req.GetMutableParameters()[param]
+				}
+			}
+			if supervisorVACName != "" {
+				if isFileVolumeRequest {
+					return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCode(log,
+						codes.Unimplemented, "VolumeAttributesClass is not supported for file volumes")
+				}
+				log.Infof("CreateVolume: VolumeAttributesClass %q specified in mutable_parameters for supervisor PVC %s",
+					supervisorVACName, supervisorPVCName)
+			}
+		}
+
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupportFSS) {
 			// Check if this is a LinkedClone request
 			isLinkedCloneRequest, err = commonco.ContainerOrchestratorUtility.IsLinkedCloneRequest(ctx, pvcName, pvcNamespace)
@@ -563,6 +584,9 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				claim := getPersistentVolumeClaimSpecWithStorageClass(supervisorPVCName, c.supervisorNamespace,
 					diskSize, supervisorStorageClass, getAccessMode(accessMode), annotations, labels, finalizers,
 					volumeSnapshotName, isLinkedCloneRequest)
+				if supervisorVACName != "" {
+					claim.Spec.VolumeAttributesClassName = &supervisorVACName
+				}
 				log.Debugf("PVC claim spec is %+v", spew.Sdump(claim))
 				pvc, err = c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Create(
 					ctx, claim, metav1.CreateOptions{})

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -2041,3 +2041,122 @@ func TestWaitForSupervisorPVCModifyVolume(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+const (
+	vacTestSupervisorNS = "test-namespace-vac"
+	testVACName         = "gold-vac"
+)
+
+// newVACTestController creates a fresh isolated controller for VAC CreateVolume
+// tests. The returned CO interface has the VMPVCStoragePolicyMutabilityFSS
+// disabled by default; callers enable or disable it as needed. The original
+// commonco.ContainerOrchestratorUtility is restored via t.Cleanup.
+func newVACTestController(t *testing.T) (*controller, commonco.COCommonInterface) {
+	t.Helper()
+	supervisorClient := testclient.NewClientset()
+	c := &controller{
+		supervisorClient:    supervisorClient,
+		supervisorNamespace: vacTestSupervisorNS,
+		topologyEnabled:     true,
+	}
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+	origCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = co
+	t.Cleanup(func() { commonco.ContainerOrchestratorUtility = origCO })
+	return c, co
+}
+
+// vacCreateRequest builds a CreateVolumeRequest for block volumes with the
+// given mutable_parameters.
+func vacCreateRequest(mutableParams map[string]string) *csi.CreateVolumeRequest {
+	return &csi.CreateVolumeRequest{
+		Name: testVolumeName,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters: map[string]string{
+			common.AttributeSupervisorStorageClass: testStorageClass,
+		},
+		MutableParameters: mutableParams,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			}},
+		},
+	}
+}
+
+// TestCreateVolumeVACSetsVolumeAttributesClassName tests that CreateVolume sets
+// VolumeAttributesClassName on the supervisor PVC when VMPVCStoragePolicyMutabilityFSS
+// is enabled and svvolumeattributesclass is present in mutable_parameters.
+func TestCreateVolumeVACSetsVolumeAttributesClassName(t *testing.T) {
+	c, co := newVACTestController(t)
+	require.NoError(t, co.EnableFSS(context.Background(), common.VMPVCStoragePolicyMutabilityFSS))
+
+	req := vacCreateRequest(map[string]string{
+		common.AttributeSupervisorVolumeAttributesClass: testVACName,
+	})
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c, req)
+	require.NoError(t, err)
+	if pvc.Spec.VolumeAttributesClassName == nil {
+		t.Fatalf("expected supervisor PVC to have VolumeAttributesClassName=%q, got nil", testVACName)
+	}
+	if *pvc.Spec.VolumeAttributesClassName != testVACName {
+		t.Fatalf("expected VolumeAttributesClassName=%q, got %q",
+			testVACName, *pvc.Spec.VolumeAttributesClassName)
+	}
+}
+
+// TestCreateVolumeVACFileVolumeRejected tests that CreateVolume returns
+// codes.Unimplemented when a file volume is requested alongside a VAC in
+// mutable_parameters.
+func TestCreateVolumeVACFileVolumeRejected(t *testing.T) {
+	c, co := newVACTestController(t)
+	require.NoError(t, co.EnableFSS(context.Background(), common.VMPVCStoragePolicyMutabilityFSS))
+
+	req := &csi.CreateVolumeRequest{
+		Name: testVolumeName,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters: map[string]string{
+			common.AttributeSupervisorStorageClass: testStorageClass,
+		},
+		MutableParameters: map[string]string{
+			common.AttributeSupervisorVolumeAttributesClass: testVACName,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			}},
+		},
+	}
+
+	_, err := c.CreateVolume(context.Background(), req)
+	require.Error(t, err)
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("expected codes.Unimplemented for file volume + VAC, got %v (err=%v)",
+			status.Code(err), err)
+	}
+}
+
+// TestCreateVolumeVACFSSDisabledIgnoresMutableParams tests that when
+// VMPVCStoragePolicyMutabilityFSS is disabled, mutable_parameters are ignored and
+// VolumeAttributesClassName is NOT set on the supervisor PVC.
+func TestCreateVolumeVACFSSDisabledIgnoresMutableParams(t *testing.T) {
+	c, co := newVACTestController(t)
+	require.NoError(t, co.DisableFSS(context.Background(), common.VMPVCStoragePolicyMutabilityFSS))
+
+	req := vacCreateRequest(map[string]string{
+		common.AttributeSupervisorVolumeAttributesClass: testVACName,
+	})
+
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c, req)
+	require.NoError(t, err)
+	if pvc.Spec.VolumeAttributesClassName != nil {
+		t.Fatalf("expected VolumeAttributesClassName to be nil when FSS disabled, got %q",
+			*pvc.Spec.VolumeAttributesClassName)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds VolumeAttributesClass (VAC) support to CreateVolume in the vSphere CSI driver, so that a VAC's storage policy specified via mutable_parameters correctly takes precedence over the StorageClass's policy in parameters, per the CSI spec — implemented in both the guest (wcpguest) driver, which propagates the VAC name onto the supervisor PVC at creation, and the supervisor (wcp) driver, which overrides storagePolicyID before creating the CNS volume. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
VKS pre-check pipelines: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1335/ (passed)
WCP pre-check pipelines: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1770/ (passed)

[Manual testing](https://gist.github.com/xing-yang/a305bd8deb902788aa7f6c2d62bebca6#file-pvcsi-cns-csi-createvolume-vac-storagepolicy-md)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Supports VolumeAttributesClass when creating volume.
```
