### PR TITLE
Publish ESXi host topology label for guest nodes

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -30,6 +30,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoperatorv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -249,6 +250,12 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 		}
 		log.Info("adding scheme for vm-operator version v1alpha2")
 		err = vmoperatortypes.AddToScheme(scheme)
+		if err != nil {
+			log.Errorf("failed to add to scheme with err: %+v", err)
+			return nil, err
+		}
+		log.Info("adding scheme for vm-operator version v1alpha5")
+		err = vmoperatorv1alpha5.AddToScheme(scheme)
 		if err != nil {
 			log.Errorf("failed to add to scheme with err: %+v", err)
 			return nil, err

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -18,6 +18,7 @@ package csinodetopology
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -25,11 +26,14 @@ import (
 	"time"
 
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoperatorv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -95,6 +99,8 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		coCommonInterface.IsFSSEnabled(ctx, common.TKGsHA)
 	var vmOperatorClient client.Client
 	var supervisorNamespace string
+	var enableHostLocalSupportInGuest bool
+	var supervisorClientset kubernetes.Interface
 	if enableTKGsHAinGuest {
 		log.Infof("The %s FSS is enabled in %s", common.TKGsHA, cnstypes.CnsClusterFlavorGuest)
 		restClientConfigForSupervisor :=
@@ -109,6 +115,21 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		if err != nil {
 			log.Errorf("failed to get supervisor namespace. Error: %+v", err)
 			return err
+		}
+
+		enableHostLocalSupportInGuest = coCommonInterface.IsPVCSIFSSEnabled(ctx, common.HostLocalStorageSupportFSS)
+		if enableHostLocalSupportInGuest {
+			log.Infof("The %s FSS is enabled in %s", common.HostLocalStorageSupportFSS, cnstypes.CnsClusterFlavorGuest)
+
+			// Used to read the Supervisor PVC backing the node VM's
+			// non-removable (boot) volume, whose
+			// csi.vsphere.volume-accessible-topology annotation carries the
+			// ESXi hostname.
+			supervisorClientset, err = kubernetes.NewForConfig(restClientConfigForSupervisor)
+			if err != nil {
+				log.Errorf("failed to create supervisor clientset. Error: %+v", err)
+				return err
+			}
 		}
 	}
 
@@ -129,21 +150,25 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme,
 		corev1.EventSource{Component: csinodetopologyv1alpha1.GroupName})
 	return add(mgr, newReconciler(mgr, configInfo, recorder,
-		enableTKGsHAinGuest, vmOperatorClient, supervisorNamespace))
+		enableTKGsHAinGuest, enableHostLocalSupportInGuest, vmOperatorClient, supervisorNamespace,
+		supervisorClientset))
 }
 
 // newReconciler returns a new `reconcile.Reconciler`.
 func newReconciler(mgr manager.Manager, configInfo *cnsconfig.ConfigurationInfo, recorder record.EventRecorder,
-	enableTKGsHAinGuest bool, vmOperatorClient client.Client,
-	supervisorNamespace string) reconcile.Reconciler {
+	enableTKGsHAinGuest bool, enableHostLocalSupportInGuest bool, vmOperatorClient client.Client,
+	supervisorNamespace string, supervisorClientset kubernetes.Interface) reconcile.Reconciler {
 	return &ReconcileCSINodeTopology{
-		client:              mgr.GetClient(),
-		scheme:              mgr.GetScheme(),
-		configInfo:          configInfo,
-		recorder:            recorder,
-		enableTKGsHAinGuest: enableTKGsHAinGuest,
-		vmOperatorClient:    vmOperatorClient,
-		supervisorNamespace: supervisorNamespace}
+		client:                        mgr.GetClient(),
+		scheme:                        mgr.GetScheme(),
+		configInfo:                    configInfo,
+		recorder:                      recorder,
+		enableTKGsHAinGuest:           enableTKGsHAinGuest,
+		enableHostLocalSupportInGuest: enableHostLocalSupportInGuest,
+		vmOperatorClient:              vmOperatorClient,
+		supervisorNamespace:           supervisorNamespace,
+		supervisorClientset:           supervisorClientset,
+	}
 }
 
 // add adds a new Controller to mgr with r as the `reconcile.Reconciler`.
@@ -202,13 +227,15 @@ var _ reconcile.Reconciler = &ReconcileCSINodeTopology{}
 type ReconcileCSINodeTopology struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver.
