### PR TITLE
Wire Zone CR events into the StoragePolicyInfo controller so zone assignment/unassignment triggers a topology update.

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -625,6 +625,11 @@ func (c *FakeK8SOrchestrator) GetZonesForNamespace(ns string) map[string]struct{
 	return nil
 }
 
+// RegisterZoneEventHandler registers a callback invoked whenever a Zone CR is
+// added, updated, or deleted.
+func (c *FakeK8SOrchestrator) RegisterZoneEventHandler(ctx context.Context, handler func(namespace string)) {
+}
+
 func (c *FakeK8SOrchestrator) IsLinkedCloneRequest(ctx context.Context, pvcName string,
 	pvcNamespace string) (bool, error) {
 	return false, nil

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -106,6 +106,11 @@ type COCommonInterface interface {
 	// StartZonesInformer starts a dynamic informer which listens on Zones CR in
 	// topology.tanzu.vmware.com/v1alpha1 API group.
 	StartZonesInformer(ctx context.Context, restClientConfig *restclient.Config, namespace string) error
+	// RegisterZoneEventHandler registers a callback invoked whenever a Zone CR is
+	// added, updated, or deleted. The callback receives the namespace of the
+	// changed Zone. It may be called before or after StartZonesInformer — the
+	// handler is attached to the informer as soon as both have happened.
+	RegisterZoneEventHandler(ctx context.Context, handler func(namespace string))
 	// GetZonesForNamespace fetches the zones associated with a namespace when
 	// WorkloadDomainIsolation is supported in supervisor.
 	GetZonesForNamespace(ns string) map[string]struct{}

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -143,6 +143,13 @@ var (
 	zoneInformer cache.SharedIndexInformer
 	// startZoneInformerOnce ensures zone informer is started only once
 	startZoneInformerOnce sync.Once
+	// zoneEventHandlers holds callbacks invoked on Zone CR add/update/delete,
+	// each receiving the namespace of the changed Zone. Registered via
+	// RegisterZoneEventHandler and attached to zoneInformer in StartZonesInformer.
+	zoneEventHandlers []func(namespace string)
+	// zoneEventHandlersLock guards zoneEventHandlers from concurrent
+	// registration and invocation.
+	zoneEventHandlersLock sync.RWMutex
 )
 
 // nodeVolumeTopology implements the commoncotypes.NodeTopologyService interface. It stores
@@ -1699,6 +1706,14 @@ func (c *K8sOrchestrator) StartZonesInformer(ctx context.Context, restClientConf
 		}
 		zoneInformer = dynInformer.Informer()
 
+		// Attach every handler registered so far (via RegisterZoneEventHandler)
+		// to the new informer. RegisterZoneEventHandler attaches directly when
+		// called after this point, so handlers are picked up regardless of the
+		// order in which RegisterZoneEventHandler and StartZonesInformer are called.
+		if err := attachZoneEventHandlers(ctx, zoneInformer); err != nil {
+			return logger.LogNewErrorf(log, "failed to attach zone event handlers. Error: %+v", err)
+		}
+
 		stopCh = make(chan struct{})
 		go func() {
 			log.Info("Informer to watch on Zones CR starting..")
@@ -1719,6 +1734,88 @@ func (c *K8sOrchestrator) StartZonesInformer(ctx context.Context, restClientConf
 		}
 	})
 	return initErr
+}
+
+// RegisterZoneEventHandler registers a callback invoked whenever a Zone CR is
+// added, updated, or deleted. The callback receives the namespace of the changed
+// Zone. If the zone informer is already running (started by another caller via
+// StartZonesInformer), the dispatcher is attached to it immediately; otherwise
+// the handler is picked up when StartZonesInformer later creates the informer
+// (see attachZoneEventHandlers), so registration order relative to
+// StartZonesInformer does not matter.
+func (c *K8sOrchestrator) RegisterZoneEventHandler(ctx context.Context, handler func(namespace string)) {
+	if handler == nil {
+		return
+	}
+	zoneEventHandlersLock.Lock()
+	zoneEventHandlers = append(zoneEventHandlers, handler)
+	informer := zoneInformer
+	zoneEventHandlersLock.Unlock()
+
+	// If the zone informer is already running, attach the dispatcher now.
+	// SharedIndexInformer allows AddEventHandler after Start as long as the
+	// informer has not been stopped.
+	if informer != nil {
+		if err := addZoneEventDispatcher(informer); err != nil {
+			log := logger.GetLogger(ctx)
+			// Log but don't fail — the handler is still in zoneEventHandlers
+			// and will be attached the next time the zone informer is (re)started.
+			log.Warnf("RegisterZoneEventHandler: failed to attach event handler to zone informer: %v", err)
+		}
+	}
+}
+
+// attachZoneEventHandlers attaches the Zone event dispatcher to a freshly
+// created zone informer so every handler registered so far via
+// RegisterZoneEventHandler starts receiving events immediately.
+func attachZoneEventHandlers(ctx context.Context, informer cache.SharedIndexInformer) error {
+	log := logger.GetLogger(ctx)
+	zoneEventHandlersLock.RLock()
+	hasHandlers := len(zoneEventHandlers) > 0
+	zoneEventHandlersLock.RUnlock()
+	if !hasHandlers {
+		log.Debug("attachZoneEventHandlers: no zone event handlers registered yet")
+		return nil
+	}
+	return addZoneEventDispatcher(informer)
+}
+
+// addZoneEventDispatcher wires the given zone informer's add/update/delete
+// events to notifyZoneEventHandlers, which fans them out to every callback
+// registered via RegisterZoneEventHandler.
+func addZoneEventDispatcher(informer cache.SharedIndexInformer) error {
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			notifyZoneEventHandlers(obj)
+		},
+		UpdateFunc: func(_ interface{}, newObj interface{}) {
+			notifyZoneEventHandlers(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			// Unwrap a missed-delete tombstone (same pattern as topoCRDeleted).
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
+			notifyZoneEventHandlers(obj)
+		},
+	})
+	return err
+}
+
+// notifyZoneEventHandlers extracts the namespace from the changed Zone object and
+// invokes every registered Zone event handler with it.
+func notifyZoneEventHandlers(obj interface{}) {
+	zone, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return
+	}
+	namespace := zone.GetNamespace()
+
+	zoneEventHandlersLock.RLock()
+	defer zoneEventHandlersLock.RUnlock()
+	for _, handler := range zoneEventHandlers {
+		handler(namespace)
+	}
 }
 
 // GetZonesForNamespace fetches the zones associated with a namespace.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology_test.go
