### PR TITLE
Support host-local volume registration via CnsRegisterVolume API

### DIFF
--- a/pkg/common/cns-lib/vsphere/pbm.go
+++ b/pkg/common/cns-lib/vsphere/pbm.go
@@ -189,6 +189,67 @@ func (vc *VirtualCenter) PbmRetrieveContent(ctx context.Context, policyIds []str
 	return simplifyProfileStructs(ctx, profiles), err
 }
 
+const (
+	// hostLocalStorageNamespace and hostLocalStorageCapabilityID identify the SPBM capability
+	// that marks a storage policy as host-local storage. This mirrors the check used by the WCP
+	// control plane; the hostlocalstorage namespace defines exactly one capability
+	// (hostLocalStorage) and it carries no constraint/property instances, so it must be matched
+	// directly against the capability id rather than via PbmRetrieveContent/SpbmPolicyContent,
+	// which only emits a rule per PropertyInstance and would silently drop a property-less
+	// capability like this one. This does NOT match vSAN Direct or vSAN locality/SNA policies.
+	hostLocalStorageNamespace    = "com.vmware.storage.hostlocalstorage"
+	hostLocalStorageCapabilityID = "hostLocalStorage"
+)
+
+// IsHostLocalStorageCapabilityPolicy reports whether the SPBM capability subprofile constraints
+// contain the com.vmware.storage.hostlocalstorage/hostLocalStorage capability.
+func IsHostLocalStorageCapabilityPolicy(subprofiles *pbmtypes.PbmCapabilitySubProfileConstraints) bool {
+	if subprofiles == nil {
+		return false
+	}
+	for _, subprofile := range subprofiles.SubProfiles {
+		for _, capIns := range subprofile.Capability {
+			if capIns.Id.Namespace == hostLocalStorageNamespace && capIns.Id.Id == hostLocalStorageCapabilityID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsHostLocalStoragePolicy fetches the SPBM profile for the given policyID and reports whether
+// it carries the host-local storage capability. An empty policyID returns (false, nil).
+func (vc *VirtualCenter) IsHostLocalStoragePolicy(ctx context.Context, policyID string) (bool, error) {
+	log := logger.GetLogger(ctx)
+	if policyID == "" {
+		return false, nil
+	}
+	if err := vc.ConnectPbm(ctx); err != nil {
+		log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
+		return false, err
+	}
+	profiles, err := vc.PbmClient.RetrieveContent(ctx, []pbmtypes.PbmProfileId{{UniqueId: policyID}})
+	if err != nil {
+		log.Errorf("failed to retrieve SPBM profile for policy %q: %v", policyID, err)
+		return false, err
+	}
+	for _, baseProfile := range profiles {
+		profile, ok := baseProfile.(*pbmtypes.PbmCapabilityProfile)
+		if !ok {
+			continue
+		}
+		constraints, ok := profile.Constraints.(*pbmtypes.PbmCapabilitySubProfileConstraints)
+		if !ok {
+			continue
+		}
+		if IsHostLocalStorageCapabilityPolicy(constraints) {
+			return true, nil
+		}
+	}
+	log.Infof("storage policy %q does not carry the host-local storage capability", policyID)
+	return false, nil
+}
+
 // QueryAllProfileDetails queries all profiles of a specific category from vCenter SPBM.
 // This uses the queryProfileDetails API to get all profiles in the specified category.
 func (vc *VirtualCenter) QueryAllProfileDetails(ctx context.Context, profileCategory string,

--- a/pkg/common/cns-lib/vsphere/pbm_test.go
+++ b/pkg/common/cns-lib/vsphere/pbm_test.go
@@ -603,3 +603,80 @@ func TestPbmQueryMatchingHub_LoggingBehavior(t *testing.T) {
 		assert.Contains(t, expectedErrorLog, errorMsg)
 	})
 }
+
+func TestIsHostLocalStorageCapabilityPolicy(t *testing.T) {
+	hostLocalCapability := pbmtypes.PbmCapabilityInstance{
+		Id: pbmtypes.PbmCapabilityMetadataUniqueId{
+			Namespace: "com.vmware.storage.hostlocalstorage",
+			Id:        "hostLocalStorage",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		subprofiles *pbmtypes.PbmCapabilitySubProfileConstraints
+		want        bool
+	}{
+		{
+			name: "hostLocalStorage capability present",
+			subprofiles: &pbmtypes.PbmCapabilitySubProfileConstraints{
+				SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
+					{Capability: []pbmtypes.PbmCapabilityInstance{hostLocalCapability}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "hostLocalStorage capability alongside other capabilities",
+			subprofiles: &pbmtypes.PbmCapabilitySubProfileConstraints{
+				SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
+					{Capability: []pbmtypes.PbmCapabilityInstance{
+						{Id: pbmtypes.PbmCapabilityMetadataUniqueId{Namespace: "VSAN", Id: "hostFailuresToTolerate"}},
+						hostLocalCapability,
+					}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no hostLocalStorage capability",
+			subprofiles: &pbmtypes.PbmCapabilitySubProfileConstraints{
+				SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
+					{Capability: []pbmtypes.PbmCapabilityInstance{
+						{Id: pbmtypes.PbmCapabilityMetadataUniqueId{Namespace: "VSAN", Id: "hostFailuresToTolerate"}},
+					}},
+				},
+			},
+			want: false,
+		},
+		{
+			name:        "nil subprofiles",
+			subprofiles: nil,
+			want:        false,
+		},
+		{
+			name: "matching id but different namespace (vSAN locality, not host-local storage)",
+			subprofiles: &pbmtypes.PbmCapabilitySubProfileConstraints{
+				SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
+					{Capability: []pbmtypes.PbmCapabilityInstance{
+						{Id: pbmtypes.PbmCapabilityMetadataUniqueId{Namespace: "VSAN", Id: "locality"}},
+					}},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsHostLocalStorageCapabilityPolicy(tt.subprofiles))
+		})
+	}
+}
+
+func TestIsHostLocalStoragePolicyEmptyPolicyID(t *testing.T) {
+	vc := &VirtualCenter{}
+	isHostLocal, err := vc.IsHostLocalStoragePolicy(context.Background(), "")
+	assert.NoError(t, err)
+	assert.False(t, isHostLocal)
+}

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -374,7 +374,98 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 
-	if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
+	// Detect whether the volume uses a vSAN host-local storage policy. This is gated on the
+	// supports_host_local_storage capability; re-checking IsFSSEnabled here (rather than caching it
+	// at startup) picks up late enablement of the capability on the running syncer. A host-local
+	// volume lives on the local storage of a single ESX host, so the regular "accessible to all
+	// hosts" gate and the intersection-based topology computation are replaced with a node-driven
+	// resolution below. When the capability is off or the policy is not host-local, isHostLocal
+	// stays false and the existing behavior is preserved.
+	isHostLocal := false
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.HostLocalStorageSupport) {
+		isHostLocal, err = vc.IsHostLocalStoragePolicy(ctx, volume.StoragePolicyId)
+		if err != nil {
+			msg := fmt.Sprintf("failed to determine host-local status for storage policy %s: %+v",
+				volume.StoragePolicyId, err)
+			log.Error(msg)
+			setInstanceError(ctx, r, instance, msg)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+	}
+
+	// datastoreAccessibleTopology holds the PV/PVC topology segments. For host-local volumes it is
+	// populated by the node-driven resolver below; otherwise it is computed later from shared
+	// datastores in the IsPodVMOnStretchSupervisorFSSEnabled block.
+	var datastoreAccessibleTopology []map[string]string
+
+	if isHostLocal {
+		// Bypass the shared-datastore "accessible to all hosts" gate. Build the clusterMoID -> zone
+		// map (inverted AvailabilityZone map) used both to discover the candidate clusters that may
+		// hold the datastore and to derive the zone from the host's cluster.
+		var clusterToZone map[string]string
+		if topologyMgr != nil {
+			clusterToZone = buildClusterToZoneMap(topologyMgr.GetAZClustersMap(ctx))
+		}
+		candidateClusterIDs := make([]string, 0, len(clusterToZone))
+		for clusterID := range clusterToZone {
+			candidateClusterIDs = append(candidateClusterIDs, clusterID)
+		}
+		if len(candidateClusterIDs) == 0 {
+			candidateClusterIDs = clusterComputeResourceMoIds
+		}
+
+		// Resolve the datastore object the disk lives on.
+		dsInfo, dsErr := cnsvsphere.GetDatastoreInfoByURL(ctx, vc, candidateClusterIDs, volume.DatastoreUrl)
+		if dsErr != nil || dsInfo == nil {
+			log.Errorf("failed to resolve datastore %s for host-local volume %s: %+v",
+				volume.DatastoreUrl, volumeID, dsErr)
+			setInstanceError(ctx, r, instance,
+				"host-local volume in the spec is on a datastore not found in the namespace's clusters")
+			if err = r.cleanupCNSVolume(ctx, instance, volumeID); err != nil {
+				log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, err)
+				return reconcile.Result{RequeueAfter: timeout}, nil
+			}
+			// permanent failure and not requeue.
+			return reconcile.Result{}, nil
+		}
+
+		// Requirement: the host-local policy must be PBM-compatible with the datastore the disk
+		// lives on. Reject registration if it is not.
+		compatible, compatErr := checkDatastorePolicyCompatibilityFn(ctx, vc, dsInfo, volume.StoragePolicyId)
+		if compatErr != nil {
+			// Transient PBM/VC error: requeue without cleanup.
+			setInstanceError(ctx, r, instance,
+				fmt.Sprintf("failed to verify PBM compatibility for host-local volume %s: %+v", volumeID, compatErr))
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+		if !compatible {
+			log.Errorf("host-local policy %s is not PBM-compatible with datastore %s for volume %s",
+				volume.StoragePolicyId, volume.DatastoreUrl, volumeID)
+			setInstanceError(ctx, r, instance,
+				"host-local storage policy is not compatible with the datastore the disk lives on")
+			if err = r.cleanupCNSVolume(ctx, instance, volumeID); err != nil {
+				log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, err)
+				return reconcile.Result{RequeueAfter: timeout}, nil
+			}
+			// permanent failure and not requeue.
+			return reconcile.Result{}, nil
+		}
+
+		// Derive the PV topology from Datastore.host[0] -> {zone (from host's cluster), hostname}.
+		datastoreAccessibleTopology, err = getHostLocalAccessibleTopologyFn(ctx, vc, dsInfo, clusterToZone)
+		if err != nil {
+			log.Errorf("failed to resolve host-local topology for volume %s on datastore %s: %+v",
+				volumeID, volume.DatastoreUrl, err)
+			setInstanceError(ctx, r, instance,
+				fmt.Sprintf("failed to resolve host-local topology for volume %s: %+v", volumeID, err))
+			if err = r.cleanupCNSVolume(ctx, instance, volumeID); err != nil {
+				log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, err)
+				return reconcile.Result{RequeueAfter: timeout}, nil
+			}
+			// permanent failure and not requeue.
+			return reconcile.Result{}, nil
+		}
+	} else if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
 		if workloadDomainIsolationEnabled || len(clusterComputeResourceMoIds) > 1 {
 			if isMultipleClustersPerVsphereZoneEnabled {
 				// Get zones assigned to the namespace
@@ -473,9 +564,13 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 
-	// Calculate accessible topology for the provisioned volume.
-	var datastoreAccessibleTopology []map[string]string
-	if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
+	// Calculate accessible topology for the provisioned volume. datastoreAccessibleTopology is
+	// declared earlier and, for host-local volumes, is already populated by the node-driven
+	// resolver, so build the PV node affinity from it directly (covering all configurations,
+	// including non-stretched supervisors). Otherwise fall back to the shared-datastore topology.
+	if isHostLocal {
+		pvNodeAffinity = buildNodeAffinityFromSegments(datastoreAccessibleTopology)
+	} else if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
 		if workloadDomainIsolationEnabled {
 			datastoreAccessibleTopology, err = topologyMgr.GetTopologyInfoFromNodes(ctx,
 				commoncotypes.WCPRetrieveTopologyInfoParams{
@@ -627,10 +722,13 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 
-		// Validate topology compatibility if PVC exists and can be reused
-		if topologyMgr != nil {
+		// Validate topology compatibility if PVC exists and can be reused. For host-local volumes the
+		// topology is already resolved (datastoreAccessibleTopology is non-empty) and topologyMgr is
+		// not consulted, so run the validation even when topologyMgr is nil (e.g. non-stretched
+		// supervisor) to ensure the reused PVC gets the {zone, hostname} annotation.
+		if topologyMgr != nil || isHostLocal {
 			err = validatePVCTopologyCompatibility(ctx, k8sclient, pvc, volume.DatastoreUrl, topologyMgr, vc,
-				datastoreAccessibleTopology)
+				datastoreAccessibleTopology, isHostLocal)
 			if err != nil {
 				msg := fmt.Sprintf("PVC topology validation failed: %v", err)
 				log.Error(msg)
@@ -926,7 +1024,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 // with the volume's actual placement zone.
 func validatePVCTopologyCompatibility(ctx context.Context, k8sclient clientset.Interface, pvc *v1.PersistentVolumeClaim,
 	volumeDatastoreURL string, topologyMgr commoncotypes.ControllerTopologyService,
-	vc *cnsvsphere.VirtualCenter, datastoreAccessibleTopology []map[string]string) error {
+	vc *cnsvsphere.VirtualCenter, datastoreAccessibleTopology []map[string]string, isHostLocal bool) error {
 	log := logger.GetLogger(ctx)
 
 	// Check if PVC has topology annotation
@@ -991,16 +1089,24 @@ func validatePVCTopologyCompatibility(ctx context.Context, k8sclient clientset.I
 			pvc.Namespace, pvc.Name, err)
 	}
 
-	// Get volume topology from datastore URL
-	volumeTopologySegments, err := topologyMgr.GetTopologyInfoFromNodes(ctx,
-		commoncotypes.WCPRetrieveTopologyInfoParams{
-			DatastoreURL:        volumeDatastoreURL,
-			StorageTopologyType: "",
-			TopologyRequirement: nil,
-			Vc:                  vc,
-		})
-	if err != nil {
-		return fmt.Errorf("failed to get topology for volume datastore %s: %v", volumeDatastoreURL, err)
+	// Determine the volume's actual topology. For host-local volumes the caller already resolved the
+	// node-driven {zone, hostname} topology; reuse it directly and skip the shared-datastore
+	// intersection recompute (GetTopologyInfoFromNodes), which would incorrectly drop the single-host
+	// datastore and reject the PVC.
+	var volumeTopologySegments []map[string]string
+	if isHostLocal && len(datastoreAccessibleTopology) > 0 {
+		volumeTopologySegments = datastoreAccessibleTopology
+	} else {
+		volumeTopologySegments, err = topologyMgr.GetTopologyInfoFromNodes(ctx,
+			commoncotypes.WCPRetrieveTopologyInfoParams{
+				DatastoreURL:        volumeDatastoreURL,
+				StorageTopologyType: "",
+				TopologyRequirement: nil,
+				Vc:                  vc,
+			})
+		if err != nil {
+			return fmt.Errorf("failed to get topology for volume datastore %s: %v", volumeDatastoreURL, err)
+		}
 	}
 
 	// Check if volume topology segments are compatible with PVC topology segments

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -30,8 +30,13 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	"github.com/vmware/govmomi"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/pbm"
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
 	vim25types "github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -303,7 +308,20 @@ func (m *mockCOCommon) IsDPOServiceInstalled(ctx context.Context) (bool, error) 
 func (m *mockCOCommon) HandleLateInstallationOfDPOService(ctx context.Context) {
 }
 
+// fssEnabledOverride lets individual tests control the result of mockCOCommon.IsFSSEnabled.
+// When nil (the default), IsFSSEnabled returns true to preserve existing test behavior.
+// Tests that set it must reset it (defer) to avoid leaking state across specs.
+var fssEnabledOverride func(featureName string) bool
+
 func (m *mockCOCommon) IsFSSEnabled(ctx context.Context, featureName string) bool {
+	if fssEnabledOverride != nil {
+		return fssEnabledOverride(featureName)
+	}
+	// Host-local registration is disabled by default so existing specs are unaffected by the
+	// host-local detection path; host-local tests opt in explicitly via fssEnabledOverride.
+	if featureName == common.HostLocalStorageSupport {
+		return false
+	}
 	return true
 }
 
@@ -354,9 +372,11 @@ func (m *mockCOCommon) GetNodeIDtoNameMap(ctx context.Context) map[string]string
 	panic("implement me")
 }
 
+// nodeNameToHostMoIDMapOverride lets host-local tests supply a fixed node-name -> host-MoID map.
+var nodeNameToHostMoIDMapOverride map[string]string
+
 func (m *mockCOCommon) GetNodeNameToHostMoIDMap(ctx context.Context) map[string]string {
-	//TODO implement me
-	panic("implement me")
+	return nodeNameToHostMoIDMapOverride
 }
 
 func (m *mockCOCommon) GetFakeAttachedVolumes(ctx context.Context, volumeIDs []string) map[string]bool {
@@ -896,7 +916,7 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 		patches.ApplyFunc(validatePVCTopologyCompatibility,
 			func(ctx context.Context, k8sclient kubernetes.Interface, pvc *corev1.PersistentVolumeClaim,
 				datastoreURL string, topoMgr commoncotypes.ControllerTopologyService,
-				vc *cnsvsphere.VirtualCenter, datastoreAccessibleTopology []map[string]string) error {
+				vc *cnsvsphere.VirtualCenter, datastoreAccessibleTopology []map[string]string, isHostLocal bool) error {
 				return fmt.Errorf("topology conflict: zone mismatch")
 			})
 		patches.ApplyFunc(setInstanceError, func(ctx context.Context, r *ReconcileCnsRegisterVolume,
@@ -1307,7 +1327,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 			Expect(err).To(BeNil())
 
 			err = validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
-				datastoreAccessibleTopology)
+				datastoreAccessibleTopology, false)
 			Expect(err).To(BeNil())
 		})
 	})
@@ -1325,7 +1345,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 			Expect(err).To(BeNil())
 
 			err = validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
-				datastoreAccessibleTopology)
+				datastoreAccessibleTopology, false)
 			Expect(err).To(BeNil())
 		})
 	})
@@ -1339,7 +1359,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 
 		It("should return error for invalid JSON", func() {
 			err := validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
-				datastoreAccessibleTopology)
+				datastoreAccessibleTopology, false)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("failed to parse topology annotation"))
 		})
