### PR TITLE
Use VAC's storage policy for BYOK encryption tracking

### DIFF
--- a/pkg/common/cns-lib/crypto/client.go
+++ b/pkg/common/cns-lib/crypto/client.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,6 +47,8 @@ type Client interface {
 	IsEncryptedStorageProfile(ctx context.Context, profileID string) (bool, error)
 	// MarkEncryptedStorageClass records the provided StorageClass as encrypted.
 	MarkEncryptedStorageClass(ctx context.Context, storageClass *storagev1.StorageClass, encrypted bool) error
+	// MarkEncryptedVAC records the provided VolumeAttributesClass as encrypted.
+	MarkEncryptedVAC(ctx context.Context, vac *storagev1.VolumeAttributesClass, encrypted bool) error
 	// GetEncryptionClass retrieves the encryption class associated with a specific name
 	// and namespace.
 	GetEncryptionClass(ctx context.Context, name, namespace string) (*byokv1.EncryptionClass, error)
@@ -111,14 +114,33 @@ func (c *defaultClient) IsEncryptedStorageClass(ctx context.Context, name string
 }
 
 func (c *defaultClient) IsEncryptedStorageProfile(ctx context.Context, profileID string) (bool, error) {
-	var obj storagev1.StorageClassList
-	if err := c.Client.List(ctx, &obj); err != nil {
+	var scList storagev1.StorageClassList
+	if err := c.Client.List(ctx, &scList); err != nil {
 		return false, err
 	}
 
-	for i := range obj.Items {
-		if pid := GetStoragePolicyID(&obj.Items[i]); pid == profileID {
-			ok, _, err := c.isEncryptedStorageClass(ctx, &obj.Items[i])
+	for i := range scList.Items {
+		if pid := GetStoragePolicyID(&scList.Items[i]); pid == profileID {
+			ok, _, err := c.isEncryptedStorageClass(ctx, &scList.Items[i])
+			return ok, err
+		}
+	}
+
+	// No StorageClass references this policy; it may still be referenced exclusively by a
+	// VolumeAttributesClass, so fall back to scanning those.
+	var vacList storagev1.VolumeAttributesClassList
+	if err := c.Client.List(ctx, &vacList); err != nil {
+		// Clusters older than 1.34 don't serve the VolumeAttributesClass API at all; treat
+		// that the same as "no VAC references this policy" instead of failing the lookup.
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	for i := range vacList.Items {
+		if pid := GetStoragePolicyIDFromVAC(&vacList.Items[i]); pid == profileID {
+			ok, _, err := c.isEncryptedVAC(ctx, &vacList.Items[i])
 			return ok, err
 		}
 	}
@@ -202,6 +224,102 @@ func (c *defaultClient) MarkEncryptedStorageClass(
 
 	// Patch the ConfigMap with the change.
 	return c.Client.Patch(ctx, &obj, objPatch)
+}
+
+func (c *defaultClient) MarkEncryptedVAC(
+	ctx context.Context,
+	vac *storagev1.VolumeAttributesClass,
+	encrypted bool) error {
+
+	log := logger.GetLogger(ctx)
+
+	var (
+		obj = corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.csiNamespace,
+				Name:      internal.EncryptedStorageClassNamesConfigMapName,
+			},
+		}
+		ownerRef = internal.GetOwnerRefForVAC(vac)
+	)
+
+	// Get the ConfigMap.
+	err := c.Client.Get(ctx, ctrlclient.ObjectKeyFromObject(&obj), &obj)
+
+	if err != nil {
+		// Return any error other than 404.
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		// The ConfigMap was not found.
+		if !encrypted {
+			// If the goal is to mark the VAC as not encrypted, then we do not need
+			// to actually create the underlying ConfigMap if it does not exist.
+			return nil
+		}
+
+		// The ConfigMap does not already exist and the goal is to mark the VAC as
+		// encrypted, so go ahead and create the ConfigMap and return early.
+		log.Infof("Creating config map %s for storing references to VolumeAttributesClasses "+
+			"with encryption capabilities",
+			internal.EncryptedStorageClassNamesConfigMapName)
+		obj.OwnerReferences = []metav1.OwnerReference{ownerRef}
+		return c.Client.Create(ctx, &obj)
+	}
+
+	// The ConfigMap already exists, so check if it needs to be updated.
+	vacIsOwner := slices.Contains(obj.OwnerReferences, ownerRef)
+
+	if encrypted == vacIsOwner {
+		// The desired state (encrypted) already matches the current state (vacIsOwner):
+		// either the VAC should be encrypted and already is in the ConfigMap, or it should
+		// not be encrypted and already isn't. Either way, there's nothing to do.
+		return nil
+	}
+
+	// Create the patch used to update the ConfigMap.
+	objPatch := ctrlclient.StrategicMergeFrom(obj.DeepCopyObject().(ctrlclient.Object))
+	if encrypted {
+		// Add the VAC as an owner of the ConfigMap.
+		log.Infof("Marking VolumeAttributesClass %s as encrypted", vac.Name)
+		obj.OwnerReferences = append(obj.OwnerReferences, ownerRef)
+	} else {
+		// Remove the VAC as an owner of the ConfigMap.
+		log.Infof("Unmarking VolumeAttributesClass %s as encrypted", vac.Name)
+		obj.OwnerReferences = slices.DeleteFunc(
+			obj.OwnerReferences,
+			func(o metav1.OwnerReference) bool { return o == ownerRef })
+	}
+
+	// Patch the ConfigMap with the change.
+	return c.Client.Patch(ctx, &obj, objPatch)
+}
+
+func (c *defaultClient) isEncryptedVAC(
+	ctx context.Context,
+	vac *storagev1.VolumeAttributesClass,
+) (bool, string, error) {
+	var (
+		obj    corev1.ConfigMap
+		objKey = ctrlclient.ObjectKey{
+			Namespace: c.csiNamespace,
+			Name:      internal.EncryptedStorageClassNamesConfigMapName,
+		}
+		ownerRef = internal.GetOwnerRefForVAC(vac)
+	)
+
+	if err := c.Client.Get(ctx, objKey, &obj); err != nil {
+		return false, "", ctrlclient.IgnoreNotFound(err)
+	}
+
+	if slices.Contains(obj.OwnerReferences, ownerRef) {
+		if profileID := GetStoragePolicyIDFromVAC(vac); profileID != "" {
+			return true, profileID, nil
+		}
+	}
+
+	return false, "", nil
 }
 
 func (c *defaultClient) isEncryptedStorageClass(

--- a/pkg/common/cns-lib/crypto/client_test.go
+++ b/pkg/common/cns-lib/crypto/client_test.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/crypto/internal"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
+)
+
+const testCSINamespace = "vmware-system-csi"
+
+func testCryptoScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme, err := NewK8sScheme()
+	require.NoError(t, err)
+	return scheme
+}
+
+// listErrorClient wraps a ctrlclient.Client and forces List calls for a given object list type
+// to fail with a fixed error, to simulate the target API not being served by the API server
+// (e.g. VolumeAttributesClass on a pre-1.34 cluster).
+type listErrorClient struct {
+	ctrlclient.Client
+	errsByType map[reflect.Type]error
+}
+
+func (c *listErrorClient) List(ctx context.Context, list ctrlclient.ObjectList, opts ...ctrlclient.ListOption) error {
+	if err, ok := c.errsByType[reflect.TypeOf(list)]; ok {
+		return err
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+
+func noMatchErrorForVACList() error {
+	return &meta.NoResourceMatchError{
+		PartialResource: schema.GroupVersionResource{
+			Group: "storage.k8s.io", Version: "v1", Resource: "volumeattributesclasses",
+		},
+	}
+}
+
+func TestIsEncryptedStorageProfile(t *testing.T) {
+	scheme := testCryptoScheme(t)
+
+	encryptedSC := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: "encrypted-sc", UID: types.UID("sc-uid-1")},
+		Provisioner: csitypes.Name,
+		Parameters:  map[string]string{"storagepolicyid": "profile-encrypted-sc"},
+	}
+	plainSC := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: "plain-sc", UID: types.UID("sc-uid-2")},
+		Provisioner: csitypes.Name,
+		Parameters:  map[string]string{"storagepolicyid": "profile-plain-sc"},
+	}
+	encryptedVAC := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "encrypted-vac", UID: types.UID("vac-uid-1")},
+		Parameters: map[string]string{"storagePolicyID": "profile-vac-only"},
+	}
+
+	newConfigMapMarkingEncrypted := func(refs ...metav1.OwnerReference) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            internal.EncryptedStorageClassNamesConfigMapName,
+				Namespace:       testCSINamespace,
+				OwnerReferences: refs,
+			},
+		}
+	}
+
+	t.Run("MatchesEncryptedStorageClass", func(t *testing.T) {
+		cm := newConfigMapMarkingEncrypted(internal.GetOwnerRefForStorageClass(encryptedSC))
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(encryptedSC, plainSC, cm).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		ok, err := c.IsEncryptedStorageProfile(context.Background(), "profile-encrypted-sc")
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("MatchesNonEncryptedStorageClass", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(encryptedSC, plainSC).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		ok, err := c.IsEncryptedStorageProfile(context.Background(), "profile-plain-sc")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("FallsBackToVACWhenNoStorageClassMatches", func(t *testing.T) {
+		cm := newConfigMapMarkingEncrypted(internal.GetOwnerRefForVAC(encryptedVAC))
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(encryptedSC, plainSC, encryptedVAC, cm).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		ok, err := c.IsEncryptedStorageProfile(context.Background(), "profile-vac-only")
+		require.NoError(t, err)
+		assert.True(t, ok, "profile referenced only by a VAC must still be reported as encrypted")
+	})
+
+	t.Run("NoMatchAnywhere", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(encryptedSC, plainSC, encryptedVAC).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		ok, err := c.IsEncryptedStorageProfile(context.Background(), "profile-does-not-exist")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("VACAPINotServedIsTreatedAsNoMatch", func(t *testing.T) {
+		// Simulate a pre-1.34 cluster where the VolumeAttributesClass API isn't served:
+		// listing it fails with a RESTMapper "no match" error. This must be treated the
+		// same as "no VAC references this policy", not propagated as a hard error.
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(encryptedSC, plainSC).Build()
+		wrapped := &listErrorClient{
+			Client: fakeClient,
+			errsByType: map[reflect.Type]error{
+				reflect.TypeOf(&storagev1.VolumeAttributesClassList{}): noMatchErrorForVACList(),
+			},
+		}
+		c := &defaultClient{Client: wrapped, csiNamespace: testCSINamespace}
+
+		ok, err := c.IsEncryptedStorageProfile(context.Background(), "profile-vac-only")
+		require.NoError(t, err, "VAC API unavailability must not surface as an error")
+		assert.False(t, ok)
+	})
+
+	t.Run("OtherVACListErrorsStillPropagate", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(encryptedSC, plainSC).Build()
+		wrapped := &listErrorClient{
+			Client: fakeClient,
+			errsByType: map[reflect.Type]error{
+				reflect.TypeOf(&storagev1.VolumeAttributesClassList{}): assertErr,
+			},
+		}
+		c := &defaultClient{Client: wrapped, csiNamespace: testCSINamespace}
+
+		_, err := c.IsEncryptedStorageProfile(context.Background(), "profile-vac-only")
+		assert.ErrorIs(t, err, assertErr)
+	})
+}
+
+var assertErr = &genericTestError{"boom"}
+
+type genericTestError struct{ msg string }
+
+func (e *genericTestError) Error() string { return e.msg }
+
+func TestMarkEncryptedVAC(t *testing.T) {
+	scheme := testCryptoScheme(t)
+	vac := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-vac", UID: types.UID("vac-uid")},
+	}
+	ownerRef := internal.GetOwnerRefForVAC(vac)
+
+	t.Run("ConfigMapMissingMarkEncryptedCreatesIt", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		require.NoError(t, c.MarkEncryptedVAC(context.Background(), vac, true))
+
+		var cm corev1.ConfigMap
+		require.NoError(t, fakeClient.Get(context.Background(),
+			ctrlclient.ObjectKey{Namespace: testCSINamespace, Name: internal.EncryptedStorageClassNamesConfigMapName}, &cm))
+		assert.Contains(t, cm.OwnerReferences, ownerRef)
+	})
+
+	t.Run("ConfigMapMissingMarkNotEncryptedIsNoOp", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		require.NoError(t, c.MarkEncryptedVAC(context.Background(), vac, false))
+
+		var cm corev1.ConfigMap
+		err := fakeClient.Get(context.Background(),
+			ctrlclient.ObjectKey{Namespace: testCSINamespace, Name: internal.EncryptedStorageClassNamesConfigMapName}, &cm)
+		assert.True(t, apierrors.IsNotFound(err),
+			"ConfigMap should not be created just to mark something as not-encrypted")
+	})
+
+	t.Run("ConfigMapExistsAddsOwnerRef", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: internal.EncryptedStorageClassNamesConfigMapName, Namespace: testCSINamespace},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		require.NoError(t, c.MarkEncryptedVAC(context.Background(), vac, true))
+
+		var got corev1.ConfigMap
+		require.NoError(t, fakeClient.Get(context.Background(), ctrlclient.ObjectKeyFromObject(cm), &got))
+		assert.Contains(t, got.OwnerReferences, ownerRef)
+	})
+
+	t.Run("ConfigMapExistsAlreadyOwnerMarkEncryptedIsNoOp", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: internal.EncryptedStorageClassNamesConfigMapName, Namespace: testCSINamespace,
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		require.NoError(t, c.MarkEncryptedVAC(context.Background(), vac, true))
+
+		var got corev1.ConfigMap
+		require.NoError(t, fakeClient.Get(context.Background(), ctrlclient.ObjectKeyFromObject(cm), &got))
+		assert.Len(t, got.OwnerReferences, 1)
+	})
+
+	t.Run("ConfigMapExistsRemovesOwnerRefWhenNotEncrypted", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: internal.EncryptedStorageClassNamesConfigMapName, Namespace: testCSINamespace,
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		require.NoError(t, c.MarkEncryptedVAC(context.Background(), vac, false))
+
+		var got corev1.ConfigMap
+		require.NoError(t, fakeClient.Get(context.Background(), ctrlclient.ObjectKeyFromObject(cm), &got))
+		assert.NotContains(t, got.OwnerReferences, ownerRef)
+	})
+
+	t.Run("ConfigMapExistsNotOwnerMarkNotEncryptedIsNoOp", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: internal.EncryptedStorageClassNamesConfigMapName, Namespace: testCSINamespace},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		require.NoError(t, c.MarkEncryptedVAC(context.Background(), vac, false))
+
+		var got corev1.ConfigMap
+		require.NoError(t, fakeClient.Get(context.Background(), ctrlclient.ObjectKeyFromObject(cm), &got))
+		assert.Empty(t, got.OwnerReferences)
+	})
+}
+
+func TestIsEncryptedVAC(t *testing.T) {
+	scheme := testCryptoScheme(t)
+	vacWithPolicy := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-vac", UID: types.UID("vac-uid")},
+		Parameters: map[string]string{"storagePolicyID": "profile-1"},
+	}
+	vacWithoutPolicy := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-policy-vac", UID: types.UID("vac-uid-2")},
+	}
+
+	t.Run("ConfigMapMissing", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		ok, profileID, err := c.isEncryptedVAC(context.Background(), vacWithPolicy)
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Empty(t, profileID)
+	})
+
+	t.Run("VACIsOwnerWithPolicyID", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: internal.EncryptedStorageClassNamesConfigMapName, Namespace: testCSINamespace,
+				OwnerReferences: []metav1.OwnerReference{internal.GetOwnerRefForVAC(vacWithPolicy)},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		ok, profileID, err := c.isEncryptedVAC(context.Background(), vacWithPolicy)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, "profile-1", profileID)
+	})
+
+	t.Run("VACIsOwnerButHasNoPolicyIDParam", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: internal.EncryptedStorageClassNamesConfigMapName, Namespace: testCSINamespace,
+				OwnerReferences: []metav1.OwnerReference{internal.GetOwnerRefForVAC(vacWithoutPolicy)},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		ok, _, err := c.isEncryptedVAC(context.Background(), vacWithoutPolicy)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("VACNotOwner", func(t *testing.T) {
+		other := &storagev1.VolumeAttributesClass{ObjectMeta: metav1.ObjectMeta{Name: "other", UID: types.UID("other-uid")}}
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: internal.EncryptedStorageClassNamesConfigMapName, Namespace: testCSINamespace,
+				OwnerReferences: []metav1.OwnerReference{internal.GetOwnerRefForVAC(other)},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+		c := &defaultClient{Client: fakeClient, csiNamespace: testCSINamespace}
+
+		ok, _, err := c.isEncryptedVAC(context.Background(), vacWithPolicy)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/pkg/common/cns-lib/crypto/internal/volumeattributesclass.go
+++ b/pkg/common/cns-lib/crypto/internal/volumeattributesclass.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// VolumeAttributesClassKind is the kind for a VolumeAttributesClass resource.
+	VolumeAttributesClassKind = "VolumeAttributesClass"
+
+	// VolumeAttributesClassGroupVersion is the API group and version for a
+	// VolumeAttributesClass resource.
+	VolumeAttributesClassGroupVersion = StorageClassGroup + "/v1"
+)
+
+// GetOwnerRefForVAC returns an OwnerRef for the provided VolumeAttributesClass. It is
+// recorded on the same ConfigMap as GetOwnerRefForStorageClass, distinguished by Kind, so
+// existing consumers that filter owner refs by StorageClassKind are unaffected.
+func GetOwnerRefForVAC(vac *storagev1.VolumeAttributesClass) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: VolumeAttributesClassGroupVersion,
+		Kind:       VolumeAttributesClassKind,
+		Name:       vac.Name,
+		UID:        vac.UID,
+	}
+}