@@ -172,3 +172,84 @@ func TestGetActiveClusters_Ginkgo(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "K8sOrchestrator GetActiveClusters Suite")
 }
+
+// resetZoneEventHandlers clears the package-level zone-event handler state,
+// including zoneInformer (other tests in this package assign a *fakeInformer
+// to it), so tests don't leak state into one another. RegisterZoneEventHandler
+// reads zoneInformer to decide whether to attach an AddEventHandler dispatcher,
+// and fakeInformer embeds a nil cache.SharedIndexInformer, so a leaked value
+// segfaults on that call.
+func resetZoneEventHandlers(t *testing.T) {
+	t.Helper()
+	zoneEventHandlersLock.Lock()
+	zoneEventHandlers = nil
+	zoneEventHandlersLock.Unlock()
+	zoneInformer = nil
+	t.Cleanup(func() {
+		zoneEventHandlersLock.Lock()
+		zoneEventHandlers = nil
+		zoneEventHandlersLock.Unlock()
+		zoneInformer = nil
+	})
+}
+
+func TestRegisterZoneEventHandler_NilHandlerIsNoOp(t *testing.T) {
+	resetZoneEventHandlers(t)
+	orch := &K8sOrchestrator{}
+
+	orch.RegisterZoneEventHandler(context.Background(), nil)
+
+	zoneEventHandlersLock.RLock()
+	defer zoneEventHandlersLock.RUnlock()
+	if len(zoneEventHandlers) != 0 {
+		t.Errorf("expected no handlers to be registered, got %d", len(zoneEventHandlers))
+	}
+}
+
+func TestRegisterZoneEventHandler_MultipleHandlersAllInvoked(t *testing.T) {
+	resetZoneEventHandlers(t)
+	orch := &K8sOrchestrator{}
+
+	var calledA, calledB bool
+	var nsA, nsB string
+	orch.RegisterZoneEventHandler(context.Background(), func(namespace string) {
+		calledA = true
+		nsA = namespace
+	})
+	orch.RegisterZoneEventHandler(context.Background(), func(namespace string) {
+		calledB = true
+		nsB = namespace
+	})
+
+	zoneEventHandlersLock.RLock()
+	handlerCount := len(zoneEventHandlers)
+	zoneEventHandlersLock.RUnlock()
+	if handlerCount != 2 {
+		t.Fatalf("expected 2 registered handlers, got %d", handlerCount)
+	}
+
+	notifyZoneEventHandlers(makeZone("zone-A", "ns1", false, nil, false))
+
+	if !calledA || nsA != "ns1" {
+		t.Errorf("handler A: expected called with ns1, got called=%v ns=%q", calledA, nsA)
+	}
+	if !calledB || nsB != "ns1" {
+		t.Errorf("handler B: expected called with ns1, got called=%v ns=%q", calledB, nsB)
+	}
+}
+
+func TestNotifyZoneEventHandlers_ExtractsNamespace(t *testing.T) {
+	resetZoneEventHandlers(t)
+	orch := &K8sOrchestrator{}
+
+	var got string
+	orch.RegisterZoneEventHandler(context.Background(), func(namespace string) {
+		got = namespace
+	})
+
+	notifyZoneEventHandlers(makeZone("zone-A", "ns2", false, nil, false))
+
+	if got != "ns2" {
+		t.Errorf("expected namespace %q, got %q", "ns2", got)
+	}
+}

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -215,6 +215,10 @@ func (m *MockCOCommonInterface) StartZonesInformer(ctx context.Context,
 	return args.Error(0)
 }
 
