### PR TITLE
Translate VKS host-local topology key to/from Supervisor PVC annotations

### DIFF
--- a/manifests/guestcluster/1.36/pvcsi.yaml
+++ b/manifests/guestcluster/1.36/pvcsi.yaml
@@ -747,6 +747,7 @@ data:
   "vsan-file-volume-service-support": "false"
   "CSI_Backup_API": "false"
   "improved-volume-visibility": "false"
+  "host-local-storage-support": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -343,6 +343,12 @@ const (
 	// topology labels applied on the node by vSphere CSI driver.
 	TopologyLabelsDomain = "topology.csi.vmware.com"
 
+	// GuestClusterTopologyLabelHost is the host-scoped topology key published on VKS/guest cluster
+	// CSINode objects when host-local storage provisioning is available. It must be translated to
+	// v1.LabelHostname ("kubernetes.io/hostname") on the Supervisor PVC's requested/accessible
+	// topology annotations, since the Supervisor only recognizes the standard hostname label.
+	GuestClusterTopologyLabelHost = TopologyLabelsDomain + "/host"
+
 	// AnnGuestClusterRequestedTopology is the key for guest cluster requested topology
 	AnnGuestClusterRequestedTopology = "csi.vsphere.volume-requested-topology"
 
@@ -686,6 +692,9 @@ const (
 	// CnsVolumeCreateSpec, and builds PV node affinity from the host returned in
 	// the CNS placement result.
 	HostLocalStorageSupport = "supports_host_local_storage"
+	// HostLocalStorageSupportFSS is the pvCSI FSS paired with HostLocalStorageSupport
+	// on the supervisor.
+	HostLocalStorageSupportFSS = "host-local-storage-support"
 )
 
 var WCPFeatureStates = map[string]struct{}{
@@ -740,4 +749,5 @@ var WCPFeatureStateAssociatedWithPVCSI = map[string]string{
 	VsanFileVolumeServiceSupportFSS: VsanFileVolumeService,
 	CSI_Backup_API_FSS:              CSI_Backup_API,
 	VMPVCStoragePolicyMutabilityFSS: VMPVCStoragePolicyMutability,
+	HostLocalStorageSupportFSS:      HostLocalStorageSupport,
 }

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -407,6 +407,13 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		} else {
 			volumeType = prometheus.PrometheusBlockVolumeType
 		}
+		// isHostLocalStorageSupportFSSEnabled ANDs the pvCSI-side host-local-storage-support FSS
+		// with the Supervisor's supports_host_local_storage capability, via
+		// common.WCPFeatureStateAssociatedWithPVCSI. Used both when building the requested-topology
+		// annotation below and when building the accessible-topology response after the Supervisor
+		// PVC is bound.
+		isHostLocalStorageSupportFSSEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+			common.HostLocalStorageSupportFSS)
 
 		// Get PVC name and disk size for the supervisor cluster
 		// We use default prefix 'pvc-' for pvc created in the guest cluster, it is mandatory.