--- a/pkg/common/cns-lib/crypto/internal/volumeattributesclass_test.go
+++ b/pkg/common/cns-lib/crypto/internal/volumeattributesclass_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestGetOwnerRefForVAC(t *testing.T) {
+	vac := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-vac",
+			UID:  types.UID("11111111-2222-3333-4444-555555555555"),
+		},
+	}
+
+	ref := GetOwnerRefForVAC(vac)
+
+	assert.Equal(t, VolumeAttributesClassKind, ref.Kind)
+	assert.Equal(t, VolumeAttributesClassGroupVersion, ref.APIVersion)
+	assert.Equal(t, "my-vac", ref.Name)
+	assert.Equal(t, types.UID("11111111-2222-3333-4444-555555555555"), ref.UID)
+
+	// The VAC owner ref must be distinguishable by Kind from a StorageClass owner ref on the
+	// same shared ConfigMap, so external consumers filtering by Kind=="StorageClass" (e.g.
+	// vm-operator's GetEncryptedStorageClassRefs) transparently ignore VAC entries.
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-vac", UID: types.UID("11111111-2222-3333-4444-555555555555")},
+	}
+	scRef := GetOwnerRefForStorageClass(sc)
+	assert.NotEqual(t, scRef.Kind, ref.Kind)
+}

