### PR TITLE
Fix finalizer removal from CNSFileAccessConfig CR when volume is not …

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -691,14 +691,30 @@ func (r *ReconcileCnsFileAccessConfig) configureNetPermissionsForFileVolume(ctx 
 	instanceLock, _ := volumePermissionLock.(*sync.Mutex)
 	instanceLock.Lock()
 	defer instanceLock.Unlock()
+	cnsFileVolumeClientInstance, err := getFileVolumeClientInstanceFn(ctx)
+	if err != nil {
+		return logger.LogNewErrorf(log, "Failed to get CNSFileVolumeClient instance. Error: %+v", err)
+	}
+	if removePermission {
+		// CnsFileVolumeClient does not exist for this PVC — nothing was ever configured, so there is
+		// nothing to clean up here. Skip resolving the VM's external IP, which may legitimately fail
+		// while the VM/network objects are being torn down.
+		exists, err := cnsFileVolumeClientInstance.CnsFileVolumeClientExistsForPvc(ctx,
+			instance.Namespace+"/"+instance.Spec.PvcName)
+		if err != nil {
+			return logger.LogNewErrorf(log, "Failed to check if CNSFileVolumeClient exists for PVC %q. Error: %+v",
+				instance.Spec.PvcName, err)
+		}
+		if !exists {
+			log.Infof("No CnsFileVolumeClient found for PVC %q; skipping net permission removal for "+
+				"CnsFileAccessConfig %q", instance.Spec.PvcName, instance.Name)
+			return nil
+		}
+	}
 	tkgVMIP, err := r.getVMExternalIP(ctx, vm)
 	if err != nil {
 		return logger.LogNewErrorf(log, "Failed to get external facing IP address for VM: %s/%s instance. Error: %+v",
 			vm.Namespace, vm.Name, err)
-	}
-	cnsFileVolumeClientInstance, err := getFileVolumeClientInstanceFn(ctx)
-	if err != nil {
-		return logger.LogNewErrorf(log, "Failed to get CNSFileVolumeClient instance. Error: %+v", err)
 	}
 	clientVms, err := cnsFileVolumeClientInstance.GetClientVMsFromIPList(ctx,
 		instance.Namespace+"/"+instance.Spec.PvcName, tkgVMIP)


### PR DESCRIPTION
…a file volume

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
