### PR TITLE
Coalesce PC events to prevent multiple events for the same change

### DIFF
--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -60,6 +60,7 @@ import (
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/vsphereinfra"
 )
 
 // backOffDuration is a map of ClusterStoragePolicyInfo names to the time after
@@ -220,7 +221,78 @@ func add(mgr manager.Manager, r *ReconcileClusterStoragePolicyInfo) error {
 		log.Errorf("failed to register periodic resync runnable. Err: %v", err)
 		return err
 	}
+
+	if err := mgr.Add(manager.RunnableFunc(func(mgrCtx context.Context) error {
+		forwardInventoryPolicyChanges(mgrCtx, resyncCh)
+		return nil
+	})); err != nil {
+		log.Errorf("failed to register inventory watcher policy-change forwarder runnable. Err: %v", err)
+		return err
+	}
 	return nil
+}
+
+// forwardInventoryPolicyChanges relays storage policy names coalesced by the
+// shared PropertyCollector inventory watcher (see vsphereinfra.OnInventoryChange)
+// onto ch, so this controller re-reconciles the named ClusterStoragePolicyInfo
+// against the vCenter.
+func forwardInventoryPolicyChanges(ctx context.Context, ch chan<- event.GenericEvent) {
+	forwardPolicyChanges(ctx, vsphereinfra.PolicyChanges(), ch)
+}
+
+// forwardPolicyChanges is forwardInventoryPolicyChanges with its source
+// channel injected, so tests can drive it without reaching into vsphereinfra's
+// process-wide PolicyChanges() channel.
+func forwardPolicyChanges(ctx context.Context, src <-chan string, dst chan<- event.GenericEvent) {
+	log := logger.GetLogger(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Infof("ClusterStoragePolicyInfo inventory policy-change forwarder stopping")
+			return
+		case policyName, ok := <-src:
+			if !ok {
+				log.Infof("ClusterStoragePolicyInfo inventory policy-change forwarder stopping: source channel closed")
+				return
+			}
+			if policyName == "" {
+				log.Warnf("ClusterStoragePolicyInfo inventory policy-change forwarder: received empty policy name, skipping")
+				continue
+			}
+			namespacedName := apitypes.NamespacedName{Name: policyName}
+			backOffDurationMapMutex.Lock()
+			backoff := backOffDuration[namespacedName]
+			backOffDurationMapMutex.Unlock()
+			if backoff > time.Second {
+				// A backoff greater than one second means this instance is already scheduled to
+				// reconcile via RequeueAfter after a prior failure. Forwarding
+				// it now would just add a redundant, immediate reconcile on top
+				// of that already-pending one.
+				log.Debugf("ClusterStoragePolicyInfo inventory policy-change forwarder: "+
+					"%q is backed off and already scheduled to reconcile, skipping", policyName)
+				continue
+			}
+
+			obj := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: policyName},
+			}
+			select {
+			case dst <- event.GenericEvent{Object: obj}:
+				log.Infof("ClusterStoragePolicyInfo inventory policy-change forwarder: "+
+					"queued %q for reconciliation", policyName)
+			case <-ctx.Done():
+				return
+			default:
+				// resyncCh is full; do not block this forwarder waiting for a
+				// slot. The policy stays out of the coalescing queue at this
+				// point (see queuePolicyReconcile), so it will be re-queued by
+				// the next inventory event that affects it, or picked up by
+				// the periodic slow-sync in the meantime.
+				log.Warnf("ClusterStoragePolicyInfo inventory policy-change forwarder: "+
+					"resync channel full, dropping reconcile for %q", policyName)
+			}
+		}
+	}
 }
 
 // mapObjectToClusterSPI maps any client.Object to a ClusterStoragePolicyInfo reconcile request.
@@ -764,15 +836,23 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 
 	log.Infof("Storage policy %s: populating accessible zones", profileID)
 
-	accessibleZones, err := cnsoperatorutil.GetAccessibleZonesForPolicy(ctx, r.topologyMgr, vc, profileID,
-		clusterDatastoreCache)
+	// GetAccessibleZonesAndDatastoresForPolicy returns the flat set of
+	// compatible datastore morefs needed for the DsToPolicy cache update
+	// below alongside the accessible zones, from the same PBM query.
+	accessibleZones, dsIDs, err := cnsoperatorutil.GetAccessibleZonesAndDatastoresForPolicy(ctx, r.topologyMgr, vc,
+		profileID, clusterDatastoreCache)
 	if err != nil {
 		return fmt.Errorf("failed to get accessible zones: %w", err)
 	}
 
+	// Record which datastores this policy is compatible with, so the shared
+	// PropertyCollector inventory watcher (vsphereinfra.OnInventoryChange) can
+	// resolve a future datastore/host topology change straight to this policy
+	// without a separate vCenter round trip.
+	vsphereinfra.GetCache().SetDatastoresForPolicy(clusterSPI.Name, dsIDs)
+
 	// Update InfraSPI with topology information including accessible zones
 	infraSPI.Status.Topology.AccessibleZones = accessibleZones
-	log.Infof("Storage policy %s is accessible in zones: %v", profileID, accessibleZones)
 
 	return nil
 }

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -2433,8 +2433,9 @@ func testPopulateTopologyCapabilities(r *ReconcileClusterStoragePolicyInfo, ctx 
 		// Empty compatible hubs means no zones are accessible
 		accessibleZones = []string{}
 	}
-	// In a real implementation, this would call cnsoperatorutil.GetAccessibleZonesForPolicy
-	// which requires complex VirtualCenter mocking that's more suitable for integration tests
+	// In a real implementation, this would call
+	// cnsoperatorutil.GetAccessibleZonesAndDatastoresForPolicy, which requires complex
+	// VirtualCenter mocking that's more suitable for integration tests
 
 	// Update InfraSPI with topology information including accessible zones
 	infraSPI.Status.Topology.AccessibleZones = accessibleZones