--- a/pkg/common/cns-lib/crypto/util.go
+++ b/pkg/common/cns-lib/crypto/util.go
@@ -67,3 +67,32 @@ func GetStoragePolicyID(sc *storagev1.StorageClass) string {
 	}
 	return ""
 }
+
+// GetStoragePolicyIDFromVAC retrieves the storage policy ID associated with the
+// provided VolumeAttributesClass.
+func GetStoragePolicyIDFromVAC(vac *storagev1.VolumeAttributesClass) string {
+	// vSphere CSI supports case insensitive parameters.
+	for key, value := range vac.Parameters {
+		if strings.ToLower(key) == internal.StorageClassAttributeStoragePolicyID {
+			return value
+		}
+	}
+	return ""
+}
+
+// IsVACPolicyEffective returns true if the PVC's VolumeAttributesClassName is set and
+// its policy has actually taken effect on the underlying volume. A non-nil
+// pvc.Status.ModifyVolumeStatus means a ModifyVolume operation is still pending or in
+// progress, so the volume may still be backed by its previous (StorageClass) policy —
+// callers should keep using the StorageClass's policy until this returns true.
+//
+// ModifyVolumeStatus == nil alone is not sufficient: it is also the initial PVC state
+// before any modify has ever been attempted. Only treat the VAC as effective once
+// CurrentVolumeAttributesClassName has actually caught up to the target VAC.
+func IsVACPolicyEffective(pvc *corev1.PersistentVolumeClaim) bool {
+	if pvc.Spec.VolumeAttributesClassName == nil || pvc.Status.ModifyVolumeStatus != nil {
+		return false
+	}
+	return pvc.Status.CurrentVolumeAttributesClassName != nil &&
+		*pvc.Status.CurrentVolumeAttributesClassName == *pvc.Spec.VolumeAttributesClassName
+}