@@ -559,8 +566,28 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					!isLinkedCloneRequest && // the cns-csi mutation webhook in supervisor will automatically set it.
 					(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 						!isFileVolumeRequest) {
+					// Reject the request if it carries the VKS host-scoped topology key while the
+					// host-local-storage-support FSS/capability is disabled. Silently dropping the
+					// host key here would let the volume be provisioned without honoring the
+					// topology constraint the guest scheduler required (e.g. a pod already bound to
+					// a specific node via WaitForFirstConsumer), which is worse than failing fast.
+					// Mirrors the equivalent rejection in pkg/csi/service/wcp/controller.go.
+					translatedPreferred := make([]*csi.Topology, 0, len(req.AccessibilityRequirements.Preferred))
+					for _, t := range req.AccessibilityRequirements.Preferred {
+						if _, hasHostKey := t.Segments[common.GuestClusterTopologyLabelHost]; hasHostKey &&
+							!isHostLocalStorageSupportFSSEnabled {
+							msg := fmt.Sprintf("host-local storage policy volume provisioning is not supported: "+
+								"%s FSS/capability is not enabled, but requested topology contains %s. Request: %+v",
+								common.HostLocalStorageSupportFSS, common.GuestClusterTopologyLabelHost, req)
+							return nil, csifault.CSIUnimplementedFault, status.Error(codes.Unimplemented, msg)
+						}
+						translatedPreferred = append(translatedPreferred, &csi.Topology{
+							Segments: translateTopologyHostKey(t.Segments, common.GuestClusterTopologyLabelHost,
+								corev1.LabelHostname, true),
+						})
+					}
 					// Generate volume topology requirement annotation.
-					topologyAnnotation, err := generateGuestClusterRequestedTopologyJSON(req.AccessibilityRequirements.Preferred)
+					topologyAnnotation, err := generateGuestClusterRequestedTopologyJSON(translatedPreferred)
 					if err != nil {
 						msg := fmt.Sprintf("failed to generate accessibility topology for pvc with name: %s "+
 							"on namespace: %s from supervisorCluster. Error: %+v",
@@ -723,10 +750,17 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			log.Infof("Volume %q created is accessible from zones: %+v", supervisorPVCName,
 				accessibleTopologies)
 
-			// Add topology segments to the CreateVolumeResponse.
+			// Add topology segments to the CreateVolumeResponse. The hostname key is always
+			// translated back to the VKS host key when present, regardless of the current
+			// host-local-storage-support FSS/capability state: by this point the volume's host
+			// pinning in CNS (if any) is already a committed fact, so dropping the key here
+			// (e.g. on an idempotent retry against an already-bound PVC, or if the
+			// FSS/capability was toggled off after the volume was created) would misrepresent
+			// it and could let Kubernetes schedule the pod where the volume can't attach.
 			for _, topoSegments := range accessibleTopologies {
 				volumeTopology := &csi.Topology{
-					Segments: topoSegments,
+					Segments: translateTopologyHostKey(topoSegments, corev1.LabelHostname,
+						common.GuestClusterTopologyLabelHost, true),
 				}
 				resp.Volume.AccessibleTopology = append(resp.Volume.AccessibleTopology, volumeTopology)
 			}

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -284,6 +284,30 @@ func constructVolumeSnapshotWithVolumeSnapshotClass(volumeSnapshotName string, n
 	return volumeSnapshot
 }
 
+// translateTopologyHostKey returns a copy of segments with fromKey renamed to
+// toKey. If keepHostKey is false, fromKey is dropped instead of renamed
+// (used when the host-local FSS/capability is disabled, so a host-scoped
+// key is never forwarded across the guest/supervisor boundary where the
+// other side wouldn't recognize it, or would misinterpret its value).
+// Segments without fromKey are returned unchanged.
+func translateTopologyHostKey(segments map[string]string, fromKey, toKey string,
+	keepHostKey bool) map[string]string {
+	val, ok := segments[fromKey]
+	if !ok {
+		return segments
+	}
+	translated := make(map[string]string, len(segments))
+	for k, v := range segments {
+		if k != fromKey {
+			translated[k] = v
+		}
+	}
+	if keepHostKey {
+		translated[toKey] = val
+	}
+	return translated
+}
+
 // generateGuestClusterRequestedTopologyJSON translates the topology into a json string to be set on the supervisor
 // PVC
 func generateGuestClusterRequestedTopologyJSON(topologies []*csi.Topology) (string, error) {

--- a/pkg/csi/service/wcpguest/controller_hostlocal_test.go
+++ b/pkg/csi/service/wcpguest/controller_hostlocal_test.go
@@ -1,0 +1,373 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wcpguest
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+)
+
+const (
+	hostLocalZoneValue  = "az1"
+	hostLocalHostValue  = "lvn-dvm-10-161-28-26.dvm.lvn.broadcom.net"
+	hostLocalAccessMode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+)
+
+// hostLocalWantAnnotation builds the expected JSON value for a single-segment topology
+// annotation (used for both the requested- and accessible-topology annotations, which share
+// the same array-of-segment-maps shape) carrying hostKey and the standard zone key.
+func hostLocalWantAnnotation(hostKey string) string {
+	return `[{"` + hostKey + `":"` + hostLocalHostValue + `","topology.kubernetes.io/zone":"` + hostLocalZoneValue + `"}]`
+}
+
+// hostLocalCreateRequest builds a CreateVolumeRequest carrying the VKS host
+// topology key (common.GuestClusterTopologyLabelHost) alongside the standard
+// zone key, mirroring what a WaitForFirstConsumer PVC scheduled to a VKS node
+// with a host-local storage class would produce. Either zone or host may be
+// left empty to omit that segment.
+func hostLocalCreateRequest(accessMode csi.VolumeCapability_AccessMode_Mode,
+	zone, host string) *csi.CreateVolumeRequest {
+	params := map[string]string{
+		common.AttributeSupervisorStorageClass: testStorageClass,
+		common.AttributePvcName:                fvsCreateGuestPVCName,
+		common.AttributePvcNamespace:           fvsCreateGuestPVCNamespace,
+	}
+	req := &csi.CreateVolumeRequest{
+		Name: testVolumeName,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters: params,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{AccessMode: &csi.VolumeCapability_AccessMode{Mode: accessMode}},
+		},
+	}
+	segment := map[string]string{}
+	if zone != "" {
+		segment["topology.kubernetes.io/zone"] = zone
+	}
+	if host != "" {
+		segment[common.GuestClusterTopologyLabelHost] = host
+	}
+	if len(segment) > 0 {
+		req.AccessibilityRequirements = &csi.TopologyRequirement{
+			Requisite: []*csi.Topology{{Segments: segment}},
+			Preferred: []*csi.Topology{{Segments: segment}},
+		}
+	}
+	return req
+}
+
+// waitForSupervisorPVCCreated polls until the supervisor PVC referenced by the CreateVolume call
+// under way in respCh/errCh appears, or that call has already returned (e.g. an early rejection
+// before the PVC would have been created). Returns the created PVC, or nil plus the CreateVolume
+// result if the call already completed without creating one.
+func waitForSupervisorPVCCreated(t *testing.T, c *controller, respCh chan *csi.CreateVolumeResponse,
+	errCh chan error) (*v1.PersistentVolumeClaim, *csi.CreateVolumeResponse, error) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("supervisor PVC %s was not created within timeout", fvsCreateSupervisorPVCName)
+		default:
+		}
+		got, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+			context.Background(), fvsCreateSupervisorPVCName, metav1.GetOptions{})
+		if err == nil {
+			return got, nil, nil
+		}
+		select {
+		case respErr := <-errCh:
+			resp := <-respCh
+			return nil, resp, respErr
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}
+
+// runCreateVolumeAndBindSupervisorPVCWithAccessibleTopology mirrors
+// runCreateVolumeAndBindSupervisorPVC (controller_fvs_create_test.go) but lets
+// the caller control the csi.vsphere.volume-accessible-topology annotation
+// set on the supervisor PVC before it is marked Bound, so tests can exercise
+// the response-side host-key translation with an arbitrary annotation value.
+// The optional beforeBind hook runs after the supervisor PVC is observed but
+// before it is patched to Bound, so a test can mutate shared state (e.g.
+// toggle an FSS) in that window.
+func runCreateVolumeAndBindSupervisorPVCWithAccessibleTopology(t *testing.T, c *controller,
+	req *csi.CreateVolumeRequest, accessibleTopologyAnnotation string,
+	beforeBind func()) (*csi.CreateVolumeResponse, error) {
+	t.Helper()
+	respCh := make(chan *csi.CreateVolumeResponse, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		resp, err := c.CreateVolume(context.Background(), req)
+		respCh <- resp
+		errCh <- err
+	}()
+
+	pvc, earlyResp, earlyErr := waitForSupervisorPVCCreated(t, c, respCh, errCh)
+	if pvc == nil {
+		return earlyResp, earlyErr
+	}
+
+	if beforeBind != nil {
+		beforeBind()
+	}
+
+	if pvc.Annotations == nil {
+		pvc.Annotations = map[string]string{}
+	}
+	pvc.Annotations[common.AnnVolumeAccessibleTopology] = accessibleTopologyAnnotation
+	pvc.Status.Phase = v1.ClaimBound
+	if _, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Update(
+		context.Background(), pvc, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to mark supervisor PVC bound: %v", err)
+	}
+
+	resp := <-respCh
+	err := <-errCh
+	return resp, err
+}
+
+// --- translateTopologyHostKey helper tests --------------------------------
+
+func TestTranslateTopologyHostKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		segments    map[string]string
+		fromKey     string
+		toKey       string
+		keepHostKey bool
+		want        map[string]string
+	}{
+		{
+			name: "key present, keepHostKey true renames the key",
+			segments: map[string]string{
+				common.GuestClusterTopologyLabelHost: hostLocalHostValue,
+				"topology.kubernetes.io/zone":        hostLocalZoneValue,
+			},
+			fromKey:     common.GuestClusterTopologyLabelHost,
+			toKey:       v1.LabelHostname,
+			keepHostKey: true,
+			want: map[string]string{
+				v1.LabelHostname:              hostLocalHostValue,
+				"topology.kubernetes.io/zone": hostLocalZoneValue,
+			},
+		},
+		{
+			name: "key present, keepHostKey false drops the key",
+			segments: map[string]string{
+				common.GuestClusterTopologyLabelHost: hostLocalHostValue,
+				"topology.kubernetes.io/zone":        hostLocalZoneValue,
+			},
+			fromKey:     common.GuestClusterTopologyLabelHost,
+			toKey:       v1.LabelHostname,
+			keepHostKey: false,
+			want: map[string]string{
+				"topology.kubernetes.io/zone": hostLocalZoneValue,
+			},
+		},
+		{
+			name: "key absent is a no-op regardless of keepHostKey",
+			segments: map[string]string{
+				"topology.kubernetes.io/zone": hostLocalZoneValue,
+			},
+			fromKey:     common.GuestClusterTopologyLabelHost,
+			toKey:       v1.LabelHostname,
+			keepHostKey: true,
+			want: map[string]string{
+				"topology.kubernetes.io/zone": hostLocalZoneValue,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := translateTopologyHostKey(tc.segments, tc.fromKey, tc.toKey, tc.keepHostKey)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("translateTopologyHostKey() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- CreateVolume request-side translation tests --------------------------
+
+func TestCreateVolume_HostLocal_RequestedTopology_TranslatesHostKey(t *testing.T) {
+	c := newFVSCreateController(t)
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("failed to build fake CO: %v", err)
+	}
+	commonco.ContainerOrchestratorUtility = co
+	if err := co.EnableFSS(context.Background(), common.HostLocalStorageSupportFSS); err != nil {
+		t.Fatalf("failed to enable FSS: %v", err)
+	}
+
+	req := hostLocalCreateRequest(hostLocalAccessMode, hostLocalZoneValue, hostLocalHostValue)
+	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c, req)
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	expectSupervisorAnnotation(t, pvc, hostLocalWantAnnotation(v1.LabelHostname))
+}
+
+func TestCreateVolume_HostLocal_FSSDisabled_RejectsHostKey(t *testing.T) {
+	c := newFVSCreateController(t)
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("failed to build fake CO: %v", err)
+	}
+	commonco.ContainerOrchestratorUtility = co
+	if err := co.DisableFSS(context.Background(), common.HostLocalStorageSupportFSS); err != nil {
+		t.Fatalf("failed to disable FSS: %v", err)
+	}
+
+	req := hostLocalCreateRequest(hostLocalAccessMode, hostLocalZoneValue, hostLocalHostValue)
+	_, err = c.CreateVolume(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected CreateVolume to fail when host key is present and FSS is disabled")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Unimplemented {
+		t.Fatalf("expected codes.Unimplemented, got: %v", err)
+	}
+
+	_, getErr := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+		context.Background(), fvsCreateSupervisorPVCName, metav1.GetOptions{})
+	if !apierrors.IsNotFound(getErr) {
+		t.Fatalf("expected no supervisor PVC to be created, got err: %v", getErr)
+	}
+}
+
+func TestCreateVolume_HostLocal_NoHostKey_Unaffected(t *testing.T) {
+	for _, fssEnabled := range []bool{true, false} {
+		fssEnabled := fssEnabled
+		t.Run(fmt.Sprintf("fssEnabled=%v", fssEnabled), func(t *testing.T) {
+			c := newFVSCreateController(t)
+			co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+			if err != nil {
+				t.Fatalf("failed to build fake CO: %v", err)
+			}
+			commonco.ContainerOrchestratorUtility = co
+			if fssEnabled {
+				err = co.EnableFSS(context.Background(), common.HostLocalStorageSupportFSS)
+			} else {
+				err = co.DisableFSS(context.Background(), common.HostLocalStorageSupportFSS)
+			}
+			if err != nil {
+				t.Fatalf("failed to set FSS: %v", err)
+			}
+
+			req := hostLocalCreateRequest(hostLocalAccessMode, hostLocalZoneValue, "")
+			pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c, req)
+			if err != nil {
+				t.Fatalf("CreateVolume failed: %v", err)
+			}
+			want := `[{"topology.kubernetes.io/zone":"` + hostLocalZoneValue + `"}]`
+			expectSupervisorAnnotation(t, pvc, want)
+		})
+	}
+}
+
+// --- CreateVolume response-side translation tests --------------------------
+
+func TestCreateVolume_HostLocal_AccessibleTopology_TranslatesBack(t *testing.T) {
+	c := newFVSCreateController(t)
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("failed to build fake CO: %v", err)
+	}
+	commonco.ContainerOrchestratorUtility = co
+	if err := co.EnableFSS(context.Background(), common.HostLocalStorageSupportFSS); err != nil {
+		t.Fatalf("failed to enable FSS: %v", err)
+	}
+
+	req := hostLocalCreateRequest(hostLocalAccessMode, hostLocalZoneValue, hostLocalHostValue)
+	accessibleTopologyAnnotation := hostLocalWantAnnotation(v1.LabelHostname)
+	resp, err := runCreateVolumeAndBindSupervisorPVCWithAccessibleTopology(t, c, req, accessibleTopologyAnnotation, nil)
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	assertAccessibleTopologyHasHostKey(t, resp)
+}
+
+// TestCreateVolume_HostLocal_AccessibleTopology_TranslatesBack_FSSDisabledAtReadTime proves the
+// response-side translation is unconditional: even if the FSS becomes disabled after the request
+// was accepted (but before the response-side block re-reads the bound supervisor PVC), a hostname
+// key already present in the accessible-topology annotation is still translated back to the VKS
+// host key, since the volume's host pinning in CNS is already a committed fact by that point
+// (idempotent-retry / FSS-toggled-off-after-creation case).
+func TestCreateVolume_HostLocal_AccessibleTopology_TranslatesBack_FSSDisabledAtReadTime(t *testing.T) {
+	c := newFVSCreateController(t)
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("failed to build fake CO: %v", err)
+	}
+	commonco.ContainerOrchestratorUtility = co
+	// Enabled so the request-side check (which runs before the PVC is created) does not reject
+	// the request; it is disabled below, after the PVC is observed but before it is marked Bound,
+	// so only the response-side read-path behavior is under test.
+	if err := co.EnableFSS(context.Background(), common.HostLocalStorageSupportFSS); err != nil {
+		t.Fatalf("failed to enable FSS: %v", err)
+	}
+
+	req := hostLocalCreateRequest(hostLocalAccessMode, hostLocalZoneValue, hostLocalHostValue)
+	accessibleTopologyAnnotation := hostLocalWantAnnotation(v1.LabelHostname)
+
+	disableFSS := func() {
+		if err := co.DisableFSS(context.Background(), common.HostLocalStorageSupportFSS); err != nil {
+			t.Fatalf("failed to disable FSS: %v", err)
+		}
+	}
+	resp, err := runCreateVolumeAndBindSupervisorPVCWithAccessibleTopology(t, c, req,
+		accessibleTopologyAnnotation, disableFSS)
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+	assertAccessibleTopologyHasHostKey(t, resp)
+}
+
+func assertAccessibleTopologyHasHostKey(t *testing.T, resp *csi.CreateVolumeResponse) {
+	t.Helper()
+	if len(resp.Volume.AccessibleTopology) != 1 {
+		t.Fatalf("expected exactly one accessible topology segment, got: %+v", resp.Volume.AccessibleTopology)
+	}
+	segments := resp.Volume.AccessibleTopology[0].Segments
+	want := map[string]string{
+		common.GuestClusterTopologyLabelHost: hostLocalHostValue,
+		"topology.kubernetes.io/zone":        hostLocalZoneValue,
+	}
+	if !reflect.DeepEqual(segments, want) {
+		t.Fatalf("AccessibleTopology segments = %+v, want %+v", segments, want)
+	}
+}