@@ -1355,7 +1375,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 
 		It("should return error from topology manager", func() {
 			err := validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
-				datastoreAccessibleTopology)
+				datastoreAccessibleTopology, false)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("failed to get topology for volume datastore"))
 		})
@@ -1373,7 +1393,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 
 		It("should return nil without error", func() {
 			err := validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
-				datastoreAccessibleTopology)
+				datastoreAccessibleTopology, false)
 			Expect(err).To(BeNil())
 		})
 	})
@@ -1390,7 +1410,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 
 		It("should return error for incompatible zones", func() {
 			err := validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
-				datastoreAccessibleTopology)
+				datastoreAccessibleTopology, false)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("is not compatible with volume placement"))
 		})
@@ -1428,7 +1448,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 
 			// Call the function
 			err = validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
-				datastoreAccessibleTopology)
+				datastoreAccessibleTopology, false)
 			Expect(err).To(BeNil())
 
 			// Verify topology annotation was added
@@ -1462,7 +1482,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 
 			// Call the function
 			err = validatePVCTopologyCompatibility(ctx, mockK8sClient, pvcWithNilAnnotations, volumeDatastoreURL,
-				mockTopologyMgr, mockVC, datastoreAccessibleTopology)
+				mockTopologyMgr, mockVC, datastoreAccessibleTopology, false)
 			Expect(err).To(BeNil())
 
 			// Verify annotations map was created and topology annotation was added