--- a/pkg/common/cns-lib/crypto/util_test.go
+++ b/pkg/common/cns-lib/crypto/util_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+)
+
+func TestGetStoragePolicyIDFromVAC(t *testing.T) {
+	t.Run("CamelCaseKey", func(t *testing.T) {
+		vac := &storagev1.VolumeAttributesClass{
+			Parameters: map[string]string{"storagePolicyID": "policy-123"},
+		}
+		assert.Equal(t, "policy-123", GetStoragePolicyIDFromVAC(vac))
+	})
+
+	t.Run("CaseInsensitiveKey", func(t *testing.T) {
+		vac := &storagev1.VolumeAttributesClass{
+			Parameters: map[string]string{"STORAGEPOLICYID": "policy-456"},
+		}
+		assert.Equal(t, "policy-456", GetStoragePolicyIDFromVAC(vac))
+	})
+
+	t.Run("NoParameters", func(t *testing.T) {
+		vac := &storagev1.VolumeAttributesClass{}
+		assert.Empty(t, GetStoragePolicyIDFromVAC(vac))
+	})
+
+	t.Run("UnrelatedParameters", func(t *testing.T) {
+		vac := &storagev1.VolumeAttributesClass{
+			Parameters: map[string]string{"otherParam": "value"},
+		}
+		assert.Empty(t, GetStoragePolicyIDFromVAC(vac))
+	})
+}
+
+func TestIsVACPolicyEffective(t *testing.T) {
+	vacName := "encrypted-vac"
+	otherVACName := "other-vac"
+
+	t.Run("NoVACSet", func(t *testing.T) {
+		pvc := &corev1.PersistentVolumeClaim{}
+		assert.False(t, IsVACPolicyEffective(pvc))
+	})
+
+	t.Run("ModifyVolumeInProgress", func(t *testing.T) {
+		pvc := &corev1.PersistentVolumeClaim{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeAttributesClassName: &vacName,
+			},
+			Status: corev1.PersistentVolumeClaimStatus{
+				ModifyVolumeStatus: &corev1.ModifyVolumeStatus{
+					TargetVolumeAttributesClassName: vacName,
+					Status:                          corev1.PersistentVolumeClaimModifyVolumeInProgress,
+				},
+			},
+		}
+		assert.False(t, IsVACPolicyEffective(pvc), "VAC must not be trusted while a modify is in flight")
+	})
+
+	t.Run("InitialStateNeverModified", func(t *testing.T) {
+		// ModifyVolumeStatus == nil is also the initial PVC state before any modify has
+		// ever been attempted (e.g. a PVC created with a VAC set at creation time before
+		// the provisioner/resizer has populated CurrentVolumeAttributesClassName). This is
+		// the exact regression the fix addresses: nil ModifyVolumeStatus alone is not proof
+		// the VAC is in effect.
+		pvc := &corev1.PersistentVolumeClaim{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeAttributesClassName: &vacName,
+			},
+		}
+		assert.False(t, IsVACPolicyEffective(pvc))
+	})
+
+	t.Run("CurrentVACDoesNotMatchTarget", func(t *testing.T) {
+		current := otherVACName
+		pvc := &corev1.PersistentVolumeClaim{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeAttributesClassName: &vacName,
+			},
+			Status: corev1.PersistentVolumeClaimStatus{
+				CurrentVolumeAttributesClassName: &current,
+			},
+		}
+		assert.False(t, IsVACPolicyEffective(pvc))
+	})
+
+	t.Run("ModifyCompletedAndCurrentMatchesTarget", func(t *testing.T) {
+		current := vacName
+		pvc := &corev1.PersistentVolumeClaim{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeAttributesClassName: &vacName,
+			},
+			Status: corev1.PersistentVolumeClaimStatus{
+				CurrentVolumeAttributesClassName: &current,
+			},
+		}
+		assert.True(t, IsVACPolicyEffective(pvc))
+	})
+}

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -295,6 +295,12 @@ func (m *MockCryptoClient) MarkEncryptedStorageClass(ctx context.Context,
 	return args.Error(0)
 }
 
+func (m *MockCryptoClient) MarkEncryptedVAC(ctx context.Context,
+	vac *storagev1.VolumeAttributesClass, encrypted bool) error {
+	args := m.Called(ctx, vac, encrypted)
+	return args.Error(0)
+}
+
 func (m *MockCryptoClient) GetEncryptionClass(ctx context.Context,
 	name, namespace string) (*byokv1.EncryptionClass, error) {
 	args := m.Called(ctx, name, namespace)

--- a/pkg/syncer/byokoperator/controller/controller.go
+++ b/pkg/syncer/byokoperator/controller/controller.go
@@ -19,10 +19,15 @@ package controller
 import (
 	"context"
 
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/persistentvolumeclaim"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/storageclass"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/volumeattributesclass"
 )
 
 var addToManagerFuncs = []func(ctx context.Context, mgr manager.Manager, opts common.Options) error{
@@ -36,5 +41,40 @@ func AddToManager(ctx context.Context, mgr manager.Manager, opts common.Options)
 			return err
 		}
 	}
