### PR TITLE
Add a Namespace watch to the ClusterStoragePolicyInfo controller for marker policy

### DIFF
--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -162,6 +162,40 @@ func add(mgr manager.Manager, r *ReconcileClusterStoragePolicyInfo) error {
 		},
 	}
 
+	// Trigger re-reconcile of the cluster-wide marker-policy ClusterStoragePolicyInfo when an
+	// FVS instance namespace is created/deleted or its vpc_network_config annotation /
+	// fvs_instance_namespace label changes.
+	nsFVSPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			if e.Object == nil {
+				return false
+			}
+			return e.Object.GetLabels()[cnsoperatorutil.NamespaceLabelFVSInstance] == "true"
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			oldLabel := e.ObjectOld.GetLabels()[cnsoperatorutil.NamespaceLabelFVSInstance]
+			newLabel := e.ObjectNew.GetLabels()[cnsoperatorutil.NamespaceLabelFVSInstance]
+			if oldLabel != "true" && newLabel != "true" {
+				// Not an FVS instance namespace before or after the update; the
+				// vpc_network_config annotation is set on every supervisor namespace,
+				// so ignore its changes unless this namespace is FVS-relevant.
+				return false
+			}
+			oldAnnotation := e.ObjectOld.GetAnnotations()[cnsoperatorutil.AnnotationVPCNetworkConfig]
+			newAnnotation := e.ObjectNew.GetAnnotations()[cnsoperatorutil.AnnotationVPCNetworkConfig]
+			return oldAnnotation != newAnnotation || oldLabel != newLabel
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if e.Object == nil {
+				return false
+			}
+			return e.Object.GetLabels()[cnsoperatorutil.NamespaceLabelFVSInstance] == "true"
+		},
+	}
+
 	blder := ctrl.NewControllerManagedBy(mgr).Named("clusterstoragepolicyinfo-controller").
 		For(&clusterspiv1alpha1.ClusterStoragePolicyInfo{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
@@ -169,6 +203,11 @@ func add(mgr manager.Manager, r *ReconcileClusterStoragePolicyInfo) error {
 			&storagev1.StorageClass{},
 			handler.EnqueueRequestsFromMapFunc(r.mapObjectToClusterSPI),
 			builder.WithPredicates(scVacPredicates),
+		).
+		Watches(
+			&v1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.mapFVSNamespaceToClusterMarkerSPI),
+			builder.WithPredicates(nsFVSPredicate),
 		)
 
 	// VolumeAttributesClass API is supported from K8s version 1.34 onwards.
@@ -215,6 +254,25 @@ func (r *ReconcileClusterStoragePolicyInfo) mapObjectToClusterSPI(ctx context.Co
 	}
 
 	return []reconcile.Request{{NamespacedName: apitypes.NamespacedName{Name: obj.GetName()}}}
+}
+
+// mapFVSNamespaceToClusterMarkerSPI maps an FVS instance namespace event to a reconcile
+// request for the single cluster-scoped vSAN File Service marker-policy
+// ClusterStoragePolicyInfo. Marker-policy topology depends on FVS instance namespace VPC
+// membership, so any relevant namespace change must re-trigger recomputation.
+func (r *ReconcileClusterStoragePolicyInfo) mapFVSNamespaceToClusterMarkerSPI(ctx context.Context,
+	obj client.Object) []reconcile.Request {
+	log := logger.GetLogger(ctx)
+	nsName := ""
+	if obj != nil {
+		nsName = obj.GetName()
+	}
+	log.Infof("FVS instance namespace %q changed; requeuing marker-policy ClusterStoragePolicyInfo %q",
+		nsName, common.StorageClassVsanFileServicePolicy)
+
+	return []reconcile.Request{{
+		NamespacedName: apitypes.NamespacedName{Name: common.StorageClassVsanFileServicePolicy},
+	}}
 }
 
 var _ reconcile.Reconciler = &ReconcileClusterStoragePolicyInfo{}

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
@@ -3463,6 +3464,13 @@ func TestPopulateTopologyCapabilities_MarkerPolicy(t *testing.T) {
 			}
 			k8sClient := k8sfake.NewSimpleClientset(k8sObjs...)
 
