### PR TITLE
Fix CnsRegisterVolume PVC self-conflict on topology annotation update

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -593,8 +593,9 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	// control flag that CNS auto-sets on a newly registered FCD. This ensures the
 	// FCD lifecycle is governed by the PVC, not by the consuming VM. The clear is
 	// performed via the VSLM endpoint, which is broadly available on older vSphere too.
-	if err = clearKeepAfterDeleteVmIfNonRemovable(ctx, r.client, r.volumeManager,
-		pvc, instance.Namespace, volumeID); err != nil {
+	pvc, err = clearKeepAfterDeleteVmIfNonRemovable(ctx, r.client, r.volumeManager,
+		pvc, instance.Namespace, volumeID)
+	if err != nil {
 		setInstanceError(ctx, r, instance, err.Error())
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
@@ -950,15 +951,31 @@ func validatePVCTopologyCompatibility(ctx context.Context, k8sclient clientset.I
 		}
 		pvc.Annotations[common.AnnVolumeAccessibleTopology] = topologyAnnotation
 
-		// Update the PVC in Kubernetes to persist the topology annotation
-		// Note: Using Update instead of PatchObject here because this function receives
-		// a clientset.Interface and creating a controller-runtime client would require
-		// additional configuration that may not be available in test environments
-		_, err := k8sclient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(ctx, pvc, metav1.UpdateOptions{})
+		// Persist the topology annotation via a merge patch (resourceVersion-agnostic) instead of a
+		// full-object Update, so this write can't 409 if the PVC was already mutated earlier in this
+		// same reconcile pass (e.g. by clearKeepAfterDeleteVmIfNonRemovable).
+		patchAnnotations := make(map[string]interface{})
+		for k, v := range pvc.Annotations {
+			patchAnnotations[k] = v
+		}
+		patch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": patchAnnotations,
+			},
+		}
+		patchBytes, err := json.Marshal(patch)
 		if err != nil {
-			return logger.LogNewErrorf(log, "failed to update PVC %s/%s with topology annotation: %+v",
+			return logger.LogNewErrorf(log, "failed to marshal topology annotation patch for PVC %s/%s: %+v",
 				pvc.Namespace, pvc.Name, err)
 		}
+		patchedPVC, err := k8sclient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Patch(ctx, pvc.Name,
+			apitypes.MergePatchType, patchBytes, metav1.PatchOptions{})
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to patch PVC %s/%s with topology annotation. PVC: %+v, err: %+v",
+				pvc.Namespace, pvc.Name, pvc, err)
+		}
+		log.Debugf("Patched PVC: %+v", patchedPVC)
+		pvc = patchedPVC
 
 		log.Infof("Successfully added topology annotation %s to PVC %s/%s",
 			topologyAnnotation, pvc.Namespace, pvc.Name)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -883,8 +883,8 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			})
 		patches.ApplyFunc(clearKeepAfterDeleteVmIfNonRemovable,
 			func(ctx context.Context, c ctrlclient.Client, vm cnsvolume.Manager,
-				pvc *corev1.PersistentVolumeClaim, namespace, volumeID string) error {
-				return nil
+				pvc *corev1.PersistentVolumeClaim, namespace, volumeID string) (*corev1.PersistentVolumeClaim, error) {
+				return pvc, nil
 			})
 		// Force topology validation to fail (simulates zone mismatch — the root cause of bug 3733250)
 		topologyMgr = &mockTopologyService{}
@@ -1501,6 +1501,34 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 			}))
 		})
 
+	})
+
+	Context("when the in-memory PVC's resourceVersion is stale relative to the server", func() {
+		// Reproduces the bug-3740243 precondition: an earlier write in the same reconcile pass
+		// (e.g. clearKeepAfterDeleteVmIfNonRemovable) already bumped the PVC's resourceVersion on
+		// the server, but the in-memory pvc object here still carries the old one. A full-object
+		// Update against that stale resourceVersion would be rejected with a 409 Conflict; this
+		// test fails if the code regresses to Update and passes only when a merge patch is used.
+		It("should still succeed by patching instead of updating", func() {
+			_, err := mockK8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+
+			mockK8sClient.PrependReactor("update", "persistentvolumeclaims",
+				func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewConflict(
+						corev1.Resource("persistentvolumeclaims"), pvc.Name,
+						fmt.Errorf("the object has been modified; please apply your changes to the "+
+							"latest version and try again"))
+				})
+
+			err = validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
+				datastoreAccessibleTopology)
+			Expect(err).To(BeNil())
+
+			topologyAnnotation, exists := pvc.Annotations["csi.vsphere.volume-accessible-topology"]
+			Expect(exists).To(BeTrue())
+			Expect(topologyAnnotation).To(Equal(`[{"topology.kubernetes.io/zone":"zone-1"}]`))
+		})
 	})
 })
 