+
+	// The VolumeAttributesClass API is only present on K8s 1.34+ clusters; registering a watch
+	// for it on older clusters would fail since the API server does not serve the resource.
+	if available, err := volumeAttributesClassAPIAvailable(mgr.GetConfig()); err != nil {
+		return err
+	} else if available {
+		if err := volumeattributesclass.AddToManager(ctx, mgr, opts); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// volumeAttributesClassAPIAvailable checks whether the VolumeAttributesClass API is served by
+// the API server the given REST config points to. It queries discovery for just the
+// storage.k8s.io/v1 group/version instead of ServerGroupsAndResources(), which would perform a
+// full discovery of every group/resource on the cluster.
+func volumeAttributesClassAPIAvailable(cfg *rest.Config) (bool, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return false, err
+	}
+	resources, err := dc.ServerResourcesForGroupVersion(storagev1.SchemeGroupVersion.String())
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for i := range resources.APIResources {
+		if resources.APIResources[i].Name == "volumeattributesclasses" {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/syncer/byokoperator/controller/controller_test.go
+++ b/pkg/syncer/byokoperator/controller/controller_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+// newDiscoveryTestServer stubs just the storage.k8s.io/v1 discovery endpoint that
+// volumeAttributesClassAPIAvailable queries via ServerResourcesForGroupVersion.
+func newDiscoveryTestServer(t *testing.T, includeVAC bool) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/apis/storage.k8s.io/v1", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		verbs := []string{"create", "delete", "get", "list", "patch", "update", "watch"}
+		list := &metav1.APIResourceList{
+			GroupVersion: storagev1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "storageclasses", Namespaced: false, Kind: "StorageClass", Verbs: verbs},
+			},
+		}
+		if includeVAC {
+			list.APIResources = append(list.APIResources, metav1.APIResource{
+				Name: "volumeattributesclasses", Namespaced: false, Kind: "VolumeAttributesClass", Verbs: verbs,
+			})
+		}
+		payload, err := json.Marshal(list)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(payload)
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestVolumeAttributesClassAPIAvailable(t *testing.T) {
+	t.Run("VolumeAttributesClassesPresent", func(t *testing.T) {
+		srv := newDiscoveryTestServer(t, true)
+		t.Cleanup(srv.Close)
+
+		ok, err := volumeAttributesClassAPIAvailable(&rest.Config{Host: srv.URL})
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("VolumeAttributesClassesAbsent", func(t *testing.T) {
+		srv := newDiscoveryTestServer(t, false)
+		t.Cleanup(srv.Close)
+
+		ok, err := volumeAttributesClassAPIAvailable(&rest.Config{Host: srv.URL})
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("GroupVersionNotFound", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/apis/storage.k8s.io/v1", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+
+		ok, err := volumeAttributesClassAPIAvailable(&rest.Config{Host: srv.URL})
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller.go
+++ b/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller.go
@@ -27,6 +27,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/crypto"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	ctrlcommoon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/common"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
@@ -87,7 +89,7 @@ func (r *reconciler) reconcileNormal(ctx context.Context, pvc *corev1.Persistent
 		return nil
 	}
 
-	encrypted, profileID, err := r.cryptoClient.IsEncryptedStorageClass(ctx, *pvc.Spec.StorageClassName)
+	encrypted, profileID, err := r.isEncryptedStoragePolicyForPVC(ctx, pvc)
 	if err != nil {
 		return err
 	} else if !encrypted {
@@ -159,6 +161,40 @@ func (r *reconciler) reconcileNormal(ctx context.Context, pvc *corev1.Persistent
 	}
 
 	return r.volumeManager.UpdateVolumeCrypto(ctx, updateSpec)
+}
+
+// isEncryptedStoragePolicyForPVC determines whether the storage policy currently backing
+// the PVC's volume supports encryption. If the PVC's VolumeAttributesClass has taken effect
+// (crypto.IsVACPolicyEffective), its policy takes precedence over the StorageClass's, consistent
+// with CSI ModifyVolume semantics. Otherwise the StorageClass's policy is used, since a
+// ModifyVolume switching the PVC to the VAC's policy may still be pending or in progress.
+func (r *reconciler) isEncryptedStoragePolicyForPVC(
+	ctx context.Context,
+	pvc *corev1.PersistentVolumeClaim,
+) (bool, string, error) {
+	// VAC-based storage-policy mutability is gated behind this capability; when it's disabled,
+	// keep the pre-existing StorageClass-only behavior intact rather than assuming VAC support.
+	// Checked after the (pvc.Spec.VolumeAttributesClassName != nil) condition inside
+	// IsVACPolicyEffective's callers below via short-circuit evaluation, so PVCs with no VAC set
+	// never need to consult the capability at all.
+	if pvc.Spec.VolumeAttributesClassName != nil &&
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, csicommon.VMPVCStoragePolicyMutability) &&
+		crypto.IsVACPolicyEffective(pvc) {
+		vac := &storagev1.VolumeAttributesClass{}
+		if err := r.Get(ctx, client.ObjectKey{Name: *pvc.Spec.VolumeAttributesClassName}, vac); err != nil {
+			return false, "", client.IgnoreNotFound(err)
+		}
+
+		profileID := crypto.GetStoragePolicyIDFromVAC(vac)
+		if profileID == "" {
+			return false, "", nil
+		}
+
+		encrypted, err := r.cryptoClient.IsEncryptedStorageProfile(ctx, profileID)
+		return encrypted, profileID, err
+	}
+
+	return r.cryptoClient.IsEncryptedStorageClass(ctx, *pvc.Spec.StorageClassName)
 }
 
 func (r *reconciler) findEncryptionClass(

--- a/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
+++ b/pkg/syncer/byokoperator/controller/persistentvolumeclaim/persistentvolumeclaim_controller_test.go
@@ -21,12 +21,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	byokv1 "github.com/vmware-tanzu/vm-operator/external/byok/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
@@ -35,8 +41,76 @@ import (
 func createTestScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
 	_ = vmoperatortypes.AddToScheme(scheme)
 	return scheme
+}
+
+// setVACSupportForTest points commonco.ContainerOrchestratorUtility at a fake orchestrator
+// with VMPVCStoragePolicyMutability set to the given state, restoring the previous value (nil,
+// in these tests) on cleanup so other tests aren't affected.
+func setVACSupportForTest(t *testing.T, enabled bool) {
+	t.Helper()
+	previous := commonco.ContainerOrchestratorUtility
+	t.Cleanup(func() { commonco.ContainerOrchestratorUtility = previous })
+
+	fakeCO, err := unittestcommon.GetFakeContainerOrchestratorInterface(csicommon.Kubernetes)
+	require.NoError(t, err)
+	if enabled {
+		require.NoError(t, fakeCO.EnableFSS(context.Background(), csicommon.VMPVCStoragePolicyMutability))
+	}
+	commonco.ContainerOrchestratorUtility = fakeCO
+}
+
+// fakeCryptoClient is a minimal stand-in for crypto.Client that records the arguments it was
+// called with and returns canned results, scoped to what isEncryptedStoragePolicyForPVC needs
+// (IsEncryptedStorageClass / IsEncryptedStorageProfile). The remaining crypto.Client methods
+// are not exercised by these tests and return zero values.
+type fakeCryptoClient struct {
+	client.Client
+
+	isEncryptedStorageClassResult  bool
+	isEncryptedStorageClassProfile string
+	isEncryptedStorageClassErr     error
+	storageClassCalledWith         string
+	storageClassCallCount          int
+
+	isEncryptedProfileResult bool
+	isEncryptedProfileErr    error
+	profileCalledWith        string
+	profileCallCount         int
+}
+
+func (f *fakeCryptoClient) IsEncryptedStorageClass(_ context.Context, name string) (bool, string, error) {
+	f.storageClassCalledWith = name
+	f.storageClassCallCount++
+	return f.isEncryptedStorageClassResult, f.isEncryptedStorageClassProfile, f.isEncryptedStorageClassErr
+}
+
+func (f *fakeCryptoClient) IsEncryptedStorageProfile(_ context.Context, profileID string) (bool, error) {
+	f.profileCalledWith = profileID
+	f.profileCallCount++
+	return f.isEncryptedProfileResult, f.isEncryptedProfileErr
+}
+
+func (f *fakeCryptoClient) MarkEncryptedStorageClass(context.Context, *storagev1.StorageClass, bool) error {
+	return nil
+}
+
+func (f *fakeCryptoClient) MarkEncryptedVAC(context.Context, *storagev1.VolumeAttributesClass, bool) error {
+	return nil
+}
+
+func (f *fakeCryptoClient) GetEncryptionClass(context.Context, string, string) (*byokv1.EncryptionClass, error) {
+	return nil, nil
+}
+
+func (f *fakeCryptoClient) GetDefaultEncryptionClass(context.Context, string) (*byokv1.EncryptionClass, error) {
+	return nil, nil
+}
+
+func (f *fakeCryptoClient) GetEncryptionClassForPVC(context.Context, string, string) (*byokv1.EncryptionClass, error) {
+	return nil, nil
 }
 
 // TestFindVolume tests the findVolume function
@@ -267,4 +341,210 @@ func TestIsPVCAttachedToVM_UnrelatedAnnotationAndFinalizer(t *testing.T) {
 
 	assert.False(t, isAttached, "unrelated annotation/finalizer should not count as VM attachment")
 	assert.Empty(t, detail)
+}
+
+// TestIsEncryptedStoragePolicyForPVC_NoVAC verifies that a PVC with no VAC set resolves
+// encryption purely via the StorageClass path.
+func TestIsEncryptedStoragePolicyForPVC_NoVAC(t *testing.T) {
+	scName := "plain-sc"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "default"},
+		Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &scName},
+	}
+	fakeCrypto := &fakeCryptoClient{
+		isEncryptedStorageClassResult:  true,
+		isEncryptedStorageClassProfile: "sc-profile-id",
+	}
+	r := &reconciler{
+		Client:       fake.NewClientBuilder().WithScheme(createTestScheme()).Build(),
+		logger:       logger.GetLoggerWithNoContext().Named("test"),
+		cryptoClient: fakeCrypto,
+	}
+
+	encrypted, profileID, err := r.isEncryptedStoragePolicyForPVC(context.Background(), pvc)
+
+	require.NoError(t, err)
+	assert.True(t, encrypted)
+	assert.Equal(t, "sc-profile-id", profileID)
+	assert.Equal(t, scName, fakeCrypto.storageClassCalledWith)
+	assert.Equal(t, 0, fakeCrypto.profileCallCount, "VAC path must not be consulted when no VAC is set")
+}
+
+// TestIsEncryptedStoragePolicyForPVC_VACModifyInProgress verifies the ModifyVolumeStatus
+// guardrail: a VAC that has not yet taken effect must not be trusted, and the SC path is
+// used instead — this is the regression case the review comment flagged.
+func TestIsEncryptedStoragePolicyForPVC_VACModifyInProgress(t *testing.T) {
+	setVACSupportForTest(t, true)
+	scName := "plain-sc"
+	vacName := "encrypted-vac"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName:          &scName,
+			VolumeAttributesClassName: &vacName,
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			ModifyVolumeStatus: &corev1.ModifyVolumeStatus{
+				TargetVolumeAttributesClassName: vacName,
+				Status:                          corev1.PersistentVolumeClaimModifyVolumeInProgress,
+			},
+		},
+	}
+	fakeCrypto := &fakeCryptoClient{isEncryptedStorageClassResult: false}
+	r := &reconciler{
+		Client:       fake.NewClientBuilder().WithScheme(createTestScheme()).Build(),
+		logger:       logger.GetLoggerWithNoContext().Named("test"),
+		cryptoClient: fakeCrypto,
+	}
+
+	encrypted, _, err := r.isEncryptedStoragePolicyForPVC(context.Background(), pvc)
+
+	require.NoError(t, err)
+	assert.False(t, encrypted)
+	assert.Equal(t, scName, fakeCrypto.storageClassCalledWith, "must fall back to the SC while modify is in flight")
+	assert.Equal(t, 0, fakeCrypto.profileCallCount, "VAC path must not be consulted while modify is in progress")
+}
+
+// TestIsEncryptedStoragePolicyForPVC_VACEffective verifies that once the VAC has taken effect
+// (ModifyVolumeStatus cleared and CurrentVolumeAttributesClassName caught up), the VAC's
+// policy is resolved and takes precedence over the StorageClass's.
+func TestIsEncryptedStoragePolicyForPVC_VACEffective(t *testing.T) {
+	setVACSupportForTest(t, true)
+	scName := "plain-sc"
+	vacName := "encrypted-vac"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName:          &scName,
+			VolumeAttributesClassName: &vacName,
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			CurrentVolumeAttributesClassName: &vacName,
+		},
+	}
+	vac := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: vacName},
+		Parameters: map[string]string{"storagePolicyID": "vac-profile-id"},
+	}
+	fakeCrypto := &fakeCryptoClient{
+		isEncryptedStorageClassResult: false, // if this were consulted, the test should fail
+		isEncryptedProfileResult:      true,
+	}
+	r := &reconciler{
+		Client:       fake.NewClientBuilder().WithScheme(createTestScheme()).WithObjects(vac).Build(),
+		logger:       logger.GetLoggerWithNoContext().Named("test"),
+		cryptoClient: fakeCrypto,
+	}
+
+	encrypted, profileID, err := r.isEncryptedStoragePolicyForPVC(context.Background(), pvc)
+
+	require.NoError(t, err)
+	assert.True(t, encrypted)
+	assert.Equal(t, "vac-profile-id", profileID)
+	assert.Equal(t, "vac-profile-id", fakeCrypto.profileCalledWith)
+	assert.Equal(t, 0, fakeCrypto.storageClassCallCount, "SC path must not be consulted once the VAC is effective")
+}
+
+// TestIsEncryptedStoragePolicyForPVC_VACEffectiveButMissing verifies that a VAC referenced by
+// an effective PVC but no longer present in the cluster (e.g. deleted concurrently) is treated
+// as not encrypted, without erroring.
+func TestIsEncryptedStoragePolicyForPVC_VACEffectiveButMissing(t *testing.T) {
+	setVACSupportForTest(t, true)
+	scName := "plain-sc"
+	vacName := "deleted-vac"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName:          &scName,
+			VolumeAttributesClassName: &vacName,
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			CurrentVolumeAttributesClassName: &vacName,
+		},
+	}
+	fakeCrypto := &fakeCryptoClient{}
+	r := &reconciler{
+		Client:       fake.NewClientBuilder().WithScheme(createTestScheme()).Build(),
+		logger:       logger.GetLoggerWithNoContext().Named("test"),
+		cryptoClient: fakeCrypto,
+	}
+
+	encrypted, profileID, err := r.isEncryptedStoragePolicyForPVC(context.Background(), pvc)
+
+	require.NoError(t, err)
+	assert.False(t, encrypted)
+	assert.Empty(t, profileID)
+	assert.Equal(t, 0, fakeCrypto.profileCallCount)
+}
+
+// TestIsEncryptedStoragePolicyForPVC_VACEffectiveNoPolicyID verifies a VAC with no
+// storagePolicyID parameter is treated as not encrypted without calling the crypto client.
+func TestIsEncryptedStoragePolicyForPVC_VACEffectiveNoPolicyID(t *testing.T) {
+	setVACSupportForTest(t, true)
+	scName := "plain-sc"
+	vacName := "no-policy-vac"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName:          &scName,
+			VolumeAttributesClassName: &vacName,
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			CurrentVolumeAttributesClassName: &vacName,
+		},
+	}
+	vac := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: vacName},
+	}
+	fakeCrypto := &fakeCryptoClient{}
+	r := &reconciler{
+		Client:       fake.NewClientBuilder().WithScheme(createTestScheme()).WithObjects(vac).Build(),
+		logger:       logger.GetLoggerWithNoContext().Named("test"),
+		cryptoClient: fakeCrypto,
+	}
+
+	encrypted, profileID, err := r.isEncryptedStoragePolicyForPVC(context.Background(), pvc)
+
+	require.NoError(t, err)
+	assert.False(t, encrypted)
+	assert.Empty(t, profileID)
+	assert.Equal(t, 0, fakeCrypto.profileCallCount)
+}
+
+// TestIsEncryptedStoragePolicyForPVC_VACSupportDisabled verifies that when the
+// VMPVCStoragePolicyMutability capability is disabled, the pre-existing StorageClass-only
+// behavior is preserved even for a PVC whose VAC would otherwise be effective — VAC support
+// must not be assumed to always be enabled.
+func TestIsEncryptedStoragePolicyForPVC_VACSupportDisabled(t *testing.T) {
+	setVACSupportForTest(t, false)
+	scName := "plain-sc"
+	vacName := "encrypted-vac"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName:          &scName,
+			VolumeAttributesClassName: &vacName,
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			CurrentVolumeAttributesClassName: &vacName,
+		},
+	}
+	fakeCrypto := &fakeCryptoClient{
+		isEncryptedStorageClassResult:  true,
+		isEncryptedStorageClassProfile: "sc-profile-id",
+	}
+	r := &reconciler{
+		Client:       fake.NewClientBuilder().WithScheme(createTestScheme()).Build(),
+		logger:       logger.GetLoggerWithNoContext().Named("test"),
+		cryptoClient: fakeCrypto,
+	}
+
+	encrypted, profileID, err := r.isEncryptedStoragePolicyForPVC(context.Background(), pvc)
+
+	require.NoError(t, err)
+	assert.True(t, encrypted)
+	assert.Equal(t, "sc-profile-id", profileID)
+	assert.Equal(t, scName, fakeCrypto.storageClassCalledWith,
+		"must use the SC even though the VAC would otherwise be effective, since VAC support is disabled")
+	assert.Equal(t, 0, fakeCrypto.profileCallCount, "VAC path must not be consulted when VAC support is disabled")
 }