@@ -2680,8 +2681,9 @@ func TestPopulateTopologyCapabilities(t *testing.T) {
 					// For accessible zones, we can only verify the structure since the actual
 					// zone population requires complex VirtualCenter mocking
 					assert.NotNil(t, infraSPI.Status.Topology.AccessibleZones)
-					// In our simplified test, zones will be empty because cnsoperatorutil.GetAccessibleZonesForPolicy
-					// requires complex VirtualCenter mocking which is beyond the scope of unit tests
+					// In our simplified test, zones will be empty because
+					// cnsoperatorutil.GetAccessibleZonesAndDatastoresForPolicy requires complex
+					// VirtualCenter mocking which is beyond the scope of unit tests
 					assert.Equal(t, []string{}, infraSPI.Status.Topology.AccessibleZones)
 				}
 			}

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/inventory_forwarder_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/inventory_forwarder_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterstoragepolicyinfo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+func TestForwardPolicyChanges_RelaysAsGenericEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(logger.NewContextWithLogger(context.Background()))
+	defer cancel()
+
+	src := make(chan string, 1)
+	dst := make(chan event.GenericEvent, 1)
+	go forwardPolicyChanges(ctx, src, dst)
+
+	src <- "policy-1"
+
+	select {
+	case e := <-dst:
+		assert.Equal(t, "policy-1", e.Object.GetName())
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for forwarded event")
+	}
+}
+
+func TestForwardPolicyChanges_DropsWhenDstFull(t *testing.T) {
+	ctx, cancel := context.WithCancel(logger.NewContextWithLogger(context.Background()))
+	defer cancel()
+
+	src := make(chan string, 2)
+	dst := make(chan event.GenericEvent) // unbuffered and never read: always full
+	go forwardPolicyChanges(ctx, src, dst)
+
+	src <- "policy-1"
+	src <- "policy-2"
+
+	// Must not block or panic despite dst never draining.
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-dst:
+		t.Fatal("expected forwarded events to be dropped, not delivered")
+	default:
+	}
+}
+
+func TestForwardPolicyChanges_SkipsBackedOffPolicy(t *testing.T) {
+	ctx, cancel := context.WithCancel(logger.NewContextWithLogger(context.Background()))
+	defer cancel()
+
+	backOffDurationMapMutex.Lock()
+	backOffDuration = map[apitypes.NamespacedName]time.Duration{
+		// A backoff greater than one second marks this policy as already
+		// scheduled to reconcile via RequeueAfter after a prior failure; the
+		// forwarder must skip it rather than push a redundant immediate reconcile.
+		{Name: "backed-off"}: 2 * time.Second,
+	}
+	backOffDurationMapMutex.Unlock()
+	t.Cleanup(func() {
+		backOffDurationMapMutex.Lock()
+		backOffDuration = nil
+		backOffDurationMapMutex.Unlock()
+	})
+
+	src := make(chan string, 2)
+	dst := make(chan event.GenericEvent, 2)
+	go forwardPolicyChanges(ctx, src, dst)
+
+	src <- "backed-off"
+	src <- "eligible"
+
+	select {
+	case e := <-dst:
+		assert.Equal(t, "eligible", e.Object.GetName(), "only the eligible policy should be forwarded")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for eligible policy to be forwarded")
+	}
+
+	select {
+	case e := <-dst:
+		t.Fatalf("unexpected second forwarded event for %q; backed-off policy should have been skipped", e.Object.GetName())
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestForwardPolicyChanges_BaselineBackoffIsNotSkipped(t *testing.T) {
+	ctx, cancel := context.WithCancel(logger.NewContextWithLogger(context.Background()))
+	defer cancel()
+
+	backOffDurationMapMutex.Lock()
+	backOffDuration = map[apitypes.NamespacedName]time.Duration{
+		// The one-second baseline (set for new/just-succeeded instances) must
+		// not be treated as "backed off" — only values greater than it are.
+		{Name: "policy-1"}: time.Second,
+	}
+	backOffDurationMapMutex.Unlock()
+	t.Cleanup(func() {
+		backOffDurationMapMutex.Lock()
+		backOffDuration = nil
+		backOffDurationMapMutex.Unlock()
+	})
+
+	src := make(chan string, 1)
+	dst := make(chan event.GenericEvent, 1)
+	go forwardPolicyChanges(ctx, src, dst)
+
+	src <- "policy-1"
+
+	select {
+	case e := <-dst:
+		assert.Equal(t, "policy-1", e.Object.GetName())
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for forwarded event")
+	}
+}
+
+func TestForwardPolicyChanges_SkipsEmptyPolicyName(t *testing.T) {
+	ctx, cancel := context.WithCancel(logger.NewContextWithLogger(context.Background()))
+	defer cancel()
+
+	src := make(chan string, 2)
+	dst := make(chan event.GenericEvent, 2)
+	go forwardPolicyChanges(ctx, src, dst)
+
+	src <- ""
+	src <- "policy-1"
+
+	select {
+	case e := <-dst:
+		assert.Equal(t, "policy-1", e.Object.GetName(), "the empty name must be skipped, not forwarded")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for policy-1 to be forwarded")
+	}
+
+	select {
+	case e := <-dst:
+		t.Fatalf("unexpected second forwarded event for %q", e.Object.GetName())
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestForwardPolicyChanges_StopsWhenSrcClosed(t *testing.T) {
+	ctx, cancel := context.WithCancel(logger.NewContextWithLogger(context.Background()))
+	defer cancel()
+
+	src := make(chan string)
+	dst := make(chan event.GenericEvent)
+	done := make(chan struct{})
+	go func() {
+		forwardPolicyChanges(ctx, src, dst)
+		close(done)
+	}()
+
+	close(src)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("forwardPolicyChanges did not stop after src was closed; " +
+			"a single-value receive from a closed channel never blocks, so this would spin forever")
+	}
+}
+
+func TestForwardPolicyChanges_StopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(logger.NewContextWithLogger(context.Background()))
+
+	src := make(chan string)
+	dst := make(chan event.GenericEvent)
+	done := make(chan struct{})
+	go func() {
+		forwardPolicyChanges(ctx, src, dst)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("forwardPolicyChanges did not stop after context cancellation")
+	}
+}

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/populate_topology_cache_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/populate_topology_cache_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterstoragepolicyinfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/object"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
+	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/vsphereinfra"
+)
+
+// fakeDatastoreInfo builds a *cnsvsphere.DatastoreInfo whose Reference() is
+// dsID, without needing a real vCenter connection: object.NewDatastore's
+// Reference() only ever returns the moref it was constructed with.
+func fakeDatastoreInfo(dsID string) *cnsvsphere.DatastoreInfo {
+	return &cnsvsphere.DatastoreInfo{
+		Datastore: &cnsvsphere.Datastore{
+			Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{Type: "Datastore", Value: dsID}),
+		},
+	}
+}
+
+// withMockCompatibleDatastores replaces cnsoperatorutil.GetPolicyCompatibleDatastoresFn
+// for the duration of the test, so populateTopologyCapabilities's PBM query
+// resolves to a fixed set of datastore morefs without a real vCenter/PBM
+// connection.
+func withMockCompatibleDatastores(t *testing.T, dsIDs ...string) {
+	t.Helper()
+	orig := cnsoperatorutil.GetPolicyCompatibleDatastoresFn
+	cnsoperatorutil.GetPolicyCompatibleDatastoresFn = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+		profileID string) (map[string]struct{}, error) {
+		ids := make(map[string]struct{}, len(dsIDs))
+		for _, id := range dsIDs {
+			ids[id] = struct{}{}
+		}
+		return ids, nil
+	}
+	t.Cleanup(func() { cnsoperatorutil.GetPolicyCompatibleDatastoresFn = orig })
+}
+
+func TestPopulateTopologyCapabilities_PopulatesDsToPolicyCache(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "zonal-storage"},
+		Parameters: map[string]string{
+			"storagepolicyid":                   "profile-1",
+			common.AttributeStorageTopologyType: "zonal",
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sc).Build()
+
+	withMockCompatibleDatastores(t, "ds-1")
+
+	clusterDatastoreCache := map[string][]*cnsvsphere.DatastoreInfo{
+		"cluster-1": {fakeDatastoreInfo("ds-1")},
+		"cluster-2": {fakeDatastoreInfo("ds-2")},
+	}
+
+	r := &ReconcileClusterStoragePolicyInfo{
+		client: k8sClient,
+		scheme: scheme,
+		topologyMgr: &mockControllerTopologyService{
+			azClustersMap: map[string][]string{
+				"zone-a": {"cluster-1"},
+				"zone-b": {"cluster-2"},
+			},
+		},
+	}
+
+	clusterSPI := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+	}
+	// vsphereinfra.GetCache() is a process-wide singleton shared by every test
+	// in this binary; clear this test's entry so it can't leak into others
+	// that reuse the same datastore IDs.
+	t.Cleanup(func() { vsphereinfra.GetCache().SetDatastoresForPolicy(clusterSPI.Name, nil) })
+
+	err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil, clusterDatastoreCache)
+	require.NoError(t, err)
+
+	// Only zone-a's cluster mounts the compatible datastore (ds-1).
+	assert.ElementsMatch(t, []string{"zone-a"}, infraSPI.Status.Topology.AccessibleZones)
+
+	assert.ElementsMatch(t, []string{"test-policy"}, vsphereinfra.GetCache().PoliciesForDatastore("ds-1"),
+		"the datastore backing the policy's only accessible zone must be recorded in the shared cache")
+	assert.Empty(t, vsphereinfra.GetCache().PoliciesForDatastore("ds-2"),
+		"ds-2 is not compatible with this policy and must not be recorded")
+}
+
+func TestPopulateTopologyCapabilities_CacheEntryClearedWhenNoLongerCompatible(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "zonal-storage"},
+		Parameters: map[string]string{
+			"storagepolicyid":                   "profile-1",
+			common.AttributeStorageTopologyType: "zonal",
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sc).Build()
+
+	clusterDatastoreCache := map[string][]*cnsvsphere.DatastoreInfo{
+		"cluster-1": {fakeDatastoreInfo("ds-1")},
+	}
+	r := &ReconcileClusterStoragePolicyInfo{
+		client: k8sClient,
+		scheme: scheme,
+		topologyMgr: &mockControllerTopologyService{
+			azClustersMap: map[string][]string{"zone-a": {"cluster-1"}},
+		},
+	}
+	clusterSPI := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy-2"},
+	}
+	t.Cleanup(func() { vsphereinfra.GetCache().SetDatastoresForPolicy(clusterSPI.Name, nil) })
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy-2"},
+	}
+
+	// First reconcile: ds-1 is compatible.
+	withMockCompatibleDatastores(t, "ds-1")
+	require.NoError(t, r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil, clusterDatastoreCache))
+	require.ElementsMatch(t, []string{"test-policy-2"}, vsphereinfra.GetCache().PoliciesForDatastore("ds-1"))
+
+	// Second reconcile: PBM now reports no compatible datastores at all.
+	withMockCompatibleDatastores(t)
+	require.NoError(t, r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil, clusterDatastoreCache))
+
+	assert.Empty(t, vsphereinfra.GetCache().PoliciesForDatastore("ds-1"),
+		"stale cache entry must be cleared once the policy is no longer compatible with ds-1")
+	assert.Empty(t, infraSPI.Status.Topology.AccessibleZones)
+}

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -565,23 +565,36 @@ func GetPolicyCompatibleDatastores(ctx context.Context, vc *cnsvsphere.VirtualCe
 	return compatibleDSIDs, nil
 }
 