+func (m *MockCOCommonInterface) RegisterZoneEventHandler(ctx context.Context, handler func(namespace string)) {
+	m.Called(ctx, handler)
+}
+
 func (m *MockCOCommonInterface) GetZonesForNamespace(ns string) map[string]struct{} {
 	args := m.Called(ns)
 	return args.Get(0).(map[string]struct{})

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -422,6 +422,11 @@ func (m *mockCOCommon) StartZonesInformer(ctx context.Context,
 	panic("implement me")
 }
 
+func (m *mockCOCommon) RegisterZoneEventHandler(ctx context.Context, handler func(namespace string)) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockCOCommon) PreLinkedCloneCreateAction(ctx context.Context, pvcNamespace string,
 	pvcName string) error {
 	//TODO implement me

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -67,6 +67,10 @@ type zonesProvider interface {
 	// dereference a nil informer and panic.
 	StartZonesInformer(ctx context.Context, restClientConfig *restclient.Config, namespace string) error
 	GetZonesForNamespace(ns string) map[string]struct{}
+	// RegisterZoneEventHandler registers a callback invoked on Zone CR
+	// add/update/delete, carrying the namespace of the changed Zone. May be
+	// called before or after StartZonesInformer.
+	RegisterZoneEventHandler(ctx context.Context, handler func(namespace string))
 }
 
 const (
@@ -78,6 +82,9 @@ const (
 	// spiNameIndexField is the field index key used to look up StoragePolicyInfo
 	// objects by name, enabling efficient cross-namespace lookups in mapInfraSPItoSPI.
 	spiNameIndexField = ".metadata.name"
+	// zoneEventChannelBuffer is the buffer size of the wakeup channel bridging
+	// Zone CR events into the controller workqueue.
+	zoneEventChannelBuffer = 1
 )
 
 // Add registers the StoragePolicyInfo controller with the Manager (WCP / Workload only).
@@ -100,11 +107,6 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
-	if err := commonco.ContainerOrchestratorUtility.StartZonesInformer(
-		ctx, nil, metav1.NamespaceAll); err != nil {
-		return logger.LogNewErrorf(log, "failed to start zone informer for StoragePolicyInfo controller. Err: %v", err)
-	}
-
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(
 		&typedcorev1.EventSinkImpl{
@@ -112,19 +114,32 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		},
 	)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: apis.GroupName})
-	return add(mgr, newReconciler(mgr, configInfo, recorder, commonco.ContainerOrchestratorUtility))
+	r := newReconciler(mgr, configInfo, recorder, commonco.ContainerOrchestratorUtility)
+
+	// Bridges Zone CR changes into this controller's workqueue. Attached to the
+	// informer once StartZonesInformer creates it below.
+	commonco.ContainerOrchestratorUtility.RegisterZoneEventHandler(ctx, r.enqueueZoneNamespace)
+
+	if err := commonco.ContainerOrchestratorUtility.StartZonesInformer(
+		ctx, nil, metav1.NamespaceAll); err != nil {
+		return logger.LogNewErrorf(log, "failed to start zone informer for StoragePolicyInfo controller. Err: %v", err)
+	}
+
+	return add(mgr, r)
 }
 
 func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 	recorder record.EventRecorder, zp zonesProvider) *ReconcileStoragePolicyInfo {
 
 	return &ReconcileStoragePolicyInfo{
-		client:          mgr.GetClient(),
-		scheme:          mgr.GetScheme(),
-		configInfo:      configInfo,
-		recorder:        recorder,
-		zonesProvider:   zp,
-		backOffDuration: make(map[apitypes.NamespacedName]time.Duration),
+		client:                mgr.GetClient(),
+		scheme:                mgr.GetScheme(),
+		configInfo:            configInfo,
+		recorder:              recorder,
+		zonesProvider:         zp,
+		zoneEventCh:           make(chan event.GenericEvent, zoneEventChannelBuffer),
+		pendingZoneNamespaces: make(map[string]struct{}),
+		backOffDuration:       make(map[apitypes.NamespacedName]time.Duration),
 	}
 }
 