@@ -1484,7 +1504,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 			Expect(err).To(BeNil())
 
 			err = validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
-				complexTopology)
+				complexTopology, false)
 			Expect(err).To(BeNil())
 
 			// Verify the complex topology was properly serialized
@@ -1527,7 +1547,7 @@ var _ = Describe("validatePVCTopologyCompatibility", func() {
 				})
 
 			err = validatePVCTopologyCompatibility(ctx, mockK8sClient, pvc, volumeDatastoreURL, mockTopologyMgr, mockVC,
-				datastoreAccessibleTopology)
+				datastoreAccessibleTopology, false)
 			Expect(err).To(BeNil())
 
 			topologyAnnotation, exists := pvc.Annotations["csi.vsphere.volume-accessible-topology"]
@@ -3763,7 +3783,7 @@ func TestClearAndTopologyChain_NoConflict(t *testing.T) {
 	}
 
 	err = validatePVCTopologyCompatibility(ctx, k8sclientFake, updatedPVC, "dummy-datastore-url",
-		mockTopologyMgr, mockVC, datastoreAccessibleTopology)
+		mockTopologyMgr, mockVC, datastoreAccessibleTopology, false)
 	assert.NoError(t, err, `chained call must not surface "PVC topology validation failed"`)
 	assert.Equal(t, `[{"topology.kubernetes.io/zone":"zone-1"}]`,
 		updatedPVC.Annotations[common.AnnVolumeAccessibleTopology])
