### PR TITLE
Extend the periodic sync to support ModifyVolume

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1329,6 +1329,27 @@ func syncStorageQuotaReserved(ctx context.Context,
 			totalStoragePolicyReserved = mergeStoragePolicyReserved(vsReserved, totalStoragePolicyReserved)
 		}
 
+		// Check if the VM/PVC storage-policy mutability FSS is enabled before accounting for
+		// in-flight ModifyVolume (VolumeAttributesClass change) operations.
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VMPVCStoragePolicyMutability) {
+			// calculate reserved values for PVCs undergoing a ModifyVolume operation
+			modifyVolumeReserved, err := calculateModifyVolumeReservedForNamespace(ctx, ns, metadataSyncer)
+			if err != nil {
+				log.Errorf("syncStorageQuotaReserved: error while calculating expected ModifyVolume reserved value"+
+					" for given namespace %q, Error: %v", ns, err)
+				continue
+			}
+			if modifyVolumeReserved != nil {
+				if !validateReservedValues(modifyVolumeReserved) {
+					log.Errorf("syncStorageQuotaReserved: error while calculating expected ModifyVolume reserved value"+
+						" for given namespace %q, Error: %v", ns, errors.New("expected reserved is negative value"))
+					continue
+				}
+				hasValidData = true
+				totalStoragePolicyReserved = mergeStoragePolicyReserved(modifyVolumeReserved, totalStoragePolicyReserved)
+			}
+		}
+
 		// Check if storage policy reservation related FSS is enabled
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WCPMobilityNonDisruptiveImport) {
 			// calculate expected reserved values for StoragePolicyReservation CRs for given namespace
@@ -1584,6 +1605,91 @@ func calculateVolumeSnapshotReservedForNamespace(ctx context.Context,
 	return storagePolicyIdToReservedMap, nil
 }
 
+// calculateModifyVolumeReservedForNamespace calculates the expected reserved value for PVCs that are
+// currently undergoing a ModifyVolume (VolumeAttributesClass / storage-policy mutability) operation in
+// the given namespace. Until the modify completes, the PVC's capacity is anticipated consumption on the
+// target storage policy that has not yet been reflected in that policy's Used, so it is counted as
+// reserved against the target VAC's storage policy ID. Returns a map of storage policy ID to expected
+// reserved value.
+func calculateModifyVolumeReservedForNamespace(ctx context.Context,
+	namespace string, metadataSyncer *metadataSyncInformer) (map[string]*resource.Quantity, error) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("calculateModifyVolumeReservedForNamespace: Fetching PersistentVolumeClaim for namespace %q",
+		namespace)
+	pvcList, err := metadataSyncer.pvcLister.PersistentVolumeClaims(namespace).List(labels.NewSelector())
+	if err != nil {
+		log.Errorf("calculateModifyVolumeReservedForNamespace: unable to fetch all pvc from namespace %q, Error %v",
+			namespace, err)
+		return nil, err
+	}
+	// First pass: identify PVCs that have an in-flight ModifyVolume operation. Avoid listing VACs
+	// unless there is at least one such PVC, which is the common case.
+	var candidates []*v1.PersistentVolumeClaim
+	for _, pvc := range pvcList {
+		if pvc.DeletionTimestamp != nil {
+			continue
+		}
+		// A ModifyVolume only applies to an already-provisioned (Bound) volume; a Pending PVC has no PV
+		// yet and cannot have ModifyVolumeStatus populated. This guards against double-counting with
+		// calculatePVCReservedForNamespace's pending-PVC branch.
+		if pvc.Status.Phase != v1.ClaimBound {
+			continue
+		}
+		if pvc.Status.ModifyVolumeStatus == nil {
+			continue
+		}
+		// Only Pending and InProgress modify operations hold a reservation. An Infeasible modify will
+		// never consume the target policy, so it must not be counted.
+		status := pvc.Status.ModifyVolumeStatus.Status
+		if status != v1.PersistentVolumeClaimModifyVolumePending &&
+			status != v1.PersistentVolumeClaimModifyVolumeInProgress {
+			continue
+		}
+		candidates = append(candidates, pvc)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	vacToStoragePolicyIDMap, err := fetchVACToStoragePolicyMapping(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if vacToStoragePolicyIDMap == nil {
+		// VolumeAttributesClass API unavailable; nothing to account for.
+		return nil, nil
+	}
+
+	storagePolicyToReservedMap := make(map[string]*resource.Quantity)
+	for _, pvc := range candidates {
+		targetVAC := pvc.Status.ModifyVolumeStatus.TargetVolumeAttributesClassName
+		if targetVAC == "" {
+			log.Debugf("calculateModifyVolumeReservedForNamespace: empty target VAC for PVC %q/%q, skipping",
+				pvc.Namespace, pvc.Name)
+			continue
+		}
+		storagePolicyID, ok := vacToStoragePolicyIDMap[targetVAC]
+		if !ok || storagePolicyID == "" {
+			log.Debugf("calculateModifyVolumeReservedForNamespace: target VAC %q for PVC %q/%q could not be "+
+				"resolved to a storage policy ID, skipping", targetVAC, pvc.Namespace, pvc.Name)
+			continue
+		}
+		if pvc.Spec.Resources.Requests == nil {
+			log.Debugf("calculateModifyVolumeReservedForNamespace: pvc resources not populated, continuing "+
+				"processing others Name: %q, Namespace: %q", pvc.Name, pvc.Namespace)
+			continue
+		}
+		if storagePolicyToReservedMap[storagePolicyID] == nil {
+			storagePolicyToReservedMap[storagePolicyID] = resource.NewQuantity(0, resource.BinarySI)
+		}
+		pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+		log.Debugf("calculateModifyVolumeReservedForNamespace: PVC %q/%q is undergoing ModifyVolume to VAC %q, "+
+			"adding capacity to reserved for storage policy %q", pvc.Namespace, pvc.Name, targetVAC, storagePolicyID)
+		storagePolicyToReservedMap[storagePolicyID].Add(pvcSize)
+	}
+	return storagePolicyToReservedMap, nil
+}
+
 // calculateSPRReservedForNamespace calculates the expected reserved capacity values for StoragePolicyReservation
 // CRs in the given namespace and returns map of storage policy ID to expected reserved capacity for that policy.
 func calculateSPRReservedForNamespace(ctx context.Context, cnsOperatorClient client.Client,
@@ -1828,6 +1934,48 @@ var fetchStorageClassToStoragePolicyMapping = func(ctx context.Context) (map[str
 		storageClassToStoragePolicy[sc.Name] = sc.Parameters["storagePolicyID"]
 	}
 	return storageClassToStoragePolicy, nil
+}
+
+// fetchVACToStoragePolicyMapping fetches all VolumeAttributesClasses and returns a mapping of
+// VAC name to its storage policy ID (read from the VAC's own parameters). It returns (nil, nil)
+// when the VolumeAttributesClass API is unavailable (e.g. pre-1.34 clusters), so callers can
+// treat that as a soft-skip rather than an error. The FSS gate is applied by the caller.
+var fetchVACToStoragePolicyMapping = func(ctx context.Context) (map[string]string, error) {
+	log := logger.GetLogger(ctx)
+	log.Debug("fetchVACToStoragePolicyMapping: Fetching VolumeAttributesClasses and creating mapping " +
+		"for VAC name and storagepolicyid")
+	// Skip if the VolumeAttributesClass API is not available on this cluster.
+	vacSupported, err := vacAPIAvailableCheck(ctx)
+	if err != nil {
+		log.Warnf("fetchVACToStoragePolicyMapping: Could not discover VolumeAttributesClass API; "+
+			"skipping VAC mapping. Err: %v", err)
+		return nil, nil
+	}
+	if !vacSupported {
+		log.Debug("fetchVACToStoragePolicyMapping: VolumeAttributesClass API not available; skipping VAC mapping")
+		return nil, nil
+	}
+	k8sconfig, err := k8s.GetKubeConfig(ctx)
+	if err != nil {
+		log.Errorf("fetchVACToStoragePolicyMapping: Failed to get KubeConfig. err: %v", err)
+		return nil, err
+	}
+	k8sClient, err := clientset.NewForConfig(k8sconfig)
+	if err != nil {
+		log.Errorf("fetchVACToStoragePolicyMapping: Failed to create kubernetes client. Err: %+v", err)
+		return nil, err
+	}
+	vacList, err := k8sClient.StorageV1().VolumeAttributesClasses().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("fetchVACToStoragePolicyMapping: Failed to list VolumeAttributesClasses. Err: %+v", err)
+		return nil, err
+	}
+	vacToStoragePolicy := make(map[string]string)
+	for i := range vacList.Items {
+		vac := vacList.Items[i]
+		vacToStoragePolicy[vac.Name] = getStoragePolicyIDFromVAC(&vac)
+	}
+	return vacToStoragePolicy, nil
 }
 
 // initCnsVolumeOperationRequestCRInformer creates and starts an informer for CnsVolumeOperationRequest custom resource.

--- a/pkg/syncer/metadatasyncer_test.go
+++ b/pkg/syncer/metadatasyncer_test.go
@@ -1411,6 +1411,200 @@ func TestMergeStoragePolicyReserved(t *testing.T) {
 	}
 }
 
+// buildSyncerWithPVCs returns a metadataSyncInformer whose pvcLister is populated with the given PVCs.
+func buildSyncerWithPVCs(t *testing.T, pvcs ...*v1.PersistentVolumeClaim) *metadataSyncInformer {
+	t.Helper()
+	objs := make([]runtime.Object, 0, len(pvcs))
+	for _, pvc := range pvcs {
+		objs = append(objs, pvc)
+	}
+	k8sClient := testclient.NewClientset(objs...)
+	informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+	// Register the listers before starting the factory so the informers are actually started
+	// and their caches populated.
+	pvLister := informerFactory.Core().V1().PersistentVolumes().Lister()
+	pvcLister := informerFactory.Core().V1().PersistentVolumeClaims().Lister()
+	stopCh := make(chan struct{})
+	// Close the stop channel when the test finishes so the started informers shut down
+	// instead of leaking goroutines across the test suite.
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	for _, synced := range informerFactory.WaitForCacheSync(stopCh) {
+		if !synced {
+			t.Fatal("Failed to sync informer cache")
+		}
+	}
+	return &metadataSyncInformer{
+		pvLister:  pvLister,
+		pvcLister: pvcLister,
+	}
+}
+
+// modifyingPVC builds a Bound PVC with a ModifyVolumeStatus set to the given target VAC and status.
+func modifyingPVC(name, namespace, size, targetVAC string,
+	status v1.PersistentVolumeClaimModifyVolumeStatus) *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1.PersistentVolumeClaimSpec{
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse(size)},
+			},
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+			ModifyVolumeStatus: &v1.ModifyVolumeStatus{
+				TargetVolumeAttributesClassName: targetVAC,
+				Status:                          status,
+			},
+		},
+	}
+}
+
+func TestCalculateModifyVolumeReservedForNamespace(t *testing.T) {
+	ctx := context.Background()
+	const namespace = "test-ns"
+
+	// fakeVACMapping resolves "vac1" -> "policy1".
+	fakeVACMapping := func(ctx context.Context) (map[string]string, error) {
+		return map[string]string{"vac1": "policy1"}, nil
+	}
+	// unavailableVACMapping simulates the VolumeAttributesClass API being unavailable.
+	unavailableVACMapping := func(ctx context.Context) (map[string]string, error) {
+		return nil, nil
+	}
+
+	tests := []struct {
+		name        string
+		pvcs        []*v1.PersistentVolumeClaim
+		vacMapping  func(ctx context.Context) (map[string]string, error)
+		expectNil   bool
+		expectError bool
+		expected    map[string]string // storagePolicyID -> expected reserved quantity
+	}{
+		{
+			name: "No modifying PVCs returns nil",
+			pvcs: []*v1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "bound-pvc", Namespace: namespace},
+					Status:     v1.PersistentVolumeClaimStatus{Phase: v1.ClaimBound},
+				},
+			},
+			vacMapping: fakeVACMapping,
+			expectNil:  true,
+		},
+		{
+			name: "PVC with Pending modify status is counted",
+			pvcs: []*v1.PersistentVolumeClaim{
+				modifyingPVC("pvc1", namespace, "10Gi", "vac1", v1.PersistentVolumeClaimModifyVolumePending),
+			},
+			vacMapping: fakeVACMapping,
+			expected:   map[string]string{"policy1": "10Gi"},
+		},
+		{
+			name: "PVC with InProgress modify status is counted",
+			pvcs: []*v1.PersistentVolumeClaim{
+				modifyingPVC("pvc1", namespace, "10Gi", "vac1", v1.PersistentVolumeClaimModifyVolumeInProgress),
+			},
+			vacMapping: fakeVACMapping,
+			expected:   map[string]string{"policy1": "10Gi"},
+		},
+		{
+			name: "PVC with Infeasible modify status is not counted",
+			pvcs: []*v1.PersistentVolumeClaim{
+				modifyingPVC("pvc1", namespace, "10Gi", "vac1", v1.PersistentVolumeClaimModifyVolumeInfeasible),
+			},
+			vacMapping: fakeVACMapping,
+			expectNil:  true,
+		},
+		{
+			name: "PVC whose target VAC is unresolvable is skipped",
+			pvcs: []*v1.PersistentVolumeClaim{
+				modifyingPVC("pvc1", namespace, "10Gi", "vacX", v1.PersistentVolumeClaimModifyVolumeInProgress),
+			},
+			vacMapping: fakeVACMapping,
+			expected:   map[string]string{},
+		},
+		{
+			name: "PVC with empty target VAC is skipped",
+			pvcs: []*v1.PersistentVolumeClaim{
+				modifyingPVC("pvc1", namespace, "10Gi", "", v1.PersistentVolumeClaimModifyVolumeInProgress),
+			},
+			vacMapping: fakeVACMapping,
+			expected:   map[string]string{},
+		},
+		{
+			name: "VAC API unavailable returns nil",
+			pvcs: []*v1.PersistentVolumeClaim{
+				modifyingPVC("pvc1", namespace, "10Gi", "vac1", v1.PersistentVolumeClaimModifyVolumeInProgress),
+			},
+			vacMapping: unavailableVACMapping,
+			expectNil:  true,
+		},
+		{
+			name: "Multiple PVCs to same policy are summed",
+			pvcs: []*v1.PersistentVolumeClaim{
+				modifyingPVC("pvc1", namespace, "10Gi", "vac1", v1.PersistentVolumeClaimModifyVolumePending),
+				modifyingPVC("pvc2", namespace, "5Gi", "vac1", v1.PersistentVolumeClaimModifyVolumeInProgress),
+			},
+			vacMapping: fakeVACMapping,
+			expected:   map[string]string{"policy1": "15Gi"},
+		},
+	}
+
+	orig := fetchVACToStoragePolicyMapping
+	defer func() { fetchVACToStoragePolicyMapping = orig }()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fetchVACToStoragePolicyMapping = tt.vacMapping
+			metadataSyncer := buildSyncerWithPVCs(t, tt.pvcs...)
+
+			result, err := calculateModifyVolumeReservedForNamespace(ctx, namespace, metadataSyncer)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			if tt.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+			assert.NotNil(t, result)
+			assert.Equal(t, len(tt.expected), len(result))
+			for policyID, want := range tt.expected {
+				got, ok := result[policyID]
+				if !assert.True(t, ok, "expected policy %q in result", policyID) || got == nil {
+					continue
+				}
+				wantQty := resource.MustParse(want)
+				assert.Equalf(t, 0, got.Cmp(wantQty), "policy %q: got %s want %s", policyID, got.String(), want)
+			}
+		})
+	}
+}
+
+func TestFetchVACToStoragePolicyMapping(t *testing.T) {
+	ctx := context.Background()
+	orig := vacAPIAvailableCheck
+	defer func() { vacAPIAvailableCheck = orig }()
+
+	t.Run("VAC API not available returns nil map", func(t *testing.T) {
+		vacAPIAvailableCheck = func(ctx context.Context) (bool, error) { return false, nil }
+		result, err := fetchVACToStoragePolicyMapping(ctx)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("VAC API discovery error is soft-skipped", func(t *testing.T) {
+		vacAPIAvailableCheck = func(ctx context.Context) (bool, error) {
+			return false, errors.New("discovery error")
+		}
+		result, err := fetchVACToStoragePolicyMapping(ctx)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
 func TestCalculateSPRReservedForNamespace(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Extend the periodic storage-quota sync to account for PVCs undergoing an in-flight ModifyVolume

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1803/ (passed)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1359/ (passed)

[Manual Testing](https://gist.github.com/xing-yang/74f3a84594e11b62d5324b22ed159dad#file-periodsync-modifyvolume-md)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Extend the periodic sync to support ModifyVolume.
```