@@ -193,6 +208,12 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 			builder.WithPredicates(infraSPIPredicates),
 		).
 		WatchesRawSource(source.Channel(resyncCh, &handler.EnqueueRequestForObject{})).
+		WatchesRawSource(
+			source.Channel(
+				r.zoneEventCh,
+				handler.EnqueueRequestsFromMapFunc(r.mapZoneNamespaceToSPIs),
+			),
+		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxWorkerThreads}).
 		Complete(r)
 	if err != nil {
@@ -267,6 +288,70 @@ func (r *ReconcileStoragePolicyInfo) mapInfraSPItoSPI(ctx context.Context,
 	return reqs
 }
 
+// enqueueZoneNamespace is the Zone event-handler callback registered with the
+// commonco layer. It is invoked whenever a Zone CR is added, updated, or
+// deleted. The affected namespace is recorded in pendingZoneNamespaces (a
+// coalescing set guarded by pendingZoneNamespacesMutex), and a wakeup signal is
+// sent on the buffered channel. mapZoneNamespaceToSPIs drains the whole set on
+// each wakeup, so no namespace is ever lost even if multiple Zone events land
+// before the previous wakeup is processed.
+func (r *ReconcileStoragePolicyInfo) enqueueZoneNamespace(namespace string) {
+	if namespace == "" {
+		return
+	}
+
+	r.pendingZoneNamespacesMutex.Lock()
+	r.pendingZoneNamespaces[namespace] = struct{}{}
+	r.pendingZoneNamespacesMutex.Unlock()
+
+	// Non-blocking: zoneEventCh only carries a wakeup signal, so a pending one
+	// already covers this namespace. Blocking here would stall the informer's
+	// event-delivery goroutine.
+	evt := event.GenericEvent{Object: &metav1.PartialObjectMetadata{}}
+	select {
+	case r.zoneEventCh <- evt:
+	default:
+	}
+}
+
+// mapZoneNamespaceToSPIs handles a wakeup signal from enqueueZoneNamespace by
+// draining the full set of namespaces touched by Zone CR changes since the
+// last wakeup, and returning reconcile requests for every StoragePolicyInfo CR
+// in each of those namespaces so their AccessibleZones are recomputed.
+func (r *ReconcileStoragePolicyInfo) mapZoneNamespaceToSPIs(ctx context.Context,
+	_ client.Object) []reconcile.Request {
+	log := logger.GetLogger(ctx)
+
+	r.pendingZoneNamespacesMutex.Lock()
+	namespaces := make([]string, 0, len(r.pendingZoneNamespaces))
+	for ns := range r.pendingZoneNamespaces {
+		namespaces = append(namespaces, ns)
+	}
+	r.pendingZoneNamespaces = make(map[string]struct{})
+	r.pendingZoneNamespacesMutex.Unlock()
+
+	var reqs []reconcile.Request
+	for _, namespace := range namespaces {
+		spiList := &spiv1alpha1.StoragePolicyInfoList{}
+		if err := r.client.List(ctx, spiList, client.InNamespace(namespace)); err != nil {
+			log.Errorf("Failed to list StoragePolicyInfo in namespace %q on zone change: %v",
+				namespace, err)
+			continue
+		}
+		for i := range spiList.Items {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: apitypes.NamespacedName{
+					Namespace: spiList.Items[i].Namespace,
+					Name:      spiList.Items[i].Name,
+				},
+			})
+		}
+	}
+	log.Infof("Zone change in namespace(s) %v enqueued %d StoragePolicyInfo reconcile request(s)",
+		namespaces, len(reqs))
+	return reqs
+}
+
 var _ reconcile.Reconciler = &ReconcileStoragePolicyInfo{}
 
 // ReconcileStoragePolicyInfo reconciles StoragePolicyInfo objects.