@@ -3560,11 +3588,16 @@ func TestClearKeepAfterDeleteVm_RemovableFalse_ClearCalled(t *testing.T) {
 	pvc := vmImportPVC(pvcName, ns, vmName)
 	c, mockVM, calls := vmImportTestSetup(t, vm, pvc, nil)
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
+	updatedPVC, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"vol-1"}, *calls,
 		"UnprotectVolumeFromVMDeletion must be called exactly once for the registered volume")
+	assert.NotNil(t, updatedPVC, "returned PVC must not be nil")
+	assert.Equal(t, "true", updatedPVC.Annotations[common.AnnVMDeleteProtectionCleared],
+		"returned PVC must carry the AnnVMDeleteProtectionCleared annotation")
+	assert.NotEqual(t, pvc.ResourceVersion, updatedPVC.ResourceVersion,
+		"returned PVC must have a refreshed resourceVersion after the patch")
 }
 
 func TestClearKeepAfterDeleteVm_RemovableTrue_NoOp(t *testing.T) {
@@ -3576,7 +3609,7 @@ func TestClearKeepAfterDeleteVm_RemovableTrue_NoOp(t *testing.T) {
 	vm := vmWithVolume(vmName, ns, pvcName, &removable)
 	c, mockVM, calls := vmImportTestSetup(t, vm, nil, nil)
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+	_, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
 	assert.NoError(t, err)
 
@@ -3591,7 +3624,7 @@ func TestClearKeepAfterDeleteVm_RemovableNil_NoOp(t *testing.T) {
 	vm := vmWithVolume(vmName, ns, pvcName, nil)
 	c, mockVM, calls := vmImportTestSetup(t, vm, nil, nil)
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+	_, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
 	assert.NoError(t, err)
 
@@ -3609,7 +3642,7 @@ func TestClearKeepAfterDeleteVm_NoDataSourceRef_NoOp(t *testing.T) {
 		Spec:       corev1.PersistentVolumeClaimSpec{DataSourceRef: nil},
 	}
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
+	_, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
 	assert.NoError(t, err)
 
 	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called without DataSourceRef")
@@ -3619,7 +3652,7 @@ func TestClearKeepAfterDeleteVm_NilPVC_NoOp(t *testing.T) {
 	ctx := context.Background()
 	c, mockVM, calls := vmImportTestSetup(t, nil, nil, nil)
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, nil, "test-ns", "vol-1")
+	_, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, nil, "test-ns", "vol-1")
 	assert.NoError(t, err)
 
 	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called when pvc is nil")
@@ -3643,7 +3676,7 @@ func TestClearKeepAfterDeleteVm_NonVMDataSourceRef_NoOp(t *testing.T) {
 		},
 	}
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
+	_, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
 	assert.NoError(t, err)
 
 	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called for non-VirtualMachine DataSourceRef")
@@ -3656,7 +3689,7 @@ func TestClearKeepAfterDeleteVm_VMNotFound_ReturnsError(t *testing.T) {
 	vmName := "missing-vm"
 	c, mockVM, calls := vmImportTestSetup(t, nil, nil, nil)
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+	_, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
 	assert.Error(t, err, "missing VM CR must surface as an error so the reconciler requeues")
 
@@ -3672,7 +3705,7 @@ func TestClearKeepAfterDeleteVm_ClearAPIError_ReturnsError(t *testing.T) {
 	vm := vmWithVolume(vmName, ns, pvcName, &removable)
 	c, mockVM, calls := vmImportTestSetup(t, vm, nil, fmt.Errorf("boom"))
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+	_, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
 	assert.Error(t, err, "underlying VSLM error must surface so the reconciler requeues")
 
@@ -3690,11 +3723,45 @@ func TestClearKeepAfterDeleteVm_PVCClaimNameMismatch_NoOp(t *testing.T) {
 	vm := vmWithVolume(vmName, ns, "other-pvc", &removable)
 	c, mockVM, calls := vmImportTestSetup(t, vm, nil, nil)
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
+	_, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM,
 		vmImportPVC(pvcName, ns, vmName), ns, "vol-1")
 	assert.NoError(t, err)
 
 	assert.Empty(t, *calls, "UnprotectVolumeFromVMDeletion must not be called when no VM volume matches the PVC")
+}
+
+// TestClearAndTopologyChain_NoConflict runs clearKeepAfterDeleteVmIfNonRemovable followed by
+// validatePVCTopologyCompatibility for real (not mocked), mirroring the exact call chain in
+// Reconcile (cnsregistervolume_controller.go ~596-641). It reproduces bug-3740243's precondition —
+// a PVC with a non-removable VM DataSourceRef and no topology annotation yet — and asserts the
+// second call succeeds using the PVC object returned by the first, instead of the stale one.
+func TestClearAndTopologyChain_NoConflict(t *testing.T) {
+	ctx := context.Background()
+	ns := "test-ns"
+	pvcName := "test-pvc"
+	vmName := "test-vm"
+	removable := false
+	vm := vmWithVolume(vmName, ns, pvcName, &removable)
+	pvc := vmImportPVC(pvcName, ns, vmName)
+	c, mockVM, calls := vmImportTestSetup(t, vm, pvc, nil)
+
+	updatedPVC, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"vol-1"}, *calls)
+	assert.Equal(t, "true", updatedPVC.Annotations[common.AnnVMDeleteProtectionCleared])
+
+	k8sclientFake := k8sfake.NewClientset(updatedPVC)
+	mockTopologyMgr := &mockTopologyService{}
+	mockVC := &cnsvsphere.VirtualCenter{}
+	datastoreAccessibleTopology := []map[string]string{
+		{"topology.kubernetes.io/zone": "zone-1"},
+	}
+
+	err = validatePVCTopologyCompatibility(ctx, k8sclientFake, updatedPVC, "dummy-datastore-url",
+		mockTopologyMgr, mockVC, datastoreAccessibleTopology)
+	assert.NoError(t, err, `chained call must not surface "PVC topology validation failed"`)
+	assert.Equal(t, `[{"topology.kubernetes.io/zone":"zone-1"}]`,
+		updatedPVC.Annotations[common.AnnVolumeAccessibleTopology])
 }
 
 // TestCleanupCNSVolume_DiskURLPath verifies that cleanupCNSVolume routes to
