### PR TITLE
Create ClusterStoragePolicyInfo/InfraStoragePolicyInfo CRs from full sync ahead of StorageClass creation

### DIFF
--- a/pkg/syncer/clusterstoragepolicyinfo_fullsync.go
+++ b/pkg/syncer/clusterstoragepolicyinfo_fullsync.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// clusterStoragePolicyInfoFullSync ensures a ClusterStoragePolicyInfo CR exists for every storage
+// policy present on the VC, even if no StorageClass/VolumeAttributesClass references it yet.
+// The reactive ClusterStoragePolicyInfo controller (pkg/syncer/cnsoperator/controller/
+// clusterstoragepolicyinfo) continues to own attribute syncing, InfraStoragePolicyInfo creation,
+// and owner-reference management once a CR exists; this function only guarantees the CR's presence.
+func clusterStoragePolicyInfoFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer,
+	vc string, vcenter *cnsvsphere.VirtualCenter) {
+	log := logger.GetLogger(ctx)
+
+	if !metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.SupportsExposingStoragePolicyAttributes) {
+		log.Debugf("clusterStoragePolicyInfoFullSync: capability %q is not activated, skipping",
+			common.SupportsExposingStoragePolicyAttributes)
+		return
+	}
+
+	if vcenter == nil {
+		log.Errorf("clusterStoragePolicyInfoFullSync: no VirtualCenter instance provided for VC %s", vc)
+		return
+	}
+
+	profiles, err := vcenter.QueryAllProfileDetails(ctx, "REQUIREMENT", false)
+	if err != nil {
+		log.Errorf("clusterStoragePolicyInfoFullSync: failed to query storage policies for VC %s. Err: %v",
+			vc, err)
+		return
+	}
+
+	ensureClusterStoragePolicyInfoCRsExist(ctx, metadataSyncer.cnsOperatorClient, profiles)
+}
+
+// ensureClusterStoragePolicyInfoCRsExist creates a bare ClusterStoragePolicyInfo CR (by
+// K8sCompliantName, no owner references) for every profile that doesn't already have one.
+// Owner references, InfraStoragePolicyInfo creation, and attribute syncing are left to the
+// existing reactive reconcile loop, which is triggered automatically by the CR create event.
+func ensureClusterStoragePolicyInfoCRsExist(ctx context.Context, cnsOperatorClient client.Client,
+	profiles []cnsvsphere.ProfileDetail) {
+	log := logger.GetLogger(ctx)
+
+	for _, profile := range profiles {
+		if profile.K8sCompliantName == "" {
+			log.Debugf("clusterStoragePolicyInfoFullSync: skipping storage policy %q (ID %s) with no "+
+				"K8s compliant name", profile.Name, profile.ID)
+			continue
+		}
+
+		name := profile.K8sCompliantName
+		existing := &clusterspiv1alpha1.ClusterStoragePolicyInfo{}
+		err := cnsOperatorClient.Get(ctx, apitypes.NamespacedName{Name: name}, existing)
+		if err == nil {
+			continue
+		}
+		if !apierrors.IsNotFound(err) {
+			log.Errorf("clusterStoragePolicyInfoFullSync: failed to get ClusterStoragePolicyInfo %q. Err: %v",
+				name, err)
+			continue
+		}
+
+		instance := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: apis.SchemeGroupVersion.String(),
+				Kind:       "ClusterStoragePolicyInfo",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+		if err := cnsOperatorClient.Create(ctx, instance); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				continue
+			}
+			log.Errorf("clusterStoragePolicyInfoFullSync: failed to create ClusterStoragePolicyInfo %q. Err: %v",
+				name, err)
+			continue
+		}
+		log.Infof("clusterStoragePolicyInfoFullSync: created ClusterStoragePolicyInfo %q for storage policy %q "+
+			"(ID %s) ahead of any StorageClass", name, profile.Name, profile.ID)
+	}
+}

