### PR TITLE
fix capability name for supports_per_namespace_network_provider

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -609,7 +609,7 @@ const (
 	SupportsExposingStoragePolicyAttributes = "supports_exposing_storage_policy_attributes"
 	// SupportsPerNamespaceNetworkProviders is a WCP capability indicating that network provider
 	// is resolved per namespace (NetworkSettings CR) rather than from the global wcp-network-config.
-	SupportsPerNamespaceNetworkProviders = "supports_per_namespace_network_providers"
+	SupportsPerNamespaceNetworkProviders = "supports_per_namespace_network_provider"
 
 	// SupervisorPVCWorkloadTypeAnnotation is the FSS that gates
 	// annotateSupervisorPVCsWithWorkloadType (see pkg/syncer/fullsync.go).

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -108,7 +108,7 @@ var (
 	// When false, ControllerModifyVolume returns Unimplemented and MODIFY_VOLUME is not advertised
 	// in ControllerGetCapabilities.
 	isVMPVCStoragePolicyMutabilityEnabled bool
-	// isPerNamespaceNetworkProvidersFSSEnabled is true when the supports_per_namespace_network_providers
+	// isPerNamespaceNetworkProvidersFSSEnabled is true when the supports_per_namespace_network_provider
 	// capability is enabled on the supervisor; when true, FVS routing reads the namespace-scoped
 	// NetworkSettings CR per CreateVolume call instead of consulting the cached global provider.
 	isPerNamespaceNetworkProvidersFSSEnabled bool
@@ -242,7 +242,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		} else {
 			cachedGlobalNetworkProvider = np
 			log.Infof("cached global network provider %q from wcp-network-config "+
-				"(supports_per_namespace_network_providers capability disabled)", cachedGlobalNetworkProvider)
+				"(supports_per_namespace_network_provider capability disabled)", cachedGlobalNetworkProvider)
 		}
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
 			cnstypes.CnsClusterFlavorWorkload, common.SupportsPerNamespaceNetworkProviders, "", "")

--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -695,7 +695,7 @@ func (c *controller) expandFileVolumeViaFVS(ctx context.Context, req *csi.Contro
 //
 // The reserved vsan-file-service-policy / vsan-file-service-policy-latebinding storage classes
 // require the NSX_VPC network provider. The provider is resolved either per-namespace (from the
-// PVC namespace's NetworkSettings CR) when supports_per_namespace_network_providers is on, or from
+// PVC namespace's NetworkSettings CR) when supports_per_namespace_network_provider is on, or from
 // the cached global wcp-network-config value resolved once at controller.Init when the per-
 // namespace capability is off. Non-reserved storage classes return useFVS=false without consulting
 // the network provider.
@@ -720,7 +720,7 @@ func shouldProvisionVsanFileVolumeViaFVS(ctx context.Context, dc dynamic.Interfa
 }
 
 // resolveNetworkProviderForFVS reads the per-namespace NetworkSettings CR when
-// supports_per_namespace_network_providers is on, otherwise returns the global provider value
+// supports_per_namespace_network_provider is on, otherwise returns the global provider value
 // cached during controller.Init (no per-call wcp-network-config read).
 func resolveNetworkProviderForFVS(ctx context.Context, dc dynamic.Interface,
 	pvcNamespace string) (string, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixed the capability name string supports_per_namespace_network_providers → supports_per_namespace_network_provider in constants.go, controller.go, and fvs_filevolume.go (constant value and matching comments); 

**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1766/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix capability name for supports_per_namespace_network_provider
```
