### PR TITLE
Update external-attacher image to v4.12.0_vmware.1 for SVC k8s 1.32

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -365,7 +365,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.10.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1
           args:
             - "--reconcile-sync=5m"
             - "--v=4"


### PR DESCRIPTION
Updates the csi-attacher image tag to v4.12.0_vmware.1 in supervisorcluster manifests for versions 1.32

WCP Test logs -> https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1781/artifact/Results/1781/test-e2e-logs.txt

VKS Test logs -> https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1346/artifact/Results/1346/test-e2e-logs.txt