@@ -3880,4 +3900,341 @@ func TestClearKeepAfterDeleteVm_AnnotationUpdateFailure_ReturnsError(t *testing.
 	// VSLM call should have been made before the annotation update failed
 	assert.Equal(t, []string{"vol-1"}, *calls,
 		"UnprotectVolumeFromVMDeletion should be called before annotation update")
+}
+
+// --- Host-local volume registration tests ---
+
+// TestBuildNodeAffinityFromSegments verifies that PV node affinity is built with both the
+// zone and hostname keys as required node-selector terms, and that an empty input yields nil.
+func TestBuildNodeAffinityFromSegments(t *testing.T) {
+	// Empty input -> nil affinity.
+	assert.Nil(t, buildNodeAffinityFromSegments(nil))
+	assert.Nil(t, buildNodeAffinityFromSegments([]map[string]string{}))
+
+	segments := []map[string]string{
+		{
+			corev1.LabelTopologyZone: "zone-a",
+			corev1.LabelHostname:     "esx-node-1",
+		},
+	}
+	affinity := buildNodeAffinityFromSegments(segments)
+	assert.NotNil(t, affinity)
+	assert.NotNil(t, affinity.Required)
+	assert.Len(t, affinity.Required.NodeSelectorTerms, 1)
+
+	// Collect the match expressions into a key->value map for order-independent assertions.
+	got := map[string]string{}
+	for _, expr := range affinity.Required.NodeSelectorTerms[0].MatchExpressions {
+		assert.Equal(t, corev1.NodeSelectorOpIn, expr.Operator)
+		assert.Len(t, expr.Values, 1)
+		got[expr.Key] = expr.Values[0]
+	}
+	assert.Equal(t, "zone-a", got[corev1.LabelTopologyZone])
+	assert.Equal(t, "esx-node-1", got[corev1.LabelHostname])
+}
+
+// newFakeVCWithClient returns a VirtualCenter with a non-nil client so that object.NewHostSystem
+// can be constructed in tests (the host method itself is patched, so no network call is made).
+func newFakeVCWithClient() *cnsvsphere.VirtualCenter {
+	return &cnsvsphere.VirtualCenter{
+		Config: &cnsvsphere.VirtualCenterConfig{Host: "dummy-vcenter"},
+		Client: &govmomi.Client{Client: &vim25.Client{}},
+	}
+}
+
+func TestBuildClusterToZoneMap(t *testing.T) {
+	azClustersMap := map[string][]string{
+		"zone-a": {"cluster-a1", "cluster-a2"},
+		"zone-b": {"cluster-b1"},
+	}
+	got := buildClusterToZoneMap(azClustersMap)
+	assert.Equal(t, "zone-a", got["cluster-a1"])
+	assert.Equal(t, "zone-a", got["cluster-a2"])
+	assert.Equal(t, "zone-b", got["cluster-b1"])
+	assert.Len(t, got, 3)
+
+	assert.Empty(t, buildClusterToZoneMap(nil))
+}
+
+// newHostLocalDatastoreInfo builds a DatastoreInfo backed by a real object.Datastore so that
+// getHostLocalAccessibleTopology's property-collector calls can be gomonkey-patched.
+func newHostLocalDatastoreInfo(vc *cnsvsphere.VirtualCenter, url string) *cnsvsphere.DatastoreInfo {
+	dsRef := vim25types.ManagedObjectReference{Type: "Datastore", Value: "ds-1"}
+	return &cnsvsphere.DatastoreInfo{
+		Datastore: &cnsvsphere.Datastore{Datastore: object.NewDatastore(vc.Client.Client, dsRef)},
+		Info:      &vim25types.DatastoreInfo{Url: url},
+	}
+}
+
+// patchDatastoreAndHostProperties patches object.Common.Properties (promoted onto both Datastore
+// and HostSystem) to return a fixed Datastore.host[0] and host.parent cluster.
+func patchDatastoreAndHostProperties(patches *gomonkey.Patches, hostMoID, clusterMoID string,
+	emptyHostMounts bool) {
+	patches.ApplyMethod(reflect.TypeOf(object.Common{}), "Properties",
+		func(_ object.Common, _ context.Context, _ vim25types.ManagedObjectReference,
+			ps []string, dst any) error {
+			for _, p := range ps {
+				switch p {
+				case "host":
+					d := dst.(*mo.Datastore)
+					if !emptyHostMounts {
+						d.Host = []vim25types.DatastoreHostMount{
+							{Key: vim25types.ManagedObjectReference{Type: "HostSystem", Value: hostMoID}},
+						}
+					}
+				case "parent":
+					h := dst.(*mo.HostSystem)
+					if clusterMoID != "" {
+						h.Parent = &vim25types.ManagedObjectReference{
+							Type: "ClusterComputeResource", Value: clusterMoID,
+						}
+					}
+				}
+			}
+			return nil
+		})
+}
+
+// TestGetHostLocalAccessibleTopology verifies the reworked derivation: host from Datastore.host[0],
+// hostname from the node-name<->host-MoID map, and zone from the host's cluster.
+func TestGetHostLocalAccessibleTopology(t *testing.T) {
+	ctx := context.Background()
+	commonco.ContainerOrchestratorUtility = &mockCOCommon{}
+	vc := newFakeVCWithClient()
+
+	t.Run("resolves zone+hostname from datastore host[0] and cluster", func(t *testing.T) {
+		nodeNameToHostMoIDMapOverride = map[string]string{"esx-node-2": "host-22"}
+		defer func() { nodeNameToHostMoIDMapOverride = nil }()
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		patchDatastoreAndHostProperties(patches, "host-22", "cluster-a", false)
+
+		dsInfo := newHostLocalDatastoreInfo(vc, "hl-ds-url")
+		topology, err := getHostLocalAccessibleTopology(ctx, vc, dsInfo,
+			map[string]string{"cluster-a": "zone-a"})
+		assert.NoError(t, err)
+		assert.Len(t, topology, 1)
+		assert.Equal(t, "esx-node-2", topology[0][corev1.LabelHostname])
+		assert.Equal(t, "zone-a", topology[0][corev1.LabelTopologyZone])
+	})
+
+	t.Run("errors when datastore has no host mounts", func(t *testing.T) {
+		nodeNameToHostMoIDMapOverride = map[string]string{"esx-node-2": "host-22"}
+		defer func() { nodeNameToHostMoIDMapOverride = nil }()
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		patchDatastoreAndHostProperties(patches, "host-22", "cluster-a", true)
+
+		dsInfo := newHostLocalDatastoreInfo(vc, "hl-ds-url")
+		_, err := getHostLocalAccessibleTopology(ctx, vc, dsInfo, map[string]string{"cluster-a": "zone-a"})
+		assert.Error(t, err)
+	})
+
+	t.Run("errors when host has no matching node", func(t *testing.T) {
+		nodeNameToHostMoIDMapOverride = map[string]string{"esx-node-1": "host-11"}
+		defer func() { nodeNameToHostMoIDMapOverride = nil }()
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		patchDatastoreAndHostProperties(patches, "host-22", "cluster-a", false)
+
+		dsInfo := newHostLocalDatastoreInfo(vc, "hl-ds-url")
+		_, err := getHostLocalAccessibleTopology(ctx, vc, dsInfo, map[string]string{"cluster-a": "zone-a"})
+		assert.Error(t, err)
+	})
+
+	t.Run("errors when host cluster has no zone mapping", func(t *testing.T) {
+		nodeNameToHostMoIDMapOverride = map[string]string{"esx-node-2": "host-22"}
+		defer func() { nodeNameToHostMoIDMapOverride = nil }()
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		patchDatastoreAndHostProperties(patches, "host-22", "cluster-a", false)
+
+		dsInfo := newHostLocalDatastoreInfo(vc, "hl-ds-url")
+		// clusterToZone does not contain cluster-a -> registration must fail.
+		_, err := getHostLocalAccessibleTopology(ctx, vc, dsInfo, map[string]string{"cluster-x": "zone-x"})
+		assert.Error(t, err)
+	})
+}
+
+// TestCheckDatastorePolicyCompatibility verifies the PBM compatibility gate (requirement 1).
+func TestCheckDatastorePolicyCompatibility(t *testing.T) {
+	ctx := context.Background()
+	vc := newFakeVCWithClient()
+	dsInfo := newHostLocalDatastoreInfo(vc, "hl-ds-url") // MoRef value == "ds-1"
+
+	t.Run("compatible when datastore MoRef is in the compatible set", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		patches.ApplyMethod(reflect.TypeOf(&cnsvsphere.VirtualCenter{}), "PbmCheckCompatibility",
+			func(_ *cnsvsphere.VirtualCenter, _ context.Context, _ []vim25types.ManagedObjectReference,
+				_ string) (pbm.PlacementCompatibilityResult, error) {
+				return pbm.PlacementCompatibilityResult{
+					{Hub: pbmtypes.PbmPlacementHub{HubType: "Datastore", HubId: "ds-1"}},
+				}, nil
+			})
+		compatible, err := checkDatastorePolicyCompatibility(ctx, vc, dsInfo, "policy-1")
+		assert.NoError(t, err)
+		assert.True(t, compatible)
+	})
+
+	t.Run("incompatible when datastore MoRef is absent or has errors", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		patches.ApplyMethod(reflect.TypeOf(&cnsvsphere.VirtualCenter{}), "PbmCheckCompatibility",
+			func(_ *cnsvsphere.VirtualCenter, _ context.Context, _ []vim25types.ManagedObjectReference,
+				_ string) (pbm.PlacementCompatibilityResult, error) {
+				// A different datastore is compatible; ds-1 carries an error so it is excluded.
+				return pbm.PlacementCompatibilityResult{
+					{Hub: pbmtypes.PbmPlacementHub{HubType: "Datastore", HubId: "ds-other"}},
+					{
+						Hub:   pbmtypes.PbmPlacementHub{HubType: "Datastore", HubId: "ds-1"},
+						Error: []vim25types.LocalizedMethodFault{{LocalizedMessage: "not compatible"}},
+					},
+				}, nil
+			})
+		compatible, err := checkDatastorePolicyCompatibility(ctx, vc, dsInfo, "policy-1")
+		assert.NoError(t, err)
+		assert.False(t, compatible)
+	})
+}
+
+// newHostLocalReconcileFixture wires a reconciler and the patches common to a host-local reconcile
+// test: capability enabled, VC instance, create spec, volume query (host-local policy),
+// IsHostLocalStoragePolicy=true, datastore resolution, and setInstanceError/cleanup observers.
+// Callers add PBM/topology behavior and must `defer func(){ fssEnabledOverride = nil }()`.
+func newHostLocalReconcileFixture(patches *gomonkey.Patches) (
+	*ReconcileCnsRegisterVolume, *bool, *bool) {
+	// Initialize backOffDuration map to prevent nil map assignment panic when a test runs alone.
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	scheme.AddKnownTypes(schema.GroupVersion{Group: "cnsoperator.vmware.com", Version: "v1alpha1"},
+		&cnsregistervolumev1alpha1.CnsRegisterVolume{}, &cnsregistervolumev1alpha1.CnsRegisterVolumeList{})
+
+	crv := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-volume", Namespace: "test-ns"},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName: "test-pvc", VolumeID: "dummy-volume-id", AccessMode: "ReadWriteOnce",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(crv).Build()
+
+	commonco.ContainerOrchestratorUtility = &mockCOCommon{}
+	fssEnabledOverride = func(_ string) bool { return true }
+
+	r := &ReconcileCnsRegisterVolume{
+		client: fakeClient,
+		scheme: scheme,
+		volumeManager: &mockVolumeManager{
+			createVolumeFunc: func(_ context.Context, _ *cnstypes.CnsVolumeCreateSpec,
+				_ interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+				return &cnsvolume.CnsVolumeInfo{VolumeID: cnstypes.CnsVolumeId{Id: "dummy-volume-id"}}, "", nil
+			},
+		},
+	}
+
+	patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(_ context.Context,
+		_ *config.ConfigurationInfo, _ bool) (*cnsvsphere.VirtualCenter, error) {
+		return newFakeVCWithClient(), nil
+	})
+	patches.ApplyFunc(constructCreateSpecForInstance, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ string, _ bool) *cnstypes.CnsVolumeCreateSpec {
+		return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}
+	})
+	patches.ApplyFunc(common.QueryVolumeByID, func(_ context.Context, _ cnsvolume.Manager,
+		volumeID string, _ *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
+		return &cnstypes.CnsVolume{
+			VolumeId:        cnstypes.CnsVolumeId{Id: volumeID},
+			DatastoreUrl:    "host-local-ds-url",
+			StoragePolicyId: "host-local-policy-id",
+			BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+				CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
+			},
+		}, nil
+	})
+	patches.ApplyMethod(reflect.TypeOf(&cnsvsphere.VirtualCenter{}), "IsHostLocalStoragePolicy",
+		func(_ *cnsvsphere.VirtualCenter, _ context.Context, _ string) (bool, error) {
+			return true, nil
+		})
+	patches.ApplyFunc(cnsvsphere.GetDatastoreInfoByURL, func(_ context.Context, vc *cnsvsphere.VirtualCenter,
+		_ []string, url string) (*cnsvsphere.DatastoreInfo, error) {
+		return newHostLocalDatastoreInfo(vc, url), nil
+	})
+
+	setErrCalled := false
+	patches.ApplyFunc(setInstanceError, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ string) {
+		setErrCalled = true
+	})
+	// cleanupCNSVolume (unexported) calls untagCNSVolume -> common.DeleteVolumeUtil for a non-DiskURLPath
+	// registration; patch DeleteVolumeUtil to observe the cleanup and avoid touching a real volume manager.
+	cleanupCalled := false
+	patches.ApplyFunc(common.DeleteVolumeUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ string, _ bool) (string, error) {
+		cleanupCalled = true
+		return "", nil
+	})
+
+	return r, &setErrCalled, &cleanupCalled
+}
+
+// TestReconcileHostLocalPBMIncompatible verifies that a host-local volume whose datastore is not
+// PBM-compatible with the policy fails registration permanently (no requeue) and is cleaned up.
+func TestReconcileHostLocalPBMIncompatible(t *testing.T) {
+	ctx := context.Background()
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	r, setErrCalled, cleanupCalled := newHostLocalReconcileFixture(patches)
+	defer func() { fssEnabledOverride = nil }()
+
+	checkDatastorePolicyCompatibilityFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ *cnsvsphere.DatastoreInfo, _ string) (bool, error) {
+		return false, nil
+	}
+	defer func() { checkDatastorePolicyCompatibilityFn = checkDatastorePolicyCompatibility }()
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-volume", Namespace: "test-ns"}}
+	result, err := r.Reconcile(ctx, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+	assert.True(t, *setErrCalled, "setInstanceError should be called for a PBM-incompatible host-local volume")
+	assert.True(t, *cleanupCalled, "cleanupCNSVolume should be called for a PBM-incompatible host-local volume")
+}
+
+// TestReconcileHostLocalTopologyError verifies that when the host-local topology cannot be derived
+// (e.g. no cluster-derived zone), the reconcile fails permanently and the CNS volume is cleaned up.
+func TestReconcileHostLocalTopologyError(t *testing.T) {
+	ctx := context.Background()
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	r, setErrCalled, cleanupCalled := newHostLocalReconcileFixture(patches)
+	defer func() { fssEnabledOverride = nil }()
+
+	checkDatastorePolicyCompatibilityFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ *cnsvsphere.DatastoreInfo, _ string) (bool, error) {
+		return true, nil
+	}
+	defer func() { checkDatastorePolicyCompatibilityFn = checkDatastorePolicyCompatibility }()
+
+	getHostLocalAccessibleTopologyFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ *cnsvsphere.DatastoreInfo, _ map[string]string) ([]map[string]string, error) {
+		return nil, fmt.Errorf("no zone mapping found for the host's cluster")
+	}
+	defer func() { getHostLocalAccessibleTopologyFn = getHostLocalAccessibleTopology }()
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-volume", Namespace: "test-ns"}}
+	result, err := r.Reconcile(ctx, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+	assert.True(t, *setErrCalled, "setInstanceError should be called when host-local topology cannot be derived")
+	assert.True(t, *cleanupCalled, "cleanupCNSVolume should be called when host-local topology cannot be derived")
 }

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -27,6 +27,9 @@ import (
 	"github.com/google/uuid"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -106,6 +109,149 @@ func isDatastoreAccessibleToAZClusters(ctx context.Context, vc *vsphere.VirtualC
 		}
 	}
 	return false