--- a/pkg/syncer/byokoperator/controller/volumeattributesclass/volumeattributesclass_controller.go
+++ b/pkg/syncer/byokoperator/controller/volumeattributesclass/volumeattributesclass_controller.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumeattributesclass
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"go.uber.org/zap"
+	storagev1 "k8s.io/api/storage/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/crypto"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	ctrlcommoon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/common"
+)
+
+func AddToManager(ctx context.Context, mgr manager.Manager, opts ctrlcommoon.Options) error {
+	var (
+		controlledType     = &storagev1.VolumeAttributesClass{}
+		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
+	)
+
+	r := &reconciler{
+		Client:       mgr.GetClient(),
+		logger:       logger.GetLoggerWithNoContext().Named("controllers").Named(controlledTypeName),
+		vcClient:     opts.VCenterClient,
+		cryptoClient: opts.CryptoClient,
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&storagev1.VolumeAttributesClass{}).
+		Complete(r)
+}
+
+type reconciler struct {
+	client.Client
+	logger       *zap.SugaredLogger
+	vcClient     *vsphere.VirtualCenter
+	cryptoClient crypto.Client
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	obj := &storagev1.VolumeAttributesClass{}
+	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !obj.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, r.reconcileNormal(ctx, obj)
+}
+
+func (r *reconciler) reconcileNormal(ctx context.Context, obj *storagev1.VolumeAttributesClass) error {
+	policyID := crypto.GetStoragePolicyIDFromVAC(obj)
+	if policyID == "" {
+		return nil
+	}
+
+	// VolumeAttributesClass-driven storage-policy mutability is gated behind this capability;
+	// when it's disabled, don't track VAC-derived policies as encryption-capable at all — no
+	// PVC could ever actually reach one via ModifyVolume anyway.
+	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, csicommon.VMPVCStoragePolicyMutability) {
+		return nil
+	}
+
+	if err := r.vcClient.ConnectPbm(ctx); err != nil {
+		return fmt.Errorf("failed to connect VirtualCenter: %w", err)
+	}
+
+	ok, err := r.vcClient.PbmClient.SupportsEncryption(ctx, policyID)
+	if err != nil {
+		return err
+	}
+
+	r.logger.Debugf("Marking the VolumeAttributesClass %s as encryption-enabled: %v", obj.Name, ok)
+
+	return r.cryptoClient.MarkEncryptedVAC(ctx, obj, ok)
+}

