### PR TITLE
fix: validate webhook deployment script arguments

### DIFF
--- a/manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh
+++ b/manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh
@@ -14,30 +14,42 @@
 # limitations under the License.
 set -e
 
-if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+usage() {
     cat <<EOF
 Usage: Generate self-signed certificate for validation webhook service.
 Patch validatingwebhook.yaml with CA_BUNDLE retrieved from self-signed certificate
 and create ValidatingWebhookConfiguration and vsphere-webhook-svc service using patched yaml file
 
 usage: ${0} [OPTIONS]
-The following flags are required.
-       --namespace        Namespace where webhook service and secret reside.
+OPTIONS
+       --namespace VALUE  Namespace where webhook service and secret reside.
+       -h, --help         Show this help message.
 EOF
-    exit 1
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
 fi
 
+namespace=""
 while [[ $# -gt 0 ]]; do
     case ${1} in
         --namespace)
+            if [[ $# -lt 2 || -z "${2}" ]]; then
+                echo "missing value for --namespace" >&2
+                usage >&2
+                exit 1
+            fi
             namespace="$2"
-            shift
+            shift 2
             ;;
         *)
-            usage
+            echo "unknown option: ${1}" >&2
+            usage >&2
+            exit 1
             ;;
     esac
-    shift
 done
 
 [ -z "${namespace}" ] && namespace=vmware-system-csi


### PR DESCRIPTION
What this PR does / why we need it:

`deploy-vsphere-csi-validation-webhook.sh` had busted CLI error handling.
Unknown flags tried to run `usage` like a command, and `--namespace` with no value died on a bare `shift`, so the script faceplanted before it even touched the cluster. Kinda rough.

This patch adds a real `usage()` helper, returns `0` for `--help`, validates `--namespace`, and keeps the normal path the same.

Which issue this PR fixes: None

Testing done:

`bash -n manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh`

Repro with the old script blob from `HEAD`:
`tmp_old=$(mktemp) && git show HEAD:manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh > "$tmp_old" && chmod +x "$tmp_old" && bash "$tmp_old" --bad-flag`
old output: `usage: command not found`

`tmp_old=$(mktemp) && git show HEAD:manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh > "$tmp_old" && chmod +x "$tmp_old" && bash -x "$tmp_old" --namespace`
old behavior: exits after a bare `shift`

Repro with this patch:
`bash manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh --bad-flag`
now prints a clean unknown-option error and usage text

`bash manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh --namespace`
now prints a clean missing-value error and usage text

`bash manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh --help`
now exits `0`

`bash manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh --namespace vmware-system-csi`
still follows the normal path, and in this env stops at `kubectl not found`

Special notes for your reviewer:

No matching issue found, so this is just a tiny paper-cut fix.

Release note:
```release-note
NONE
```
