### PR TITLE
Fix -  CnsRegisterVolume error handling for behavioral correctness

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -403,8 +403,8 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 						"the active cluster on the namespace")
 
 					// Attempt volume cleanup
-					if _, err = common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false); err != nil {
-						log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, err)
+					if err = r.cleanupCNSVolume(ctx, instance, volumeID); err != nil {
+						log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, err)
 						return reconcile.Result{RequeueAfter: timeout}, nil
 					}
 					// permanent failure and not requeue.
@@ -417,9 +417,8 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 					log.Errorf("Volume: %s present on datastore: %s is not accessible to any of the AZ clusters: %v",
 						volumeID, volume.DatastoreUrl, azClustersMap)
 					setInstanceError(ctx, r, instance, "Volume in the spec is not accessible to any of the AZ clusters")
-					_, err = common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false)
-					if err != nil {
-						log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, err)
+					if err = r.cleanupCNSVolume(ctx, instance, volumeID); err != nil {
+						log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, err)
 						return reconcile.Result{RequeueAfter: timeout}, nil
 					}
 					// permanent failure and not requeue.
@@ -427,31 +426,25 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 				}
 			}
 		}
-	} else {
+	} else if !isDatastoreAccessibleToCluster(
+		ctx, vc, r.configInfo.Cfg.Global.ClusterID, volume.DatastoreUrl) {
 		// Verify if the volume is accessible to Supervisor cluster.
-		isAccessible := isDatastoreAccessibleToCluster(ctx, vc, r.configInfo.Cfg.Global.ClusterID, volume.DatastoreUrl)
-		if !isAccessible {
-			log.Errorf("Volume: %s present on datastore: %s is not accessible to all nodes in the cluster: %s",
-				volumeID, volume.DatastoreUrl, r.configInfo.Cfg.Global.ClusterID)
-			setInstanceError(ctx, r, instance, "Volume in the spec is not accessible to all nodes in the cluster")
-			// Untag the CNS volume which was created previously.
-			_, err = common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false)
-			if err != nil {
-				log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, err)
-				return reconcile.Result{RequeueAfter: timeout}, nil
-			}
-			// permanent failure and not requeue.
-			return reconcile.Result{}, nil
+		log.Errorf("Volume: %s present on datastore: %s is not accessible to all nodes in the cluster: %s",
+			volumeID, volume.DatastoreUrl, r.configInfo.Cfg.Global.ClusterID)
+		setInstanceError(ctx, r, instance, "Volume in the spec is not accessible to all nodes in the cluster")
+		if err = r.cleanupCNSVolume(ctx, instance, volumeID); err != nil {
+			log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, err)
+			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
+		// permanent failure and not requeue.
+		return reconcile.Result{}, nil
 	}
 	// Verify if storage policy is empty.
 	if volume.StoragePolicyId == "" {
 		log.Errorf("Volume: %s doesn't have storage policy associated with it", volumeID)
 		setInstanceError(ctx, r, instance, "Volume in the spec doesn't have storage policy associated with it")
-		// Untag the CNS volume which was created previously.
-		_, err = common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false)
-		if err != nil {
-			log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, err)
+		if err = r.cleanupCNSVolume(ctx, instance, volumeID); err != nil {
+			log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, err)
 		}
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
@@ -618,10 +611,8 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 				instance.Spec.PvcName, *pvc.Spec.StorageClassName, storageClassName)
 			log.Error(msg)
 			setInstanceError(ctx, r, instance, msg)
-			// Untag the CNS volume which was created previously.
-			_, delErr := common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false)
-			if delErr != nil {
-				log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, delErr)
+			if delErr := r.cleanupCNSVolume(ctx, instance, volumeID); delErr != nil {
+				log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, delErr)
 			}
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		} else if pvc.Spec.StorageClassName == nil {
@@ -629,10 +620,8 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 				instance.Spec.PvcName, storageClassName)
 			log.Error(msg)
 			setInstanceError(ctx, r, instance, msg)
-			// Untag the CNS volume which was created previously.
-			_, delErr := common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false)
-			if delErr != nil {
-				log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, delErr)
+			if delErr := r.cleanupCNSVolume(ctx, instance, volumeID); delErr != nil {
+				log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, delErr)
 			}
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
@@ -645,10 +634,8 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 				msg := fmt.Sprintf("PVC topology validation failed: %v", err)
 				log.Error(msg)
 				setInstanceError(ctx, r, instance, msg)