+			// Verify every FVS instance namespace was actually added to the fake client.
+			for _, ns := range tt.namespaces {
+				got, err := k8sClient.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
+				require.NoError(t, err)
+				assert.Equal(t, "true", got.Labels[cnsoperatorutil.NamespaceLabelFVSInstance])
+			}
+
 			r := &ReconcileClusterStoragePolicyInfo{
 				client:    fake.NewClientBuilder().WithScheme(scheme).Build(),
 				scheme:    scheme,
@@ -3911,4 +3919,39 @@ func TestCheckHighPerformanceLinkedClone_TwoZones_PartialESA(t *testing.T) {
 	result, err := checkHighPerformanceLinkedClone(ctx, vc, input)
 	require.NoError(t, err)
 	assert.False(t, result, "HPLC should be false when not all zones have ESA-enabled clusters")
+}
+
+// TestMapFVSNamespaceToClusterMarkerSPI verifies that any FVS instance namespace event maps to
+// exactly one reconcile request for the single cluster-scoped marker-policy
+// ClusterStoragePolicyInfo, regardless of the triggering object.
+func TestMapFVSNamespaceToClusterMarkerSPI(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	r := &ReconcileClusterStoragePolicyInfo{}
+
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "fvs-instance-ns",
+			Labels: map[string]string{cnsoperatorutil.NamespaceLabelFVSInstance: "true"},
+			Annotations: map[string]string{
+				cnsoperatorutil.AnnotationVPCNetworkConfig: "vpc-config-1",
+			},
+		},
+	}
+
+	reqs := r.mapFVSNamespaceToClusterMarkerSPI(ctx, ns)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: common.StorageClassVsanFileServicePolicy},
+	}, reqs[0])
+}
+
+// TestMapFVSNamespaceToClusterMarkerSPI_NilObject verifies the mapper is unconditional: it
+// returns the single marker-policy reconcile request even when the triggering object is nil.
+func TestMapFVSNamespaceToClusterMarkerSPI_NilObject(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	r := &ReconcileClusterStoragePolicyInfo{}
+
+	reqs := r.mapFVSNamespaceToClusterMarkerSPI(ctx, nil)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, common.StorageClassVsanFileServicePolicy, reqs[0].Name)
 }


### PR DESCRIPTION
ClusterStoragePolicyInfo computes cluster-wide accessible zones for the vSAN File Service marker policy (vsan-file-service-policy) from FVS instance namespaces and their NSX VPC membership, but previously only recomputed this on StorageClass/VolumeAttributesClass create events — it had no way to react when an FVS instance namespace's nsx.vmware.com/vpc_network_config annotation or fvs_instance_namespace label actually changed.
 This mirrors the same pattern already present for the namespace-scoped StoragePolicyInfo controller onto the cluster-scoped controller: a Watches(&v1.Namespace{}, ...) with a predicate that fires only on meaningful FVS/VPC changes, paired with a mapper that unconditionallyreconciles the single vsan-file-service-policy ClusterStoragePolicyInfo.

Testing done:
Pipelines passed:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1813/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1373/ - Passed

Unit tests passed:
```
=== RUN   TestMapFVSNamespaceToClusterMarkerSPI
{"level":"info","time":"2026-07-03T07:50:14.836596768Z","caller":"clusterstoragepolicyinfo/controller.go:264","msg":"FVS instance namespace \"fvs-instance-ns\" changed; requeuing marker-policy ClusterStoragePolicyInfo \"vsan-file-service-policy\"","TraceId":"dc459dca-689f-4925-bda3-05a2e3a91565"}
--- PASS: TestMapFVSNamespaceToClusterMarkerSPI (0.00s)
=== RUN   TestMapFVSNamespaceToClusterMarkerSPI_NilObject
{"level":"info","time":"2026-07-03T07:50:14.836880668Z","caller":"clusterstoragepolicyinfo/controller.go:264","msg":"FVS instance namespace \"\" changed; requeuing marker-policy ClusterStoragePolicyInfo \"vsan-file-service-policy\"","TraceId":"5b75b28c-7fc6-4935-8cb9-fe992beae471"}
--- PASS: TestMapFVSNamespaceToClusterMarkerSPI_NilObject (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo    2.783s

```

Testing done (Supervisor cluster)
Validated the new Namespace watch on the ClusterStoragePolicyInfo controller reactively recomputes the vSAN File Service marker-policy (vsan-file-service-policy) accessible zones on FVS instance namespace label/annotation changes, without requiring a StorageClass/VolumeAttributesClass event.

Test namespace: test-marker-policy (contains Zone CR zone1).

Test 1: New FVS-labeled namespace triggers reconcile and populates zones Labeled test-marker-policy with fvs_instance_namespace=true and annotated it with nsx.vmware.com/vpc_network_config=svc-cci-ns-8o66f-b2501dc3-6b96-4ef9-a1b3-a9f2a156cce8.

Result: Watch fired, reconcile ran, InfraStoragePolicyInfo.status.topology.accessibleZones populated with ["zone1"].
```
{"level":"info","time":"2026-07-06T16:02:55.660205845Z","caller":"clusterstoragepolicyinfo/controller.go:264","msg":"FVS instance namespace \"test-marker-policy\" changed; requeuing marker-policy ClusterStoragePolicyInfo \"vsan-file-service-policy\""}
{"level":"info","time":"2026-07-06T16:02:55.667661788Z","caller":"clusterstoragepolicyinfo/controller.go:292","msg":"Reconciling ClusterStoragePolicyInfo","name":"/vsan-file-service-policy"}
{"level":"info","time":"2026-07-06T16:02:55.776242206Z","caller":"clusterstoragepolicyinfo/controller.go:755","msg":"\"vsan-file-service-policy\" is a vSAN File Service marker policy; deriving zones from FVS instance namespaces"}
{"level":"info","time":"2026-07-06T16:02:55.785592409Z","caller":"util/markerzones.go:125","msg":"Accessible zones for vSAN File Service: [zone1]"}
{"level":"info","time":"2026-07-06T16:02:55.786144967Z","caller":"clusterstoragepolicyinfo/controller.go:768","msg":"vSAN File Service marker policy \"vsan-file-service-policy\" accessible zones: [zone1]"}
{"level":"info","time":"2026-07-06T16:02:55.834152077Z","caller":"clusterstoragepolicyinfo/controller.go:654","msg":"Successfully reconciled ClusterStoragePolicyInfo","name":"/vsan-file-service-policy"}
```