@@ -3770,21 +3837,22 @@ func TestClearKeepAfterDeleteVm_AnnotationUpdateFailure_ReturnsError(t *testing.
 
 	pvc := vmImportPVC(pvcName, ns, vmName)
 
-	// Create a fake client with an interceptor that fails on PVC Update
+	// Create a fake client with an interceptor that fails on PVC Patch
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(vm, pvc).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(
+			Patch: func(
 				ctx context.Context,
 				client ctrlclient.WithWatch,
 				obj ctrlclient.Object,
-				opts ...ctrlclient.UpdateOption,
+				patch ctrlclient.Patch,
+				opts ...ctrlclient.PatchOption,
 			) error {
 				if _, ok := obj.(*corev1.PersistentVolumeClaim); ok {
 					return fmt.Errorf("simulated update failure")
 				}
-				return client.Update(ctx, obj, opts...)
+				return client.Patch(ctx, obj, patch, opts...)
 			},
 		}).
 		Build()
@@ -3797,11 +3865,12 @@ func TestClearKeepAfterDeleteVm_AnnotationUpdateFailure_ReturnsError(t *testing.
 		},
 	}
 
-	err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
+	updatedPVC, err := clearKeepAfterDeleteVmIfNonRemovable(ctx, c, mockVM, pvc, ns, "vol-1")
 
 	// The error should be returned so the reconciler can retry
 	assert.Error(t, err, "annotation update failure must return an error")
 	assert.Contains(t, err.Error(), "simulated update failure")
