### PR TITLE
Allow CnsRegisterVolume to accept both VolumeID and DiskURLPath for volume restore via VKSRegisterVolume.

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -695,6 +695,18 @@ const (
 	// HostLocalStorageSupportFSS is the pvCSI FSS paired with HostLocalStorageSupport
 	// on the supervisor.
 	HostLocalStorageSupportFSS = "host-local-storage-support"
+
+	// DataProtectionSnapshotService is the WCP capability that gates VKS volume restore
+	// (VKSRegisterVolume). It is activated when VC >= 9.1.2, Supervisor >= 9.1.2,
+	// TKG >= 3.8.0, and the dp-operator snapservice has been registered and activated.
+	// The capability string matches the entry in supervisor-capabilities.yaml owned by
+	// the snapservice team.
+	DataProtectionSnapshotService = "supports_data_protection_snaphot_service"
+
+	// VKSRegisterVolume is the guest-cluster FSS that gates the VKSRegisterVolume
+	// operator. Requires both this flag in the guest PVCSI ConfigMap and the
+	// DataProtectionSnapshotService WCP capability on the Supervisor.
+	VKSRegisterVolume = "vks-register-volume"
 )
 
 var WCPFeatureStates = map[string]struct{}{
@@ -717,6 +729,7 @@ var WCPFeatureStates = map[string]struct{}{
 	SupportsPerNamespaceNetworkProviders:    {},
 	VMPVCStoragePolicyMutability:            {},
 	HostLocalStorageSupport:                 {},
+	DataProtectionSnapshotService:           {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
@@ -737,6 +750,7 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 	SupportsPerNamespaceNetworkProviders:    {},
 	VMPVCStoragePolicyMutability:            {},
 	HostLocalStorageSupport:                 {},
+	DataProtectionSnapshotService:           {},
 }
 
 // WCPFeatureAssociatedWithPVCSI contains FSS name used in PVCSI and associated WCP Capability name on a
@@ -750,4 +764,5 @@ var WCPFeatureStateAssociatedWithPVCSI = map[string]string{
 	CSI_Backup_API_FSS:              CSI_Backup_API,
 	VMPVCStoragePolicyMutabilityFSS: VMPVCStoragePolicyMutability,
 	HostLocalStorageSupportFSS:      HostLocalStorageSupport,
+	VKSRegisterVolume:               DataProtectionSnapshotService,
 }

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -92,6 +92,10 @@ var (
 	isTKGSHAEnabled                         bool
 	isMultipleClustersPerVsphereZoneEnabled bool
 	isSharedDiskEnabled                     bool
+	// isDataProtectionSnapshotServiceEnabled caches the DataProtectionSnapshotService
+	// WCP capability at controller startup. Set once in Add(); late enablement triggers
+	// a pod restart which re-evaluates this value.
+	isDataProtectionSnapshotServiceEnabled bool
 )
 
 // Add creates a new CnsRegisterVolume Controller and adds it to the Manager,
@@ -111,6 +115,8 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	isTKGSHAEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 	isMultipleClustersPerVsphereZoneEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.MultipleClustersPerVsphereZone)
+	isDataProtectionSnapshotServiceEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.DataProtectionSnapshotService)
 
 	var volumeInfoService cnsvolumeinfo.VolumeInfoService
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
@@ -1206,9 +1212,19 @@ func checkExistingPVCDataSourceRef(ctx context.Context, k8sclient clientset.Inte
 // CnsRegisterVolume instance.
 func validateCnsRegisterVolumeSpec(ctx context.Context, instance *cnsregistervolumev1alpha1.CnsRegisterVolume) error {
 	var msg string
+	// Both VolumeID and DiskURLPath may be set by ss-metadata-manager for the VKSRegisterVolume
+	// restore path: CNS locates the VMDK by URL and stamps the provided FCD UUID onto it.
+	// This combination is only permitted when the DataProtectionSnapshotService WCP capability
+	// is active on the Supervisor; on older Supervisors the original rejection is preserved.
 	if instance.Spec.VolumeID != "" && instance.Spec.DiskURLPath != "" {
-		msg = "VolumeID and DiskURLPath cannot be specified together"
-	} else if instance.Spec.DiskURLPath != "" && instance.Spec.AccessMode != "" &&
+		if !isDataProtectionSnapshotServiceEnabled {
+			return errors.New("VolumeID and DiskURLPath cannot be specified together")
+		}
+		// Capability is active: both fields are valid. The single-field checks below
+		// (AccessMode requirement, duplicate-PV lookup) do not apply to this path.
+		return nil
+	}
+	if instance.Spec.DiskURLPath != "" && instance.Spec.AccessMode != "" &&
 		instance.Spec.AccessMode != v1.ReadWriteOnce {
 		if isSharedDiskEnabled {
 			if instance.Spec.AccessMode == v1.ReadWriteMany &&

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -1817,6 +1817,190 @@ func TestValidateCnsRegisterVolumeSpecWithVolumeIdAndAccessMode(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityEnabled verifies that
+// both VolumeID and DiskURLPath are accepted when the DataProtectionSnapshotService WCP capability
+// is active (VKSRegisterVolume restore path via ss-metadata-manager).
+func TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityEnabled(t *testing.T) {
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:     "pvc-1",
+			VolumeID:    "fcd-uuid-123456",
+			DiskURLPath: "https://vc-ip/folder/path/disk.vmdk?dcPath=dc&dsName=ds",
+			AccessMode:  corev1.ReadWriteOnce,
+		},
+	}
+
+	isSharedDiskEnabled = false
+	isDataProtectionSnapshotServiceEnabled = true
+	err := validateCnsRegisterVolumeSpec(context.TODO(), instance)
+	assert.NoError(t, err)
+}
+
+// TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityDisabled verifies that
+// both VolumeID and DiskURLPath are rejected when the DataProtectionSnapshotService WCP capability
+// is absent, preserving the original behaviour on older Supervisors.
+func TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityDisabled(t *testing.T) {
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:     "pvc-1",
+			VolumeID:    "fcd-uuid-123456",
+			DiskURLPath: "https://vc-ip/folder/path/disk.vmdk?dcPath=dc&dsName=ds",
+			AccessMode:  corev1.ReadWriteOnce,
+		},
+	}
+
+	isSharedDiskEnabled = false
+	isDataProtectionSnapshotServiceEnabled = false
+	err := validateCnsRegisterVolumeSpec(context.TODO(), instance)
+	assert.EqualError(t, err, "VolumeID and DiskURLPath cannot be specified together")
+}
+
+// TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityEnabled verifies that
+// when both VolumeID and DiskURLPath are set and the DataProtectionSnapshotService WCP capability
+// is active, BackingObjectDetails carries both fields.
+func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityEnabled(t *testing.T) {
+	volumeID := "fcd-uuid-123456"
+	diskURL := "https://vc-ip/folder/path/disk.vmdk?dcPath=dc&dsName=ds"
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:     "pvc-1",
+			VolumeID:    volumeID,
+			DiskURLPath: diskURL,
+			AccessMode:  corev1.ReadWriteOnce,
+		},
+	}
+
+	cfg := &config.Config{
+		VirtualCenter: map[string]*config.VirtualCenterConfig{
+			"test-host": {User: "test-user"},
+		},
+	}
+	cfg.Global.ClusterID = "test-cluster"
+	r := &ReconcileCnsRegisterVolume{
+		configInfo: &config.ConfigurationInfo{Cfg: cfg},
+	}
+
+	isDataProtectionSnapshotServiceEnabled = true
+	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
+	assert.Equal(t, volumeID, backing.BackingDiskId, "BackingDiskId should be VolumeID")
+	assert.Equal(t, diskURL, backing.BackingDiskUrlPath, "BackingDiskUrlPath should be DiskURLPath")
+}
+
+// TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityDisabled verifies that
+// when both VolumeID and DiskURLPath are set but the DataProtectionSnapshotService WCP capability
+// is absent (older vCenter), the spec falls back to VolumeID-only to avoid sending an unsupported
+// API call to the vCenter.
+func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityDisabled(t *testing.T) {
+	volumeID := "fcd-uuid-123456"
+	diskURL := "https://vc-ip/folder/path/disk.vmdk?dcPath=dc&dsName=ds"
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:     "pvc-1",
+			VolumeID:    volumeID,
+			DiskURLPath: diskURL,
+			AccessMode:  corev1.ReadWriteOnce,
+		},
+	}
+
+	cfg := &config.Config{
+		VirtualCenter: map[string]*config.VirtualCenterConfig{
+			"test-host": {User: "test-user"},
+		},
+	}
+	cfg.Global.ClusterID = "test-cluster"
+	r := &ReconcileCnsRegisterVolume{
+		configInfo: &config.ConfigurationInfo{Cfg: cfg},
+	}
+
+	isDataProtectionSnapshotServiceEnabled = false
+	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
+	assert.Equal(t, volumeID, backing.BackingDiskId, "BackingDiskId should be VolumeID")
+	assert.Empty(t, backing.BackingDiskUrlPath, "BackingDiskUrlPath should be empty — capability not active")
+}
+
+// TestConstructCreateSpecForInstanceWithVolumeIDOnly verifies the single-VolumeID path is unchanged.
+func TestConstructCreateSpecForInstanceWithVolumeIDOnly(t *testing.T) {
+	volumeID := "fcd-uuid-only"
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:    "pvc-1",
+			VolumeID:   volumeID,
+			AccessMode: corev1.ReadWriteOnce,
+		},
+	}
+
+	cfg := &config.Config{
+		VirtualCenter: map[string]*config.VirtualCenterConfig{
+			"test-host": {User: "test-user"},
+		},
+	}
+	cfg.Global.ClusterID = "test-cluster"
+	r := &ReconcileCnsRegisterVolume{
+		configInfo: &config.ConfigurationInfo{Cfg: cfg},
+	}
+
+	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
+	assert.Equal(t, volumeID, backing.BackingDiskId, "BackingDiskId should be VolumeID")
+	assert.Empty(t, backing.BackingDiskUrlPath, "BackingDiskUrlPath should be empty")
+}
+
+// TestConstructCreateSpecForInstanceWithDiskURLPathOnly verifies the single-DiskURLPath path is unchanged.
+func TestConstructCreateSpecForInstanceWithDiskURLPathOnly(t *testing.T) {
+	diskURL := "https://vc-ip/folder/path/disk.vmdk?dcPath=dc&dsName=ds"
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:     "pvc-1",
+			DiskURLPath: diskURL,
+		},
+	}
+
+	cfg := &config.Config{
+		VirtualCenter: map[string]*config.VirtualCenterConfig{
+			"test-host": {User: "test-user"},
+		},
+	}
+	cfg.Global.ClusterID = "test-cluster"
+	r := &ReconcileCnsRegisterVolume{
+		configInfo: &config.ConfigurationInfo{Cfg: cfg},
+	}
+
+	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
+	assert.Empty(t, backing.BackingDiskId, "BackingDiskId should be empty")
+	assert.Equal(t, diskURL, backing.BackingDiskUrlPath, "BackingDiskUrlPath should be DiskURLPath")
+}
+
 func TestIsBlockVolumeRegisterRequestWithSharedBlockVolume(t *testing.T) {
 	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -364,7 +364,17 @@ func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegister
 			ContainerCluster: containerCluster,
 		},
 	}