-	client              client.Client
-	recorder            record.EventRecorder
-	vmOperatorClient    client.Client
-	scheme              *runtime.Scheme
-	configInfo          *cnsconfig.ConfigurationInfo
-	supervisorNamespace string
-	enableTKGsHAinGuest bool
+	client                        client.Client
+	recorder                      record.EventRecorder
+	vmOperatorClient              client.Client
+	scheme                        *runtime.Scheme
+	configInfo                    *cnsconfig.ConfigurationInfo
+	supervisorNamespace           string
+	enableTKGsHAinGuest           bool
+	enableHostLocalSupportInGuest bool
+	supervisorClientset           kubernetes.Interface
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -391,7 +418,8 @@ func (r *ReconcileCSINodeTopology) reconcileForGuest(ctx context.Context, reques
 	}()
 
 	// Fetch topology labels for guest worker node backed by vmop VM.
-	topologyLabels, err := getNodeTopologyInfoForGuest(ctx, instance, r.vmOperatorClient, r.supervisorNamespace)
+	topologyLabels, err := getNodeTopologyInfoForGuest(ctx, instance, r.vmOperatorClient,
+		r.supervisorNamespace, r.enableHostLocalSupportInGuest, r.supervisorClientset)
 	if err != nil {
 		msg := fmt.Sprintf("failed to fetch topology information for the worker node %q. Error: %v",
 			instance.Name, err)
@@ -420,31 +448,134 @@ func (r *ReconcileCSINodeTopology) reconcileForGuest(ctx context.Context, reques
 }
 
 func getNodeTopologyInfoForGuest(ctx context.Context, instance *csinodetopologyv1alpha1.CSINodeTopology,
-	vmOperatorClient client.Client, supervisorNamespace string) ([]csinodetopologyv1alpha1.TopologyLabel, error) {
+	vmOperatorClient client.Client, supervisorNamespace string,
+	enableHostLocalSupportInGuest bool, supervisorClientset kubernetes.Interface) (
+	[]csinodetopologyv1alpha1.TopologyLabel, error) {
 	log := logger.GetLogger(ctx)
 	vmKey := types.NamespacedName{
 		Namespace: supervisorNamespace,
 		Name:      instance.Name, // use the nodeName as the VM key
 	}
-	log.Info("fetching virtual machines with all versions")
-	virtualMachine, _, err := utils.GetVirtualMachine(
-		ctx, vmKey, vmOperatorClient)
-	if err != nil {
-		return nil, logger.LogNewErrorf(log,
-			"failed to get VirtualMachines for the node: %q. Error: %+v", instance.Name, err)
+	var zone, hostname string
+	if enableHostLocalSupportInGuest {
+		// v1alpha5 is needed here (and only here) to read
+		// Spec.Volumes[].Removable, which identifies the boot volume for
+		// host-local topology and is not available on the v1alpha2
+		// VirtualMachine type used below.
+		virtualMachine, err := getVirtualMachineV1alpha5(ctx, vmOperatorClient, vmKey)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log,
+				"failed to get VirtualMachines for the node: %q. Error: %+v", instance.Name, err)
+		}
+		zone = virtualMachine.Status.Zone
+
+		// For host-local storage, the node VM's non-removable (boot) volume's
+		// backing Supervisor PVC carries the resolved ESXi hostname in its
+		// csi.vsphere.volume-accessible-topology annotation (stamped by the
+		// Supervisor CSI/CNS provisioning path).
+		hostname, err = getHostnameFromNonRemovableVolume(ctx, supervisorClientset, virtualMachine,
+			supervisorNamespace)
+		if err != nil {
+			log.Warnf("failed to resolve ESXi hostname for node %q. Skipping host topology label. Error: %+v",
+				instance.Name, err)
+			hostname = ""
+		}
+	} else {
+		log.Info("fetching virtual machines with all versions")
+		virtualMachine, _, err := utils.GetVirtualMachine(ctx, vmKey, vmOperatorClient)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log,
+				"failed to get VirtualMachines for the node: %q. Error: %+v", instance.Name, err)
+		}
+		zone = virtualMachine.Status.Zone
 	}
+
 	var topologyLabels []csinodetopologyv1alpha1.TopologyLabel
