### PR TITLE
Return codes.OutOfRange gRPC code from pvCSI CBT API call, if returned so from supervisor CBT service

### DIFF
--- a/pkg/csi/service/wcpguest/controller_cbt.go
+++ b/pkg/csi/service/wcpguest/controller_cbt.go
@@ -109,7 +109,7 @@ func (c *controller) GetMetadataAllocated(
 		for {
 			svResp, err := stream.Recv()
 			if err != nil {
-				if err == io.EOF || status.Code(err) == codes.OutOfRange {
+				if err == io.EOF {
 					break
 				}
 				if status.Code(err) == codes.Canceled || status.Code(err) == codes.DeadlineExceeded {
@@ -236,7 +236,7 @@ func (c *controller) GetMetadataDelta(
 		for {
 			svResp, err := stream.Recv()
 			if err != nil {
-				if err == io.EOF || status.Code(err) == codes.OutOfRange {
+				if err == io.EOF {
 					break
 				}
 				if status.Code(err) == codes.Canceled || status.Code(err) == codes.DeadlineExceeded {

--- a/pkg/csi/service/wcpguest/controller_cbt_test.go
+++ b/pkg/csi/service/wcpguest/controller_cbt_test.go
@@ -94,7 +94,8 @@ type mockSupervisorSnapshotMetadataServer struct {
 	allocatedResponses []*snapshotmetadataapi.GetMetadataAllocatedResponse
 	deltaResponses     []*snapshotmetadataapi.GetMetadataDeltaResponse
 	errToReturn        error
-	// afterSendsReturn is returned from the handler after all configured Sends (e.g. OutOfRange for EOF-like end).
+	// afterSendsReturn is returned from the handler after all configured Sends (e.g. io.EOF for a
+	// normal end of stream, or a non-EOF status such as OutOfRange to simulate a Supervisor error).
 	afterSendsReturn error
 	// blockAfterSendsUntilCtxDone: after sending all responses, block until server.Context() is done,
 	// then return afterSendsReturn (or Canceled).
@@ -597,16 +598,18 @@ func TestGetMetadataAllocated(t *testing.T) {
 		assert.NotEqual(t, codes.OK, status.Code(err))
 	})
 
-	t.Run("OutOfRange from supervisor ends stream", func(t *testing.T) {
+	t.Run("OutOfRange from supervisor propagates as error", func(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.allocatedResponses = []*snapshotmetadataapi.GetMetadataAllocatedResponse{{VolumeCapacityBytes: 100}}
-		mockServer.afterSendsReturn = status.Error(codes.OutOfRange, "end")
+		mockServer.afterSendsReturn = status.Error(codes.OutOfRange, "startOffset is out of range")
 		mockServer.blockAfterSendsUntilCtxDone = false
 
-		req := &csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1", StartingOffset: 0, MaxResults: 10}
+		req := &csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1",
+			StartingOffset: 123456789123456789, MaxResults: 10}
 		mockStream := &mockAllocatedStreamServer{ctx: ctx}
 		err := ct.controller.GetMetadataAllocated(req, mockStream)
-		assert.NoError(t, err)
+		assert.Error(t, err)
+		assert.Equal(t, codes.OutOfRange, status.Code(err))
 		assert.Len(t, mockStream.responses, 1)
 	})
 
@@ -1054,18 +1057,20 @@ func TestGetMetadataDelta(t *testing.T) {
 		assert.NotEqual(t, codes.OK, status.Code(err))
 	})
 
-	t.Run("OutOfRange from supervisor ends stream", func(t *testing.T) {
+	t.Run("OutOfRange from supervisor propagates as error", func(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.deltaResponses = []*snapshotmetadataapi.GetMetadataDeltaResponse{{VolumeCapacityBytes: 100}}
-		mockServer.afterSendsReturn = status.Error(codes.OutOfRange, "end")
+		mockServer.afterSendsReturn = status.Error(codes.OutOfRange, "startOffset is out of range")
 		mockServer.blockAfterSendsUntilCtxDone = false
 
 		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
+			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2",
+			StartingOffset: 123456789123456789, MaxResults: 10,
 		}
 		mockStream := &mockDeltaStreamServer{ctx: ctx}
 		err := ct.controller.GetMetadataDelta(req, mockStream)
-		assert.NoError(t, err)
+		assert.Error(t, err)
+		assert.Equal(t, codes.OutOfRange, status.Code(err))
 		assert.Len(t, mockStream.responses, 1)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently in pvCSI CBT API calls, we call underlying supervisor CBT service, which returns the CBT metadata from VC layer. In case of any error, we mostly return the error returned from supervisor service as is as response to pvCSI CBT API call. However, for errorcode codes.OutOfRange, pvCSI handling masked the error and returned success, which breaks the functionality.
In case of complete metadata byte stream/response received, we get io.EOF from underlying supervisor API call, which can be used to return success. However, if underlying API returns codes.OutOfRange for genuine cases like startoffset more than disksize, we should return error code as it is from pvCSI API call. This PR handles the same.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested the change by manually replacing the image on setup and running CBT FVT testcases, verifying different inputs, passed successfully.

WCP precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1779/
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked

VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1342/
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Return codes.OutOfRange gRPC code from pvCSI CBT API call, if returned so from supervisor CBT service, instead of considering as success
```