@@ -276,13 +361,24 @@ type ReconcileStoragePolicyInfo struct {
 	configInfo    *config.ConfigurationInfo
 	recorder      record.EventRecorder
 	zonesProvider zonesProvider
+	// zoneEventCh receives a wakeup signal whenever a Zone CR in some namespace
+	// changes. It bridges the package-level zone informer's events into this
+	// controller's workqueue via source.Channel. The affected namespace(s) are
+	// tracked separately in pendingZoneNamespaces, not on the event itself.
+	zoneEventCh chan event.GenericEvent
+	// pendingZoneNamespaces coalesces namespaces touched by Zone CR changes since
+	// the last time mapZoneNamespaceToSPIs drained it, so a wakeup signal dropped
+	// due to a full zoneEventCh never loses track of which namespaces need their
+	// StoragePolicyInfo topology recomputed.
+	pendingZoneNamespaces map[string]struct{}
 	// backOffDuration tracks per-instance requeue delays, incremented
 	// exponentially on failure and reset to 1s on success. A value greater than
 	// one second means the instance is currently backed off after a failure;
 	// slow-sync skips such instances, since they are already scheduled to
 	// reconcile via RequeueAfter.
-	backOffDuration         map[apitypes.NamespacedName]time.Duration
-	backOffDurationMapMutex sync.Mutex
+	backOffDuration            map[apitypes.NamespacedName]time.Duration
+	backOffDurationMapMutex    sync.Mutex
+	pendingZoneNamespacesMutex sync.Mutex
 }
 
 // Reconcile creates or updates the StoragePolicyInfo for the given namespace
@@ -471,6 +567,16 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 	accessibleZones := r.namespaceFilteredZones(ctx, instance.Namespace,
 		infraSPI.Status.Topology.AccessibleZones)
 
+	if len(accessibleZones) == 0 {
+		// No zones are accessible in this namespace (no Zone CRs assigned).
+		// Clear TopologyInfo rather than writing an empty accessibleZones slice,
+		// which the CRD schema rejects as a required field.
+		log.Debugf("StoragePolicyInfo %s/%s has no accessible zones; clearing TopologyInfo",
+			instance.Namespace, instance.Name)
+		instance.Status.TopologyInfo = nil
+		return nil
+	}
+
 	instance.Status.TopologyInfo = &spiv1alpha1.Topology{
 		TopologyType:    infraSPI.Status.Topology.TopologyType,
 		AccessibleZones: accessibleZones,
@@ -490,11 +596,12 @@ func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 
 	nsZones := r.zonesProvider.GetZonesForNamespace(namespace)
 	if len(nsZones) == 0 {
-		// Non-zonal deployment or namespace has no zone constraints; expose all
-		// cluster-accessible zones.
-		log.Debugf("Namespace %q has no zone assignments; using all %d cluster-accessible zones",
-			namespace, len(clusterZones))
-		return clusterZones
+		// No Zone CRs in this namespace means no zone has been assigned to it yet.
+		// Return empty rather than falling back to all cluster zones — exposing all
+		// zones for an unassigned namespace would be incorrect in a WDI deployment.
+		log.Debugf("Namespace %q has no zone assignments; accessibleZones will be empty",
+			namespace)
+		return nil
 	}
 
 	// Intersect cluster-accessible zones with namespace-assigned zones.

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
@@ -54,6 +55,9 @@ func testScheme(t *testing.T) *runtime.Scheme {
 // to control which zones are returned per namespace.
 type mockZonesProvider struct {
 	zonesForNamespace map[string]map[string]struct{}
+	// zoneHandler captures the callback registered via RegisterZoneEventHandler so
+	// tests can simulate a zone assign/unassign event.
+	zoneHandler func(namespace string)
 }
 
 func (m *mockZonesProvider) StartZonesInformer(_ context.Context, _ *restclient.Config, _ string) error {
@@ -65,6 +69,10 @@ func (m *mockZonesProvider) GetZonesForNamespace(ns string) map[string]struct{} 
 		return m.zonesForNamespace[ns]
 	}
 	return nil
+}
+
+func (m *mockZonesProvider) RegisterZoneEventHandler(_ context.Context, handler func(namespace string)) {
+	m.zoneHandler = handler
 }
 
 var _ zonesProvider = &mockZonesProvider{}
@@ -401,9 +409,8 @@ func TestSyncTopologyFromInfraSPI_CopiesTopology(t *testing.T) {
 
 	err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
 	require.NoError(t, err)
-	require.NotNil(t, inst.Status.TopologyInfo)
-	assert.Equal(t, "zonal", inst.Status.TopologyInfo.TopologyType)
-	assert.ElementsMatch(t, []string{"az1", "az2"}, inst.Status.TopologyInfo.AccessibleZones)
+	// No Zone CRs in ns1 → no zone assignments → TopologyInfo is cleared.
+	assert.Nil(t, inst.Status.TopologyInfo)
 }
 
 // TestSyncTopologyFromInfraSPI_ClearsWhenNilTopology verifies that when
@@ -445,10 +452,10 @@ func TestNamespaceFilteredZones(t *testing.T) {
 		expectedZones []string
 	}{
 		{
-			name:          "no namespace zone constraints returns all cluster zones",
+			name:          "no namespace zone assignments returns empty",
 			nsZones:       nil,
 			clusterZones:  []string{"az1", "az2", "az3"},
-			expectedZones: []string{"az1", "az2", "az3"},
+			expectedZones: nil,
 		},
 		{
 			name:          "namespace zones intersect cluster zones",
@@ -800,10 +807,11 @@ func TestReconcile_ZoneFilteringApplied(t *testing.T) {
 		"az2 should be filtered out because ns1 is not assigned to it")
 }
 
-// TestReconcile_NoNamespaceZonesReturnsAll verifies that when a namespace has
-// no zone assignments (non-zonal or unconstrained namespace), all
-// cluster-accessible zones are exposed.
-func TestReconcile_NoNamespaceZonesReturnsAll(t *testing.T) {
+// TestReconcile_NoNamespaceZonesReturnsEmpty verifies that when a namespace has
+// no Zone CRs assigned, accessibleZones is empty — not all cluster zones.
+// In a WDI deployment, no Zone CR means the namespace has not been assigned a
+// zone yet, so exposing all cluster zones would be incorrect.
+func TestReconcile_NoNamespaceZonesReturnsEmpty(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
 
@@ -837,13 +845,12 @@ func TestReconcile_NoNamespaceZonesReturnsAll(t *testing.T) {
 
 	got := &spiv1alpha1.StoragePolicyInfo{}
 	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "gold"}, got))
-	require.NotNil(t, got.Status.TopologyInfo)
-	assert.ElementsMatch(t, []string{"az1", "az2"}, got.Status.TopologyInfo.AccessibleZones,
-		"all cluster zones should be exposed when namespace has no zone constraints")
+	assert.Nil(t, got.Status.TopologyInfo,
+		"TopologyInfo should be nil when namespace has no zone assignments")
 }
 
 // TestReconcile_InfraSPITopologyUpdated verifies the scenario where an InfraStoragePolicyInfo
-// status update changes the accessible zones, the next reconcile correctly reflects the updated topology
+// status update changes the accessible zones, the next reconcile correctly reflects the updated topology.
 func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
@@ -867,6 +874,10 @@ func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
 			},
 		},
 	}