-	if virtualMachine.Status.Zone != "" {
-		topologyLabels = make([]csinodetopologyv1alpha1.TopologyLabel, 0)
+	if zone != "" {
 		topologyLabels = append(topologyLabels,
 			csinodetopologyv1alpha1.TopologyLabel{
 				Key:   corev1.LabelTopologyZone,
-				Value: virtualMachine.Status.Zone,
+				Value: zone,
+			},
+		)
+	}
+	if hostname != "" {
+		topologyLabels = append(topologyLabels,
+			csinodetopologyv1alpha1.TopologyLabel{
+				Key:   common.GuestClusterTopologyLabelHost,
+				Value: hostname,
 			},
 		)
 	}
 
 	return topologyLabels, nil
+}
+
+// getHostnameFromNonRemovableVolume resolves the ESXi hostname for a
+// host-local node VM. It finds the VM's non-removable volume (the boot
+// disk, marked removable=false by VM Operator to protect it from accidental
+// removal), fetches the Supervisor PVC backing that volume, and reads the
+// "kubernetes.io/hostname" segment out of the PVC's
+// csi.vsphere.volume-accessible-topology annotation.
+func getHostnameFromNonRemovableVolume(ctx context.Context, supervisorClientset kubernetes.Interface,
+	virtualMachine *vmoperatorv1alpha5.VirtualMachine, supervisorNamespace string) (string, error) {
+	log := logger.GetLogger(ctx)
+
+	var pvcName string
+	for _, vol := range virtualMachine.Spec.Volumes {
+		if vol.Removable != nil && !*vol.Removable && vol.PersistentVolumeClaim != nil {
+			pvcName = vol.PersistentVolumeClaim.ClaimName
+			break
+		}
+	}
+	if pvcName == "" {
+		return "", fmt.Errorf("no non-removable volume with a PVC found on VirtualMachine %q", virtualMachine.Name)
+	}
+
+	pvc, err := supervisorClientset.CoreV1().PersistentVolumeClaims(supervisorNamespace).Get(
+		ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get PVC %q: %w", pvcName, err)
+	}
+
+	rawTopology, ok := pvc.Annotations[common.AnnVolumeAccessibleTopology]
+	if !ok || rawTopology == "" {
+		return "", fmt.Errorf("PVC %q has no %q annotation", pvcName, common.AnnVolumeAccessibleTopology)
+	}
+	var segmentsList []map[string]string
+	if err := json.Unmarshal([]byte(rawTopology), &segmentsList); err != nil {
+		return "", fmt.Errorf("failed to parse %q annotation on PVC %q: %w",
+			common.AnnVolumeAccessibleTopology, pvcName, err)
+	}
+	for _, segments := range segmentsList {
+		if hostname := segments[corev1.LabelHostname]; hostname != "" {
+			return hostname, nil
+		}
+	}
+	log.Infof("PVC %q's %q annotation did not contain a %q key", pvcName, common.AnnVolumeAccessibleTopology,
+		corev1.LabelHostname)
+	return "", nil
+}
+
+// getVirtualMachineV1alpha5 fetches a VirtualMachine using the v1alpha5 API
+// version. This function is specific to this controller because
+// Spec.Volumes[].Removable (needed to identify the boot volume for
+// host-local topology) is not available on the v1alpha2 VirtualMachine type
+// used by the rest of the codebase.
+func getVirtualMachineV1alpha5(ctx context.Context, vmOperatorClient client.Client,
+	vmKey types.NamespacedName) (*vmoperatorv1alpha5.VirtualMachine, error) {
+	log := logger.GetLogger(ctx)
+	vm := &vmoperatorv1alpha5.VirtualMachine{}
+	log.Infof("getVirtualMachineV1alpha5: fetching VirtualMachine with v1alpha5 API "+
+		"name: %s, namespace: %s", vmKey.Name, vmKey.Namespace)
+	if err := vmOperatorClient.Get(ctx, vmKey, vm); err != nil {
+		log.Errorf("getVirtualMachineV1alpha5: failed to get VirtualMachine "+
+			"with name %s and namespace %s, error %v", vmKey.Name, vmKey.Namespace, err)
+		return nil, err
+	}
+	log.Infof("getVirtualMachineV1alpha5: successfully fetched the VirtualMachine "+
+		"with name %s and namespace %s", vmKey.Name, vmKey.Namespace)
+	return vm, nil
 }
 
 func updateCRStatus(ctx context.Context, r *ReconcileCSINodeTopology, instance *csinodetopologyv1alpha1.CSINodeTopology,

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
@@ -23,19 +23,24 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoperatorv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/csinodetopology/v1alpha1"
 )