--- a/pkg/syncer/clusterstoragepolicyinfo_fullsync_test.go
+++ b/pkg/syncer/clusterstoragepolicyinfo_fullsync_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+func fullSyncTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, apis.SchemeBuilder.AddToScheme(s))
+	return s
+}
+
+func TestEnsureClusterStoragePolicyInfoCRsExist_CreatesMissingCRs(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := fullSyncTestScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	profiles := []cnsvsphere.ProfileDetail{
+		{ID: "policy-1", Name: "Policy One", K8sCompliantName: "policy-one"},
+		{ID: "policy-2", Name: "Policy Two", K8sCompliantName: "policy-two"},
+	}
+
+	ensureClusterStoragePolicyInfoCRsExist(ctx, cli, profiles)
+
+	for _, name := range []string{"policy-one", "policy-two"} {
+		got := &clusterspiv1alpha1.ClusterStoragePolicyInfo{}
+		err := cli.Get(ctx, apitypes.NamespacedName{Name: name}, got)
+		require.NoError(t, err, "expected ClusterStoragePolicyInfo %q to be created", name)
+		assert.Empty(t, got.OwnerReferences, "expected no owner references on a bare CR created from full sync")
+	}
+}
+
+func TestEnsureClusterStoragePolicyInfoCRsExist_SkipsExistingCR(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := fullSyncTestScheme(t)
+
+	existing := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "policy-one",
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "storage.k8s.io/v1", Kind: "StorageClass", Name: "sc-1"},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	profiles := []cnsvsphere.ProfileDetail{
+		{ID: "policy-1", Name: "Policy One", K8sCompliantName: "policy-one"},
+	}
+
+	ensureClusterStoragePolicyInfoCRsExist(ctx, cli, profiles)
+
+	got := &clusterspiv1alpha1.ClusterStoragePolicyInfo{}
+	require.NoError(t, cli.Get(ctx, apitypes.NamespacedName{Name: "policy-one"}, got))
+	assert.Equal(t, existing.OwnerReferences, got.OwnerReferences,
+		"existing CR with owner references must not be touched by full sync")
+}
+
+func TestEnsureClusterStoragePolicyInfoCRsExist_SkipsProfileWithoutK8sCompliantName(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := fullSyncTestScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	profiles := []cnsvsphere.ProfileDetail{
+		{ID: "policy-1", Name: "Policy One", K8sCompliantName: ""},
+	}
+
+	ensureClusterStoragePolicyInfoCRsExist(ctx, cli, profiles)
+
+	list := &clusterspiv1alpha1.ClusterStoragePolicyInfoList{}
+	require.NoError(t, cli.List(ctx, list))
+	assert.Empty(t, list.Items, "expected no CR to be created for a profile with no K8s compliant name")
+}
+
+// erroringCreateClient wraps a client.Client and forces Create calls to fail, to verify that a
+// per-policy Create error does not stop processing of the remaining policies.
+type erroringCreateClient struct {
+	client.Client
+	failNames map[string]bool
+}
+
+func (e *erroringCreateClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if e.failNames[obj.GetName()] {
+		return assert.AnError
+	}
+	return e.Client.Create(ctx, obj, opts...)
+}
+
+func TestEnsureClusterStoragePolicyInfoCRsExist_ContinuesAfterPerPolicyCreateError(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := fullSyncTestScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cli := &erroringCreateClient{Client: base, failNames: map[string]bool{"policy-one": true}}
+
+	profiles := []cnsvsphere.ProfileDetail{
+		{ID: "policy-1", Name: "Policy One", K8sCompliantName: "policy-one"},
+		{ID: "policy-2", Name: "Policy Two", K8sCompliantName: "policy-two"},
+	}
+
+	ensureClusterStoragePolicyInfoCRsExist(ctx, cli, profiles)
+
+	// The failing policy's CR should not exist...
+	err := base.Get(ctx, apitypes.NamespacedName{Name: "policy-one"}, &clusterspiv1alpha1.ClusterStoragePolicyInfo{})
+	assert.Error(t, err)
+
+	// ...but the remaining policy should still have been processed and created.
+	err = base.Get(ctx, apitypes.NamespacedName{Name: "policy-two"}, &clusterspiv1alpha1.ClusterStoragePolicyInfo{})
+	assert.NoError(t, err)
+}

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -365,9 +365,9 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
-	// If no instance returned, it means both SC and VAC are gone - nothing to manage.
-	// No need to return an error as in the next reconcile, the CR should get a deletionTimestamp
-	// which will anyway trigger a deletion event.
+	// If no instance returned, the CR doesn't exist and neither does a backing SC/VAC - nothing to manage.
+	// If the CR already existed (e.g. pre-created by full sync) it is returned even without a backing
+	// SC/VAC so InfraStoragePolicyInfo creation below still proceeds.
 	if instance == nil {
 		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName, timeout)
 	}
@@ -418,8 +418,18 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName, timeout)
 	}
 
+	policyContent, err := vc.PbmRetrieveContent(ctx, []string{profile.ID})
+	if err != nil {
+		log.Errorf("Failed to retrieve policy content for profile %s: %v", profile.ID, err)
+		errorMsg := fmt.Sprintf("Failed to retrieve policy content: %v", err)
+		if setErr := r.setClusterSPIError(ctx, instance, errorMsg); setErr != nil {
+			log.Errorf("Failed to set error status: %v", setErr)
+		}
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	}
+
 	// Sync storage policy attributes for ClusterSPI instance.
-	err = r.syncClusterSPIAttributes(ctx, instance, vc, profile)
+	err = r.syncClusterSPIAttributes(ctx, instance, profile, vc, policyContent)
 	if err != nil {
 		log.Errorf("Failed to sync storage policy attributes for %q: %v.", request.Name, err)
 		errorMsg := fmt.Sprintf("Failed to sync storage policy attributes: %v", err)
@@ -436,7 +446,7 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 	}
 
 	// Sync InfraSPI attributes for InfraSPI instance.