-// GetAccessibleZonesForPolicy determines which zones are accessible to the datastores
-// compatible with the given storage policy.
-func GetAccessibleZonesForPolicy(ctx context.Context, topologyMgr commoncotypes.ControllerTopologyService,
+// GetAccessibleZonesAndDatastoresForPolicy determines which zones are
+// accessible to the datastores compatible with the given storage policy, and
+// returns the flat set of compatible datastore morefs behind those zones
+// (deduped across zones that share a datastore).
+func GetAccessibleZonesAndDatastoresForPolicy(ctx context.Context, topologyMgr commoncotypes.ControllerTopologyService,
 	vc *cnsvsphere.VirtualCenter, profileID string,
-	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) ([]string, error) {
+	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) (zones []string, dsIDs []string, err error) {
 	log := logger.GetLogger(ctx)
 
 	zoneCompatibleDS, err := GetPolicyCompatibleDatastoresPerZone(ctx, topologyMgr, vc, profileID, clusterDatastoreCache)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// Convert map to slice of zones that have compatible datastores
-	zones := make([]string, 0)
+	// A zone is accessible if it has at least one compatible datastore.
+	zones = make([]string, 0, len(zoneCompatibleDS))
+	seenDsIDs := make(map[string]struct{})
 	for zone, compatibleDS := range zoneCompatibleDS {
-		if len(compatibleDS) > 0 {
-			zones = append(zones, zone)
+		if len(compatibleDS) == 0 {
+			continue
+		}
+		zones = append(zones, zone)
+		for _, ds := range compatibleDS {
+			dsID := ds.Reference().Value
+
+			if _, ok := seenDsIDs[dsID]; ok {
+				continue
+			}
+			seenDsIDs[dsID] = struct{}{}
+			dsIDs = append(dsIDs, dsID)
 		}
 	}
 
@@ -591,7 +604,7 @@ func GetAccessibleZonesForPolicy(ctx context.Context, topologyMgr commoncotypes.
 		log.Infof("Storage policy %s is accessible from zones: %v", profileID, zones)
 	}
 
-	return zones, nil
+	return zones, dsIDs, nil
 }
 
 // GetPolicyCompatibleDatastoresPerZone returns compatible datastores grouped by zone.

--- a/pkg/syncer/cnsoperator/util/util_test.go
+++ b/pkg/syncer/cnsoperator/util/util_test.go
@@ -619,7 +619,7 @@ func TestGetTKGVMIP_PerNamespaceVDSUsesVMIP(t *testing.T) {
 	assert.Equal(t, "192.0.2.10", ip)
 }
 
-// --- helpers for GetPolicyCompatibleDatastoresPerZone / GetAccessibleZonesForPolicy ----
+// --- helpers for GetPolicyCompatibleDatastoresPerZone / GetAccessibleZonesAndDatastoresForPolicy ----
 
 // mockTopologyService is a minimal ControllerTopologyService for unit tests.
 type mockTopologyService struct {
@@ -796,20 +796,22 @@ func TestGetPolicyCompatibleDatastoresPerZone_MultipleClustersPerZone(t *testing
 	})
 }
 
-// --- GetAccessibleZonesForPolicy tests ------------------------------------------------
+// --- GetAccessibleZonesAndDatastoresForPolicy tests -----------------------------------
 
-// TestGetAccessibleZonesForPolicy_NilTopologyManager verifies that a nil topology
-// manager returns an error.
-func TestGetAccessibleZonesForPolicy_NilTopologyManager(t *testing.T) {
+// TestGetAccessibleZonesAndDatastoresForPolicy_NilTopologyManager verifies that a nil
+// topology manager returns an error.
+func TestGetAccessibleZonesAndDatastoresForPolicy_NilTopologyManager(t *testing.T) {
 	ctx := context.Background()
-	zones, err := GetAccessibleZonesForPolicy(ctx, nil, nil, "policy-1", nil)
+	zones, dsIDs, err := GetAccessibleZonesAndDatastoresForPolicy(ctx, nil, nil, "policy-1", nil)
 	assert.Error(t, err)
 	assert.Nil(t, zones)
+	assert.Nil(t, dsIDs)
 }
 
-// TestGetAccessibleZonesForPolicy_NoCompatibleDatastores verifies that zones without
-// any compatible datastores are excluded from the result.
-func TestGetAccessibleZonesForPolicy_NoCompatibleDatastores(t *testing.T) {
+// TestGetAccessibleZonesAndDatastoresForPolicy_NoCompatibleDatastores verifies that
+// zones without any compatible datastores are excluded from the result, and no
+// datastore morefs are returned either.
+func TestGetAccessibleZonesAndDatastoresForPolicy_NoCompatibleDatastores(t *testing.T) {
 	ctx := context.Background()
 	topo := &mockTopologyService{
 		azClustersMap: map[string][]string{"zone-a": {"cluster-1"}},
@@ -819,15 +821,18 @@ func TestGetAccessibleZonesForPolicy_NoCompatibleDatastores(t *testing.T) {
 	}
 	// No compatible datastores → zone-a should not appear.
 	withCompatibleDSIDs(map[string]struct{}{}, func() {
-		zones, err := GetAccessibleZonesForPolicy(ctx, topo, nil, "policy-1", cache)
+		zones, dsIDs, err := GetAccessibleZonesAndDatastoresForPolicy(ctx, topo, nil, "policy-1", cache)
 		require.NoError(t, err)
 		assert.Empty(t, zones)
+		assert.Empty(t, dsIDs)
 	})
 }
 
-// TestGetAccessibleZonesForPolicy_OnlyZonesWithCompatibleDSReturned verifies that only
-// zones containing at least one compatible datastore are included in the result.
-func TestGetAccessibleZonesForPolicy_OnlyZonesWithCompatibleDSReturned(t *testing.T) {
+// TestGetAccessibleZonesAndDatastoresForPolicy_OnlyZonesWithCompatibleDSReturned verifies
+// that only zones containing at least one compatible datastore are included in the
+// result, and that the returned datastore morefs are exactly the compatible ones,
+// deduped.
+func TestGetAccessibleZonesAndDatastoresForPolicy_OnlyZonesWithCompatibleDSReturned(t *testing.T) {
 	ctx := context.Background()
 	topo := &mockTopologyService{
 		azClustersMap: map[string][]string{
@@ -844,9 +849,11 @@ func TestGetAccessibleZonesForPolicy_OnlyZonesWithCompatibleDSReturned(t *testin
 	compatible := map[string]struct{}{"ds-match": {}, "ds-match2": {}}
 
 	withCompatibleDSIDs(compatible, func() {
-		zones, err := GetAccessibleZonesForPolicy(ctx, topo, nil, "policy-1", cache)
+		zones, dsIDs, err := GetAccessibleZonesAndDatastoresForPolicy(ctx, topo, nil, "policy-1", cache)
 		require.NoError(t, err)
 		sort.Strings(zones)
 		assert.Equal(t, []string{"zone-also-has", "zone-has-ds"}, zones)
+		sort.Strings(dsIDs)
+		assert.Equal(t, []string{"ds-match", "ds-match2"}, dsIDs)
 	})
 }

--- a/pkg/syncer/cnsoperator/vsphereinfra/cache.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/cache.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package vsphereinfra
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
 // StoragePolicyInfoCache is a shared in-memory cache used by the
 // PropertyCollector watcher and the storage-policy-info
@@ -28,12 +31,12 @@ type StoragePolicyInfoCache struct {
 	// Written by the PropertyCollector on Datastore.host changes.
 	DsToHosts map[string]map[string]struct{}
 
-	// TODO: not yet written or read by anything. Intended for the
-	// clusterstoragepolicyinfo/storagepolicyinfo controllers to record which
-	// storage policies a datastore is compatible with (after a PBM query), so
-	// EventDatastoreHostChanged/EventHostClusterChanged handlers can look up
-	// affected policies without a separate vCenter round trip. Wire this up
-	// (and add real accessors) once those controllers consume this cache.
+	// DsToPolicy records which storage policies a datastore is compatible
+	// with, keyed by datastore moref. Written by the clusterstoragepolicyinfo
+	// controller (SetDatastoresForPolicy) after each policy's PBM compatibility
+	// query, and read by OnInventoryChange (via PoliciesForDatastore) to
+	// resolve an inventory change to the policies it affects, without a
+	// separate vCenter round trip.
 	DsToPolicy map[string][]string
 
 	// HostToVersion tracks the last-known ESXi version string per host
@@ -72,12 +75,24 @@ func GetCache() *StoragePolicyInfoCache {
 	return defaultCache
 }
 
-// InvalidateDatastore removes all cache entries associated with a deleted datastore.
-func (c *StoragePolicyInfoCache) InvalidateDatastore(dsID string) {
+// InvalidateDatastore removes all cache entries associated with a deleted
+// datastore, returning the policy names it was last recorded as compatible
+// with. A deleted datastore no longer resolves to anything once this returns
+// (PoliciesForDatastore(dsID) goes back to empty), so callers that still need
+// to notify those policies about the removal must use the returned list
+// instead of trying to look it up afterwards.
+func (c *StoragePolicyInfoCache) InvalidateDatastore(dsID string) []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	policies := c.DsToPolicy[dsID]
 	delete(c.DsToHosts, dsID)
 	delete(c.DsToPolicy, dsID)
+	if len(policies) == 0 {
+		return nil
+	}
+	cp := make([]string, len(policies))
+	copy(cp, policies)
+	return cp
 }
 
 // UpdateDsHosts compares newHosts (the current set of host morefs mounting
@@ -120,6 +135,65 @@ func (c *StoragePolicyInfoCache) GetDsHosts(dsID string) (map[string]struct{}, b
 		cp[h] = struct{}{}
 	}
 	return cp, true
+}
+
+// DatastoresForHost returns the morefs of all datastores currently known to
+// mount the given host, by scanning DsToHosts for membership.
+func (c *StoragePolicyInfoCache) DatastoresForHost(hostID string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	var datastores []string
+	for dsID, hosts := range c.DsToHosts {
+		if _, ok := hosts[hostID]; ok {
+			datastores = append(datastores, dsID)
+		}
+	}
+	return datastores
+}
+
+// PoliciesForDatastore returns a copy of the K8s compliant names
+// compatible with the given datastore.
+func (c *StoragePolicyInfoCache) PoliciesForDatastore(dsID string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	policies := c.DsToPolicy[dsID]
+	if len(policies) == 0 {
+		return nil
+	}
+	cp := make([]string, len(policies))
+	copy(cp, policies)
+	return cp
+}
+
+// SetDatastoresForPolicy replaces the set of datastores recorded as
+// compatible with policyName with dsIDs, so a datastore the policy is no
+// longer compatible with doesn't keep a stale entry pointing back to it.
+func (c *StoragePolicyInfoCache) SetDatastoresForPolicy(policyName string, dsIDs []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	stillCompatible := make(map[string]struct{}, len(dsIDs))
+	for _, dsID := range dsIDs {
+		stillCompatible[dsID] = struct{}{}
+	}
+
+	for dsID, policies := range c.DsToPolicy {
+		if _, ok := stillCompatible[dsID]; ok {
+			continue
+		}
+		policies = slices.DeleteFunc(policies, func(p string) bool { return p == policyName })
+		if len(policies) == 0 {
+			delete(c.DsToPolicy, dsID)
+		} else {
+			c.DsToPolicy[dsID] = policies
+		}
+	}
+
+	for dsID := range stillCompatible {
+		if !slices.Contains(c.DsToPolicy[dsID], policyName) {
+			c.DsToPolicy[dsID] = append(c.DsToPolicy[dsID], policyName)
+		}
+	}
 }
 
 // UpdateHostVersion compares newVersion against the cached ESXi version for a

--- a/pkg/syncer/cnsoperator/vsphereinfra/cache_test.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/cache_test.go
@@ -122,14 +122,84 @@ func TestGetDsHosts(t *testing.T) {
 func TestInvalidateDatastore(t *testing.T) {
 	c := newTestCache()
 	c.UpdateDsHosts("ds-1", hostSet("host-1"))
-	c.DsToPolicy["ds-1"] = []string{"policy-1"}
+	c.DsToPolicy["ds-1"] = []string{"policy-1", "policy-2"}
 
-	c.InvalidateDatastore("ds-1")
+	removedPolicies := c.InvalidateDatastore("ds-1")
 
+	assert.ElementsMatch(t, []string{"policy-1", "policy-2"}, removedPolicies,
+		"must return the policies the datastore was compatible with before invalidation")
 	_, ok := c.GetDsHosts("ds-1")
 	assert.False(t, ok)
 	_, ok = c.DsToPolicy["ds-1"]
 	assert.False(t, ok)
+}
+
+func TestInvalidateDatastore_NoPoliciesRecorded(t *testing.T) {
+	c := newTestCache()
+	c.UpdateDsHosts("ds-1", hostSet("host-1"))
+
+	removedPolicies := c.InvalidateDatastore("ds-1")
+
+	assert.Empty(t, removedPolicies)
+}
+
+func TestSetDatastoresForPolicy(t *testing.T) {
+	t.Run("populates a fresh policy", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicy("policy-1", []string{"ds-1", "ds-2"})
+
+		assert.ElementsMatch(t, []string{"policy-1"}, c.PoliciesForDatastore("ds-1"))
+		assert.ElementsMatch(t, []string{"policy-1"}, c.PoliciesForDatastore("ds-2"))
+	})
+
+	t.Run("shrinking the datastore set drops the stale entry", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicy("policy-1", []string{"ds-1", "ds-2"})
+
+		c.SetDatastoresForPolicy("policy-1", []string{"ds-1"})
+
+		assert.ElementsMatch(t, []string{"policy-1"}, c.PoliciesForDatastore("ds-1"))
+		assert.Empty(t, c.PoliciesForDatastore("ds-2"), "ds-2 is no longer compatible, its entry must be removed")
+	})
+
+	t.Run("growing the datastore set adds the new entry", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicy("policy-1", []string{"ds-1"})
+
+		c.SetDatastoresForPolicy("policy-1", []string{"ds-1", "ds-2"})
+
+		assert.ElementsMatch(t, []string{"policy-1"}, c.PoliciesForDatastore("ds-1"))
+		assert.ElementsMatch(t, []string{"policy-1"}, c.PoliciesForDatastore("ds-2"))
+	})
+
+	t.Run("empty datastore set clears every entry for the policy", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicy("policy-1", []string{"ds-1", "ds-2"})
+
+		c.SetDatastoresForPolicy("policy-1", nil)
+
+		assert.Empty(t, c.PoliciesForDatastore("ds-1"))
+		assert.Empty(t, c.PoliciesForDatastore("ds-2"))
+	})
+
+	t.Run("does not disturb other policies sharing a datastore", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicy("policy-1", []string{"ds-1"})
+		c.SetDatastoresForPolicy("policy-2", []string{"ds-1"})
+
+		c.SetDatastoresForPolicy("policy-1", nil)
+
+		assert.ElementsMatch(t, []string{"policy-2"}, c.PoliciesForDatastore("ds-1"))
+	})
+
+	t.Run("re-setting the identical datastore set is idempotent", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicy("policy-1", []string{"ds-1"})
+
+		c.SetDatastoresForPolicy("policy-1", []string{"ds-1"})
+
+		assert.Equal(t, []string{"policy-1"}, c.PoliciesForDatastore("ds-1"))
+	})
 }
 
 func TestUpdateHostVersion(t *testing.T) {

--- a/pkg/syncer/cnsoperator/vsphereinfra/collector.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/collector.go
@@ -201,7 +201,10 @@ func buildWaitFilter(
 //
 // Datastore updates:
 //   - Enter: populates DsToHosts baseline (no event).
-//   - Leave: emits EventDatastoreRemoved and clears cached state.
+//   - Leave: clears cached state and emits EventDatastoreRemoved, carrying the
+//     just-cleared policy names in its Policies field — the cache no longer
+//     has them by the time OnInventoryChange sees this event, so it can't
+//     resolve them the normal way.
 //   - Modify on host: emits EventDatastoreHostChanged only when the set of
 //     mounting hosts actually changed (added/removed), matching how InfraSPI
 //     itself determines datastore accessibility — it checks HostSystem.datastore
@@ -254,8 +257,8 @@ func collectEvents(ctx context.Context, updates []types.ObjectUpdate) []Inventor
 
 			case types.ObjectUpdateKindLeave:
 				log.Infof("vsphereinfra: datastore %s removed from vCenter inventory", moref)
-				cache.InvalidateDatastore(moref)
-				events = append(events, InventoryEvent{Kind: EventDatastoreRemoved, MoRef: moref})
+				removedPolicies := cache.InvalidateDatastore(moref)
+				events = append(events, InventoryEvent{Kind: EventDatastoreRemoved, MoRef: moref, Policies: removedPolicies})
 
 			case types.ObjectUpdateKindModify:
 				for _, change := range update.ChangeSet {

--- a/pkg/syncer/cnsoperator/vsphereinfra/collector_test.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/collector_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -217,6 +218,31 @@ func TestCollectEvents_DatastoreLeave(t *testing.T) {
 	assert.Equal(t, []InventoryEvent{{Kind: EventDatastoreRemoved, MoRef: ds}}, events)
 	_, ok := GetCache().GetDsHosts(ds)
 	assert.False(t, ok)
+}
+
+// TestCollectEvents_DatastoreLeave_CarriesPreResolvedPolicies verifies that
+// EventDatastoreRemoved carries the policies the datastore was compatible
+// with in its Policies field. By the time OnInventoryChange sees this event,
+// InvalidateDatastore has already cleared DsToPolicy for this datastore, so
+// PoliciesForDatastore(MoRef) would return nothing — the event must carry
+// this information itself instead.
+func TestCollectEvents_DatastoreLeave_CarriesPreResolvedPolicies(t *testing.T) {
+	ds := uniqueID(t, "ds")
+	collectEvents(context.Background(), []types.ObjectUpdate{
+		datastoreUpdate(ds, types.ObjectUpdateKindEnter, map[string]bool{"host-1": true}),
+	})
+	GetCache().SetDatastoresForPolicy(uniqueID(t, "policy"), []string{ds})
+
+	events := collectEvents(context.Background(), []types.ObjectUpdate{
+		{Obj: types.ManagedObjectReference{Type: "Datastore", Value: ds}, Kind: types.ObjectUpdateKindLeave},
+	})
+
+	require.Len(t, events, 1)
+	assert.Equal(t, EventDatastoreRemoved, events[0].Kind)
+	assert.Equal(t, ds, events[0].MoRef)
+	assert.Equal(t, []string{uniqueID(t, "policy")}, events[0].Policies)
+	assert.Empty(t, GetCache().PoliciesForDatastore(ds),
+		"the cache entry itself must still be cleared, independent of the event carrying the policy names")
 }
 
 func TestCollectEvents_HostVersion_Changed(t *testing.T) {

--- a/pkg/syncer/cnsoperator/vsphereinfra/events.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/events.go
@@ -18,6 +18,8 @@ package vsphereinfra
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
@@ -55,20 +57,146 @@ const (
 type InventoryEvent struct {
 	Kind  EventKind
 	MoRef string // moref of the changed object — see EventKind docs for which object type
+
+	// Policies carries pre-resolved policy names for EventDatastoreRemoved,
+	// since collectEvents invalidates the cache's MoRef -> policy mapping
+	// before this event is ever seen by OnInventoryChange — by then,
+	// PoliciesForDatastore(MoRef) would just return nothing. Unused (nil) for
+	// every other EventKind, which resolve to policies the normal way, via
+	// the cache, in OnInventoryChange.
+	Policies []string
+}
+
+// policyReconcileDelay is how long an affected storage policy sits in the
+// coalescing queue, from the first event that names it, before being handed
+// off for reconciliation. A single real-world change (e.g. a host moving
+// clusters) can cascade into many individual PropertyCollector updates in a
+// short burst — e.g. several datastores the host mounts each getting their
+// own Datastore.host update — so this window absorbs the whole burst into a
+// single reconcile per policy instead of one per update. It is a fixed
+// window measured from the first event, not reset by later events in the
+// same burst: real bursts complete in well under two minutes, and a fixed
+// window keeps worst-case reconcile latency bounded.
+//
+// Not a const so tests can shrink it instead of waiting out the real delay.
+var policyReconcileDelay = 2 * time.Minute
+
+var (
+	pendingPoliciesMu sync.Mutex
+	// pendingPolicies is the set of storage policy names currently waiting out
+	// policyReconcileDelay in the coalescing queue. Membership here is what
+	// dedupes repeated events for the same policy within one burst down to a
+	// single reconcile.
+	pendingPolicies = make(map[string]struct{})
+)
+
+var (
+	policyChangeChOnce sync.Once
+	policyChangeCh     chan string
+)
+
+// PolicyChanges returns the channel on which storage policy names are
+// delivered once they have cleared the coalescing queue, so controllers can
+// re-reconcile the corresponding ClusterStoragePolicyInfo/InfraStoragePolicyInfo
+// against the vCenter. Safe to call from multiple goroutines; the channel is
+// created once and shared.
+func PolicyChanges() <-chan string {
+	return getPolicyChangeCh()
+}
+
+func getPolicyChangeCh() chan string {
+	policyChangeChOnce.Do(func() {
+		// Buffered so a slow or not-yet-started consumer doesn't stall the
+		// PropertyCollector callback goroutine; see queuePolicyReconcile.
+		policyChangeCh = make(chan string, 256)
+	})
+	return policyChangeCh
 }
 
 // OnInventoryChange is called whenever the PropertyCollector watcher detects a topology change.
+// It resolves each event to the storage policies it can affect and queues
+// those policies for coalesced reconciliation.
+//
+// DsToPolicy is in-memory only, so events arriving before it's been populated
+// resolve to no policies and are silently dropped here — periodic slow-sync
+// is what eventually catches those up, not this function.
 func OnInventoryChange(ctx context.Context, events []InventoryEvent) {
 	log := logger.GetLogger(ctx)
-	log.Infof("vsphereinfra: OnInventoryChange not yet implemented, received %d event(s)", len(events))
-	// TODO: coalesce events over a short window (e.g. a couple minutes) before
-	// reconciling. A single real-world change (e.g. a host moving clusters) can
-	// cascade into many individual PropertyCollector updates — e.g. several
-	// datastores that host mounts each getting their own Datastore.host update
-	// in the same burst — so without coalescing, the same affected storage
-	// policy gets reconciled once per update instead of once for the whole
-	// burst. Resolve events to affected policies (via DsToPolicy/DsToHosts)
-	// and dedupe by policy ID, not by raw event, since several different
-	// events can resolve to the same policy.
-	// TODO: implement — look up affected datastores via DsToHosts and enqueue for reconciliation.
+	cache := GetCache()
+
+	// Resolve events to affected datastores. Datastore-scoped events already
+	// name the datastore directly; host-scoped events are resolved via the
+	// cache's reverse index, since a host change can affect every datastore
+	// it mounts. EventDatastoreRemoved is handled separately below: by the
+	// time this runs, collectEvents has already invalidated that datastore's
+	// cache entry, so there's nothing left here to resolve it through.
+	affectedDatastores := make(map[string]struct{})
+	affectedPolicies := make(map[string]struct{})
+	for _, ev := range events {
+		switch ev.Kind {
+		case EventDatastoreRemoved:
+			for _, policy := range ev.Policies {
+				affectedPolicies[policy] = struct{}{}
+			}
+		case EventDatastoreHostChanged:
+			affectedDatastores[ev.MoRef] = struct{}{}
+		case EventHostClusterChanged, EventHostVersionChanged:
+			for _, dsID := range cache.DatastoresForHost(ev.MoRef) {
+				affectedDatastores[dsID] = struct{}{}
+			}
+		}
+	}
+
+	// Resolve affected datastores to affected policies, deduping by policy:
+	// several different events (and several different datastores) can resolve
+	// to the same policy, and it must only be queued once per burst.
+	for dsID := range affectedDatastores {
+		for _, policy := range cache.PoliciesForDatastore(dsID) {
+			affectedPolicies[policy] = struct{}{}
+		}
+	}
+
+	log.Infof("vsphereinfra: %d inventory event(s) resolved to %d affected datastore(s) and %d affected policy(ies)",
+		len(events), len(affectedDatastores), len(affectedPolicies))
+
+	for policy := range affectedPolicies {
+		queuePolicyReconcile(ctx, policy)
+	}
+}
+
+// queuePolicyReconcile adds policyName to the coalescing queue if it isn't
+// already waiting there, and schedules it to be sent on the PolicyChanges
+// channel after policyReconcileDelay. Calling this again for a policy already
+// in the queue is a no-op: that's the coalescing behavior — the whole burst
+// of events for a policy is collapsed into the single reconcile already
+// scheduled for it.
+func queuePolicyReconcile(ctx context.Context, policyName string) {
+	log := logger.GetLogger(ctx)
+
+	pendingPoliciesMu.Lock()
+	if _, alreadyQueued := pendingPolicies[policyName]; alreadyQueued {
+		pendingPoliciesMu.Unlock()
+		log.Debugf("vsphereinfra: policy %q already queued for reconciliation, coalescing", policyName)
+		return
+	}
+	pendingPolicies[policyName] = struct{}{}
+	pendingPoliciesMu.Unlock()
+
+	log.Infof("vsphereinfra: policy %q queued for reconciliation in %s", policyName, policyReconcileDelay)
+	time.AfterFunc(policyReconcileDelay, func() {
+		pendingPoliciesMu.Lock()
+		delete(pendingPolicies, policyName)
+		pendingPoliciesMu.Unlock()
+
+		select {
+		case getPolicyChangeCh() <- policyName:
+			log.Infof("vsphereinfra: policy %q pushed onto policy change channel", policyName)
+		default:
+			// The consumer isn't keeping up or hasn't started yet. Drop rather
+			// than block this timer goroutine; the policy will be re-queued by
+			// the next inventory event that affects it, or picked up by the
+			// periodic slow-sync in the meantime.
+			log.Warnf("vsphereinfra: policy change channel full, dropping reconcile for %q", policyName)
+		}
+	})
 }

--- a/pkg/syncer/cnsoperator/vsphereinfra/events_test.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/events_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphereinfra
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withShortReconcileDelay shrinks policyReconcileDelay for the duration of a
+// test, so coalescing tests don't have to wait out the real two minutes.
+func withShortReconcileDelay(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := policyReconcileDelay
+	policyReconcileDelay = d
+	t.Cleanup(func() { policyReconcileDelay = orig })
+}
+
+// drainPolicyChanges reads exactly n values off PolicyChanges() within
+// timeout, failing the test if fewer arrive in time.
+func drainPolicyChanges(t *testing.T, n int, timeout time.Duration) []string {
+	t.Helper()
+	var got []string
+	deadline := time.After(timeout)
+	for i := 0; i < n; i++ {
+		select {
+		case p := <-PolicyChanges():
+			got = append(got, p)
+		case <-deadline:
+			t.Fatalf("timed out waiting for policy change %d/%d, got so far: %v", i+1, n, got)
+		}
+	}
+	return got
+}
+
+// assertNoPolicyChange fails the test if a policy change arrives within d.
+func assertNoPolicyChange(t *testing.T, d time.Duration) {
+	t.Helper()
+	select {
+	case p := <-PolicyChanges():
+		t.Fatalf("unexpected policy change for %q before the coalescing window elapsed", p)
+	case <-time.After(d):
+	}
+}
+
+func TestOnInventoryChange_DatastoreEventResolvesToPolicy(t *testing.T) {
+	withShortReconcileDelay(t, 20*time.Millisecond)
+	ctx := context.Background()
+	cache := GetCache()
+
+	dsID := uniqueID(t, "ds")
+	policy := uniqueID(t, "policy")
+	cache.SetDatastoresForPolicy(policy, []string{dsID})
+
+	OnInventoryChange(ctx, []InventoryEvent{{Kind: EventDatastoreHostChanged, MoRef: dsID}})
+
+	got := drainPolicyChanges(t, 1, time.Second)
+	assert.Equal(t, []string{policy}, got)
+}
+
+func TestOnInventoryChange_HostEventResolvesToPolicyViaDatastores(t *testing.T) {
+	withShortReconcileDelay(t, 20*time.Millisecond)
+	ctx := context.Background()
+	cache := GetCache()
+
+	hostID := uniqueID(t, "host")
+	dsID := uniqueID(t, "ds")
+	policy := uniqueID(t, "policy")
+	cache.UpdateDsHosts(dsID, hostSet(hostID))
+	cache.SetDatastoresForPolicy(policy, []string{dsID})
+
+	OnInventoryChange(ctx, []InventoryEvent{{Kind: EventHostClusterChanged, MoRef: hostID}})
+
+	got := drainPolicyChanges(t, 1, time.Second)
+	assert.Equal(t, []string{policy}, got)
+}
+
+func TestOnInventoryChange_UnresolvedEventQueuesNothing(t *testing.T) {
+	withShortReconcileDelay(t, 20*time.Millisecond)
+	ctx := context.Background()
+
+	// A moref with no cache entries (unknown datastore/host) must not panic
+	// and must not produce a policy change.
+	OnInventoryChange(ctx, []InventoryEvent{{Kind: EventHostVersionChanged, MoRef: uniqueID(t, "host")}})
+
+	assertNoPolicyChange(t, 50*time.Millisecond)
+}
+
+func TestOnInventoryChange_MultipleEventsForSamePolicyCoalesceIntoOneReconcile(t *testing.T) {
+	withShortReconcileDelay(t, 100*time.Millisecond)
+	ctx := context.Background()
+	cache := GetCache()
+
+	policy := uniqueID(t, "policy")
+	ds1, ds2 := uniqueID(t, "ds1"), uniqueID(t, "ds2")
+	host := uniqueID(t, "host")
+	cache.SetDatastoresForPolicy(policy, []string{ds1, ds2})
+	cache.UpdateDsHosts(ds2, hostSet(host))
+
+	// Simulate a burst: a host leaving a cluster fires events for both the
+	// host and the datastores it mounts, all resolving to the same policy.
+	OnInventoryChange(ctx, []InventoryEvent{{Kind: EventDatastoreHostChanged, MoRef: ds1}})
+	time.Sleep(10 * time.Millisecond)
+	OnInventoryChange(ctx, []InventoryEvent{{Kind: EventHostClusterChanged, MoRef: host}})
+	time.Sleep(10 * time.Millisecond)
+	OnInventoryChange(ctx, []InventoryEvent{{Kind: EventDatastoreHostChanged, MoRef: ds1}})
+
+	// Nothing should be reconciled before the window (measured from the first
+	// event) elapses.
+	assertNoPolicyChange(t, 50*time.Millisecond)
+
+	got := drainPolicyChanges(t, 1, time.Second)
+	assert.Equal(t, []string{policy}, got, "the whole burst must collapse into a single reconcile")
+
+	// And no second reconcile should follow for this burst.
+	assertNoPolicyChange(t, 100*time.Millisecond)
+}
+
+func TestOnInventoryChange_DifferentPoliciesEachQueuedIndependently(t *testing.T) {
+	withShortReconcileDelay(t, 20*time.Millisecond)
+	ctx := context.Background()
+	cache := GetCache()
+
+	ds1, ds2 := uniqueID(t, "ds1"), uniqueID(t, "ds2")
+	policy1, policy2 := uniqueID(t, "policy1"), uniqueID(t, "policy2")
+	cache.SetDatastoresForPolicy(policy1, []string{ds1})
+	cache.SetDatastoresForPolicy(policy2, []string{ds2})
+
+	OnInventoryChange(ctx, []InventoryEvent{
+		{Kind: EventDatastoreHostChanged, MoRef: ds1},
+		{Kind: EventDatastoreHostChanged, MoRef: ds2},
+	})
+
+	got := drainPolicyChanges(t, 2, time.Second)
+	assert.ElementsMatch(t, []string{policy1, policy2}, got)
+}
+
+func TestOnInventoryChange_DatastoreRemovedResolvesToPolicy(t *testing.T) {
+	withShortReconcileDelay(t, 20*time.Millisecond)
+	ctx := context.Background()
+
+	dsID := uniqueID(t, "ds")
+	policy := uniqueID(t, "policy")
+	// By the time OnInventoryChange sees an EventDatastoreRemoved,
+	// collectEvents has already invalidated DsToPolicy for this datastore —
+	// PoliciesForDatastore(dsID) would return nothing. The event must carry
+	// the pre-resolved policy names itself, in its Policies field, exactly as
+	// collectEvents populates it from InvalidateDatastore's return value.
+	OnInventoryChange(ctx, []InventoryEvent{{Kind: EventDatastoreRemoved, MoRef: dsID, Policies: []string{policy}}})
+
+	got := drainPolicyChanges(t, 1, time.Second)
+	assert.Equal(t, []string{policy}, got)
+}
+
+func TestOnInventoryChange_DatastoreRemovedWithNoRecordedPoliciesQueuesNothing(t *testing.T) {
+	withShortReconcileDelay(t, 20*time.Millisecond)
+	ctx := context.Background()
+
+	// A datastore that had no recorded policies (Policies is nil, matching
+	// InvalidateDatastore's return when nothing was recorded) must not queue
+	// anything, and must not panic on a nil Policies slice.
+	OnInventoryChange(ctx, []InventoryEvent{{Kind: EventDatastoreRemoved, MoRef: uniqueID(t, "ds")}})
+
+	assertNoPolicyChange(t, 50*time.Millisecond)
+}
+
+func TestQueuePolicyReconcile_DropsWhenChannelFull(t *testing.T) {
+	withShortReconcileDelay(t, 10*time.Millisecond)
+	ctx := context.Background()
+
+	ch := getPolicyChangeCh()
+	require.Greater(t, cap(ch), 0)
+	// Fill the channel so the send in queuePolicyReconcile's timer callback
+	// hits its default (drop) branch instead of blocking forever.
+	for len(ch) < cap(ch) {
+		ch <- uniqueID(t, "filler")
+	}
+	defer func() {
+		for len(ch) > 0 {
+			<-ch
+		}
+	}()
+
+	// Must not panic or hang even though the channel is full.
+	queuePolicyReconcile(ctx, uniqueID(t, "policy"))
+	time.Sleep(50 * time.Millisecond)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Implements the previously-stubbed vsphereinfra.OnInventoryChange: PropertyCollector-detected vSphere inventory changes (datastore added/removed hosts, a host moving clusters, ESXi version changes) are now resolved to the storage policies they affect and trigger a coalesced reconcile of the corresponding ClusterStoragePolicyInfo/InfraStoragePolicyInfo, instead of being logged and dropped.

A single real-world change (e.g. a host moving clusters) can cascade into many individual PropertyCollector updates — several datastores the host mounts each firing their own event in the same burst. Without coalescing, that would trigger one reconcile per update instead of one for the whole burst. Events are now deduped by the policy they resolve to, and held in a queue for a fixed 2-minute window before being handed off for reconciliation, so a whole burst collapses into a single reconcile per affected policy.

Changes done:

* Implemented vsphereinfra.OnInventoryChange: resolves PropertyCollector inventory events → affected datastores → affected storage policies
* Added a 2-minute coalescing queue so a burst of events for the same policy collapses into a single reconcile, delivered via a new PolicyChanges() channel
* Added DatastoresForHost and PoliciesForDatastore cache accessors, and SetDatastoresForPolicy to populate/replace the (previously unwritten) DsToPolicy reverse index
populateTopologyCapabilities now writes DsToPolicy as a byproduct of its existing PBM compatibility query (no extra vCenter call)
* Added forwardInventoryPolicyChanges/forwardPolicyChanges, registered as a manager Runnable, to bridge coalesced policy changes into the controller's existing resyncCh workqueue path
* Forwarder skips policies already backed off from a prior failure, avoiding a redundant reconcile

**Testing done**:

The affected polciies were added to a queue for 2mins:

```
{"level":"info","time":"2026-07-14T10:44:09.814565136Z","caller":"vsphereinfra/events.go:167","msg":"vsphereinfra: policy \"vm-encryption-policy\" queued for reconciliation in 2m0s","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:44:09.81468255Z","caller":"vsphereinfra/events.go:167","msg":"vsphereinfra: policy \"management-storage-policy-encryption\" queued for reconciliation in 2m0s","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:44:09.814699662Z","caller":"vsphereinfra/events.go:167","msg":"vsphereinfra: policy \"management-storage-policy-regular\" queued for reconciliation in 2m0s","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:44:09.814710132Z","caller":"vsphereinfra/events.go:167","msg":"vsphereinfra: policy \"management-storage-policy-stretched-lite\" queued for reconciliation in 2m0s","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:44:09.81471999Z","caller":"vsphereinfra/events.go:167","msg":"vsphereinfra: policy \"vsan-default-storage-policy\" queued for reconciliation in 2m0s","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:44:09.814812567Z","caller":"vsphereinfra/events.go:167","msg":"vsphereinfra: policy \"management-storage-policy-thin\" queued for reconciliation in 2m0s","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:44:09.814823234Z","caller":"vsphereinfra/events.go:167","msg":"vsphereinfra: policy \"management-storage-policy-single-node\" queued for reconciliation in 2m0s","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
```


Logs showing affected policies being pushed on the channel after 2 mins:

```
root@4228e67030f7c7ea4cc0e7fa15a3b323 [ ~ ]# k logs vsphere-csi-controller-67c7b58467-cm2ws  -n vmware-system-csi -c vsphere-syncer | grep -i "pushed onto policy change channel"
{"level":"info","time":"2026-07-14T10:46:09.815760079Z","caller":"vsphereinfra/[events.go:175](http://events.go:175/)","msg":"vsphereinfra: policy \"vsan-default-storage-policy\" pushed onto policy change channel","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:46:09.815884412Z","caller":"vsphereinfra/[events.go:175](http://events.go:175/)","msg":"vsphereinfra: policy \"management-storage-policy-thin\" pushed onto policy change channel","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:46:09.815715777Z","caller":"vsphereinfra/[events.go:175](http://events.go:175/)","msg":"vsphereinfra: policy \"management-storage-policy-stretched-lite\" pushed onto policy change channel","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:46:09.815715815Z","caller":"vsphereinfra/[events.go:175](http://events.go:175/)","msg":"vsphereinfra: policy \"vm-encryption-policy\" pushed onto policy change channel","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:46:09.815715517Z","caller":"vsphereinfra/[events.go:175](http://events.go:175/)","msg":"vsphereinfra: policy \"management-storage-policy-single-node\" pushed onto policy change channel","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:46:09.815847066Z","caller":"vsphereinfra/[events.go:175](http://events.go:175/)","msg":"vsphereinfra: policy \"management-storage-policy-encryption\" pushed onto policy change channel","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
{"level":"info","time":"2026-07-14T10:46:09.815868518Z","caller":"vsphereinfra/[events.go:175](http://events.go:175/)","msg":"vsphereinfra: policy \"management-storage-policy-regular\" pushed onto policy change channel","TraceId":"df2ad699-900f-4439-a8eb-929187600a4b"}
```


ClusterSPI controller enqueuing them:

```
root@4228e67030f7c7ea4cc0e7fa15a3b323 [ ~ ]# k logs vsphere-csi-controller-67c7b58467-cm2ws  -n vmware-system-csi -c vsphere-syncer -f | grep -i "ClusterStoragePolicyInfo inventory policy-change forwarder"
{"level":"info","time":"2026-07-14T10:46:09.81613905Z","caller":"clusterstoragepolicyinfo/[controller.go:273](http://controller.go:273/)","msg":"ClusterStoragePolicyInfo inventory policy-change forwarder: queued \"management-storage-policy-single-node\" for reconciliation"}
{"level":"info","time":"2026-07-14T10:46:09.818214317Z","caller":"clusterstoragepolicyinfo/[controller.go:273](http://controller.go:273/)","msg":"ClusterStoragePolicyInfo inventory policy-change forwarder: queued \"vm-encryption-policy\" for reconciliation"}
{"level":"info","time":"2026-07-14T10:46:09.818587802Z","caller":"clusterstoragepolicyinfo/[controller.go:273](http://controller.go:273/)","msg":"ClusterStoragePolicyInfo inventory policy-change forwarder: queued \"management-storage-policy-stretched-lite\" for reconciliation"}
{"level":"info","time":"2026-07-14T10:46:09.818710787Z","caller":"clusterstoragepolicyinfo/[controller.go:273](http://controller.go:273/)","msg":"ClusterStoragePolicyInfo inventory policy-change forwarder: queued \"vsan-default-storage-policy\" for reconciliation"}
{"level":"info","time":"2026-07-14T10:46:09.819250979Z","caller":"clusterstoragepolicyinfo/[controller.go:273](http://controller.go:273/)","msg":"ClusterStoragePolicyInfo inventory policy-change forwarder: queued \"management-storage-policy-encryption\" for reconciliation"}
{"level":"info","time":"2026-07-14T10:46:09.819285951Z","caller":"clusterstoragepolicyinfo/[controller.go:273](http://controller.go:273/)","msg":"ClusterStoragePolicyInfo inventory policy-change forwarder: queued \"management-storage-policy-regular\" for reconciliation"}
{"level":"info","time":"2026-07-14T10:46:09.821039384Z","caller":"clusterstoragepolicyinfo/[controller.go:273](http://controller.go:273/)","msg":"ClusterStoragePolicyInfo inventory policy-change forwarder: queued \"management-storage-policy-thin\" for reconciliation"}
```
WCP precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1808/
VKS precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1365/