+}
+
+// buildClusterToZoneMap inverts the AvailabilityZone -> clusters map (zone -> []clusterMoID)
+// into a clusterMoID -> zone map, used to derive the zone of a host-local volume from the
+// cluster its backing ESX host belongs to.
+func buildClusterToZoneMap(azClustersMap map[string][]string) map[string]string {
+	clusterToZone := make(map[string]string)
+	for zone, clusters := range azClustersMap {
+		for _, cluster := range clusters {
+			clusterToZone[cluster] = zone
+		}
+	}
+	return clusterToZone
+}
+
+// checkDatastorePolicyCompatibilityFn allows tests to substitute the PBM compatibility check.
+var checkDatastorePolicyCompatibilityFn = checkDatastorePolicyCompatibility
+
+// checkDatastorePolicyCompatibility reports whether the given datastore is PBM-compatible with
+// the storage policy, using vc.PbmCheckCompatibility. A datastore is compatible when its MoRef
+// appears in the policy's compatible-datastore set (hubs with no compatibility error).
+func checkDatastorePolicyCompatibility(ctx context.Context, vc *vsphere.VirtualCenter,
+	dsInfo *vsphere.DatastoreInfo, storagePolicyID string) (bool, error) {
+	log := logger.GetLogger(ctx)
+	compat, err := vc.PbmCheckCompatibility(ctx,
+		[]vimtypes.ManagedObjectReference{dsInfo.Reference()}, storagePolicyID)
+	if err != nil {
+		return false, logger.LogNewErrorf(log,
+			"failed to check PBM compatibility of datastore %q with policy %q: %v",
+			dsInfo.Info.Url, storagePolicyID, err)
+	}
+	for _, hub := range compat.CompatibleDatastores() {
+		if hub.HubId == dsInfo.Reference().Value {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// getHostLocalAccessibleTopologyFn is the function used to resolve the accessible
+// topology of a host-local volume. It is a variable so that tests can substitute a
+// fake implementation without needing gomonkey.
+var getHostLocalAccessibleTopologyFn = getHostLocalAccessibleTopology
+
+// getHostLocalAccessibleTopology returns the PV node-affinity topology segments for a
+// host-local volume, pinned to the single ESX host that mounts the datastore:
+// {topology.kubernetes.io/zone, kubernetes.io/hostname}.
+//
+// Derivation (per feature requirements):
+//   - host: Datastore.host[0] — the first host mount of the datastore.
+//   - hostname: the kubernetes.io/hostname value for that host, obtained by reversing
+//     the node-name -> ESX-host-MoID map (on a supervisor the node name equals the
+//     kubernetes.io/hostname label value).
+//   - zone: derived from the cluster the host belongs to (host.parent) via clusterToZone,
+//     which is the inverted AvailabilityZone -> clusters map.
+//
+// Registration cannot proceed if any segment cannot be derived, so this returns an error
+// (not an empty result) when the datastore has no host mount, the host has no matching
+// supervisor node, or the host's cluster has no zone mapping.
+func getHostLocalAccessibleTopology(ctx context.Context, vc *vsphere.VirtualCenter,
+	dsInfo *vsphere.DatastoreInfo, clusterToZone map[string]string) ([]map[string]string, error) {
+	log := logger.GetLogger(ctx)
+
+	// Datastore.host[0]: the ESX host that mounts the host-local datastore.
+	var dsMo mo.Datastore
+	if err := dsInfo.Properties(ctx, dsInfo.Reference(), []string{"host"}, &dsMo); err != nil {
+		return nil, logger.LogNewErrorf(log,
+			"failed to retrieve host mounts for datastore %q: %v", dsInfo.Info.Url, err)
+	}
+	if len(dsMo.Host) == 0 {
+		return nil, logger.LogNewErrorf(log,
+			"host-local datastore %q has no host mounts", dsInfo.Info.Url)
+	}
+	hostRef := dsMo.Host[0].Key
+
+	// hostname: reverse the node-name -> host-MoID map to resolve the host to its node name,
+	// which is the kubernetes.io/hostname value on a supervisor.
+	nodeNameToHostMoID := commonco.ContainerOrchestratorUtility.GetNodeNameToHostMoIDMap(ctx)
+	hostname := ""
+	for nodeName, hostMoID := range nodeNameToHostMoID {
+		if hostMoID == hostRef.Value {
+			hostname = nodeName
+			break
+		}
+	}
+	if hostname == "" {
+		return nil, logger.LogNewErrorf(log,
+			"failed to resolve kubernetes.io/hostname for ESX host %q backing host-local datastore %q",
+			hostRef.Value, dsInfo.Info.Url)
+	}
+
+	// zone: derive from the cluster the host belongs to (host.parent).
+	hostObj := object.NewHostSystem(vc.Client.Client, hostRef)
+	var hostMo mo.HostSystem
+	if err := hostObj.Properties(ctx, hostRef, []string{"parent"}, &hostMo); err != nil {
+		return nil, logger.LogNewErrorf(log,
+			"failed to retrieve parent cluster for ESX host %q: %v", hostRef.Value, err)
+	}
+	if hostMo.Parent == nil {
+		return nil, logger.LogNewErrorf(log,
+			"ESX host %q backing host-local datastore %q has no parent cluster", hostRef.Value, dsInfo.Info.Url)
+	}
+	zone, ok := clusterToZone[hostMo.Parent.Value]
+	if !ok || zone == "" {
+		return nil, logger.LogNewErrorf(log,
+			"no zone mapping found for cluster %q (host %q); host-local registration requires a "+
+				"zone derived from the host's cluster", hostMo.Parent.Value, hostRef.Value)
+	}
+
+	segment := map[string]string{
+		v1.LabelTopologyZone: zone,
+		v1.LabelHostname:     hostname,
+	}
+	log.Infof("host-local datastore %q resolved to host %q (node %q) in cluster %q, topology: %+v",
+		dsInfo.Info.Url, hostRef.Value, hostname, hostMo.Parent.Value, segment)
+	return []map[string]string{segment}, nil
+}
+
+// buildNodeAffinityFromSegments builds a PV VolumeNodeAffinity from topology segments.
+// Each segment contributes one NodeSelectorTerm whose match expressions require every
+// segment key to equal its value (In operator), so both the zone and hostname keys of a
+// host-local segment become required node-selector terms on the PV.
+func buildNodeAffinityFromSegments(segments []map[string]string) *v1.VolumeNodeAffinity {
+	if len(segments) == 0 {
+		return nil
+	}
+	var terms []v1.NodeSelectorTerm
+	for _, segment := range segments {
+		expressions := make([]v1.NodeSelectorRequirement, 0, len(segment))
+		for key, value := range segment {
+			expressions = append(expressions, v1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{value},
+			})
+		}
+		terms = append(terms, v1.NodeSelectorTerm{MatchExpressions: expressions})
+	}
+	return &v1.VolumeNodeAffinity{
+		Required: &v1.NodeSelector{
+			NodeSelectorTerms: terms,
+		},
+	}
 }
 
 // clearKeepAfterDeleteVmIfNonRemovable clears the keepAfterDeleteVm control flag

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -397,6 +397,13 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,
 				common.WCPMobilityNonDisruptiveImport, "", "")
 		}
