### PR TITLE
Topic/anujb/bump golang 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/vsphere-csi-driver/v3
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.14.0

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -49,7 +49,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=<docker-registry>/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.26.3
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.26.5
 
 ARCH=amd64
 OSVERSION=1809

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.26.3
+ARG GOLANG_IMAGE=golang:1.26.5
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/ci/e2e/Dockerfile
+++ b/images/ci/e2e/Dockerfile
@@ -18,7 +18,7 @@
 # docker tag <image-name:version> <repo>/<image-name:version>
 # docker push <repo>/<image-name:version>
 
-FROM --platform=linux/amd64 golang:1.26.3
+FROM --platform=linux/amd64 golang:1.26.5
 
 RUN apt-get update && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.26.3
+ARG GOLANG_IMAGE=golang:1.26.5
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.26.3
+ARG GOLANG_IMAGE=golang:1.26.5
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=photon:5.0

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.26.3
+ARG GOLANG_IMAGE=golang:1.26.5
 ARG OSVERSION
 ARG ARCH=amd64
 


### PR DESCRIPTION
Updated golang 1.26.5 to fix TKGI-15279 / TKGI-15293 CVEs.
https://nvd.nist.gov/vuln/detail/CVE-2026-42504
https://go.dev/issue/79217

Testing Done: Yes
All vanilla tests passed
https://gist.github.com/anuj087/6889901abb33f45bb07987fd13085dd3