-	if instance.Spec.VolumeID != "" {
+	if instance.Spec.VolumeID != "" && instance.Spec.DiskURLPath != "" &&
+		isDataProtectionSnapshotServiceEnabled {
+		// Both fields supplied and DataProtectionSnapshotService WCP capability is active:
+		// CNS locates the VMDK by URL and stamps the provided FCD UUID onto it
+		// (VKSRegisterVolume restore path — ss-metadata-manager supplies both fields).
+		// Guard is required: older vCenters do not support both fields and would return an error.
+		createSpec.BackingObjectDetails = &cnstypes.CnsBlockBackingDetails{
+			BackingDiskId:      instance.Spec.VolumeID,
+			BackingDiskUrlPath: instance.Spec.DiskURLPath,
+		}
+	} else if instance.Spec.VolumeID != "" {
 		createSpec.BackingObjectDetails = &cnstypes.CnsBlockBackingDetails{
 			BackingDiskId: instance.Spec.VolumeID,
 		}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The existing `CnsRegisterVolume` validation in `validateCnsRegisterVolumeSpec` rejected any spec
that set both `VolumeID` and `DiskURLPath`, treating the combination as a user error. For the
VKSRegisterVolume restore path, `ss-metadata-manager` intentionally supplies both fields: CNS
locates the VMDK by URL (`DiskURLPath`) and stamps the provided FCD UUID (`VolumeID`) onto it,
which is the correct behavior for a data-protection volume restore.

This PR makes two changes, both gated behind the `DataProtectionSnapshotService` WCP capability
(`supports_data_protection_snaphot_service`):

1. **`validateCnsRegisterVolumeSpec`** — removes the mutual-exclusion check for
   `VolumeID + DiskURLPath`. When both fields are set and the WCP capability is active, the spec
   is accepted and the function returns early (skipping the single-field checks that do not apply
   to this path). When the capability is absent (older Supervisor), the original rejection is
   preserved for backward compatibility.

2. **`constructCreateSpecForInstance`** — splits the exclusive `if/else if` into three branches.
   When both inputs are present **and the WCP capability is active**, the resulting
   `CnsBlockBackingDetails` carries both `BackingDiskId` and `BackingDiskUrlPath`. When the
   capability is absent the function falls back to `VolumeID`-only, avoiding an unsupported CNS
   API call against an older vCenter. The two existing single-field branches are preserved
   unchanged.

The WCP capability guard ensures backward compatibility: on any Supervisor cluster that does not
yet have `supports_data_protection_snaphot_service` in its `supervisor-capabilities` CR, the
behavior is identical to today. The feature activates automatically once the capability is
available, with no additional code change required (late-enablement polling is wired via
`WCPFeatureStatesSupportsLateEnablement`).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Unit tests added/updated in `cnsregistervolume_controller_test.go`:
- `TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityEnabled` — both
  fields accepted when WCP capability is active
- `TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityDisabled` — both
  fields rejected when WCP capability is absent (old behavior preserved)
- `TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityEnabled` — both
  `BackingDiskId` and `BackingDiskUrlPath` populated when capability is active
- `TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityDisabled` — falls
  back to `VolumeID`-only when capability is absent (no unsupported CNS API call)
- `TestConstructCreateSpecForInstanceWithVolumeIDOnly` — regression guard for VolumeID-only path
- `TestConstructCreateSpecForInstanceWithDiskURLPathOnly` — regression guard for DiskURLPath-only
  path

All pre-existing `TestValidateCnsRegisterVolumeSpec*` tests continue to pass.

Pre-checking pipeline passed

https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1364/

**Note:** End-to-end testing of the both-fields code path requires a Supervisor cluster built
with the `supports_data_protection_snaphot_service` WCP capability, which is introduced in
https://github-vcf.devops.broadcom.net/vcf/tera/pull/93146. That PR has not yet merged.
E2E validation of this path will be performed in a follow-up once a Supervisor build containing
that capability is available.

**Release note**:
```release-note
Guard CnsRegisterVolume to accept both VolumeID and DiskURLPath for volume restore behind the DataProtectionSnapshotService WCP capability
```