+		// HostLocalStorageSupport gates host-local volume registration via CNSRegisterVolume. If the
+		// capability is not enabled yet (e.g. VC upgraded before the supervisor), poll the capabilities
+		// CR and restart the syncer container when it flips to enabled so the feature becomes active.
+		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.HostLocalStorageSupport) {
+			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, clusterFlavor,
+				common.HostLocalStorageSupport, "", "")
+		}
 		if !isSharedDiskEabled {
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
 				clusterFlavor, common.SharedDiskFss, "", "")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
**Context & Problem**
Previously, the CnsRegisterVolume operator (syncer, WCP/Supervisor) would fail to register First Class Disks (FCDs) or VMDKs residing on host-local datastores (e.g., per-host local VMFS). This occurred because the registrations failed at the accessibility gate, as GetCandidateDatastoresInCluster only returns datastores shared across all hosts, effectively dropping single-host, host-local datastores.

**Solution**
This PR enables the registration of FCDs/VMDKs on host-local datastores by introducing host-local policy detection, bypassing the shared-datastore gate, and synthesizing the appropriate Kubernetes node affinity and topologies.

🛠️ Key Changes
1. Host-Local Policy Detection
Detected host-local policies via the SPBM capability namespace com.vmware.storage.hostlocalstorage (capability ID: hostLocalStorage). This aligns with the signal the WCP control plane uses to classify a policy as host-local.