-				// Untag the CNS volume which was created previously.
-				_, delErr := common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false)
-				if delErr != nil {
-					log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, delErr)
+				if delErr := r.cleanupCNSVolume(ctx, instance, volumeID); delErr != nil {
+					log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, delErr)
 				}
 				return reconcile.Result{RequeueAfter: timeout}, nil
 			}
@@ -750,10 +737,8 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 				instance.Spec.PvcName, instance.Namespace)
 			log.Errorf(msg)
 			setInstanceError(ctx, r, instance, msg)
-			// Untag the CNS volume which was created previously.
-			_, err = common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false)
-			if err != nil {
-				log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, err)
+			if err = r.cleanupCNSVolume(ctx, instance, volumeID); err != nil {
+				log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, err)
 			} else {
 				// Delete PV created above.
 				err = k8sclient.CoreV1().PersistentVolumes().Delete(ctx, pvName, *metav1.NewDeleteOptions(0))
@@ -1508,21 +1493,10 @@ func (r *ReconcileCnsRegisterVolume) reconcileDelete(ctx context.Context,
 	}
 
 	if volumeID != "" {
-		// Different cleanup based on how the volume was registered
-		if instance.Spec.VolumeID != "" {
-			// VolumeID was specified: volume was already a FCD
-			// Just untag it from CNS (deleteDisk=false to preserve the underlying FCD)
-			if err := r.untagCNSVolume(ctx, volumeID); err != nil {
-				log.With("error", err).Error("Failed to untag CNS volume")
-				return reconcile.Result{RequeueAfter: timeout}, nil
-			}
-		} else if instance.Spec.DiskURLPath != "" {
-			// DiskURLPath was specified: volume was a legacy disk that we registered as FCD
-			// De-register it as FCD (unregDisk=true to convert back to legacy disk)
-			if err := r.unregisterFCD(ctx, volumeID); err != nil {
-				log.With("error", err).Error("Failed to unregister FCD")
-				return reconcile.Result{RequeueAfter: timeout}, nil
-			}
+		err := r.cleanupCNSVolume(ctx, instance, volumeID)
+		if err != nil {
+			log.With("error", err).Error("Failed to cleanup CNS volume")
+			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 	}
 
@@ -1720,6 +1694,21 @@ func (r *ReconcileCnsRegisterVolume) untagCNSVolume(ctx context.Context, volumeI
 	}
 	log.With("volumeID", volumeID).Info("Successfully untagged CNS volume")
 	return nil
+}
+
+// cleanupCNSVolume cleans up a CNS volume created during a failed registration.
+// For DiskURLPath registrations (legacy VMDK promoted to FCD), it unregisters the
+// FCD to convert the disk back to a legacy VMDK. For VolumeID registrations (existing
+// FCD), it only untags the CNS record, preserving the underlying FCD.
+func (r *ReconcileCnsRegisterVolume) cleanupCNSVolume(
+	ctx context.Context,
+	instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
+	volumeID string,
+) error {
+	if instance.Spec.DiskURLPath != "" {
+		return r.unregisterFCD(ctx, volumeID)
+	}
+	return r.untagCNSVolume(ctx, volumeID)
 }
 
 // unregisterFCD de-registers a volume as FCD, converting it back to a legacy disk.

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -697,6 +697,217 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 		Expect(pvcSpec.Labels).NotTo(HaveKey(cnsoperatortypes.LabelVirtualMachineName))
 		Expect(pvcSpec.Labels).NotTo(HaveKey(cnsoperatortypes.LabelStoragePolicyReservationName))
 	})