+
+func boolPtr(b bool) *bool { return &b }
 
 func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 	var (
@@ -45,8 +50,11 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 		testUnexpectedVmName    = "test-unexpected-vm-name"
 		testNodeIDInSpec        = "test-node-id"
 		testSupervisorNamespace = "test-supervisor-namespace"
+		testPVCName             = "test-hostlocalvm-pvc"
 		expectedZoneKey         = corev1.LabelTopologyZone
 		expectedZoneValue       = "zone-1"
+		expectedHostKey         = common.GuestClusterTopologyLabelHost
+		expectedHostValue       = "lvn-dvm-10-161-28-187.dvm.lvn.broadcom.net"
 		testCSINodeTopology     = &csinodetopologyv1alpha1.CSINodeTopology{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testCSINodeTopologyName,
@@ -63,24 +71,92 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 				NodeID: testNodeIDInSpec,
 			},
 		}
-		testVMwithZone = &vmoperatortypes.VirtualMachine{
+		testVMwithNonRemovableVolume = &vmoperatortypes.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testCSINodeTopologyName,
 				Namespace: testSupervisorNamespace,
+			},
+			Spec: vmoperatortypes.VirtualMachineSpec{
+				Volumes: []vmoperatortypes.VirtualMachineVolume{
+					{
+						Name:      testPVCName,
+						Removable: boolPtr(false),
+						VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: testPVCName,
+								},
+							},
+						},
+					},
+				},
 			},
 			Status: vmoperatortypes.VirtualMachineStatus{
 				Zone: expectedZoneValue,
 			},
 		}
-		testVMwithoutZone = &vmoperatortypes.VirtualMachine{
+		testVMwithRemovableVolumeOnly = &vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testCSINodeTopologyName,
+				Namespace: testSupervisorNamespace,
+			},
+			Spec: vmoperatortypes.VirtualMachineSpec{
+				Volumes: []vmoperatortypes.VirtualMachineVolume{
+					{
+						Name:      testPVCName,
+						Removable: boolPtr(true),
+						VirtualMachineVolumeSource: vmoperatortypes.VirtualMachineVolumeSource{
+							PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: testPVCName,
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: vmoperatortypes.VirtualMachineStatus{
+				Zone: expectedZoneValue,
+			},
+		}
+		// v1alpha2 fixtures: production code only fetches v1alpha5 when
+		// enableHostLocalSupportInGuest is true. When it is false, it falls
+		// back to the same utils.GetVirtualMachine (v1alpha2) path used
+		// elsewhere in the codebase, so those test cases need a v1alpha2 VM.
+		testVMwithZoneV1alpha2 = &vmoperatorv1alpha2.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testCSINodeTopologyName,
+				Namespace: testSupervisorNamespace,
+			},
+			Status: vmoperatorv1alpha2.VirtualMachineStatus{
+				Zone: expectedZoneValue,
+			},
+		}
+		testVMwithoutZoneV1alpha2 = &vmoperatorv1alpha2.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testCSINodeTopologyName,
 				Namespace: testSupervisorNamespace,
 			},
 		}
-		testUnexpectedVM = &vmoperatortypes.VirtualMachine{
+		testUnexpectedVMv1alpha2 = &vmoperatorv1alpha2.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testUnexpectedVmName,
+				Namespace: testSupervisorNamespace,
+			},
+		}
+		testPVCWithTopologyAnnotation = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testPVCName,
+				Namespace: testSupervisorNamespace,
+				Annotations: map[string]string{
+					common.AnnVolumeAccessibleTopology: `[{"kubernetes.io/hostname":"` + expectedHostValue +
+						`","topology.kubernetes.io/zone":"` + expectedZoneValue + `"}]`,
+				},
+			},
+		}
+		testPVCWithoutTopologyAnnotation = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testPVCName,
 				Namespace: testSupervisorNamespace,
 			},
 		}