Because this capability carries no property instances, it bypasses the existing PbmRetrieveContent/SpbmPolicyContent simplification (which silently drops it because it only emits a rule per property instance). Instead, it directly checks against the raw PbmCapabilitySubProfileConstraints/PbmCapabilityInstance structures.

Gated this behavior behind the supports_host_local_storage capability, including late-enablement restart handling in the syncer.

2. Gate Bypassing & Compatibility Checks
Bypassed the "accessible to all hosts" gate specifically for host-local volumes.

Added an explicit PbmCheckCompatibility gate to ensure the policy is fully compatible with the disk's datastore.

3. Topology & Node Affinity Synthesis
Synthesized PV host-level node affinity by mapping the host from Datastore.host[0] to the kubernetes.io/hostname value.

Derived the zone from the host's cluster using the AvailabilityZone map (registration will fail if no cluster-derived zone exists).

4. PV/PVC Binding & Validation
Bound the PV to the host-local StorageClass resolved from the matched policy.

Set the csi.vsphere.volume-accessible-topology annotation.

Skipped the intersection-based topology recompute in validatePVCTopologyCompatibility for host-local PVCs.



**Testing done**:
Manual testing.

Created VM using host-local spbm policy on local vmfs datastore and imported into supervisor.
Verified CNSRegisterVolume, PVC and PV