--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -398,8 +398,14 @@ func AddNodeAffinityRulesOnPV(ctx context.Context, metadataSyncer *metadataSyncI
 			}
 			var csiAccessibleTopology []*csi.Topology
 			for _, topoSegments := range accessibleTopologies {
+				// Translate the hostname key back to the VKS host key when present,
+				// unconditionally: this backstop can run long after volume creation,
+				// potentially after the host-local-storage-support FSS/capability was
+				// toggled off, but the volume's host pinning in CNS is still real and
+				// must still be reflected in the Guest PV's node affinity.
 				volumeTopology := &csi.Topology{
-					Segments: topoSegments,
+					Segments: translateTopologyHostKey(topoSegments, v1.LabelHostname,
+						common.GuestClusterTopologyLabelHost, true),
 				}
 				csiAccessibleTopology = append(csiAccessibleTopology, volumeTopology)
 			}

--- a/pkg/syncer/pvcsi_fullsync_hostlocal_test.go
+++ b/pkg/syncer/pvcsi_fullsync_hostlocal_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+)
+
+const (
+	hostLocalFullSyncZoneValue = "az1"
+	hostLocalFullSyncHostValue = "lvn-dvm-10-161-28-26.dvm.lvn.broadcom.net"
+)
+
+func TestTranslateTopologyHostKey_Syncer(t *testing.T) {
+	tests := []struct {
+		name        string
+		segments    map[string]string
+		fromKey     string
+		toKey       string
+		keepHostKey bool
+		want        map[string]string
+	}{
+		{
+			name: "key present, keepHostKey true renames the key",
+			segments: map[string]string{
+				v1.LabelHostname:              hostLocalFullSyncHostValue,
+				"topology.kubernetes.io/zone": hostLocalFullSyncZoneValue,
+			},
+			fromKey:     v1.LabelHostname,
+			toKey:       common.GuestClusterTopologyLabelHost,
+			keepHostKey: true,
+			want: map[string]string{
+				common.GuestClusterTopologyLabelHost: hostLocalFullSyncHostValue,
+				"topology.kubernetes.io/zone":        hostLocalFullSyncZoneValue,
+			},
+		},
+		{
+			name: "key present, keepHostKey false drops the key",
+			segments: map[string]string{
+				v1.LabelHostname:              hostLocalFullSyncHostValue,
+				"topology.kubernetes.io/zone": hostLocalFullSyncZoneValue,
+			},
+			fromKey:     v1.LabelHostname,
+			toKey:       common.GuestClusterTopologyLabelHost,
+			keepHostKey: false,
+			want: map[string]string{
+				"topology.kubernetes.io/zone": hostLocalFullSyncZoneValue,
+			},
+		},
+		{
+			name: "key absent is a no-op regardless of keepHostKey",
+			segments: map[string]string{
+				"topology.kubernetes.io/zone": hostLocalFullSyncZoneValue,
+			},
+			fromKey:     v1.LabelHostname,
+			toKey:       common.GuestClusterTopologyLabelHost,
+			keepHostKey: true,
+			want: map[string]string{
+				"topology.kubernetes.io/zone": hostLocalFullSyncZoneValue,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := translateTopologyHostKey(tc.segments, tc.fromKey, tc.toKey, tc.keepHostKey)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("translateTopologyHostKey() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAddNodeAffinityRulesOnPV_HostLocal_TranslatesHostKey verifies that when the supervisor
+// PVC's csi.vsphere.volume-accessible-topology annotation carries kubernetes.io/hostname (set by
+// the Supervisor CSI controller for a host-local volume), AddNodeAffinityRulesOnPV translates it
+// back to the VKS host key (common.GuestClusterTopologyLabelHost) on the Guest PV's NodeAffinity.
+// This translation is unconditional (not gated on the host-local-storage-support FSS): by the
+// time full-sync runs, the volume's host pinning in CNS is already a committed fact, so the
+// FSS/capability's current state is irrelevant here (see controller.go's CreateVolume for the
+// only gate in this feature, applied at request time).
+func TestAddNodeAffinityRulesOnPV_HostLocal_TranslatesHostKey(t *testing.T) {
+	ctx := context.Background()
+
+	supPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "volume-1",
+			Namespace: "sv-namespace",
+			Annotations: map[string]string{
+				common.AnnVolumeAccessibleTopology: `[{"kubernetes.io/hostname":"` + hostLocalFullSyncHostValue +
+					`","topology.kubernetes.io/zone":"` + hostLocalFullSyncZoneValue + `"}]`,
+			},
+		},
+	}
+	guestPV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-1",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					VolumeHandle: "volume-1",
+				},
+			},
+		},
+	}
+
+	supervisorClient := k8sfake.NewClientset(supPVC)
+	guestClient := k8sfake.NewClientset(guestPV)
+
+	metadataSyncer := &metadataSyncInformer{
+		supervisorClient: supervisorClient,
+	}
+	metadataSyncer.configInfo = &cnsconfig.ConfigurationInfo{
+		Cfg: &cnsconfig.Config{
+			GC: cnsconfig.GCConfig{
+				Endpoint: "endpoint",
+				Port:     "443",
+			},
+		},
+	}
+
+	origK8sClient := k8sNewClient
+	defer func() { k8sNewClient = origK8sClient }()
+	k8sNewClient = func(ctx context.Context) (clientset.Interface, error) {
+		return guestClient, nil
+	}
+
+	origGetPVs := getPVsInBoundAvailableOrReleased
+	defer func() { getPVsInBoundAvailableOrReleased = origGetPVs }()
+	getPVsInBoundAvailableOrReleased = func(ctx context.Context,
+		syncer *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+		return []*v1.PersistentVolume{guestPV}, nil
+	}
+
+	origGetSuperNS := cnsconfigGetSupervisorNamespace
+	defer func() { cnsconfigGetSupervisorNamespace = origGetSuperNS }()
+	cnsconfigGetSupervisorNamespace = func(ctx context.Context) (string, error) {
+		return "sv-namespace", nil
+	}
+
+	AddNodeAffinityRulesOnPV(ctx, metadataSyncer)
+
+	gotPV, err := guestClient.CoreV1().PersistentVolumes().Get(ctx, "pv-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("PV not found: %v", err)
+	}
+	if gotPV.Spec.NodeAffinity == nil {
+		t.Fatalf("expected node affinity to be set on PV")
+	}
+	gotKeys := map[string]string{}
+	for _, term := range gotPV.Spec.NodeAffinity.Required.NodeSelectorTerms {
+		for _, expr := range term.MatchExpressions {
+			if len(expr.Values) != 1 {
+				t.Fatalf("expected exactly one value for key %q, got %+v", expr.Key, expr.Values)
+			}
+			gotKeys[expr.Key] = expr.Values[0]
+		}
+	}
+	want := map[string]string{
+		common.GuestClusterTopologyLabelHost: hostLocalFullSyncHostValue,
+		"topology.kubernetes.io/zone":        hostLocalFullSyncZoneValue,
+	}
+	if !reflect.DeepEqual(gotKeys, want) {
+		t.Fatalf("PV NodeAffinity keys/values = %+v, want %+v", gotKeys, want)
+	}
+	if _, hasHostname := gotKeys[v1.LabelHostname]; hasHostname {
+		t.Fatalf("expected kubernetes.io/hostname to be translated away, but it is still present: %+v", gotKeys)
+	}
+}

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -999,6 +999,30 @@ func generateVolumeAccessibleTopologyFromPVCAnnotation(claim *v1.PersistentVolum
 	return volumeAccessibleTopologyArray, nil
 }
 