--- a/pkg/syncer/byokoperator/controller/volumeattributesclass/volumeattributesclass_controller_test.go
+++ b/pkg/syncer/byokoperator/controller/volumeattributesclass/volumeattributesclass_controller_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumeattributesclass
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
+	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// setVACSupportForTest points commonco.ContainerOrchestratorUtility at a fake orchestrator
+// with VMPVCStoragePolicyMutability set to the given state, restoring the previous value on
+// cleanup so other tests aren't affected.
+func setVACSupportForTest(t *testing.T, enabled bool) {
+	t.Helper()
+	previous := commonco.ContainerOrchestratorUtility
+	t.Cleanup(func() { commonco.ContainerOrchestratorUtility = previous })
+
+	fakeCO, err := unittestcommon.GetFakeContainerOrchestratorInterface(csicommon.Kubernetes)
+	require.NoError(t, err)
+	if enabled {
+		require.NoError(t, fakeCO.EnableFSS(context.Background(), csicommon.VMPVCStoragePolicyMutability))
+	}
+	commonco.ContainerOrchestratorUtility = fakeCO
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, storagev1.AddToScheme(scheme))
+	return scheme
+}
+
+func newTestReconciler(t *testing.T, objs ...client.Object) *reconciler {
+	t.Helper()
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(objs...).Build()
+	return &reconciler{
+		Client: fakeClient,
+		logger: logger.GetLoggerWithNoContext().Named("test"),
+		// vcClient/cryptoClient intentionally left nil: the cases exercised here must not
+		// dereference them (see TestReconcileNormal_NoPolicyID and
+		// TestReconcile_BeingDeletedSkipsReconcileNormal).
+	}
+}
+
+// TestReconcileNormal_NoPolicyID verifies that a VAC with no storagePolicyID parameter is a
+// silent no-op and, critically, never touches the (possibly nil in this test) vcClient/
+// cryptoClient — reconcileNormal must bail out before attempting any PBM/CNS I/O.
+func TestReconcileNormal_NoPolicyID(t *testing.T) {
+	r := newTestReconciler(t)
+	vac := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-policy-vac", UID: types.UID("uid-1")},
+	}
+
+	err := r.reconcileNormal(context.Background(), vac)
+
+	assert.NoError(t, err)
+}
+
+// TestReconcileNormal_VACSupportDisabled verifies that a VAC with a policyID set is still a
+// no-op — without touching the (nil in this test) vcClient/cryptoClient — when the
+// VMPVCStoragePolicyMutability capability is disabled, since no PVC could ever reach that
+// policy via ModifyVolume in that case.
+func TestReconcileNormal_VACSupportDisabled(t *testing.T) {
+	setVACSupportForTest(t, false)
+	r := newTestReconciler(t)
+	vac := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "encrypted-vac", UID: types.UID("uid-3")},
+		Parameters: map[string]string{"storagePolicyID": "policy-1"},
+	}
+
+	err := r.reconcileNormal(context.Background(), vac)
+
+	assert.NoError(t, err)
+}
+
+// TestReconcile_ObjectNotFound verifies Reconcile tolerates a VAC that no longer exists
+// (e.g. deleted between enqueue and processing) by ignoring the NotFound error.
+func TestReconcile_ObjectNotFound(t *testing.T) {
+	r := newTestReconciler(t)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "does-not-exist"},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
+// TestReconcile_BeingDeletedSkipsReconcileNormal verifies that a VAC with a DeletionTimestamp
+// set short-circuits before reconcileNormal runs, even though it has a policyID set (which
+// would otherwise require a live vcClient/cryptoClient — both nil here).
+func TestReconcile_BeingDeletedSkipsReconcileNormal(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	vac := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "deleting-vac",
+			UID:               types.UID("uid-2"),
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubernetes.io/vac-protection"},
+		},
+		Parameters: map[string]string{"storagePolicyID": "policy-1"},
+	}
+	r := newTestReconciler(t, vac)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "deleting-vac"},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
BYOK encryption tracking previously only considered a PVC's StorageClass when deciding if a volume should be encrypted, so policies referenced exclusively by a VolumeAttributesClass (VAC) were never recognized as encryption-capable, and a PVC that changed policy via ModifyVolume kept using its old (StorageClass-derived) encryption status instead of its new VAC's. This PR adds VAC-aware tracking on both sides: a new reconciler marks VAC-referenced policies as encryption-capable in the existing BYOK registry, and the PVC controller now prefers a PVC's VAC policy over its StorageClass's — but only once ModifyVolumeStatus confirms the change has actually completed, so an in-flight modify never causes a premature (or missed) encryption decision.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
VKS pre-check pipelines: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1356/ (passed)

WCP pre-check pipelines: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1800/ (passed)

[Manual Testing](https://gist.github.com/xing-yang/7027192019358d87f47bb0cab91bf13a#file-cns-csi-byok-vac-md)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Extend BYOK encryption tracking to recognize VolumeAttributesClass-only policies and correctly re-key PVCs after a completed VAC-driven ModifyVolume, instead of only considering StorageClass.
```