-	err = r.syncInfraSPIAttributes(ctx, instance, infraSPI, vc, profile)
+	err = r.syncInfraSPIAttributes(ctx, instance, infraSPI, vc, profile, policyContent)
 	if err != nil {
 		log.Errorf("Failed to sync InfraSPI attributes for %q: %v.", request.Name, err)
 		errorMsg := fmt.Sprintf("Failed to sync InfraSPI attributes: %v", err)
@@ -525,14 +535,17 @@ func (r *ReconcileClusterStoragePolicyInfo) ensureClusterSPIInstance(ctx context
 	*clusterspiv1alpha1.ClusterStoragePolicyInfo, bool, error) {
 	log := logger.GetLogger(ctx)
 
-	// If neither SC nor VAC exists, nothing to manage
+	// If neither SC nor VAC exists, there are no owner references to manage. If the instance already
+	// exists (e.g. pre-created by full sync ahead of any StorageClass), return it as-is so the caller
+	// still proceeds to ensure the InfraStoragePolicyInfo CR. If it doesn't exist, there's nothing to do;
+	// the reactive SC/VAC create event will trigger creation later.
 	if sc == nil && vac == nil {
 		if instance != nil {
-			log.Warnf("ClusterStoragePolicyInfo %q exists but no matching StorageClass or VolumeAttributesClass found",
-				name)
-		} else {
-			log.Debugf("No StorageClass or VolumeAttributesClass found for %q, nothing to create", name)
+			log.Debugf("ClusterStoragePolicyInfo %q exists but no matching StorageClass or VolumeAttributesClass "+
+				"found yet", name)
+			return instance, false, nil
 		}
+		log.Debugf("No StorageClass or VolumeAttributesClass found for %q, nothing to create", name)
 		return nil, false, nil
 	}
 
@@ -719,19 +732,12 @@ func (r *ReconcileClusterStoragePolicyInfo) completeReconciliationWithError(ctx 
 
 // syncClusterSPIAttributes syncs storage policy attributes from vCenter.
 func (r *ReconcileClusterStoragePolicyInfo) syncClusterSPIAttributes(ctx context.Context,
-	instance *clusterspiv1alpha1.ClusterStoragePolicyInfo, vc *cnsvsphere.VirtualCenter,
-	profile *cnsvsphere.ProfileDetail) error {
+	instance *clusterspiv1alpha1.ClusterStoragePolicyInfo, profile *cnsvsphere.ProfileDetail,
+	vc *cnsvsphere.VirtualCenter, policyContent []cnsvsphere.SpbmPolicyContent) error {
 	log := logger.GetLogger(ctx)
 
 	log.Infof("Syncing storage policy attributes for ClusterStoragePolicyInfo %q (policy ID: %s, name: %s)",
 		instance.Name, profile.ID, profile.Name)
-
-	// Retrieve policy content for analysis
-	policyContent, err := vc.PbmRetrieveContent(ctx, []string{profile.ID})
-	if err != nil {
-		log.Errorf("Failed to retrieve policy content for profile %s: %v", profile.ID, err)
-		return fmt.Errorf("failed to retrieve policy content: %w", err)
-	}
 
 	if len(policyContent) == 0 {
 		log.Warnf("No policy content found for profile %s", profile.ID)
@@ -755,11 +761,12 @@ func (r *ReconcileClusterStoragePolicyInfo) syncClusterSPIAttributes(ctx context
 	return overallErr
 }
 
-// syncInfraSPIAttributes syncs InfraStoragePolicyInfo attributes from vCenter
+// syncInfraSPIAttributes syncs InfraStoragePolicyInfo attributes from vCenter.
 func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.Context,
 	instance *clusterspiv1alpha1.ClusterStoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
-	vc *cnsvsphere.VirtualCenter, profile *cnsvsphere.ProfileDetail) error {
+	vc *cnsvsphere.VirtualCenter, profile *cnsvsphere.ProfileDetail,
+	policyContent []cnsvsphere.SpbmPolicyContent) error {
 	log := logger.GetLogger(ctx)
 
 	log.Infof("Syncing InfraSPI attributes for %q (policy ID: %s, name: %s)",
@@ -772,7 +779,8 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 	clusterDatastoreCache := make(map[string][]*cnsvsphere.DatastoreInfo)
 
 	// Populate topology capabilities for InfraSPI.
-	if err := r.populateTopologyCapabilities(ctx, instance, infraSPI, profile.ID, vc, clusterDatastoreCache); err != nil {
+	if err := r.populateTopologyCapabilities(ctx, instance, infraSPI, profile.ID, vc,
+		clusterDatastoreCache, policyContent); err != nil {
 		log.Errorf("Failed to populate topology capabilities for profile %s: %v", profile.ID, err)
 		overallErr = errors.Join(overallErr, err)
 	}
@@ -786,11 +794,13 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 	return overallErr
 }
 
-// populateTopologyCapabilities populates topology information for the storage policy in InfraSPI
+// populateTopologyCapabilities populates topology information for the storage policy in InfraSPI.
 func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx context.Context,
 	clusterSPI *clusterspiv1alpha1.ClusterStoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo, profileID string,
-	vc *cnsvsphere.VirtualCenter, clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) error {
+	vc *cnsvsphere.VirtualCenter,
+	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo,
+	clusterSPIPolicyContent []cnsvsphere.SpbmPolicyContent) error {
 	log := logger.GetLogger(ctx)
 
 	// Marker policies (e.g. vSAN File Service) derive their cluster-wide accessible zones from
@@ -813,21 +823,33 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 		return nil
 	}
 
-	// Get StorageClass that references this policy
+	// Determine the topology type for this policy. Prefer the StorageClass's StorageTopologyType
+	// parameter when a StorageClass references the policy; otherwise derive it directly from the
+	// policy's PBM capabilities. Deriving from PBM lets us populate topology for policies whose CRs
+	// were created ahead of any StorageClass (see full sync).
 	storageClass, err := getStorageClassForPolicy(ctx, r.client, profileID)
 	if err != nil {
 		return fmt.Errorf("failed to get StorageClass for policy: %w", err)
 	}
 
-	// Get the StorageTopologyType parameter value from StorageClass
-	topologyType, err := getStorageTopologyType(ctx, storageClass)
-	if err != nil {
-		log.Errorf("Storage policy %s does not have StorageTopologyType parameter, skipping topology population: %v",
-			profileID, err)
-		return err
+	var topologyType string
+	if storageClass != nil {
+		// Get the StorageTopologyType parameter value from StorageClass
+		topologyType, err = getStorageTopologyType(ctx, storageClass)
+		if err != nil {
+			log.Errorf("Storage policy %s does not have a valid StorageTopologyType parameter: %v",
+				profileID, err)
+			return err
+		}
+		log.Infof("Storage policy %s has topology type %q from StorageClass %q", profileID, topologyType,
+			storageClass.Name)
+	} else {
+		// No StorageClass references this policy yet; derive the topology type directly from the
+		// policy's PBM capabilities.
+		topologyType = getStorageTopologyTypeFromPolicy(ctx, clusterSPIPolicyContent)
+		log.Infof("No StorageClass found for storage policy %s; derived topology type %q from PBM policy content",
+			profileID, topologyType)
 	}
-
-	log.Infof("Storage policy %s has topology type: %q", profileID, topologyType)
 
 	// Initialize topology status with the topology type
 	infraSPI.Status.Topology = &infraspiv1alpha1.Topology{

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -516,6 +516,31 @@ func TestEnsureClusterSPIInstance(t *testing.T) {
 		assert.Nil(t, instance)
 	})
 
+	t.Run("Return existing instance unchanged when neither SC nor VAC exist yet", func(t *testing.T) {
+		existingInstance := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-name",
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingInstance).Build()
+		recorder := record.NewFakeRecorder(10)
+		r := &ReconcileClusterStoragePolicyInfo{
+			client:   client,
+			scheme:   scheme,
+			recorder: recorder,
+		}
+
+		// Simulates a ClusterSPI pre-created by full sync ahead of any StorageClass/VAC. It must be
+		// returned as-is so the caller still proceeds to ensure the InfraStoragePolicyInfo CR exists.
+		instance, wasCreated, err := r.ensureClusterSPIInstance(ctx, existingInstance, "test-name", nil, nil)
+		require.NoError(t, err)
+		assert.False(t, wasCreated)
+		require.NotNil(t, instance)
+		assert.Equal(t, "test-name", instance.Name)
+		assert.Empty(t, instance.OwnerReferences)
+	})
+
 	t.Run("Update owner references when instance exists", func(t *testing.T) {
 		existingInstance := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1450,6 +1475,86 @@ func TestExtractIopsLimit(t *testing.T) {
 	}
 }
 
+func TestGetStorageTopologyTypeFromPolicy(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	topologyRule := func(value string) cnsvsphere.SpbmPolicyRule {
+		return cnsvsphere.SpbmPolicyRule{
+			Ns:     pbmTopologyNamespace,
+			CapID:  pbmTopologyCapabilityID,
+			PropID: pbmTopologyPropertyID,
+			Value:  value,
+		}
+	}
+	policyWithRule := func(rule cnsvsphere.SpbmPolicyRule) []cnsvsphere.SpbmPolicyContent {
+		return []cnsvsphere.SpbmPolicyContent{
+			{
+				ID:       "test-policy",
+				Profiles: []cnsvsphere.SpbmPolicySubProfile{{Rules: []cnsvsphere.SpbmPolicyRule{rule}}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		policyContent []cnsvsphere.SpbmPolicyContent
+		expected      string
+	}{
+		{
+			name:          "empty policy content",
+			policyContent: []cnsvsphere.SpbmPolicyContent{},
+			expected:      "",
+		},
+		{
+			name:          "Zonal topology maps to zonal",
+			policyContent: policyWithRule(topologyRule(pbmTopologyValueZonal)),
+			expected:      "zonal",
+		},
+		{
+			name:          "CrossZonal topology maps to zonal",
+			policyContent: policyWithRule(topologyRule(pbmTopologyValueCrossZonal)),
+			expected:      "zonal",
+		},
+		{
+			name:          "value comparison is case-insensitive",
+			policyContent: policyWithRule(topologyRule("zonal")),
+			expected:      "zonal",
+		},
+		{
+			name:          "HostLocal topology is not zone-aware",
+			policyContent: policyWithRule(topologyRule("HostLocal")),
+			expected:      "",
+		},
+		{
+			name: "policy without topology capability",
+			policyContent: policyWithRule(cnsvsphere.SpbmPolicyRule{
+				Ns:     vsanIopsLimitNs,
+				PropID: vsanIopsLimitPropID,
+				Value:  "100",
+			}),
+			expected: "",
+		},
+		{
+			name: "topology capability on a later sub-profile",
+			policyContent: []cnsvsphere.SpbmPolicyContent{
+				{
+					ID: "test-policy",
+					Profiles: []cnsvsphere.SpbmPolicySubProfile{
+						{Rules: []cnsvsphere.SpbmPolicyRule{{Ns: vsanIopsLimitNs, PropID: vsanIopsLimitPropID, Value: "100"}}},
+						{Rules: []cnsvsphere.SpbmPolicyRule{topologyRule(pbmTopologyValueZonal)}},
+					},
+				},
+			},
+			expected: "zonal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getStorageTopologyTypeFromPolicy(ctx, tt.policyContent))
+		})
+	}
+}
+
 func TestPopulatePerformanceCapabilities(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	iops500 := int64(500)
@@ -1832,6 +1937,7 @@ func TestGetStorageClassForPolicy(t *testing.T) {
 		expectedSC      *storagev1.StorageClass
 		expectedError   string
 		expectedErrType error
+		expectNilNoErr  bool
 	}{
 		{
 			name:      "Single matching StorageClass",
@@ -1891,7 +1997,7 @@ func TestGetStorageClassForPolicy(t *testing.T) {
 			expectedErrType: fmt.Errorf(""),
 		},
 		{
-			name:      "No matching StorageClass should error",
+			name:      "No matching StorageClass returns nil, no error",
 			profileID: "non-existent-policy",
 			storageClasses: []*storagev1.StorageClass{
 				{
@@ -1901,8 +2007,7 @@ func TestGetStorageClassForPolicy(t *testing.T) {
 					},
 				},
 			},
-			expectedError:   "no StorageClass found referencing storage policy ID \"non-existent-policy\"",
-			expectedErrType: fmt.Errorf(""),
+			expectNilNoErr: true,
 		},
 		{
 			name:      "Skip WaitForFirstConsumer StorageClasses",
@@ -1941,7 +2046,7 @@ func TestGetStorageClassForPolicy(t *testing.T) {
 			},
 		},
 		{
-			name:      "StorageClass with nil parameters",
+			name:      "StorageClass with nil parameters returns nil, no error",
 			profileID: "test-policy-nil",
 			storageClasses: []*storagev1.StorageClass{
 				{
@@ -1949,18 +2054,16 @@ func TestGetStorageClassForPolicy(t *testing.T) {
 					Parameters: nil,
 				},
 			},
-			expectedError:   "no StorageClass found referencing storage policy ID \"test-policy-nil\"",
-			expectedErrType: fmt.Errorf(""),
+			expectNilNoErr: true,
 		},
 		{
-			name:            "Empty StorageClass list",
-			profileID:       "any-policy",
-			storageClasses:  []*storagev1.StorageClass{},
-			expectedError:   "no StorageClass found referencing storage policy ID \"any-policy\"",
-			expectedErrType: fmt.Errorf(""),
+			name:           "Empty StorageClass list returns nil, no error",
+			profileID:      "any-policy",
+			storageClasses: []*storagev1.StorageClass{},
+			expectNilNoErr: true,
 		},
 		{
-			name:      "StorageClass with empty parameters map",
+			name:      "StorageClass with empty parameters map returns nil, no error",
 			profileID: "test-policy-empty",
 			storageClasses: []*storagev1.StorageClass{
 				{
@@ -1968,11 +2071,10 @@ func TestGetStorageClassForPolicy(t *testing.T) {
 					Parameters: map[string]string{},
 				},
 			},
-			expectedError:   "no StorageClass found referencing storage policy ID \"test-policy-empty\"",
-			expectedErrType: fmt.Errorf(""),
+			expectNilNoErr: true,
 		},
 		{
-			name:      "StorageClass with matching key but different value",
+			name:      "StorageClass with matching key but different value returns nil, no error",
 			profileID: "desired-policy",
 			storageClasses: []*storagev1.StorageClass{
 				{
@@ -1982,8 +2084,7 @@ func TestGetStorageClassForPolicy(t *testing.T) {
 					},
 				},
 			},
-			expectedError:   "no StorageClass found referencing storage policy ID \"desired-policy\"",
-			expectedErrType: fmt.Errorf(""),
+			expectNilNoErr: true,
 		},
 	}
 
@@ -2005,6 +2106,9 @@ func TestGetStorageClassForPolicy(t *testing.T) {
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, result)
+			} else if tt.expectNilNoErr {
+				require.NoError(t, err)
 				assert.Nil(t, result)
 			} else {
 				require.NoError(t, err)
@@ -2394,7 +2498,7 @@ func testFindStoragePolicyProfile(ctx context.Context, instance *clusterspiv1alp
 func testPopulateTopologyCapabilities(r *ReconcileClusterStoragePolicyInfo, ctx context.Context,
 	clusterSPI *clusterspiv1alpha1.ClusterStoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo, profileID string,
-	mockVCConfig *mockVirtualCenter) error {
+	mockVCConfig *mockVirtualCenter, policyContent []cnsvsphere.SpbmPolicyContent) error {
 
 	log := logger.GetLogger(ctx)
 
@@ -2404,15 +2508,23 @@ func testPopulateTopologyCapabilities(r *ReconcileClusterStoragePolicyInfo, ctx 
 		return fmt.Errorf("failed to get StorageClass for policy: %w", err)
 	}
 
-	// Get the StorageTopologyType parameter value from StorageClass
-	topologyType, err := getStorageTopologyType(ctx, storageClass)
-	if err != nil {
-		log.Errorf("Storage policy %s does not have StorageTopologyType parameter, skipping topology population: %v",
-			profileID, err)
-		return err
+	var topologyType string
+	if storageClass != nil {
+		// Get the StorageTopologyType parameter value from StorageClass
+		topologyType, err = getStorageTopologyType(ctx, storageClass)
+		if err != nil {
+			log.Errorf("Storage policy %s does not have StorageTopologyType parameter, skipping topology population: %v",
+				profileID, err)
+			return err
+		}
+		log.Infof("Storage policy %s has topology type: %q", profileID, topologyType)
+	} else {
+		// No StorageClass references this policy yet; derive the topology type directly from the
+		// policy's PBM capabilities, mirroring production behavior.
+		topologyType = getStorageTopologyTypeFromPolicy(ctx, policyContent)
+		log.Infof("No StorageClass found for storage policy %s; derived topology type %q from PBM policy content",
+			profileID, topologyType)
 	}
-
-	log.Infof("Storage policy %s has topology type: %q", profileID, topologyType)
 
 	// Initialize topology status with the topology type
 	infraSPI.Status.Topology = &infraspiv1alpha1.Topology{
@@ -2453,6 +2565,7 @@ func TestPopulateTopologyCapabilities(t *testing.T) {
 		name             string
 		profileID        string
 		storageClasses   []*storagev1.StorageClass
+		policyContent    []cnsvsphere.SpbmPolicyContent
 		topologyMgr      commoncotypes.ControllerTopologyService
 		mockVCConfig     *mockVirtualCenter
 		expectedError    string
@@ -2511,7 +2624,7 @@ func TestPopulateTopologyCapabilities(t *testing.T) {
 			},
 		},
 		{
-			name:      "StorageClass not found error",
+			name:      "StorageClass not found derives topology from PBM policy content",
 			profileID: "non-existent-policy",
 			storageClasses: []*storagev1.StorageClass{
 				{
@@ -2521,12 +2634,31 @@ func TestPopulateTopologyCapabilities(t *testing.T) {
 					},
 				},
 			},
+			policyContent: []cnsvsphere.SpbmPolicyContent{
+				{
+					ID: "non-existent-policy",
+					Profiles: []cnsvsphere.SpbmPolicySubProfile{
+						{
+							Rules: []cnsvsphere.SpbmPolicyRule{
+								{
+									Ns:     pbmTopologyNamespace,
+									CapID:  pbmTopologyCapabilityID,
+									PropID: pbmTopologyPropertyID,
+									Value:  pbmTopologyValueZonal,
+								},
+							},
+						},
+					},
+				},
+			},
 			topologyMgr: &mockControllerTopologyService{},
 			mockVCConfig: &mockVirtualCenter{
 				compatibleHubs: []pbmtypes.PbmPlacementHub{},
 			},
-			expectedError: "failed to get StorageClass for policy: no StorageClass found referencing " +
-				"storage policy ID \"non-existent-policy\"",
+			expectedTopology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{},
+			},
 		},
 		{
 			name:      "Invalid topology type error",
@@ -2662,7 +2794,8 @@ func TestPopulateTopologyCapabilities(t *testing.T) {
 			}
 
 			// Call the function under test
-			err := testPopulateTopologyCapabilities(r, ctx, clusterSPI, infraSPI, tt.profileID, tt.mockVCConfig)
+			err := testPopulateTopologyCapabilities(r, ctx, clusterSPI, infraSPI, tt.profileID, tt.mockVCConfig,
+				tt.policyContent)
 
 			// Verify results
 			if tt.expectedError != "" {
@@ -2738,7 +2871,7 @@ func TestPopulateTopologyCapabilities_Integration(t *testing.T) {
 		// Execute - use the test wrapper to avoid VirtualCenter issues
 		err := testPopulateTopologyCapabilities(r, ctx, clusterSPI, infraSPI, "test-policy-id", &mockVirtualCenter{
 			compatibleHubs: []pbmtypes.PbmPlacementHub{},
-		})
+		}, nil)
 
 		// Verify
 		require.NoError(t, err)
@@ -2788,7 +2921,7 @@ func TestPopulateTopologyCapabilities_Integration(t *testing.T) {
 		// Execute - use the test wrapper to avoid VirtualCenter issues
 		err := testPopulateTopologyCapabilities(r, ctx, clusterSPI, infraSPI, "test-policy-no-topo", &mockVirtualCenter{
 			compatibleHubs: []pbmtypes.PbmPlacementHub{},
-		})
+		}, nil)
 
 		// Verify
 		require.NoError(t, err)

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
@@ -316,7 +316,10 @@ func populateEncryptionCapabilities(ctx context.Context,
 }
 
 // getStorageClassForPolicy returns the StorageClass that references the given storage policy ID.
-// Returns error if no StorageClass is found or if multiple StorageClasses reference the same policy.
+// Returns (nil, nil) if no StorageClass references the policy yet — this is an expected state for
+// policies whose ClusterStoragePolicyInfo/InfraStoragePolicyInfo CRs were created ahead of any
+// StorageClass (see full sync). Returns an error only if multiple StorageClasses reference the
+// same policy, which is a genuine misconfiguration.
 func getStorageClassForPolicy(ctx context.Context, k8sClient client.Client,
 	profileID string) (*storagev1.StorageClass, error) {
 	log := logger.GetLogger(ctx)
@@ -353,7 +356,8 @@ func getStorageClassForPolicy(ctx context.Context, k8sClient client.Client,
 	// Validate exactly one StorageClass found
 	switch len(matchingSCs) {
 	case 0:
-		return nil, fmt.Errorf("no StorageClass found referencing storage policy ID %q", profileID)
+		log.Debugf("No StorageClass found referencing storage policy ID %q", profileID)
+		return nil, nil
 	case 1:
 		log.Infof("Found StorageClass %q referencing storage policy ID %q", matchingSCs[0].Name, profileID)
 		return matchingSCs[0], nil
@@ -365,6 +369,54 @@ func getStorageClassForPolicy(ctx context.Context, k8sClient client.Client,
 		return nil, fmt.Errorf("multiple StorageClasses (%v) found referencing storage policy ID %q, expected exactly one",
 			scNames, profileID)
 	}
+}
+
+// PBM capability that carries a storage policy's zone-availability topology, independent of any
+// StorageClass. vSphere encodes this directly on the policy via the consumption-domain namespace;
+// this mirrors the supervisor (wcpsvc) PolicyTopology helper so we can derive the topology type
+// when no StorageClass references the policy yet.
+const (
+	pbmTopologyNamespace    = "com.vmware.storage.consumptiondomain"
+	pbmTopologyCapabilityID = "StorageTopology"
+	pbmTopologyPropertyID   = "StorageTopologyType"
+
+	// PBM StorageTopologyType values. Both Zonal and CrossZonal are zone-aware and map to the
+	// InfraStoragePolicyInfo "zonal" TopologyType; anything else (including HostLocal or an absent
+	// capability) maps to the empty "no topology" value.
+	pbmTopologyValueZonal      = "Zonal"
+	pbmTopologyValueCrossZonal = "CrossZonal"
+)
+
+// getStorageTopologyTypeFromPolicy derives the topology type ("zonal" or "" for no topology)
+// directly from the storage policy's PBM content, without requiring a StorageClass. It looks for
+// the consumption-domain StorageTopology capability on any sub-profile and returns "zonal" when the
+// policy declares Zonal or CrossZonal availability. This is the vCenter/PBM-native source of truth
+// and is used when no StorageClass references the policy (e.g. CRs pre-created by full sync).
+func getStorageTopologyTypeFromPolicy(ctx context.Context, policyContent []cnsvsphere.SpbmPolicyContent) string {
+	log := logger.GetLogger(ctx)
+
+	for _, content := range policyContent {
+		for _, subProfile := range content.Profiles {
+			for _, rule := range subProfile.Rules {
+				if rule.Ns != pbmTopologyNamespace || rule.CapID != pbmTopologyCapabilityID ||
+					rule.PropID != pbmTopologyPropertyID {
+					continue
+				}
+				log.Debugf("Storage policy %s declares PBM StorageTopologyType %q", content.ID, rule.Value)
+				// CrossZonal is not currently supported as a distinct topology; it is treated the
+				// same as Zonal until cross-zonal provisioning is implemented.
+				if strings.EqualFold(rule.Value, pbmTopologyValueZonal) ||
+					strings.EqualFold(rule.Value, pbmTopologyValueCrossZonal) {
+					return "zonal"
+				}
+				// Any other declared value (e.g. HostLocal) is not zone-aware.
+				return ""
+			}
+		}
+	}
+
+	log.Debugf("No PBM StorageTopology capability found in policy content; defaulting to no topology")
+	return ""
 }
 
 // isZonalTopologyPolicy checks if the StorageClass has zonal topology configured

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/populate_topology_cache_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/populate_topology_cache_test.go
@@ -108,7 +108,7 @@ func TestPopulateTopologyCapabilities_PopulatesDsToPolicyCache(t *testing.T) {
 	// that reuse the same datastore IDs.
 	t.Cleanup(func() { vsphereinfra.GetCache().SetDatastoresForPolicy(clusterSPI.Name, nil) })
 
-	err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil, clusterDatastoreCache)
+	err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil, clusterDatastoreCache, nil)
 	require.NoError(t, err)
 
 	// Only zone-a's cluster mounts the compatible datastore (ds-1).
@@ -153,12 +153,14 @@ func TestPopulateTopologyCapabilities_CacheEntryClearedWhenNoLongerCompatible(t 
 
 	// First reconcile: ds-1 is compatible.
 	withMockCompatibleDatastores(t, "ds-1")
-	require.NoError(t, r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil, clusterDatastoreCache))
+	require.NoError(t, r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil,
+		clusterDatastoreCache, nil))
 	require.ElementsMatch(t, []string{"test-policy-2"}, vsphereinfra.GetCache().PoliciesForDatastore("ds-1"))
 
 	// Second reconcile: PBM now reports no compatible datastores at all.
 	withMockCompatibleDatastores(t)
-	require.NoError(t, r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil, clusterDatastoreCache))
+	require.NoError(t, r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil,
+		clusterDatastoreCache, nil))
 
 	assert.Empty(t, vsphereinfra.GetCache().PoliciesForDatastore("ds-1"),
 		"stale cache entry must be cleared once the policy is no longer compatible with ds-1")

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -96,6 +96,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 			createStoragePolicyUsageCRS(ctx, metadataSyncer)
 		}
 	}
+
 	// Sync VolumeInfo CRs for the below conditions:
 	// Either it is a Vanilla k8s deployment with Multi-VC configuration or, it's a StretchSupervisor cluster
 	if len(metadataSyncer.configInfo.Cfg.VirtualCenter) > 1 ||
@@ -247,6 +248,12 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 	if err != nil {
 		log.Errorf("failed to get virtual center instance for VC: %s. Error: %v", vc, err)
 		return err
+	}
+
+	// Ensure a ClusterStoragePolicyInfo CR exists for every storage policy on the VC, even if no
+	// StorageClass/VolumeAttributesClass references it yet. Reuses the VC instance fetched above.
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		clusterStoragePolicyInfoFullSync(ctx, metadataSyncer, vc, vcenter)
 	}
 
 	// Iterate through all the k8sPVs to find all PVs with node affinity missing and


### PR DESCRIPTION
Previously, ClusterStoragePolicyInfo (ClusterSPI) and InfraStoragePolicyInfo (InfraSPI) CRs were only created reactively, triggered by a StorageClass/VolumeAttributesClass create event, so a storage policy that existed on vCenter but had no matching SC/VAC never got a CR at all. This change adds a new full-sync step (clusterStoragePolicyInfoFullSync, running every 30 minutes on Supervisor/Workload clusters) that lists all storage policies from vCenter (QueryAllProfileDetails) and creates a ClusterSPI CR for any policy that doesn't have one yet. The existing reactive controller continues to own owner-reference management, InfraSPI creation, and attribute syncing once the CR exists. To support this, getStorageClassForPolicy was changed and populateTopologyCapabilities are updated.

Testing done:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1809/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1370/ -Passed

(1) (1) Policy exists on vCenter, no StorageClass yet — topology derived from PBM, not skipped:
- Created a storage policy on vCenter (test-storage-policy / test storage policy, ID 87b02093-3004-442d-91ec-00346843f1e3) with a Zonal StorageTopologyType capability set on the policy itself, and confirmed no StorageClass references it:
```
$ kubectl get storageclass -o json | jq '.items[] | select(.parameters.storagePolicyID=="87b02093-3004-442d-91ec-00346843f1e3")'
(no output)
```
- Full sync created the bare ClusterSPI CR ahead of any StorageClass:
```
{"level":"info","time":"2026-07-13T15:25:44.782900234Z","caller":"syncer/clusterstoragepolicyinfo_fullsync.go:107","msg":"clusterStoragePolicyInfoFullSync: created ClusterStoragePolicyInfo \"test-storage-policy\" for storage policy \"test storage policy\" (ID 87b02093-3004-442d-91ec-00346843f1e3) ahead of any StorageClass","TraceId":"e88732d0-b1de-4ecb-8c68-586cb4956b40"}
```
- The reactive reconciler picked up the create event and confirmed the getStorageClassForPolicy (nil, nil) path, then derived topology from PBM instead of skipping it:
```
{"level":"info","...","caller":"clusterstoragepolicyinfo/helper.go:359","msg":"No StorageClass found referencing storage policy ID \"87b02093-3004-442d-91ec-00346843f1e3\"",...}
{"level":"info","...","caller":"clusterstoragepolicyinfo/controller.go:757","msg":"No StorageClass found for storage policy 87b02093-3004-442d-91ec-00346843f1e3; derived topology type \"zonal\" from PBM policy content",...}
{"level":"info","...","caller":"clusterstoragepolicyinfo/controller.go:766","msg":"Storage policy 87b02093-3004-442d-91ec-00346843f1e3: populating accessible zones",...}
{"level":"info","...","caller":"clusterstoragepolicyinfo/controller.go:776","msg":"Storage policy 87b02093-3004-442d-91ec-00346843f1e3 is accessible in zones: []",...}
```
- Resulting InfraStoragePolicyInfo, with no StorageClass ever created for this policy:
```
$ kubectl get infrastoragepolicyinfo test-storage-policy -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
metadata:
  creationTimestamp: "2026-07-13T15:25:46Z"
  generation: 1
  name: test-storage-policy
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: test-storage-policy
    uid: 1f868792-33cd-4dd6-8585-354e85d897b9
  resourceVersion: "893036"
  uid: 927d7c55-4256-4299-8067-5121cdf05bb5
status:
  topology:
    accessibleZones: []
    topologyType: zonal
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsLinkedClone: false
    SupportsPersistentVolumeBlock: true
    SupportsPersistentVolumeFilesystem: true
```
topologyType: zonal was populated purely from the policy's own PBM StorageTopologyType capability, with no StorageClass involved at any point.

accessibleZones came back empty because PbmQueryMatchingHub found zero datastores compatible with this test policy in this environment (confirmed via the pbm.go/util.go "Found 0 compatible datastores for policy ..." log lines), not because of the topology-type change — GetAccessibleZonesForPolicy is pre-existing, unchanged logic. topologyType and accessibleZones are populated independently, so the zero-compatible-datastore result doesn't affect the topologyType assertion above.

(2) StorageClass created after full sync (from the earlier version of this change, still valid):
Confirmed that creating a StorageClass for the same policy afterward drives the reconciler to add owner references on the ClusterStoragePolicyInfo and switch topology derivation to prefer the StorageClass's StorageTopologyType parameter over the PBM-derived value.

Created a StorageClass referencing the test policy by policy ID. Watched the syncer reconcile the SC create event:

```
2026-07-10T06:55:07.612Z  INFO  clusterstoragepolicyinfo/controller.go:240  Reconciling ClusterStoragePolicyInfo  {"name": "/test-storage-policy"}
2026-07-10T06:55:07.661Z  DEBUG controllers.StorageClass  storageclass_controller.go:88  Marking the storage class test-storage-policy as encryption-enabled: false
2026-07-10T06:55:07.695Z  INFO  clusterstoragepolicyinfo/controller.go:588  Updated ClusterStoragePolicyInfo "test-storage-policy" owner references
2026-07-10T06:55:07.695Z  INFO  clusterstoragepolicyinfo/helper.go:418  Looking up storage policy for K8s compliant name "test-storage-policy"
2026-07-10T06:55:07.725Z  INFO  vsphere/pbm.go:259  Found storage policy with K8s compliant name test-storage-policy: ID=c05455bb-2ffd-40ce-8f98-1a64760830b4, Name=test storage policy
2026-07-10T06:55:07.726Z  INFO  clusterstoragepolicyinfo/helper.go:436  Storage policy found with K8s compliant name "test-storage-policy": ID=c05455bb-2ffd-40ce-8f98-1a64760830b4, Name=test storage policy
2026-07-10T06:55:07.727Z  INFO  clusterstoragepolicyinfo/controller.go:633  Syncing storage policy attributes for ClusterStoragePolicyInfo "test-storage-policy" (policy ID: c05455bb-2ffd-40ce-8f98-1a64760830b4, name: test storage policy)
2026-07-10T06:55:07.763Z  DEBUG kubernetes/kubernetes.go:772  Successfully updated status.  {"kind": "ClusterStoragePolicyInfo", "name": "/test-storage-policy"}
2026-07-10T06:55:07.764Z  INFO  clusterstoragepolicyinfo/controller.go:672  Syncing InfraSPI attributes for "test-storage-policy" (policy ID: c05455bb-2ffd-40ce-8f98-1a64760830b4, name: test storage policy)
2026-07-10T06:55:07.765Z  INFO  clusterstoragepolicyinfo/helper.go:362  Found StorageClass "test-storage-policy" referencing storage policy ID "c05455bb-2ffd-40ce-8f98-1a64760830b4"
2026-07-10T06:55:07.765Z  DEBUG clusterstoragepolicyinfo/helper.go:403  StorageTopologyType parameter not found in StorageClass "test-storage-policy", defaulting to no topology
2026-07-10T06:55:08.255Z  DEBUG kubernetes/kubernetes.go:772  Successfully updated status.  {"kind": "InfraStoragePolicyInfo", "name": "/test-storage-policy"}
2026-07-10T06:55:08.256Z  INFO  clusterstoragepolicyinfo/controller.go:359  Successfully synced storage policy attributes for "test-storage-policy"  {"name": "/test-storage-policy"}
2026-07-10T06:55:08.256Z  INFO  clusterstoragepolicyinfo/controller.go:605  Successfully reconciled ClusterStoragePolicyInfo  {"name": "/test-storage-policy"}
```
Confirmed ClusterSPI now has owner references:
```
$ kubectl get clusterstoragepolicyinfo test-storage-policy -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: ClusterStoragePolicyInfo
metadata:
  creationTimestamp: "2026-07-09T15:33:37Z"
  generation: 1
  name: test-storage-policy
  ownerReferences:
  - apiVersion: storage.k8s.io/v1
    blockOwnerDeletion: false
    controller: false
    kind: StorageClass
    name: test-storage-policy
    uid: a3572f28-a3a8-4376-90af-7bb291519637
...
```
Confirmed InfraSPI's topology now reflects the StorageClass (this StorageClass had no StorageTopologyType parameter set, so it correctly overrides the PBM-derived "zonal" value with the StorageClass's default of no topology, per the "prefer StorageClass when present" precedence):
```
$ kubectl get infrastoragepolicyinfo test-storage-policy -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
...
status:
  topology:
    accessibleZones: []
    topologyType: ""
...
```
ClusterStoragePolicyInfo.metadata.ownerReferences now points to the new StorageClass.
InfraStoragePolicyInfo.status.topology is populated per the StorageClass's own parameters, taking precedence over the PBM-derived value once a StorageClass exists.
No errors were logged during the transition from bare CR to fully-owned CR.

(3) VC instance reuse in full sync:
Confirmed via the same full-sync cycle's logs that clusterStoragePolicyInfoFullSync no longer opens its own VirtualCenter session — it now runs after CsiFullSync's existing GetVirtualCenterInstanceForVCenterHost call (post getVolManagerForVcHost) and reuses that instance, so no duplicate session/client creation was observed for the ClusterSPI step during full sync.