+// translateTopologyHostKey returns a copy of segments with fromKey renamed to
+// toKey. If keepHostKey is false, fromKey is dropped instead of renamed
+// (used when the host-local FSS/capability is disabled, so a host-scoped
+// key is never forwarded across the guest/supervisor boundary where the
+// other side wouldn't recognize it, or would misinterpret its value).
+// Segments without fromKey are returned unchanged.
+func translateTopologyHostKey(segments map[string]string, fromKey, toKey string,
+	keepHostKey bool) map[string]string {
+	val, ok := segments[fromKey]
+	if !ok {
+		return segments
+	}
+	translated := make(map[string]string, len(segments))
+	for k, v := range segments {
+		if k != fromKey {
+			translated[k] = v
+		}
+	}
+	if keepHostKey {
+		translated[toKey] = val
+	}
+	return translated
+}
+
 // vmOperatorAPIGroup is the API group for vmoperator VirtualMachine resources.
 const vmOperatorAPIGroup = "vmoperator.vmware.com"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

VKS/guest cluster nodes will publish a VKS-specific host topology key, topology.csi.vmware.com/host, alongside the standard zone key on their CSINode objects when host-local storage provisioning is available. The Supervisor only recognizes kubernetes.io/hostname for host resolution, so the Guest CSI controller must translate the VKS host key to kubernetes.io/hostname when building the requested-topology annotation on the Supervisor PVC, and translate it back when building the accessible-topology response and PV node affinity.