+
+	// DiskURLPath registrations that fail the active-clusters accessibility check
+	// must call UnregisterVolume(unregDisk=true) to demote the FCD back to a plain VMDK.
+	It("DiskURLPath + active clusters not accessible: should call UnregisterVolume(unregDisk=true)", func() {
+		diskURLCR := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "disk-url-accessible-test",
+				Namespace: "test-ns",
+			},
+			Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+				PvcName:     "test-pvc",
+				DiskURLPath: "https://vc/test.vmdk",
+				AccessMode:  "ReadWriteOnce",
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(diskURLCR).
+			Build()
+
+		var unregCalled bool
+		var unregDiskArg bool
+		diskURLMgr := &mockVolumeManager{
+			createVolumeFunc: func(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+				ctxParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+				return &cnsvolume.CnsVolumeInfo{
+					VolumeID: cnstypes.CnsVolumeId{Id: "fcd-from-diskurl"},
+				}, "", nil
+			},
+			unregisterVolume: func(_ context.Context, volumeID string, unregDisk bool) (string, error) {
+				unregCalled = true
+				unregDiskArg = unregDisk
+				return "", nil
+			},
+		}
+		diskURLReconciler := &ReconcileCnsRegisterVolume{
+			client:        fakeClient,
+			scheme:        scheme,
+			volumeManager: diskURLMgr,
+		}
+
+		patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(ctx context.Context,
+			config *config.ConfigurationInfo, reinitialize bool) (*cnsvsphere.VirtualCenter, error) {
+			return &cnsvsphere.VirtualCenter{Config: &cnsvsphere.VirtualCenterConfig{Host: "vc"}}, nil
+		})
+		patches.ApplyFunc(common.QueryVolumeByID, func(ctx context.Context, vm cnsvolume.Manager,
+			volumeID string, querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
+			return &cnstypes.CnsVolume{
+				VolumeId:        cnstypes.CnsVolumeId{Id: volumeID},
+				DatastoreUrl:    "dummy-ds-url",
+				StoragePolicyId: "dummy-storage-policy-id",
+				BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+					CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
+				},
+			}, nil
+		})
+		patches.ApplyFunc(common.GetClusterComputeResourceMoIds, func(ctx context.Context) ([]string, bool, error) {
+			return []string{"cluster-a", "cluster-b"}, true, nil
+		})
+		patches.ApplyMethod(reflect.TypeOf(&mockCOCommon{}), "GetZonesForNamespace",
+			func(_ *mockCOCommon, ns string) map[string]struct{} {
+				return map[string]struct{}{"zone-b": {}}
+			})
+		patches.ApplyMethod(reflect.TypeOf(&mockCOCommon{}), "GetActiveClustersForNamespaceInRequestedZones",
+			func(_ commonco.COCommonInterface, ctx context.Context, ns string, zones []string) ([]string, error) {
+				return []string{"cluster-a"}, nil
+			})
+		patches.ApplyFunc(isDatastoreAccessibleToAZClusters,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+				azToClusters map[string][]string, ds string) bool {
+				return false
+			})
+		patches.ApplyFunc(constructCreateSpecForInstance, func(ctx context.Context,
+			r *ReconcileCnsRegisterVolume, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
+			host string, isTKGSHAEnabled bool) *cnstypes.CnsVolumeCreateSpec {
+			return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}
+		})
+		patches.ApplyFunc(setInstanceError, func(ctx context.Context, r *ReconcileCnsRegisterVolume,
+			instance *cnsregistervolumev1alpha1.CnsRegisterVolume, msg string) {
+		})
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "disk-url-accessible-test",
+				Namespace: "test-ns",
+			},
+		}
+		result, err := diskURLReconciler.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{RequeueAfter: 0}))
+		Expect(unregCalled).To(BeTrue(), "UnregisterVolume must be called for DiskURLPath accessibility failure")
+		Expect(unregDiskArg).To(BeTrue(), "unregDisk must be true so FCD is demoted back to VMDK")
+	})
+
+	// DiskURLPath registrations that fail PVC topology validation
+	// must call UnregisterVolume(unregDisk=true) — not DeleteVolumeUtil — to demote the FCD.
+	It("DiskURLPath + PVC topology validation failure: should call UnregisterVolume(unregDisk=true)", func() {
+		storageClassName := "test-sc"
+		diskURLCR := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "disk-url-topo-test",
+				Namespace: "test-ns",
+			},
+			Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+				PvcName:     "test-pvc",
+				DiskURLPath: "https://vc/test.vmdk",
+				AccessMode:  "ReadWriteOnce",
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(diskURLCR).
+			Build()
+
+		var unregCalled bool
+		var unregDiskArg bool
+		diskURLMgr := &mockVolumeManager{
+			createVolumeFunc: func(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+				ctxParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+				return &cnsvolume.CnsVolumeInfo{
+					VolumeID: cnstypes.CnsVolumeId{Id: "fcd-from-diskurl"},
+				}, "", nil
+			},
+			unregisterVolume: func(_ context.Context, volumeID string, unregDisk bool) (string, error) {
+				unregCalled = true
+				unregDiskArg = unregDisk
+				return "", nil
+			},
+		}
+
+		// Create k8sclient with an existing PVC whose storage class matches
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "test-ns"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &storageClassName,
+			},
+		}
+		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: storageClassName}}
+		k8sclientFake := k8sfake.NewClientset(pvc, sc)
+
+		diskURLReconciler := &ReconcileCnsRegisterVolume{
+			client:        fakeClient,
+			scheme:        scheme,
+			volumeManager: diskURLMgr,
+			k8sclient:     k8sclientFake,
+		}
+
+		patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(ctx context.Context,
+			config *config.ConfigurationInfo, reinitialize bool) (*cnsvsphere.VirtualCenter, error) {
+			return &cnsvsphere.VirtualCenter{Config: &cnsvsphere.VirtualCenterConfig{Host: "vc"}}, nil
+		})
+		patches.ApplyFunc(common.QueryVolumeByID, func(ctx context.Context, vm cnsvolume.Manager,
+			volumeID string, querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
+			return &cnstypes.CnsVolume{
+				VolumeId:        cnstypes.CnsVolumeId{Id: volumeID},
+				DatastoreUrl:    "dummy-ds-url",
+				StoragePolicyId: "dummy-policy-id",
+				BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+					CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
+				},
+			}, nil
+		})
+		patches.ApplyFunc(common.GetClusterComputeResourceMoIds, func(ctx context.Context) ([]string, bool, error) {
+			return []string{"cluster-a"}, false, nil
+		})
+		patches.ApplyFunc(isDatastoreAccessibleToCluster, func(ctx context.Context,
+			vc *cnsvsphere.VirtualCenter, clusterID, ds string) bool {
+			return true
+		})
+		patches.ApplyFunc(isDatastoreAccessibleToAZClusters,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+				azToClusters map[string][]string, ds string) bool {
+				return true
+			})
+		patches.ApplyFunc(constructCreateSpecForInstance, func(ctx context.Context,
+			r *ReconcileCnsRegisterVolume, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
+			host string, isTKGSHAEnabled bool) *cnstypes.CnsVolumeCreateSpec {
+			return &cnstypes.CnsVolumeCreateSpec{Name: "fake", VolumeType: "BLOCK"}
+		})
+		patches.ApplyFunc(getK8sStorageClassNameWithImmediateBindingModeForPolicy,
+			func(ctx context.Context, k8sClient kubernetes.Interface, c ctrlclient.Client,
+				storagePolicyID, namespace string, isPodVMOnStretchSupervisor bool) (string, error) {
+				return storageClassName, nil
+			})
+		patches.ApplyFunc(clearKeepAfterDeleteVmIfNonRemovable,
+			func(ctx context.Context, c ctrlclient.Client, vm cnsvolume.Manager,
+				pvc *corev1.PersistentVolumeClaim, namespace, volumeID string) error {
+				return nil
+			})
+		// Force topology validation to fail (simulates zone mismatch — the root cause of bug 3733250)
+		topologyMgr = &mockTopologyService{}
+		patches.ApplyFunc(validatePVCTopologyCompatibility,
+			func(ctx context.Context, k8sclient kubernetes.Interface, pvc *corev1.PersistentVolumeClaim,
+				datastoreURL string, topoMgr commoncotypes.ControllerTopologyService,
+				vc *cnsvsphere.VirtualCenter, datastoreAccessibleTopology []map[string]string) error {
+				return fmt.Errorf("topology conflict: zone mismatch")
+			})
+		patches.ApplyFunc(setInstanceError, func(ctx context.Context, r *ReconcileCnsRegisterVolume,
+			instance *cnsregistervolumev1alpha1.CnsRegisterVolume, msg string) {
+		})
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "disk-url-topo-test", Namespace: "test-ns"},
+		}
+		_, err := diskURLReconciler.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(unregCalled).To(BeTrue(),
+			"UnregisterVolume must be called for DiskURLPath when topology validation fails")
+		Expect(unregDiskArg).To(BeTrue(),
+			"unregDisk must be true so the FCD is demoted back to a plain VMDK")
+	})
 })
 
 var _ = Describe("checkExistingPVCDataSourceRef", func() {
@@ -3484,6 +3695,64 @@ func TestClearKeepAfterDeleteVm_PVCClaimNameMismatch_NoOp(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called when no VM volume matches the PVC")
+}
+
+// TestCleanupCNSVolume_DiskURLPath verifies that cleanupCNSVolume routes to
+// UnregisterVolume(unregDisk=true) for DiskURLPath registrations so the FCD is
+// demoted back to a plain VMDK.
+func TestCleanupCNSVolume_DiskURLPath(t *testing.T) {
+	ctx := context.Background()
+	var calledVolumeID string
+	var calledUnregDisk bool
+	mock := &mockVolumeManager{
+		unregisterVolume: func(_ context.Context, volumeID string, unregDisk bool) (string, error) {
+			calledVolumeID = volumeID
+			calledUnregDisk = unregDisk
+			return "", nil
+		},
+	}
+	r := &ReconcileCnsRegisterVolume{volumeManager: mock}
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			DiskURLPath: "https://vc/disk.vmdk",
+		},
+	}
+
+	err := r.cleanupCNSVolume(ctx, instance, "vol-disk-url")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "vol-disk-url", calledVolumeID)
+	assert.True(t, calledUnregDisk, "DiskURLPath cleanup must call UnregisterVolume with unregDisk=true")
+}
+
+// TestCleanupCNSVolume_VolumeID verifies that cleanupCNSVolume routes to
+// DeleteVolumeUtil(deleteDisk=false) for VolumeID registrations, preserving the FCD.
+func TestCleanupCNSVolume_VolumeID(t *testing.T) {
+	ctx := context.Background()
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			VolumeID: "existing-fcd-id",
+		},
+	}
+	mock := &mockVolumeManager{}
+	r := &ReconcileCnsRegisterVolume{volumeManager: mock}
+
+	var deletedVolumeID string
+	var deleteDisk bool
+	patches := gomonkey.ApplyFunc(common.DeleteVolumeUtil,
+		func(_ context.Context, _ cnsvolume.Manager, volumeID string, forceDelete bool) (string, error) {
+			deletedVolumeID = volumeID
+			deleteDisk = forceDelete
+			return "", nil
+		},
+	)
+	defer patches.Reset()
+
+	err := r.cleanupCNSVolume(ctx, instance, "existing-fcd-id")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "existing-fcd-id", deletedVolumeID)
+	assert.False(t, deleteDisk, "VolumeID cleanup must call DeleteVolumeUtil with deleteDisk=false")
 }
 
 func TestClearKeepAfterDeleteVm_AnnotationUpdateFailure_ReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary
CnsRegisterVolume supports registering both VMDKs(via disk path) and FCDs(via FCD ID). In the existing implementation, whenever the reconciler encounters an error during volume registration it ALWAYS falls back to untagging the CNS metadata leaving the FCD behind. 

For `VolumeID` registrations this is correct , but for `DiskURLPath` registrations the FCD was just promoted from a plain VMDK and must be demoted back via `UnregisterVolume(unregDisk=true)`. 

## Problem
The above behaviour breaks mobility operator's expectations that in case of failed volume registrations(or successful unregistration subsequently), the state of the disk should be reverted.

## Changes
This PR address this issue by looking at the CnsRegisterVolume spec to decide when to unregister a volume to FCD versus when to unregister a volume to a VMDK.

## Which issue this PR fixes
Internal Bug reported by mobility operator team.

## Testing
Manual testing on a WCP Supervisor cluster (vSAN datastore):
### Bug reproduction
- Created CnsRegisterVolume with `DiskURLPath` pointing to a 1GB test VMDK
- Induced failure via storage class mismatch (PVC storage class does not match the
  storage policy the VMDK maps to)
- FCD count increased by 1 after failure — orphaned FCD confirmed on the datastore
- Syncer logs confirmed `cns.tasks.deletevolume` called (wrong — `deleteDisk=false`)
### Fix verification
- Replaced the Syncer image with the fixed version
- Same failure scenario; FCD count did not increase — no leak
- Syncer logs confirmed `cns.tasks.unregistervolume` called with `unregisterDisk=true`
- Log: `"Successfully unregistered FCD" unregisterDisk=true`

## Precheckins
### [WCP](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1763/)
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```
### [VKS](https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1327/)
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```
### Vanilla
Not applicable as volume registration is a WCP functionality.

## Special notes for your reviewer
Introduces a behavioural change in error handling during failed volume registrations.

**Release note**:
```release-note
Fix CnsRegisterVolume error-path cleanup for DiskURLPath registrations
```