+	// ns1 is assigned to both az1 and az2 so both should appear after the update.
+	nsZones := map[string]map[string]struct{}{
+		"ns1": {"az1": {}, "az2": {}},
+	}
 	recorder := record.NewFakeRecorder(10)
 	cli := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
@@ -875,8 +886,9 @@ func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
 		client:          cli,
 		scheme:          scheme,
 		recorder:        recorder,
-		zonesProvider:   &mockZonesProvider{},
-		backOffDuration: make(map[types.NamespacedName]time.Duration)}
+		zonesProvider:   &mockZonesProvider{zonesForNamespace: nsZones},
+		backOffDuration: make(map[types.NamespacedName]time.Duration),
+	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gold"},
@@ -898,4 +910,158 @@ func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
 	default:
 		t.Error("expected a Normal StoragePolicyInfoSynced event after topology update")
 	}
+}
+
+// TestMapZoneNamespaceToSPIs_EnqueuesAllInNamespace verifies that a zone change in
+// a namespace enqueues a reconcile request for every StoragePolicyInfo in that
+// namespace and none from other namespaces.
+func TestMapZoneNamespaceToSPIs_EnqueuesAllInNamespace(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	spiGold := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	spiSilver := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "silver", Namespace: "ns1"},
+	}
+	// A StoragePolicyInfo in a different namespace must not be enqueued.
+	spiOther := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns2"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(spiGold, spiSilver, spiOther).Build()
+	r := &ReconcileStoragePolicyInfo{
+		client:                cli,
+		scheme:                scheme,
+		pendingZoneNamespaces: map[string]struct{}{"ns1": {}},
+	}
+
+	reqs := r.mapZoneNamespaceToSPIs(ctx, nil)
+	require.Len(t, reqs, 2)
+	names := []string{reqs[0].Namespace + "/" + reqs[0].Name, reqs[1].Namespace + "/" + reqs[1].Name}
+	assert.ElementsMatch(t, []string{"ns1/gold", "ns1/silver"}, names)
+
+	// The dirty set must be drained so a subsequent wakeup with no new zone
+	// changes does not re-enqueue the same namespace.
+	assert.Empty(t, r.pendingZoneNamespaces)
+}
+
+// TestMapZoneNamespaceToSPIs_NilAndEmpty verifies that mapZoneNamespaceToSPIs
+// returns nil when no namespaces are pending in the dirty set.
+func TestMapZoneNamespaceToSPIs_NilAndEmpty(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client:                fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:                scheme,
+		pendingZoneNamespaces: map[string]struct{}{},
+	}
+
+	assert.Nil(t, r.mapZoneNamespaceToSPIs(ctx, nil))
+}
+
+// TestEnqueueZoneNamespace_PushesEvent verifies that enqueueZoneNamespace records
+// the namespace in the coalescing dirty set and sends a wakeup signal, skips
+// empty namespaces, and never loses a namespace even when the wakeup channel is
+// full (the namespace is recorded in the set regardless of whether the send
+// succeeds).
+func TestEnqueueZoneNamespace_PushesEvent(t *testing.T) {
+	r := &ReconcileStoragePolicyInfo{
+		zoneEventCh:           make(chan event.GenericEvent, 1),
+		pendingZoneNamespaces: make(map[string]struct{}),
+	}
+
+	// Empty namespace is ignored.
+	r.enqueueZoneNamespace("")
+	assert.Len(t, r.zoneEventCh, 0)
+	assert.Empty(t, r.pendingZoneNamespaces)
+
+	// A real namespace is recorded in the dirty set and a wakeup is sent.
+	r.enqueueZoneNamespace("ns1")
+	require.Len(t, r.zoneEventCh, 1)
+	assert.Contains(t, r.pendingZoneNamespaces, "ns1")
+	<-r.zoneEventCh
+
+	// Fill the buffer, then a further send is dropped (must not block), but the
+	// namespace is still recorded in the dirty set so it is not lost.
+	r.enqueueZoneNamespace("ns2")
+	require.Len(t, r.zoneEventCh, 1)
+	r.enqueueZoneNamespace("ns3") // channel full -> wakeup dropped, must not block
+	assert.Len(t, r.zoneEventCh, 1)
+	assert.Contains(t, r.pendingZoneNamespaces, "ns2")
+	assert.Contains(t, r.pendingZoneNamespaces, "ns3")
+}
+
+// TestZoneAssignUnassign_TriggersTopologyUpdate exercises the full trigger path:
+// the registered Zone handler enqueues the namespace, the mapper fans out to the
+// SPIs, and a follow-up reconcile recomputes AccessibleZones — first after a zone
+// is assigned, then after it is unassigned.
+func TestZoneAssignUnassign_TriggersTopologyUpdate(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", UID: types.UID("gold-uid")},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"az1", "az2"},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
+		WithObjects(spi, infraSPI).Build()
+
+	// Start with the namespace assigned to no zones.
+	zp := &mockZonesProvider{zonesForNamespace: map[string]map[string]struct{}{}}
+	r := &ReconcileStoragePolicyInfo{
+		client:                cli,
+		scheme:                scheme,
+		recorder:              record.NewFakeRecorder(10),
+		zonesProvider:         zp,
+		zoneEventCh:           make(chan event.GenericEvent, zoneEventChannelBuffer),
+		pendingZoneNamespaces: make(map[string]struct{}),
+		backOffDuration:       make(map[types.NamespacedName]time.Duration),
+	}
+
+	// Register the handler the way Add() does, then confirm it was captured.
+	zp.RegisterZoneEventHandler(context.Background(), r.enqueueZoneNamespace)
+	require.NotNil(t, zp.zoneHandler, "handler should be registered")
+
+	reconcileFromZoneEvent := func() {
+		// Drain the wakeup signal the handler pushed and run the mapper, which reads
+		// the affected namespace(s) from the dirty set, then reconcile each
+		// resulting request, mirroring the controller-runtime path.
+		require.Len(t, r.zoneEventCh, 1)
+		<-r.zoneEventCh
+		reqs := r.mapZoneNamespaceToSPIs(ctx, nil)
+		require.Len(t, reqs, 1)
+		_, err := r.Reconcile(ctx, reqs[0])
+		require.NoError(t, err)
+	}
+
+	// Assign az1 to ns1, then fire the zone event.
+	zp.zonesForNamespace["ns1"] = map[string]struct{}{"az1": {}}
+	zp.zoneHandler("ns1")
+	reconcileFromZoneEvent()
+
+	got := &spiv1alpha1.StoragePolicyInfo{}
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "gold"}, got))
+	require.NotNil(t, got.Status.TopologyInfo)
+	assert.ElementsMatch(t, []string{"az1"}, got.Status.TopologyInfo.AccessibleZones,
+		"only the assigned zone az1 should be accessible after assignment")
+
+	// Unassign az1 (delete the Zone), then fire the zone event again.
+	zp.zonesForNamespace["ns1"] = map[string]struct{}{}
+	zp.zoneHandler("ns1")
+	reconcileFromZoneEvent()
+
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "gold"}, got))
+	assert.Nil(t, got.Status.TopologyInfo,
+		"TopologyInfo should be nil after all zones are unassigned")
 }

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -592,6 +592,9 @@ func (m *mockCOCommonForFullSync) StartZonesInformer(ctx context.Context, cfg *r
 	return nil
 }
 