```
$ kubectl get infrastoragepolicyinfo vsan-file-service-policy -o jsonpath='{.status.topology.accessibleZones}'
["zone1"]
```

Test 2: Label flip (true → false) removes namespace from zone computation

```
$ kubectl label namespace test-marker-policy fvs_instance_namespace=false --overwrite
namespace/test-marker-policy labeled
```
Result: Watch fired on the label change, reconcile ran, zone list correctly dropped to empty since test-marker-policy was the only FVS-labeled namespace contributing zone1.

```
{"level":"info","time":"2026-07-06T16:05:51.137276496Z","caller":"clusterstoragepolicyinfo/controller.go:264","msg":"FVS instance namespace \"test-marker-policy\" changed; requeuing marker-policy ClusterStoragePolicyInfo \"vsan-file-service-policy\""}
{"level":"info","time":"2026-07-06T16:05:51.226640605Z","caller":"clusterstoragepolicyinfo/controller.go:755","msg":"\"vsan-file-service-policy\" is a vSAN File Service marker policy; deriving zones from FVS instance namespaces"}
{"level":"info","time":"2026-07-06T16:05:51.256822267Z","caller":"util/markerzones.go:125","msg":"Accessible zones for vSAN File Service: []"}
{"level":"info","time":"2026-07-06T16:05:51.257356585Z","caller":"clusterstoragepolicyinfo/controller.go:768","msg":"vSAN File Service marker policy \"vsan-file-service-policy\" accessible zones: []"}
```

```
$ kubectl get infrastoragepolicyinfo vsan-file-service-policy -o jsonpath='{.status.topology.accessibleZones}'
[]
```

Re-labeled back to true and confirmed the zone was restored:
```
$ kubectl label namespace test-marker-policy fvs_instance_namespace=true --overwrite
namespace/test-marker-policy labeled
$ kubectl get infrastoragepolicyinfo vsan-file-service-policy -o jsonpath='{.status.topology.accessibleZones}'
["zone1"]
```

Test 3: Negative control: unrelated namespace/label/annotation churn does not trigger the watch Performed, while tailing syncer logs filtered on "FVS instance namespace":

Created, labeled (some-other-label=foo), annotated (some-other-annotation=bar), and deleted an unrelated namespace (unrelated-ns-test, no FVS label). Added and removed an unrelated annotation (some-random-annotation) and label (some-random-label) on the already-FVS-labeled test-marker-policy namespace. Result: No "FVS instance namespace ... changed" log lines were emitted for any of the above (predicate correctly ignores namespace events that don't touch fvs_instance_namespace or nsx.vmware.com/vpc_network_config). accessibleZones remained stable at ["zone1"] throughout, confirming no spurious reconciles altered state.

```
$ kubectl get infrastoragepolicyinfo vsan-file-service-policy -o jsonpath='{.status.topology.accessibleZones}'
["zone1"]
```

4. Namespace deletion while FVS-labeled Created disposable namespace fvs-test-delete-me, labeled fvs_instance_namespace=true, annotated with a valid VPC CR.

```
{"msg":"FVS instance namespace \"fvs-test-delete-me\" changed; requeuing marker-policy ClusterStoragePolicyInfo \"vsan-file-service-policy\""}
{"msg":"Accessible zones for vSAN File Service: [zone1]"}
```

Deleted the namespace:

```
$ kubectl delete namespace fvs-test-delete-me
```
Logs:
```
{"msg":"FVS instance namespace \"fvs-test-delete-me\" changed; requeuing marker-policy ClusterStoragePolicyInfo \"vsan-file-service-policy\""}
{"msg":"Accessible zones for vSAN File Service: [zone1]"}
```

DeleteFunc predicate correctly fired; zones unaffected (namespace contributed no zone of its own).

5. Negative control: unrelated namespace/label/annotation churn does not trigger the watch While tailing syncer logs filtered on "FVS instance namespace":

Created, labeled (some-other-label=foo), annotated (some-other-annotation=bar), and deleted an unrelated namespace (unrelated-ns-test, no FVS label). Added and removed an unrelated annotation/label on the FVS-labeled test-marker-policy namespace. No "FVS instance namespace ... changed" log lines were emitted for any of the above. accessibleZones remained stable at ["zone1"] throughout.

```
$ kubectl get infrastoragepolicyinfo vsan-file-service-policy -o jsonpath='{.status.topology.accessibleZones}'
["zone1"]
```

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