```
# kubectl describe cnsregistervolume -n divyen-ns 
Name:         test-hostlocalvm-7a07db55
Namespace:    divyen-ns
Labels:       vmoperator.vmware.com/created-by=test-hostlocalvm
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsRegisterVolume
Metadata:
  Creation Timestamp:  2026-07-10T21:40:58Z
  Finalizers:
    cns.vmware.com/register-volume
  Generation:  1
  Owner References:
    API Version:           v1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  PersistentVolumeClaim
    Name:                  test-hostlocalvm-7a07db55
    UID:                   1be1c14d-9c65-4667-a371-d46232205324
  Resource Version:        3335074
  UID:                     db11df32-0ee1-424e-aa4e-9632c9f6e7b7
Spec:
  Access Mode:    ReadWriteOnce
  Backing Type:   FlatVer2BackingInfo
  Disk URL Path:  https://lvn-dvm-10-161-25-107.dvm.lvn.broadcom.net:443/folder/test-hostlocalvm/test-hostlocalvm.vmdk?dcPath=%2Fwcp-sanity&dsName=local-0
  Pvc Name:       test-hostlocalvm-7a07db55
  Volume Mode:    Block
Status:
  Registered:  true
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  CnsRegisterVolumeSucceeded  0s    cns.vmware.com  Successfully registered the volume on namespace: divyen-ns
```


```
# kubectl describe pvc test-hostlocalvm-7a07db55 -n divyen-ns
Name:          test-hostlocalvm-7a07db55
Namespace:     divyen-ns
StorageClass:  hostlocalvmfs
Status:        Bound
Volume:        static-pv-aa790224-e064-49ba-965f-306fe97bcf4d
Labels:        <none>
Annotations:   cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
               cns.vmware.com/usedby-vm-5007e119-c58a-370d-5c70-f68147c39b92: 
               cns.vmware.com/vm-delete-protection-cleared: true
               csi.vsphere.volume-accessible-topology:
                 [{"kubernetes.io/hostname":"lvn-dvm-10-161-28-187.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection cns.vmware.com/pvc-protection]
Capacity:      16Gi
Access Modes:  RWO
VolumeMode:    Block
DataSource:
  APIGroup:  vmoperator.vmware.com
  Kind:      VirtualMachine
  Name:      test-hostlocalvm
Used By:     <none>
Events:
  Type    Reason                Age                From                                                                                          Message
  ----    ------                ----               ----                                                                                          -------
  Normal  ExternalProvisioning  82s (x3 over 87s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  Provisioning          82s (x3 over 87s)  csi.vsphere.vmware.com_4207f86a13fc9ebf14fc3aeaac29df1d_cc6057c1-0458-4209-ac7c-381e69a778f6  External provisioner is provisioning volume for claim "divyen-ns/test-hostlocalvm-7a07db55"
  Normal  Provisioning          82s (x3 over 87s)  external-provisioner                                                                          Assuming an external populator will provision the volume
```


```
# kubectl describe pv static-pv-aa790224-e064-49ba-965f-306fe97bcf4d
Name:              static-pv-aa790224-e064-49ba-965f-306fe97bcf4d
Labels:            cns.vmware.com/cnsregistervolume-name=test-hostlocalvm-7a07db55
                   cns.vmware.com/cnsregistervolume-namespace=divyen-ns
                   cns.vmware.com/created-by=cnsregistervolume
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection external-provisioner.volume.kubernetes.io/finalizer]
StorageClass:      hostlocalvmfs
Status:            Bound
Claim:             divyen-ns/test-hostlocalvm-7a07db55
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Block
Capacity:          16Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [az1]
                   kubernetes.io/hostname in [lvn-dvm-10-161-28-187.dvm.lvn.broadcom.net]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            
    VolumeHandle:      aa790224-e064-49ba-965f-306fe97bcf4d
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>
```

**Special notes for your reviewer**:

WCP Pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1801/
VKS Pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1358/


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support host-local volume registration via CnsRegisterVolume API
```