+func (m *mockCOCommonForFullSync) RegisterZoneEventHandler(ctx context.Context, handler func(namespace string)) {
+}
+
 func (m *mockCOCommonForFullSync) UpdatePersistentVolumeLabel(
 	ctx context.Context, pvName string, labelKey string, labelValue string,
 ) error {


### PR DESCRIPTION
The change introduces a RegisterZoneEventHandler mechanism on the COCommonInterface and its K8sOrchestrator implementation, allowing controllers to subscribe to Zone CR add/update/delete events via a callback. The StoragePolicyInfo controller uses this to bridge zone changes that is received through a buffered chan event.GenericEvent into its controller-runtime workqueue via source.Channel. When a Zone CR changes in a namespace, enqueueZoneNamespace pushes a namespace-stamped event, and mapZoneNamespaceToSPIs invokes reconcile requests for every StoragePolicyInfo in that namespace.

Additionally, the fallback behavior in namespaceFilteredZones is corrected: previously, a namespace with no zone assignments returned all cluster-accessible zones, now it returns empty.

Testing done:

Test 1: Zone assignment updates StoragePolicyInfo topology Applied a Zone CR to namespace test:
```
kubectl apply -f - <<EOF
apiVersion: topology.tanzu.vmware.com/v1alpha1
kind: Zone
metadata:
  name: az1
  namespace: test
spec:
  availabilityZoneReference:
    apiVersion: v1alpha1
    name: az1
  disallowUnreservedDirectPathUsage: false
EOF
```
Initially, status was empty for all StoragePolicyInfo CRs in the namespace:
```
status: {}
```

After applying the Zone, the controller enqueued all 10 StoragePolicyInfo CRs in the namespace and synced topology from the corresponding InfraStoragePolicyInfo, filtered to the newly assigned zone:

```
kubectl get storagepolicyinfo management-storage-policy-encryption -n test -oyaml
status:
  topologyInfo:
    accessibleZones:
    - az1
    topologyType: ""
```

Logs:
```
{"level":"info","time":"2026-07-01T12:52:55.757582348Z","caller":"storagepolicyinfo/controller.go:327","msg":"Zone change in namespace \"test\" enqueued 10 StoragePolicyInfo reconcile request(s)"}
{"level":"info","time":"2026-07-01T12:52:55.762348101Z","caller":"storagepolicyinfo/controller.go:359","msg":"Reconciling StoragePolicyInfo","TraceId":"78ad6f3d-f22d-4539-9afe-b6700901501c","name":"test/vm-encryption-policy"}
{"level":"info","time":"2026-07-01T12:52:55.914361769Z","caller":"storagepolicyinfo/controller.go:430","msg":"Successfully reconciled StoragePolicyInfo \"test/management-storage-policy-stretched\"","TraceId":"83928003-a71c-4e9f-a905-b310d06614d0"}
{"level":"info","time":"2026-07-01T12:52:56.776433365Z","caller":"storagepolicyinfo/controller.go:618","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"ff728bad-849b-452c-afee-b5d6900bc515","name":"test/vsan-esa-default-policy-raid6"}
```

Test 2: Zone removal clears StoragePolicyInfo topology Deleted the Zone CR from namespace test:
```
kubectl delete zone az1 -n test
```

The controller again enqueued all 10 StoragePolicyInfo CRs. Since no Zone CR remained assigned to the namespace, accessibleZones filtered down to empty and the controller cleared topologyInfo entirely (rather than writing an empty required field):
```
kubectl get storagepolicyinfo management-storage-policy-encryption -n test -oyaml
status: {}
```

Logs:
```
{"level":"info","time":"2026-07-01T12:54:30.184396256Z","caller":"storagepolicyinfo/controller.go:327","msg":"Zone change in namespace \"test\" enqueued 10 StoragePolicyInfo reconcile request(s)"}
{"level":"info","time":"2026-07-01T12:54:30.238946852Z","caller":"storagepolicyinfo/controller.go:430","msg":"Successfully reconciled StoragePolicyInfo \"test/vsan-esa-default-policy-raid6\"","TraceId":"59522218-cfd2-4715-a41d-167572675512"}
{"level":"info","time":"2026-07-01T12:54:30.764122834Z","caller":"storagepolicyinfo/controller.go:618","msg":"Successfully reconciled StoragePolicyInfo","TraceId":"2e8e4890-9598-4641-b728-a269878e3a1a","name":"test/management-storage-policy-stretched"}
```