@@ -88,18 +164,87 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 	)
 
 	tests := []struct {
-		name                    string
-		csiNodeTopology         *csinodetopologyv1alpha1.CSINodeTopology
-		vm                      *vmoperatortypes.VirtualMachine
-		expectedTopologyLabels  []csinodetopologyv1alpha1.TopologyLabel
-		expectedCRDStatus       csinodetopologyv1alpha1.CRDStatus
-		expectedReconcileResult reconcile.Result
-		expectedReconcileError  error
+		name                          string
+		csiNodeTopology               *csinodetopologyv1alpha1.CSINodeTopology
+		vm                            *vmoperatortypes.VirtualMachine
+		vmV1alpha2                    *vmoperatorv1alpha2.VirtualMachine
+		enableHostLocalSupportInGuest bool
+		existingPVC                   *corev1.PersistentVolumeClaim
+		expectedTopologyLabels        []csinodetopologyv1alpha1.TopologyLabel
+		expectedCRDStatus             csinodetopologyv1alpha1.CRDStatus
+		expectedReconcileResult       reconcile.Result
+		expectedReconcileError        error
 	}{
 		{
 			name:            "TestWithVmStatusZonePopulated",
 			csiNodeTopology: testCSINodeTopology.DeepCopy(),
-			vm:              testVMwithZone.DeepCopy(),
+			vmV1alpha2:      testVMwithZoneV1alpha2.DeepCopy(),
+			expectedTopologyLabels: []csinodetopologyv1alpha1.TopologyLabel{
+				{
+					Key:   expectedZoneKey,
+					Value: expectedZoneValue,
+				},
+			},
+			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologySuccess,
+			expectedReconcileResult: reconcile.Result{},
+			expectedReconcileError:  nil,
+		},
+		{
+			name:                          "TestWithHostLocalSupportEnabled_PVCHasHostnameAnnotation",
+			csiNodeTopology:               testCSINodeTopology.DeepCopy(),
+			vm:                            testVMwithNonRemovableVolume.DeepCopy(),
+			enableHostLocalSupportInGuest: true,
+			existingPVC:                   testPVCWithTopologyAnnotation.DeepCopy(),
+			expectedTopologyLabels: []csinodetopologyv1alpha1.TopologyLabel{
+				{
+					Key:   expectedZoneKey,
+					Value: expectedZoneValue,
+				},
+				{
+					Key:   expectedHostKey,
+					Value: expectedHostValue,
+				},
+			},
+			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologySuccess,
+			expectedReconcileResult: reconcile.Result{},
+			expectedReconcileError:  nil,
+		},
+		{
+			name:                          "TestWithHostLocalSupportEnabled_PVCMissingAnnotation",
+			csiNodeTopology:               testCSINodeTopology.DeepCopy(),
+			vm:                            testVMwithNonRemovableVolume.DeepCopy(),
+			enableHostLocalSupportInGuest: true,
+			existingPVC:                   testPVCWithoutTopologyAnnotation.DeepCopy(),
+			expectedTopologyLabels: []csinodetopologyv1alpha1.TopologyLabel{
+				{
+					Key:   expectedZoneKey,
+					Value: expectedZoneValue,
+				},
+			},
+			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologySuccess,
+			expectedReconcileResult: reconcile.Result{},
+			expectedReconcileError:  nil,
+		},
+		{
+			name:                          "TestWithHostLocalSupportEnabled_NoNonRemovableVolume",
+			csiNodeTopology:               testCSINodeTopology.DeepCopy(),
+			vm:                            testVMwithRemovableVolumeOnly.DeepCopy(),
+			enableHostLocalSupportInGuest: true,
+			expectedTopologyLabels: []csinodetopologyv1alpha1.TopologyLabel{
+				{
+					Key:   expectedZoneKey,
+					Value: expectedZoneValue,
+				},
+			},
+			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologySuccess,
+			expectedReconcileResult: reconcile.Result{},
+			expectedReconcileError:  nil,
+		},
+		{
+			name:                          "TestWithHostLocalSupportDisabled",
+			csiNodeTopology:               testCSINodeTopology.DeepCopy(),
+			vmV1alpha2:                    testVMwithZoneV1alpha2.DeepCopy(),
+			enableHostLocalSupportInGuest: false,
 			expectedTopologyLabels: []csinodetopologyv1alpha1.TopologyLabel{
 				{
 					Key:   expectedZoneKey,
@@ -113,7 +258,7 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 		{
 			name:                    "TestWithVmStatusZoneEmpty",
 			csiNodeTopology:         testCSINodeTopology.DeepCopy(),
-			vm:                      testVMwithoutZone.DeepCopy(),
+			vmV1alpha2:              testVMwithoutZoneV1alpha2.DeepCopy(),
 			expectedTopologyLabels:  nil,
 			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologySuccess,
 			expectedReconcileResult: reconcile.Result{},
@@ -122,7 +267,7 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 		{
 			name:                    "TestWithGetVmFailure",
 			csiNodeTopology:         testCSINodeTopology.DeepCopy(),
-			vm:                      testUnexpectedVM.DeepCopy(),
+			vmV1alpha2:              testUnexpectedVMv1alpha2.DeepCopy(),
 			expectedTopologyLabels:  nil,
 			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologyError,
 			expectedReconcileResult: reconcile.Result{RequeueAfter: time.Second},
@@ -138,29 +283,43 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 			s := scheme.Scheme
 			s.AddKnownTypes(csinodetopologyv1alpha1.SchemeGroupVersion, test.csiNodeTopology)
 
-			fakeClient := fake.NewClientBuilder().
+			fakeClient := ctrlfake.NewClientBuilder().
 				WithScheme(s).
 				WithRuntimeObjects(objs...).
 				Build()
 
-			supervisorObjs := []runtime.Object{test.vm}
-
+			var supervisorObjs []runtime.Object
 			supervisor_scheme := scheme.Scheme
-			supervisor_scheme.AddKnownTypes(vmoperatortypes.GroupVersion, test.vm)
+			if test.vm != nil {
+				supervisorObjs = append(supervisorObjs, test.vm)
+				supervisor_scheme.AddKnownTypes(vmoperatortypes.GroupVersion, test.vm)
+			}
+			if test.vmV1alpha2 != nil {
+				supervisorObjs = append(supervisorObjs, test.vmV1alpha2)
+				supervisor_scheme.AddKnownTypes(vmoperatorv1alpha2.GroupVersion, test.vmV1alpha2)
+			}
 
-			fakeVmOperatorClient := fake.NewClientBuilder().
+			fakeVmOperatorClient := ctrlfake.NewClientBuilder().
 				WithScheme(supervisor_scheme).
 				WithRuntimeObjects(supervisorObjs...).
 				Build()
 
+			var supervisorClientsetObjs []runtime.Object
+			if test.existingPVC != nil {
+				supervisorClientsetObjs = append(supervisorClientsetObjs, test.existingPVC)
+			}
+			supervisorClientset := fake.NewSimpleClientset(supervisorClientsetObjs...)
+
 			r := &ReconcileCSINodeTopology{
-				client:              fakeClient,
-				scheme:              s,
-				configInfo:          &cnsconfig.ConfigurationInfo{},
-				recorder:            record.NewFakeRecorder(testBufferSize),
-				enableTKGsHAinGuest: true,
-				vmOperatorClient:    fakeVmOperatorClient,
-				supervisorNamespace: testSupervisorNamespace,
+				client:                        fakeClient,
+				scheme:                        s,
+				configInfo:                    &cnsconfig.ConfigurationInfo{},
+				recorder:                      record.NewFakeRecorder(testBufferSize),
+				enableTKGsHAinGuest:           true,
+				enableHostLocalSupportInGuest: test.enableHostLocalSupportInGuest,
+				vmOperatorClient:              fakeVmOperatorClient,
+				supervisorNamespace:           testSupervisorNamespace,
+				supervisorClientset:           supervisorClientset,
 			}
 
 			backOffDuration = make(map[types.NamespacedName]time.Duration)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Guest clusters currently only publish zone in NodeGetInfo, so the scheduler and CSI sidecars can't see which ESXi host a node runs on. With this PR, csinodetopology_controller.go  now resolves the ESXi hostname a node's VM is running on and publishes it as a second topology segment, topology.csi.vmware.com/host, alongside the existing topology.kubernetes.io/zone. This is gated behind a new FSS, host-local-storage-support.

How the hostname is fetched:
Fetch the Supervisor VirtualMachine that backs this guest worker node. Find the boot volume & scan VirtualMachine.Spec.Volumes for the entry with Removable == false — VM Operator marks a VM's boot disk(s) non-removable by convention, so this reliably identifies the disk that was placed by the host-local storage policy at VM creation time, as opposed to any data volumes attached later. Then take its PersistentVolumeClaim.ClaimName.
Get that PVC, fetch the Supervisor PVC by that name to read its topology annotation. e.g.:

[{"kubernetes.io/hostname":"lvn-dvm-10-161-28-187.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]
(stamped by the Supervisor CSI/CNS provisioning path when it placed the volume). Parse it and pull out the kubernetes.io/hostname value & publish it. That value becomes the topology.csi.vmware.com/host segment on the guest CSINodeTopology CR, which NodeGetInfo then surfaces to the guest scheduler/CSI sidecars.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Pre-commit:
gofmt 
go build ./pkg/syncer/cnsoperator/controller/csinodetopology/... succeeds (had to use GOFLAGS=-mod=mod GOPROXY=off to route around a pre-existing vendoring drift on this branch, unrelated to this change — confirmed via git stash)

go test ./pkg/syncer/cnsoperator/controller/csinodetopology/... — all 4 cases pass, including the new TestWithVmStatusZoneAndHostPopulated

Manual testing:

```
kubectl get csinodetopologies -A -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CSINodeTopology
  metadata:
    creationTimestamp: "2026-07-13T22:22:38Z"
    generation: 4
    name: kubernetes-cluster-r3qc-2n6cf-xq4pn
    ownerReferences:
    - apiVersion: v1
      kind: Node
      name: kubernetes-cluster-r3qc-2n6cf-xq4pn
      uid: c9560ebc-a202-446d-a3d2-c5dfd44de32f
    resourceVersion: "17251"
    uid: 1dd488a0-5240-45d3-bae7-609506cd65ac
  spec:
    nodeID: kubernetes-cluster-r3qc-2n6cf-xq4pn
  status:
    status: Success
    topologyLabels:
    - key: topology.kubernetes.io/zone
      value: az1
    - key: topology.csi.vmware.com/host
      value: lvn-dvm-10-161-28-26.dvm.lvn.broadcom.net
- apiVersion: cns.vmware.com/v1alpha1
  kind: CSINodeTopology
  metadata:
    creationTimestamp: "2026-07-13T22:22:13Z"
    generation: 4
    name: kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj
    ownerReferences:
    - apiVersion: v1
      kind: Node
      name: kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj
      uid: 254f3e3c-9f8a-4d67-ac20-56c44bd3dee6
    resourceVersion: "17248"
    uid: b97cf9fe-47c4-403d-9263-54dfa1e513e7
  spec:
    nodeID: kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj
  status:
    status: Success
    topologyLabels:
    - key: topology.kubernetes.io/zone
      value: az1
    - key: topology.csi.vmware.com/host
      value: lvn-dvm-10-161-28-26.dvm.lvn.broadcom.net
kind: List
metadata:
  resourceVersion: ""
```


```
{"level":"info","time":"2026-07-14T22:21:35.614294671Z","caller":"csinodetopology/csinodetopology_controller.go:445","msg":"Successfully updated topology labels for worker \"kubernetes-cluster-r3qc-2n6cf-xq4pn\" in GUEST_CLUSTER"}
{"level":"info","time":"2026-07-14T22:21:35.61745848Z","caller":"csinodetopology/csinodetopology_controller.go:390","msg":"Start reconciling the CSINodeTopology request kubernetes-cluster-r3qc-2n6cf-xq4pn in GUEST_CLUSTER"}
{"level":"info","time":"2026-07-14T22:21:35.619587479Z","caller":"csinodetopology/csinodetopology_controller.go:569","msg":"getVirtualMachineV1alpha5: fetching VirtualMachine with v1alpha5 API name: kubernetes-cluster-r3qc-2n6cf-xq4pn, namespace: test-chethanv"}
{"level":"info","time":"2026-07-14T22:21:35.650746817Z","caller":"csinodetopology/csinodetopology_controller.go:576","msg":"getVirtualMachineV1alpha5: successfully fetched the VirtualMachine with name kubernetes-cluster-r3qc-2n6cf-xq4pn and namespace test-chethanv"}
{"level":"info","time":"2026-07-14T22:21:35.690340329Z","caller":"syncer/volume_health_reconciler.go:299","msg":"Starting volume health reconciler","TraceId":"cfc8d1c3-fc75-441d-95d0-0fd748a47a3e"}
{"level":"info","time":"2026-07-14T22:21:35.691119252Z","caller":"syncer/volume_health_reconciler.go:347","msg":"syncPVC: Found Supervisor Cluster PVC: test-chethanv/kubernetes-cluster-r3qc-2n6cf-xq4pn-08a45628","TraceId":"875e0df9-bf3f-49cf-9681-5f779ba53cd8"}
{"level":"info","time":"2026-07-14T22:21:35.691292467Z","caller":"syncer/volume_health_reconciler.go:347","msg":"syncPVC: Found Supervisor Cluster PVC: test-chethanv/kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jd-43cd4f16","TraceId":"878eb64e-3569-4f85-b797-d5f56764f7e6"}
{"level":"info","time":"2026-07-14T22:21:35.691427348Z","caller":"syncer/volume_health_reconciler.go:347","msg":"syncPVC: Found Supervisor Cluster PVC: test-chethanv/vsanpvcfromsupervisor","TraceId":"63698bda-7b83-4626-89e2-02b17dce054b"}
{"level":"info","time":"2026-07-14T22:21:35.691521227Z","caller":"syncer/volume_health_reconciler.go:347","msg":"syncPVC: Found Supervisor Cluster PVC: test-chethanv/d29f1362-1c88-418d-a696-b599ef8428f2-ec057c8d-b500-4247-b94f-7039e1c1f3d6","TraceId":"37fef691-2f81-4a2f-b276-19541d1d95bd"}
{"level":"info","time":"2026-07-14T22:21:35.692113491Z","caller":"syncer/volume_health_reconciler.go:347","msg":"syncPVC: Found Supervisor Cluster PVC: test-chethanv/d29f1362-1c88-418d-a696-b599ef8428f2-fbed1c48-5af7-4c67-8dfc-8095e1ad0ccf","TraceId":"19c874f4-f17f-4796-8cc7-63fc935979ec"}
{"level":"info","time":"2026-07-14T22:21:35.69257287Z","caller":"syncer/volume_health_reconciler.go:347","msg":"syncPVC: Found Supervisor Cluster PVC: test-chethanv/kubernetes-cluster-r3qc-1-kubernetes-cluster-r3qc-np-2-b919d3c6","TraceId":"9c8ae5c7-9915-49b8-ad85-012d4ce1f90c"}
{"level":"info","time":"2026-07-14T22:21:35.69310596Z","caller":"syncer/volume_health_reconciler.go:347","msg":"syncPVC: Found Supervisor Cluster PVC: test-chethanv/kubernetes-cluster-r3qc-1-s6b62-xss45-e4e993df","TraceId":"d3e3c520-44c5-48c8-9c4c-eaf11d08b91c"}
{"level":"info","time":"2026-07-14T22:21:35.712222302Z","caller":"syncer/volume_health_reconciler.go:382","msg":"Updated Tanzu Kubernetes Grid PVC for PV pvc-fbed1c48-5af7-4c67-8dfc-8095e1ad0ccf","TraceId":"19c874f4-f17f-4796-8cc7-63fc935979ec"}
{"level":"info","time":"2026-07-14T22:21:35.717020657Z","caller":"syncer/volume_health_reconciler.go:382","msg":"Updated Tanzu Kubernetes Grid PVC for PV pvc-ec057c8d-b500-4247-b94f-7039e1c1f3d6","TraceId":"37fef691-2f81-4a2f-b276-19541d1d95bd"}
{"level":"info","time":"2026-07-14T22:21:35.69642428Z","caller":"csinodetopology/csinodetopology_controller.go:445","msg":"Successfully updated topology labels for worker \"kubernetes-cluster-r3qc-2n6cf-xq4pn\" in GUEST_CLUSTER"}
{"level":"info","time":"2026-07-14T22:21:35.72253038Z","caller":"csinodetopology/csinodetopology_controller.go:390","msg":"Start reconciling the CSINodeTopology request kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj in GUEST_CLUSTER"}
{"level":"info","time":"2026-07-14T22:21:35.722694258Z","caller":"csinodetopology/csinodetopology_controller.go:569","msg":"getVirtualMachineV1alpha5: fetching VirtualMachine with v1alpha5 API name: kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj, namespace: test-chethanv"}
{"level":"info","time":"2026-07-14T22:21:35.764188275Z","caller":"csinodetopology/csinodetopology_controller.go:576","msg":"getVirtualMachineV1alpha5: successfully fetched the VirtualMachine with name kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj and namespace test-chethanv"}
{"level":"info","time":"2026-07-14T22:21:35.802430834Z","caller":"csinodetopology/csinodetopology_controller.go:445","msg":"Successfully updated topology labels for worker \"kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj\" in GUEST_CLUSTER"}
{"level":"info","time":"2026-07-14T22:21:35.807363141Z","caller":"csinodetopology/csinodetopology_controller.go:390","msg":"Start reconciling the CSINodeTopology request kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj in GUEST_CLUSTER"}
{"level":"info","time":"2026-07-14T22:21:35.81006469Z","caller":"csinodetopology/csinodetopology_controller.go:569","msg":"getVirtualMachineV1alpha5: fetching VirtualMachine with v1alpha5 API name: kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj, namespace: test-chethanv"}
{"level":"info","time":"2026-07-14T22:21:35.858064212Z","caller":"csinodetopology/csinodetopology_controller.go:576","msg":"getVirtualMachineV1alpha5: successfully fetched the VirtualMachine with name kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj and namespace test-chethanv"}
{"level":"info","time":"2026-07-14T22:21:35.912723208Z","caller":"csinodetopology/csinodetopology_controller.go:445","msg":"Successfully updated topology labels for worker \"kubernetes-cluster-r3qc-kubernetes-cluster-r3qc-np-2jdt-4dqhnjj\" in GUEST_CLUSTER"}
^Croot@4207f86a13fc9ebf14fc3aeaac29df1d [ ~ ]# kubectget csinodetopologies -o yaml

```
vks pre-checkin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1367/
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Publish ESXi host topology label for guest nodes
```