- Add pvCSI FSS host-local-storage-support, paired with the Supervisor's supports_host_local_storage capability via WCPFeatureStateAssociatedWithPVCSI.
- wcpguest CreateVolume: reject requests carrying the VKS host key while the FSS/capability is disabled (codes.Unimplemented) instead of silently dropping the requested host affinity; translate host<->hostname on the request and response paths, with the response-side translation applied unconditionally since it reflects an already-committed CNS host pinning.
- Apply the same unconditional reverse translation in the pvCSI full-sync AddNodeAffinityRulesOnPV backstop.
- Register the new FSS (default false) in the guestcluster 1.36 pvcsi manifest.


**Testing done**:
Manual testing result

Created PVC from VKS using csi.vsphere.volume-requested-topology annotation
```
# kubectl describe pvc hostlocalpvcfromvks
Name:          hostlocalpvcfromvks
Namespace:     default
StorageClass:  hostlocalvmfs
Status:        Bound
Volume:        pvc-fbed1c48-5af7-4c67-8dfc-8095e1ad0ccf
Labels:        <none>
Annotations:   csi.vsphere.volume-requested-topology:
                 [{"kubernetes.io/hostname":"lvn-dvm-10-161-28-26.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Tue Jul 14 18:15:25 UTC 2026
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                                Message
  ----    ------                 ----               ----                                                                                                -------
  Normal  ExternalProvisioning   15m (x2 over 15m)  persistentvolume-controller                                                                         Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  Provisioning           15m                csi.vsphere.vmware.com_vsphere-csi-controller-944c9fdf5-w9hkc_5c7fed32-d79d-488c-9db0-62cef2772580  External provisioner is provisioning volume for claim "default/hostlocalpvcfromvks"
  Normal  ProvisioningSucceeded  15m                csi.vsphere.vmware.com_vsphere-csi-controller-944c9fdf5-w9hkc_5c7fed32-d79d-488c-9db0-62cef2772580  Successfully provisioned volume pvc-fbed1c48-5af7-4c67-8dfc-8095e1ad0ccf
```

