### PR TITLE
Support host-local storage policy provisioning on supervisor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vmware-tanzu/vm-operator/api v1.9.1-0.20260423003402-51227659e236
 	github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20260626202036-4f3bb257838c
-	github.com/vmware/govmomi v0.55.0
+	github.com/vmware/govmomi v0.55.1
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/vmware-tanzu/vm-operator/api v1.9.1-0.20260423003402-51227659e236 h1:
 github.com/vmware-tanzu/vm-operator/api v1.9.1-0.20260423003402-51227659e236/go.mod h1:nWTPpxfe4gHuuYuFcrs86+NMxfkqPk3a3IlvI8TCWak=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20260626202036-4f3bb257838c h1:E9XvcuEJ3CbrWzD+/2UaLkmOKqiM3VrjFwwfHaiGjcA=
 github.com/vmware-tanzu/vm-operator/external/byok v0.0.0-20260626202036-4f3bb257838c/go.mod h1:8tiuyYslzjLIUmOlXZuGKQdQP2ZgWGCVhVeyptmZYnk=
-github.com/vmware/govmomi v0.55.0 h1:b02z/onIxqdpV8gKw11OYrrGdCnSA9WoBc70Fbr+HBg=
-github.com/vmware/govmomi v0.55.0/go.mod h1:QR6UoTHdmvT5XvdomNKwyi7VPOnrE0QZxjPBJ0mWWQs=
+github.com/vmware/govmomi v0.55.1 h1:7FW6VXIdKe/7AXftBoFTHaf0UO8Kdl84tIjothNDlZI=
+github.com/vmware/govmomi v0.55.1/go.mod h1:QR6UoTHdmvT5XvdomNKwyi7VPOnrE0QZxjPBJ0mWWQs=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -188,6 +188,9 @@ type CnsVolumeInfo struct {
 	DatastoreURL string
 	VolumeID     cnstypes.CnsVolumeId
 	Clusters     []vim25types.ManagedObjectReference
+	// Host is the ESX HostSystem MoRef that CNS selected for a host-local volume, as reported in
+	// the CNS placement result. Nil for non-host-local volumes.
+	Host *vim25types.ManagedObjectReference
 }
 
 type CnsSnapshotInfo struct {

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -334,6 +334,7 @@ func getCnsVolumeInfoFromTaskResult(ctx context.Context, virtualCenter *cnsvsphe
 	log := logger.GetLogger(ctx)
 	var datastoreURL string
 	var placementClusters []types.ManagedObjectReference
+	var placementHost *types.ManagedObjectReference
 	volumeCreateResult := interface{}(taskResult).(*cnstypes.CnsVolumeCreateResult)
 	log.Debugf("volumeCreateResult.PlacementResults :%v", volumeCreateResult.PlacementResults)
 	if volumeCreateResult.PlacementResults != nil {
@@ -342,6 +343,12 @@ func getCnsVolumeInfoFromTaskResult(ctx context.Context, virtualCenter *cnsvsphe
 			// For the datastore which the volume is provisioned, placementFaults
 			// will not be set.
 			if len(placementResult.PlacementFaults) == 0 {
+				// For host-local volumes, CNS reports the selected host in the winning
+				// placement result. Capture it so the caller can build PV node affinity.
+				if placementResult.Host != nil {
+					placementHost = placementResult.Host
+					log.Debugf("placementHost:%v for volume:%q", placementHost, volumeID)
+				}
 				if len(placementResult.Clusters) != 0 {
 					placementClusters = placementResult.Clusters
 					log.Debugf("placementClusters:%v for volume:%q", placementClusters, volumeID)
@@ -368,6 +375,7 @@ func getCnsVolumeInfoFromTaskResult(ctx context.Context, virtualCenter *cnsvsphe
 		DatastoreURL: datastoreURL,
 		VolumeID:     volumeID,
 		Clusters:     placementClusters,
+		Host:         placementHost,
 	}, "", nil
 }
 

--- a/pkg/common/cns-lib/volume/util_placement_test.go
+++ b/pkg/common/cns-lib/volume/util_placement_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"testing"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// TestGetCnsVolumeInfoFromTaskResultHostCapture verifies that the host CNS reports in the winning
+// placement result (used for host-local volumes) is surfaced on the returned CnsVolumeInfo. The
+// placement result also carries clusters so the datastore-lookup branch (which needs a vCenter
+// connection) is not exercised.
+func TestGetCnsVolumeInfoFromTaskResultHostCapture(t *testing.T) {
+	ctx := context.Background()
+	hostRef := types.ManagedObjectReference{Type: "HostSystem", Value: "host-42"}
+	clusterRef := types.ManagedObjectReference{Type: "ClusterComputeResource", Value: "domain-c1"}
+	volumeID := cnstypes.CnsVolumeId{Id: "vol-1"}
+
+	taskResult := &cnstypes.CnsVolumeCreateResult{
+		PlacementResults: []cnstypes.CnsPlacementResult{
+			{
+				Clusters: []types.ManagedObjectReference{clusterRef},
+				Host:     &hostRef,
+			},
+		},
+	}
+
+	info, faultType, err := getCnsVolumeInfoFromTaskResult(ctx, nil, "vol", volumeID, taskResult)
+	if err != nil {
+		t.Fatalf("unexpected error: %v (faultType %q)", err, faultType)
+	}
+	if info.Host == nil {
+		t.Fatalf("expected placement host to be captured, got nil")
+	}
+	if info.Host.Value != "host-42" {
+		t.Errorf("expected host MoRef value %q, got %q", "host-42", info.Host.Value)
+	}
+}
+
+// TestGetCnsVolumeInfoFromTaskResultNoHost verifies that CnsVolumeInfo.Host stays nil when CNS does
+// not report a host in the placement result (the non-host-local case).
+func TestGetCnsVolumeInfoFromTaskResultNoHost(t *testing.T) {
+	ctx := context.Background()
+	clusterRef := types.ManagedObjectReference{Type: "ClusterComputeResource", Value: "domain-c1"}
+	volumeID := cnstypes.CnsVolumeId{Id: "vol-2"}
+
+	taskResult := &cnstypes.CnsVolumeCreateResult{
+		PlacementResults: []cnstypes.CnsPlacementResult{
+			{
+				Clusters: []types.ManagedObjectReference{clusterRef},
+			},
+		},
+	}
+
+	info, faultType, err := getCnsVolumeInfoFromTaskResult(ctx, nil, "vol", volumeID, taskResult)
+	if err != nil {
+		t.Fatalf("unexpected error: %v (faultType %q)", err, faultType)
+	}
+	if info.Host != nil {
+		t.Errorf("expected nil host, got %+v", info.Host)
+	}
+}

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -50,6 +50,9 @@ type FakeK8SOrchestrator struct {
 	csiNodeTopologyInstances []interface{}
 	// PVCs for testing
 	pvcs []*v1.PersistentVolumeClaim
+	// NodeNameToHostMoID is the node name -> ESXi host MoID map returned by
+	// GetNodeNameToHostMoIDMap in tests. Nil returns an empty map.
+	NodeNameToHostMoID map[string]string
 }
 
 // volumeMigration holds mocked migrated volume information

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -488,6 +488,19 @@ func (c *FakeK8SOrchestrator) GetNodeIDtoNameMap(ctx context.Context) map[string
 	return nodeIDToNamesMap
 }
 
+// GetNodeNameToHostMoIDMap returns the configured node name to ESXi host MoID map,
+// or an empty map when unset.
+func (c *FakeK8SOrchestrator) GetNodeNameToHostMoIDMap(ctx context.Context) map[string]string {
+	if c.NodeNameToHostMoID == nil {
+		return map[string]string{}
+	}
+	nodeNameToHostMoIDCopy := make(map[string]string, len(c.NodeNameToHostMoID))
+	for name, id := range c.NodeNameToHostMoID {
+		nodeNameToHostMoIDCopy[name] = id
+	}
+	return nodeNameToHostMoIDCopy
+}
+
 // GetFakeAttachedVolumes returns a map of volumeIDs to a bool, which is set
 // to true if volumeID key is fake attached else false
 func (c *FakeK8SOrchestrator) GetFakeAttachedVolumes(ctx context.Context, volumeID []string) map[string]bool {

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -70,6 +70,8 @@ type COCommonInterface interface {
 	GetNodesForVolumes(ctx context.Context, volumeIds []string) map[string][]string
 	// GetNodeIDtoNameMap returns a map of node ID  to node names
 	GetNodeIDtoNameMap(ctx context.Context) map[string]string
+	// GetNodeNameToHostMoIDMap returns a map of node name to ESXi host MoID.
+	GetNodeNameToHostMoIDMap(ctx context.Context) map[string]string
 	// GetFakeAttachedVolumes returns a map of volumeIDs to a bool, which is set
 	// to true if volumeID key is fake attached else false
 	GetFakeAttachedVolumes(ctx context.Context, volumeIDs []string) map[string]bool

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -207,12 +207,15 @@ func (m *volumeNameToNodesMap) get(volumeName string) []string {
 	return m.items[volumeName]
 }
 
-// Map of nodeID to node names in the cluster. Key is the nodeID
-// and value is the corresponding node name. The methods to add
-// and remove entries from the map in a threadsafe manner are defined.
+// Bidirectional map of nodeID (ESXi host MoID) to node name in the cluster.
+// items maps nodeID -> node name; nameToID maps node name -> nodeID. Both
+// directions are maintained together so consumers that need the reverse
+// (node name -> host MoID) lookup do not have to rebuild it on every call.
+// The methods to add and remove entries in a threadsafe manner are defined.
 type nodeIDToNameMap struct {
 	*sync.RWMutex
-	items map[string]string
+	items    map[string]string
+	nameToID map[string]string
 }
 
 // Adds an entry to nodeIDToNameMap in a thread safe manner.
@@ -220,13 +223,29 @@ func (m *nodeIDToNameMap) add(nodeID, nodeName string) {
 	m.Lock()
 	defer m.Unlock()
 	m.items[nodeID] = nodeName
+	m.nameToID[nodeName] = nodeID
 }
 
 // Removes an entry from nodeIDToNameMap in a thread safe manner.
 func (m *nodeIDToNameMap) remove(nodeID string) {
 	m.Lock()
 	defer m.Unlock()
+	if nodeName, ok := m.items[nodeID]; ok {
+		delete(m.nameToID, nodeName)
+	}
 	delete(m.items, nodeID)
+}
+
+// getNameToIDCopy returns a copy of the node name -> host MoID map under a read
+// lock so callers get a race-free snapshot they can iterate safely.
+func (m *nodeIDToNameMap) getNameToIDCopy() map[string]string {
+	m.RLock()
+	defer m.RUnlock()
+	nameToIDCopy := make(map[string]string, len(m.nameToID))
+	for name, id := range m.nameToID {
+		nameToIDCopy[name] = id
+	}
+	return nameToIDCopy
 }
 
 // Map of volume ID to volume name.
@@ -1989,8 +2008,9 @@ func initNodeIDToNameMap(ctx context.Context) error {
 
 	log.Debugf("Initializing node ID to node name map")
 	k8sOrchestratorInstance.nodeIDToNameMap = &nodeIDToNameMap{
-		RWMutex: &sync.RWMutex{},
-		items:   make(map[string]string),
+		RWMutex:  &sync.RWMutex{},
+		items:    make(map[string]string),
+		nameToID: make(map[string]string),
 	}
 
 	// Set up kubernetes resource listener to listen events on Node
@@ -2078,6 +2098,14 @@ func nodeRemove(obj interface{}) {
 // GetNodeIDtoNameMap returns a map containing the nodeID to node name
 func (c *K8sOrchestrator) GetNodeIDtoNameMap(ctx context.Context) map[string]string {
 	return c.nodeIDToNameMap.items
+}
+
+// GetNodeNameToHostMoIDMap returns a race-free copy of the node name to ESXi host MoID map,
+// maintained by the node informer. Used by host-local volume provisioning to resolve the
+// candidate hosts from the hostnames in the accessibility requirement without rebuilding the
+// reverse map on every CreateVolume call.
+func (c *K8sOrchestrator) GetNodeNameToHostMoIDMap(ctx context.Context) map[string]string {
+	return c.nodeIDToNameMap.getNameToIDCopy()
 }
 
 // GetFakeAttachedVolumes returns a map of volumeIDs to a bool, which is set

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
@@ -362,3 +362,35 @@ func TestSetWcpCapabilitiesMap_Success(t *testing.T) {
 	val, _ = WcpCapabilitiesMap.Load("CapabilityB")
 	assert.Equal(t, false, val)
 }
+
+// TestNodeIDToNameMapBidirectional verifies the nodeIDToNameMap keeps the forward (host MoID ->
+// node name) and reverse (node name -> host MoID) directions consistent across add/remove, and that
+// getNameToIDCopy returns an independent snapshot.
+func TestNodeIDToNameMapBidirectional(t *testing.T) {
+	m := &nodeIDToNameMap{
+		RWMutex:  &sync.RWMutex{},
+		items:    make(map[string]string),
+		nameToID: make(map[string]string),
+	}
+
+	m.add("host-1", "node-a")
+	m.add("host-2", "node-b")
+
+	assert.Equal(t, "node-a", m.items["host-1"])
+	assert.Equal(t, "host-1", m.nameToID["node-a"])
+	assert.Equal(t, "host-2", m.nameToID["node-b"])
+
+	// Snapshot is a copy: mutating it must not affect the underlying map.
+	snapshot := m.getNameToIDCopy()
+	assert.Equal(t, map[string]string{"node-a": "host-1", "node-b": "host-2"}, snapshot)
+	snapshot["node-a"] = "mutated"
+	assert.Equal(t, "host-1", m.nameToID["node-a"])
+
+	// Remove clears both directions.
+	m.remove("host-1")
+	_, forwardExists := m.items["host-1"]
+	_, reverseExists := m.nameToID["node-a"]
+	assert.False(t, forwardExists)
+	assert.False(t, reverseExists)
+	assert.Equal(t, "host-2", m.nameToID["node-b"])
+}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -82,12 +82,13 @@ const (
 	AttributeHostLocal = "hostlocal"
 
 	// AttributeHostLocalPolicy is a CreateVolume parameter injected by the external
-	// provisioner when the requested StorageClass uses a host-local storage policy.
-	// When set to "true" (and the supports_host_local_storage capability is enabled),
-	// the WCP CSI controller provisions the volume against target hosts supplied to
-	// CNS and builds PV node affinity from the host CNS selects. Using this marker
-	// avoids a PBM lookup during provisioning.
-	AttributeHostLocalPolicy = "hostLocalPolicy"
+	// provisioner (as "hostLocalPolicy") when the requested StorageClass uses a
+	// host-local storage policy. When set to "true" (and the supports_host_local_storage
+	// capability is enabled), the WCP CSI controller provisions the volume against target
+	// hosts supplied to CNS and builds PV node affinity from the host CNS selects. Using
+	// this marker avoids a PBM lookup during provisioning. Stored lowercase to match the
+	// case-insensitive parameter names received in CreateVolumeRequest.
+	AttributeHostLocalPolicy = "hostlocalpolicy"
 
 	// AttributePvName represents the name of the PV
 	AttributePvName = "csi.storage.k8s.io/pv/name"

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -81,6 +81,14 @@ const (
 	// the given storage policy. For Example: HostLocal: "True".
 	AttributeHostLocal = "hostlocal"
 
+	// AttributeHostLocalPolicy is a CreateVolume parameter injected by the external
+	// provisioner when the requested StorageClass uses a host-local storage policy.
+	// When set to "true" (and the supports_host_local_storage capability is enabled),
+	// the WCP CSI controller provisions the volume against target hosts supplied to
+	// CNS and builds PV node affinity from the host CNS selects. Using this marker
+	// avoids a PBM lookup during provisioning.
+	AttributeHostLocalPolicy = "hostLocalPolicy"
+
 	// AttributePvName represents the name of the PV
 	AttributePvName = "csi.storage.k8s.io/pv/name"
 
@@ -670,6 +678,13 @@ const (
 	// control flag has been cleared due to VM ownerRef presence. This prevents
 	// redundant VSLM calls on syncer restarts or during periodic resyncs.
 	AnnVMDeleteProtectionCleared = "cns.vmware.com/vm-delete-protection-cleared"
+
+	// HostLocalStorageSupport is the WCP capability for host-local storage policy
+	// provisioning. When enabled on the supervisor, the CSI driver honors the
+	// hostLocalPolicy volume parameter, supplies target hosts to CNS in the
+	// CnsVolumeCreateSpec, and builds PV node affinity from the host returned in
+	// the CNS placement result.
+	HostLocalStorageSupport = "supports_host_local_storage"
 )
 
 var WCPFeatureStates = map[string]struct{}{
@@ -691,6 +706,7 @@ var WCPFeatureStates = map[string]struct{}{
 	SupportsExposingStoragePolicyAttributes: {},
 	SupportsPerNamespaceNetworkProviders:    {},
 	VMPVCStoragePolicyMutability:            {},
+	HostLocalStorageSupport:                 {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
@@ -710,6 +726,7 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 	SupportsExposingStoragePolicyAttributes: {},
 	SupportsPerNamespaceNetworkProviders:    {},
 	VMPVCStoragePolicyMutability:            {},
+	HostLocalStorageSupport:                 {},
 }
 
 // WCPFeatureAssociatedWithPVCSI contains FSS name used in PVCSI and associated WCP Capability name on a

--- a/pkg/csi/service/common/types.go
+++ b/pkg/csi/service/common/types.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	vim25types "github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/crypto"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
@@ -85,6 +86,10 @@ type CreateVolumeSpec struct {
 	ContentSourceSnapshotID string // SnapshotID from VolumeContentSource in CreateVolumeRequest
 	CapacityMB              int64
 	IsLinkedCloneRequest    bool
+	// Hosts holds the candidate ESX HostSystem MoRefs supplied to CNS for host-local storage
+	// policy provisioning. CNS selects the final host from this set and returns it in the
+	// placement result. Empty for non-host-local volumes.
+	Hosts []vim25types.ManagedObjectReference
 }
 
 // StorageClassParams represents the storage class parameterss

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -132,13 +132,21 @@ func CreateBlockVolumeUtil(
 	}
 
 	if IsMultiClusterPerZoneEnabled && len(sharedDatastores) == 0 {
-		for _, ref := range vSphereClusterMorefs {
-			clusterMorefs = append(clusterMorefs, vim25types.ManagedObjectReference{
-				Type:  "ClusterComputeResource",
-				Value: ref,
-			})
+		// CNS rejects a CnsVolumeCreateSpec that sets both `hosts` and `activeClusters`
+		// ("createSpecs.hosts and createSpecs.activeClusters cannot both be set"). For host-local
+		// storage policy provisioning, supply only the candidate hosts; CNS selects the final host
+		// from this set and does not need the active clusters in that case.
+		if len(spec.Hosts) != 0 {
+			createSpec.Hosts = spec.Hosts
+		} else {
+			for _, ref := range vSphereClusterMorefs {
+				clusterMorefs = append(clusterMorefs, vim25types.ManagedObjectReference{
+					Type:  "ClusterComputeResource",
+					Value: ref,
+				})
+			}
+			createSpec.ActiveClusters = clusterMorefs
 		}
-		createSpec.ActiveClusters = clusterMorefs
 	} else {
 		var datastores []vim25types.ManagedObjectReference
 		if opts.FilterSuspendedDatastores {

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -736,7 +736,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 				return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCodef(log, codes.Unimplemented,
 					"linked clone volumes is not supported. Request: %+v", req)
 			}
-		case strings.ToLower(common.AttributeHostLocalPolicy):
+		case common.AttributeHostLocalPolicy:
 			isHostLocalRequest = strings.EqualFold(req.Parameters[paramName], "true")
 		}
 	}
@@ -1075,6 +1075,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		hostMoRefs, hostMoIDToTopology, err = getHostMoRefsForHostLocalVolume(ctx, topologyRequirement,
 			commonco.ContainerOrchestratorUtility.GetNodeNameToHostMoIDMap(ctx))
 		if err != nil {
+			log.Errorf("failed to resolve candidate hosts for host-local volume %q. Error: %+v", req.Name, err)
 			return nil, csifault.CSIInternalFault, err
 		}
 	}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -118,6 +118,10 @@ var (
 	// vsan-file-service-policy-latebinding storage classes; legacy non-FVS paths do not use this
 	// value. Empty when the per-namespace capability is on (in which case the value is unused).
 	cachedGlobalNetworkProvider string
+	// isHostLocalStorageSupportEnabled is true when the supports_host_local_storage capability is
+	// enabled on the supervisor. When false, CreateVolume requests carrying the hostLocalPolicy
+	// parameter are rejected with Unimplemented.
+	isHostLocalStorageSupportEnabled bool
 )
 
 var getCandidateDatastores = cnsvsphere.GetCandidateDatastoresInCluster
@@ -271,6 +275,12 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	if !isVMPVCStoragePolicyMutabilityEnabled {
 		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
 			common.VMPVCStoragePolicyMutability, "", "")
+	}
+	isHostLocalStorageSupportEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.HostLocalStorageSupport)
+	if !isHostLocalStorageSupportEnabled {
+		go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
+			common.HostLocalStorageSupport, "", "")
 	}
 	if idempotencyHandlingEnabled {
 		log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
@@ -686,6 +696,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		err                       error
 		isLinkedCloneRequest      bool
 		linkedCloneSupportEnabled bool
+		isHostLocalRequest        bool
 	)
 	linkedCloneSupportEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupport)
 	// Support case insensitive parameters.
@@ -725,7 +736,17 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 				return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCodef(log, codes.Unimplemented,
 					"linked clone volumes is not supported. Request: %+v", req)
 			}
+		case strings.ToLower(common.AttributeHostLocalPolicy):
+			isHostLocalRequest = strings.EqualFold(req.Parameters[paramName], "true")
 		}
+	}
+
+	// Host-local provisioning requires the supports_host_local_storage capability to be enabled
+	// on the supervisor. If the request is marked host-local but the capability is off, reject it.
+	if isHostLocalRequest && !isHostLocalStorageSupportEnabled {
+		return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCodef(log, codes.Unimplemented,
+			"host-local storage policy volume provisioning is not supported: "+
+				"supports_host_local_storage capability is not enabled. Request: %+v", req)
 	}
 
 	// If VM_PVC_STORAGE_POLICY_MUTABILITY is enabled and mutable_parameters contains a
@@ -784,6 +805,10 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		hostnameLabelPresent, zoneLabelPresent = checkTopologyKeysFromAccessibilityReqs(topologyRequirement)
 		if zoneLabelPresent && hostnameLabelPresent {
 			log.Infof("Host Local volume provisioning with requirement: %+v", topologyRequirement)
+			// CNS rejects a CnsVolumeCreateSpec that sets both `hosts` and `activeClusters`
+			// ("createSpecs.hosts and createSpecs.activeClusters cannot both be set"). For a
+			// host-local request the candidate hosts (built below) are supplied instead of
+			// clusters, so vSphereClusterMorefs is intentionally left empty here.
 		} else if zoneLabelPresent {
 			if !isWorkloadDomainIsolationEnabled {
 				if storageTopologyType == "" {
@@ -1040,6 +1065,20 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 	}
 
+	// For host-local storage policy requests, resolve the candidate hosts from the hostnames
+	// present in the accessibility requirement and supply them to CNS. CNS selects the final host.
+	// hostMoIDToTopology captures the zone + hostname of each candidate host from the same request,
+	// so the accessible topology of the CNS-selected host can be resolved without a vCenter call.
+	var hostMoRefs []types.ManagedObjectReference
+	var hostMoIDToTopology map[string]map[string]string
+	if isHostLocalRequest {
+		hostMoRefs, hostMoIDToTopology, err = getHostMoRefsForHostLocalVolume(ctx, topologyRequirement,
+			commonco.ContainerOrchestratorUtility.GetNodeNameToHostMoIDMap(ctx))
+		if err != nil {
+			return nil, csifault.CSIInternalFault, err
+		}
+	}
+
 	// Create CreateVolumeSpec and populate values.
 	var createVolumeSpec = common.CreateVolumeSpec{
 		CapacityMB:              volSizeMB,
@@ -1052,6 +1091,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		ContentSourceSnapshotID: contentSourceSnapshotID,
 		CryptoKeyID:             cryptoKeyID,
 		IsLinkedCloneRequest:    isLinkedCloneRequest,
+		Hosts:                   hostMoRefs,
 	}
 
 	volFromSnapshotOnTargetDs := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
@@ -1141,7 +1181,37 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 
 	// Calculate accessible topology for the provisioned volume in case of topology aware environment.
 	if isTKGSHAEnabled {
-		if hostnameLabelPresent {
+		if isHostLocalRequest {
+			// For host-local volumes, build the PV node affinity (zone + hostname) from the host
+			// that CNS selected, reported in the placement result. Publishing both keys pins pods
+			// to the specific host the volume was provisioned on.
+			var segments map[string]string
+			if volumeInfo.Host != nil {
+				segments, err = getHostLocalAccessibleTopology(ctx, *volumeInfo.Host, hostMoIDToTopology)
+			} else {
+				err = logger.LogNewErrorf(log, "CNS did not return a host in the placement result "+
+					"for host-local volume %q", volumeInfo.VolumeID.Id)
+			}
+			if err != nil {
+				// The provisioned volume is unusable without correct host affinity, so clean it up.
+				log.Errorf("Encountered error building host-local topology after creating volume. Cleaning up...")
+				deleteOpReqError := operationStore.DeleteRequestDetails(ctx, req.Name)
+				if deleteOpReqError != nil {
+					log.Warnf("failed to cleanup CnsVolumeOperationRequest instance before erroring "+
+						"out. Error received: %+v", deleteOpReqError)
+				} else {
+					if _, deleteVolumeError := common.DeleteVolumeUtil(ctx, c.manager.VolumeManager,
+						volumeInfo.VolumeID.Id, true); deleteVolumeError != nil {
+						log.Warnf("failed to delete volume: %q while cleaning up after CreateVolume failure. "+
+							"Error: %+v", volumeInfo.VolumeID.Id, deleteVolumeError)
+					}
+				}
+				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+					"failed to build accessible topology for host-local volume %q. Error: %+v",
+					volumeInfo.VolumeID.Id, err)
+			}
+			resp.Volume.AccessibleTopology = []*csi.Topology{{Segments: segments}}
+		} else if hostnameLabelPresent {
 			// Configure the volumeTopology in the response so that the external
 			// provisioner will properly sets up the nodeAffinity for this volume.
 			resp.Volume.AccessibleTopology = topologyRequirement.GetPreferred()

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -65,7 +65,8 @@ func validateCreateBlockReqParam(paramName, value string) bool {
 		paramName == common.AttributePvcNamespace ||
 		paramName == common.AttributeStorageClassName ||
 		paramName == common.AttributeIsLinkedCloneKey ||
-		(paramName == common.AttributeHostLocal && strings.EqualFold(value, "true"))
+		(paramName == common.AttributeHostLocal && strings.EqualFold(value, "true")) ||
+		(strings.EqualFold(paramName, common.AttributeHostLocalPolicy) && strings.EqualFold(value, "true"))
 }
 
 const (
@@ -513,6 +514,81 @@ func checkTopologyKeysFromAccessibilityReqs(topologyRequirement *csi.TopologyReq
 		}
 	}
 	return hostnameLabelPresent, zoneLabelPresent
+}
+
+// getHostMoRefsForHostLocalVolume collects the kubernetes.io/hostname values present in the
+// topology requirement's Preferred segments and resolves each to its ESX HostSystem MoRef using
+// the node name -> host MoID map maintained by the container orchestrator (no per-call rebuild).
+// The returned host MoRefs are supplied to CNS as the candidate host set for a host-local volume:
+// a single host for WaitForFirstConsumer (Case A) where the pod is already scheduled, or the full
+// candidate set for Immediate binding (Case B) where CNS selects the final host.
+//
+// It also returns a request-scoped map of host MoID -> {zone, hostname} harvested from the same
+// Preferred segments. Since CNS always selects from the candidate hosts supplied here, this map lets
+// the caller resolve the accessible topology of the CNS-selected host with a pure in-memory lookup,
+// avoiding any vCenter call.
+func getHostMoRefsForHostLocalVolume(ctx context.Context,
+	topologyRequirement *csi.TopologyRequirement,
+	nodeNameToID map[string]string) ([]vimtypes.ManagedObjectReference, map[string]map[string]string, error) {
+	log := logger.GetLogger(ctx)
+	if topologyRequirement == nil || len(topologyRequirement.GetPreferred()) == 0 {
+		return nil, nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
+			"host-local volume provisioning requires an accessibility requirement with hostname information")
+	}
+
+	seen := make(map[string]struct{})
+	var hostMoRefs []vimtypes.ManagedObjectReference
+	hostMoIDToTopology := make(map[string]map[string]string)
+	for _, topology := range topologyRequirement.GetPreferred() {
+		segments := topology.GetSegments()
+		hostname, ok := segments[v1.LabelHostname]
+		if !ok || hostname == "" {
+			continue
+		}
+		if _, dup := seen[hostname]; dup {
+			continue
+		}
+		seen[hostname] = struct{}{}
+		hostMoID, found := nodeNameToID[hostname]
+		if !found {
+			return nil, nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to resolve ESX host MoID for node %q while provisioning host-local volume", hostname)
+		}
+		hostMoRefs = append(hostMoRefs, vimtypes.ManagedObjectReference{Type: "HostSystem", Value: hostMoID})
+		// Record the zone + hostname for this host from the same Preferred segment. Both keys are
+		// expected to be present for host-local provisioning.
+		hostTopology := map[string]string{v1.LabelHostname: hostname}
+		if zone, hasZone := segments[v1.LabelTopologyZone]; hasZone && zone != "" {
+			hostTopology[v1.LabelTopologyZone] = zone
+		}
+		hostMoIDToTopology[hostMoID] = hostTopology
+	}
+	if len(hostMoRefs) == 0 {
+		return nil, nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
+			"host-local volume provisioning requires at least one hostname in the accessibility requirement")
+	}
+	return hostMoRefs, hostMoIDToTopology, nil
+}
+
+// getHostLocalAccessibleTopology returns the topology segment map (zone + hostname) to publish as PV
+// node affinity for the host that CNS selected for a host-local volume. CNS always selects from the
+// candidate hosts supplied at CreateVolume time, so the host's zone and hostname are already known
+// from the request-scoped hostMoID -> {zone, hostname} map built in getHostMoRefsForHostLocalVolume.
+// This is a pure in-memory lookup, with no vCenter call.
+func getHostLocalAccessibleTopology(ctx context.Context, hostRef vimtypes.ManagedObjectReference,
+	hostMoIDToTopology map[string]map[string]string) (map[string]string, error) {
+	log := logger.GetLogger(ctx)
+
+	segments, ok := hostMoIDToTopology[hostRef.Value]
+	if !ok {
+		return nil, logger.LogNewErrorf(log,
+			"host %q selected by CNS is not among the candidate hosts supplied for the volume", hostRef.Value)
+	}
+	if segments[v1.LabelHostname] == "" || segments[v1.LabelTopologyZone] == "" {
+		return nil, logger.LogNewErrorf(log,
+			"incomplete topology (zone/hostname) for host %q selected by CNS: %+v", hostRef.Value, segments)
+	}
+	return segments, nil
 }
 
 // GetVolumeToHostMapping returns a map containing VM MoID to host MoID and VolumeID

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -66,7 +66,7 @@ func validateCreateBlockReqParam(paramName, value string) bool {
 		paramName == common.AttributeStorageClassName ||
 		paramName == common.AttributeIsLinkedCloneKey ||
 		(paramName == common.AttributeHostLocal && strings.EqualFold(value, "true")) ||
-		(strings.EqualFold(paramName, common.AttributeHostLocalPolicy) && strings.EqualFold(value, "true"))
+		(paramName == common.AttributeHostLocalPolicy && strings.EqualFold(value, "true"))
 }
 
 const (

--- a/pkg/csi/service/wcp/controller_helper_test.go
+++ b/pkg/csi/service/wcp/controller_helper_test.go
@@ -2,7 +2,6 @@ package wcp
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -328,8 +327,8 @@ func TestGetSnapshotLimitForNamespace(t *testing.T) {
 // accepts the host-local policy marker only when its value is "true", and continues to accept the
 // existing block-volume parameters while rejecting unknown ones.
 func TestValidateCreateBlockReqParamHostLocalPolicy(t *testing.T) {
-	// The caller lowercases the parameter name before validation.
-	hostLocalParam := strings.ToLower(common.AttributeHostLocalPolicy)
+	// The constant is already lowercase; the caller lowercases incoming parameter names too.
+	hostLocalParam := common.AttributeHostLocalPolicy
 	tests := []struct {
 		name      string
 		paramName string

--- a/pkg/csi/service/wcp/controller_helper_test.go
+++ b/pkg/csi/service/wcp/controller_helper_test.go
@@ -2,9 +2,12 @@ package wcp
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -318,5 +321,136 @@ func TestGetSnapshotLimitForNamespace(t *testing.T) {
 		// Verify
 		assert.Nil(t, err)
 		assert.Equal(t, common.DefaultMaxSnapshotsPerVolume, limit) // Should return default (4)
+	})
+}
+
+// TestValidateCreateBlockReqParamHostLocalPolicy verifies the WCP block-volume parameter validator
+// accepts the host-local policy marker only when its value is "true", and continues to accept the
+// existing block-volume parameters while rejecting unknown ones.
+func TestValidateCreateBlockReqParamHostLocalPolicy(t *testing.T) {
+	// The caller lowercases the parameter name before validation.
+	hostLocalParam := strings.ToLower(common.AttributeHostLocalPolicy)
+	tests := []struct {
+		name      string
+		paramName string
+		value     string
+		want      bool
+	}{
+		{"hostLocalPolicy true", hostLocalParam, "true", true},
+		{"hostLocalPolicy True mixed case", hostLocalParam, "True", true},
+		{"hostLocalPolicy false", hostLocalParam, "false", false},
+		{"hostLocalPolicy empty", hostLocalParam, "", false},
+		{"storagePolicyID accepted", common.AttributeStoragePolicyID, "policy-1", true},
+		{"unknown param rejected", "someunknownparam", "true", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, validateCreateBlockReqParam(tt.paramName, tt.value))
+		})
+	}
+}
+
+// TestGetHostMoRefsForHostLocalVolume verifies that the candidate host set for a host-local volume
+// is built from the kubernetes.io/hostname values in the accessibility requirement's Preferred
+// segments: a single host for Case A (WFFC) and the full set for Case B (Immediate).
+func TestGetHostMoRefsForHostLocalVolume(t *testing.T) {
+	ctx := context.Background()
+	// Reverse map maintained by the orchestrator: node name -> ESX host MoID.
+	nodeNameToID := map[string]string{
+		"node-a": "host-1",
+		"node-b": "host-2",
+	}
+	// makeReq builds a topology requirement whose Preferred segments carry both the zone and the
+	// hostname for each node (zone defaults to zone-1, overridable via zoneFor).
+	makeReqZoned := func(zoneFor map[string]string, hostnames ...string) *csi.TopologyRequirement {
+		var prefs []*csi.Topology
+		for _, h := range hostnames {
+			zone := "zone-1"
+			if z, ok := zoneFor[h]; ok {
+				zone = z
+			}
+			prefs = append(prefs, &csi.Topology{Segments: map[string]string{
+				v1.LabelTopologyZone: zone,
+				v1.LabelHostname:     h,
+			}})
+		}
+		return &csi.TopologyRequirement{Preferred: prefs}
+	}
+	makeReq := func(hostnames ...string) *csi.TopologyRequirement {
+		return makeReqZoned(nil, hostnames...)
+	}
+
+	t.Run("CaseA_single_host", func(t *testing.T) {
+		refs, hostTopo, err := getHostMoRefsForHostLocalVolume(ctx, makeReq("node-a"), nodeNameToID)
+		assert.NoError(t, err)
+		assert.Equal(t, []vimtypes.ManagedObjectReference{{Type: "HostSystem", Value: "host-1"}}, refs)
+		assert.Equal(t, map[string]map[string]string{
+			"host-1": {v1.LabelHostname: "node-a", v1.LabelTopologyZone: "zone-1"},
+		}, hostTopo)
+	})
+
+	t.Run("CaseB_multiple_hosts_distinct_zones", func(t *testing.T) {
+		refs, hostTopo, err := getHostMoRefsForHostLocalVolume(ctx,
+			makeReqZoned(map[string]string{"node-b": "zone-2"}, "node-a", "node-b"), nodeNameToID)
+		assert.NoError(t, err)
+		assert.Len(t, refs, 2)
+		values := []string{refs[0].Value, refs[1].Value}
+		assert.ElementsMatch(t, []string{"host-1", "host-2"}, values)
+		assert.Equal(t, "zone-1", hostTopo["host-1"][v1.LabelTopologyZone])
+		assert.Equal(t, "zone-2", hostTopo["host-2"][v1.LabelTopologyZone])
+	})
+
+	t.Run("duplicate_hostnames_deduped", func(t *testing.T) {
+		refs, hostTopo, err := getHostMoRefsForHostLocalVolume(ctx, makeReq("node-a", "node-a"), nodeNameToID)
+		assert.NoError(t, err)
+		assert.Len(t, refs, 1)
+		assert.Len(t, hostTopo, 1)
+	})
+
+	t.Run("unresolvable_hostname_errors", func(t *testing.T) {
+		_, _, err := getHostMoRefsForHostLocalVolume(ctx, makeReq("node-x"), nodeNameToID)
+		assert.Error(t, err)
+	})
+
+	t.Run("nil_requirement_errors", func(t *testing.T) {
+		_, _, err := getHostMoRefsForHostLocalVolume(ctx, nil, nodeNameToID)
+		assert.Error(t, err)
+	})
+
+	t.Run("no_hostname_segment_errors", func(t *testing.T) {
+		req := &csi.TopologyRequirement{Preferred: []*csi.Topology{
+			{Segments: map[string]string{v1.LabelTopologyZone: "zone-1"}},
+		}}
+		_, _, err := getHostMoRefsForHostLocalVolume(ctx, req, nodeNameToID)
+		assert.Error(t, err)
+	})
+}
+
+// TestGetHostLocalAccessibleTopology verifies the pure lookup of the CNS-selected host's zone +
+// hostname from the request-scoped host MoID -> topology map (no vCenter call).
+func TestGetHostLocalAccessibleTopology(t *testing.T) {
+	ctx := context.Background()
+	hostTopo := map[string]map[string]string{
+		"host-1": {v1.LabelHostname: "node-a", v1.LabelTopologyZone: "zone-1"},
+		"host-2": {v1.LabelHostname: "node-b"}, // incomplete: zone missing
+	}
+
+	t.Run("resolved", func(t *testing.T) {
+		segments, err := getHostLocalAccessibleTopology(ctx,
+			vimtypes.ManagedObjectReference{Type: "HostSystem", Value: "host-1"}, hostTopo)
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{v1.LabelHostname: "node-a", v1.LabelTopologyZone: "zone-1"}, segments)
+	})
+
+	t.Run("host_not_in_candidate_set_errors", func(t *testing.T) {
+		_, err := getHostLocalAccessibleTopology(ctx,
+			vimtypes.ManagedObjectReference{Type: "HostSystem", Value: "host-99"}, hostTopo)
+		assert.Error(t, err)
+	})
+
+	t.Run("incomplete_topology_errors", func(t *testing.T) {
+		_, err := getHostLocalAccessibleTopology(ctx,
+			vimtypes.ManagedObjectReference{Type: "HostSystem", Value: "host-2"}, hostTopo)
+		assert.Error(t, err)
 	})
 }

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -135,6 +135,10 @@ func (m *MockCOCommonInterface) GetNodeIDtoNameMap(ctx context.Context) map[stri
 	return args.Get(0).(map[string]string)
 }
 
+func (m *MockCOCommonInterface) GetNodeNameToHostMoIDMap(ctx context.Context) map[string]string {
+	return make(map[string]string)
+}
+
 func (m *MockCOCommonInterface) GetFakeAttachedVolumes(ctx context.Context, volumeIDs []string) map[string]bool {
 	args := m.Called(ctx, volumeIDs)
 	return args.Get(0).(map[string]bool)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -354,6 +354,11 @@ func (m *mockCOCommon) GetNodeIDtoNameMap(ctx context.Context) map[string]string
 	panic("implement me")
 }
 
+func (m *mockCOCommon) GetNodeNameToHostMoIDMap(ctx context.Context) map[string]string {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockCOCommon) GetFakeAttachedVolumes(ctx context.Context, volumeIDs []string) map[string]bool {
 	//TODO implement me
 	panic("implement me")

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -632,6 +632,10 @@ func (m *mockCOCommonForFullSync) GetNodeIDtoNameMap(ctx context.Context) map[st
 	return make(map[string]string)
 }
 
+func (m *mockCOCommonForFullSync) GetNodeNameToHostMoIDMap(ctx context.Context) map[string]string {
+	return make(map[string]string)
+}
+
 func (m *mockCOCommonForFullSync) GetFakeAttachedVolumes(ctx context.Context, volumeIDs []string) map[string]bool {
 	return make(map[string]bool)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support host-local storage policy provisioning on supervisor

Add support for provisioning CNS volumes against host-local storage policies in the Supervisor (WCP) CSI controller.

- Bump govmomi to v0.55.1, which adds the Hosts field to CnsVolumeCreateSpec and the Host field to CnsPlacementResult.

- Gate the feature behind a new supports_host_local_storage WCP capability, following the existing pattern of restarting the CSI driver when the capability is enabled after the driver has already started.

- Detect host-local requests through a hostLocalPolicy volume parameter injected by the external provisioner, avoiding a PBM lookup during provisioning.

- Resolve the candidate ESX hosts for a volume from the hostnames present in the CreateVolume request's accessibility requirement, using an in-memory node-name-to-host-MoID mapping maintained by the node informer, and supply them to CNS via CnsVolumeCreateSpec.Hosts. CNS requires exactly one of Hosts or ActiveClusters to be set, never both.

- Capture the host CNS selects for the volume from CnsPlacementResult.Host and use it to build the PV's node affinity for both topology.kubernetes.io/zone and kubernetes.io/hostname, resolving the zone from a map built from the same accessibility requirement rather than querying vCenter.

- Add unit tests covering parameter validation, host resolution, and topology construction.

**Testing done**:
Manual testing result

Created profile with hostlocal requirement and assigned profile to namespace. verified storageclass is created with hostLocalPolicy annotations
```
# kubectl describe sc hostlocalvmfs
Name:                  hostlocalvmfs
IsDefaultClass:        No
Annotations:           cns.vmware.com/hostLocalPolicy=true
Provisioner:           csi.vsphere.vmware.com
Parameters:            storagePolicyID=46c54b9e-579d-4176-86f9-e910f4602e51
AllowVolumeExpansion:  True
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
Events:                <none>

```

created PVC and verified PV gets provisioned and gets hostlocal node affinity rules

```
# kubectl describe pvc hostlocalpvc -n divyen-ns
Name:          hostlocalpvc
Namespace:     divyen-ns
StorageClass:  hostlocalvmfs
Status:        Bound
Volume:        pvc-18782427-243d-4408-9779-fbb7e06f4222
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology:
                 [{"kubernetes.io/hostname":"lvn-dvm-10-161-26-210.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                          Message
  ----    ------                 ----               ----                                                                                          -------
  Normal  Provisioning           38s                csi.vsphere.vmware.com_420780597f564925490f6bafd00afd2f_83f61227-81e2-44fa-b60e-2139011d9a37  External provisioner is provisioning volume for claim "divyen-ns/hostlocalpvc"
  Normal  ProvisioningSucceeded  31s                csi.vsphere.vmware.com_420780597f564925490f6bafd00afd2f_83f61227-81e2-44fa-b60e-2139011d9a37  Successfully provisioned volume pvc-18782427-243d-4408-9779-fbb7e06f4222
  Normal  ExternalProvisioning   29s (x3 over 36s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
```

```
root@4207f86a13fc9ebf14fc3aeaac29df1d [ ~ ]# kubectl describe pv pvc-18782427-243d-4408-9779-fbb7e06f4222
Name:              pvc-18782427-243d-4408-9779-fbb7e06f4222
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [external-provisioner.volume.kubernetes.io/finalizer kubernetes.io/pv-protection]
StorageClass:      hostlocalvmfs
Status:            Bound
Claim:             divyen-ns/hostlocalpvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          5Gi
Node Affinity:     
  Required Terms:  
    Term 0:        kubernetes.io/hostname in [lvn-dvm-10-161-26-210.dvm.lvn.broadcom.net]
                   topology.kubernetes.io/zone in [az1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      18782427-243d-4408-9779-fbb7e06f4222
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1783628842604-1247-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

**Special notes for your reviewer**:

Pre-checkin 
- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1794/ :white_check_mark:
- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1357/ :white_check_mark:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support host-local storage policy provisioning on supervisor
```