+	assert.Same(t, pvc, updatedPVC, "on failure the original pvc pointer must be returned unchanged")
 
 	// VSLM call should have been made before the annotation update failed
 	assert.Equal(t, []string{"vol-1"}, *calls,

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -119,23 +119,28 @@ func isDatastoreAccessibleToAZClusters(ctx context.Context, vc *vsphere.VirtualC
 // The clear is performed via the VSLM endpoint (UnprotectVolumeFromVMDeletion),
 // which is broadly available on older vSphere as well; no FSS gate is required.
 //
-// Returns nil (no-op) when:
+// Returns the (unmodified) pvc and a nil error when:
 //   - pvc is nil or has no DataSourceRef,
 //   - DataSourceRef does not point at vmoperator.vmware.com/VirtualMachine,
 //   - the matching VM volume entry has removable=true or removable=nil (default).
 //
-// Returns a non-nil error when the VirtualMachine CR cannot be fetched or when
+// Returns the original pvc and a non-nil error when the VirtualMachine CR cannot be fetched or when
 // the underlying VSLM clear call fails. Both cases are safe to retry on the
 // next reconcile (CreateVolume and VSLM clear are both idempotent).
+//
+// On success after clearing keepAfterDeleteVm, returns the PVC refreshed with the
+// AnnVMDeleteProtectionCleared annotation and an up-to-date resourceVersion, so callers can safely
+// chain further mutations on the returned object without risking a stale-resourceVersion conflict.
 func clearKeepAfterDeleteVmIfNonRemovable(ctx context.Context, c ctrlruntimeclient.Client,
-	volumeManager volumes.Manager, pvc *v1.PersistentVolumeClaim, namespace, volumeID string) error {
+	volumeManager volumes.Manager, pvc *v1.PersistentVolumeClaim, namespace,
+	volumeID string) (*v1.PersistentVolumeClaim, error) {
 	log := logger.GetLogger(ctx)
 
 	if pvc == nil || pvc.Spec.DataSourceRef == nil ||
 		pvc.Spec.DataSourceRef.APIGroup == nil ||
 		*pvc.Spec.DataSourceRef.APIGroup != "vmoperator.vmware.com" ||
 		pvc.Spec.DataSourceRef.Kind != "VirtualMachine" {
-		return nil
+		return pvc, nil
 	}
 
 	vm := &vmoperatortypes.VirtualMachine{}
@@ -143,7 +148,7 @@ func clearKeepAfterDeleteVmIfNonRemovable(ctx context.Context, c ctrlruntimeclie
 		Namespace: namespace,
 		Name:      pvc.Spec.DataSourceRef.Name,
 	}, vm); err != nil {
-		return fmt.Errorf("failed to get VirtualMachine %s/%s referenced by PVC DataSourceRef: %v",
+		return pvc, fmt.Errorf("failed to get VirtualMachine %s/%s referenced by PVC DataSourceRef: %v",
 			namespace, pvc.Spec.DataSourceRef.Name, err)
 	}
 
@@ -158,29 +163,32 @@ func clearKeepAfterDeleteVmIfNonRemovable(ctx context.Context, c ctrlruntimeclie
 	}
 
 	if !nonRemovable {
-		return nil
+		return pvc, nil
 	}
 
 	log.Infof("Clearing keepAfterDeleteVm for volumeID %s (PVC %s/%s mounted as non-removable on VM %s)",
 		volumeID, pvc.Namespace, pvc.Name, vm.Name)
 	if err := volumeManager.UnprotectVolumeFromVMDeletion(ctx, volumeID); err != nil {
-		return fmt.Errorf("failed to clear keepAfterDeleteVm for volumeID %s: %v", volumeID, err)
+		return pvc, fmt.Errorf("failed to clear keepAfterDeleteVm for volumeID %s: %v", volumeID, err)
 	}
 
 	// Set annotation to indicate keepAfterDeleteVm has been cleared.
 	// This prevents redundant VSLM calls on syncer restarts or informer resyncs.
+	// Patch (instead of Update) so this write can't 409 on the resourceVersion, and the response is
+	// decoded back into pvcCopy, refreshing it, so the caller can safely reuse the returned object.
+	original := pvc.DeepCopy()
 	pvcCopy := pvc.DeepCopy()
 	if pvcCopy.Annotations == nil {
 		pvcCopy.Annotations = make(map[string]string)
 	}
 	pvcCopy.Annotations[common.AnnVMDeleteProtectionCleared] = "true"
-	if err := c.Update(ctx, pvcCopy); err != nil {
-		return fmt.Errorf("failed to set %s annotation on PVC %s/%s: %v",
+	if err := c.Patch(ctx, pvcCopy, ctrlruntimeclient.MergeFrom(original)); err != nil {
+		return pvc, fmt.Errorf("failed to set %s annotation on PVC %s/%s: %v",
 			common.AnnVMDeleteProtectionCleared, pvc.Namespace, pvc.Name, err)
 	}
 	log.Infof("Set %s annotation on PVC %s/%s",
 		common.AnnVMDeleteProtectionCleared, pvc.Namespace, pvc.Name)
-	return nil
+	return pvcCopy, nil
 }
 
 // constructCreateSpecForInstance creates CNS CreateVolume spec.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**Why we need it**:

This change sits directly on the VM-import → power-on path:

CnsRegisterVolume is what registers VMDK as a PVC during VM import, and a VM can't power on until its PVC is Bound — so any delay here directly delays power-on.
Previously, two annotation writes to the same PVC in one reconcile pass raced each other: the first refreshed the PVC on the server, but the second still used the stale in-memory copy and got rejected, which forced a full FCD cleanup and a from-scratch retry of the whole register-volume flow (including another vCenter round trip).

**What this PR does **:

clearKeepAfterDeleteVmIfNonRemovable and validatePVCTopologyCompatibility both mutate the same in-memory PVC in one Reconcile pass. The former updates a copy via a full-object Update and discards the result, so the latter's own full-object Update carries a stale resourceVersion and gets rejected, forcing an FCD cleanup/re-register retry.

Switch both writes to resourceVersion-agnostic merge patches, matching the pattern already used by setBackingDiskAnnotation in this package, and have clearKeepAfterDeleteVmIfNonRemovable return the refreshed PVC so callers chain off the live object instead of a stale pointer.


**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1768/
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1333/
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix CnsRegisterVolume PVC self-conflict on topology annotation update
```