```
# kubectl describe pv pvc-fbed1c48-5af7-4c67-8dfc-8095e1ad0ccf
Name:              pvc-fbed1c48-5af7-4c67-8dfc-8095e1ad0ccf
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [external-provisioner.volume.kubernetes.io/finalizer kubernetes.io/pv-protection]
StorageClass:      hostlocalvmfs
Status:            Bound
Claim:             default/hostlocalpvcfromvks
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          5Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/host in [lvn-dvm-10-161-28-26.dvm.lvn.broadcom.net]
                   topology.kubernetes.io/zone in [az1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      d29f1362-1c88-418d-a696-b599ef8428f2-fbed1c48-5af7-4c67-8dfc-8095e1ad0ccf
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1784051445504-8120-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```


Created PVC from VKS without csi.vsphere.volume-requested-topology annotation

```
# kubectl describe pvc hostlocalpvc
Name:          hostlocalpvc
Namespace:     default
StorageClass:  hostlocalvmfs
Status:        Bound
Volume:        pvc-ec057c8d-b500-4247-b94f-7039e1c1f3d6
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Tue Jul 14 18:05:25 UTC 2026
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                                Message
  ----    ------                 ----               ----                                                                                                -------
  Normal  Provisioning           26m                csi.vsphere.vmware.com_vsphere-csi-controller-944c9fdf5-w9hkc_5c7fed32-d79d-488c-9db0-62cef2772580  External provisioner is provisioning volume for claim "default/hostlocalpvc"
  Normal  ExternalProvisioning   26m (x3 over 26m)  persistentvolume-controller                                                                         Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  26m                csi.vsphere.vmware.com_vsphere-csi-controller-944c9fdf5-w9hkc_5c7fed32-d79d-488c-9db0-62cef2772580  Successfully provisioned volume pvc-ec057c8d-b500-4247-b94f-7039e1c1f3d6



# kubectl describe pv pvc-ec057c8d-b500-4247-b94f-7039e1c1f3d6
Name:              pvc-ec057c8d-b500-4247-b94f-7039e1c1f3d6
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [external-provisioner.volume.kubernetes.io/finalizer kubernetes.io/pv-protection external-attacher/csi-vsphere-vmware-com]
StorageClass:      hostlocalvmfs
Status:            Bound
Claim:             default/hostlocalpvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          5Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/host in [lvn-dvm-10-161-28-26.dvm.lvn.broadcom.net]
                   topology.kubernetes.io/zone in [az1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      d29f1362-1c88-418d-a696-b599ef8428f2-ec057c8d-b500-4247-b94f-7039e1c1f3d6
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1784051445504-8120-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>

```



**Special notes for your reviewer**:

wcp pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1805/
vks pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1361/

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Translate VKS host-local topology key to/from Supervisor PVC annotations
```
