### PR TITLE
Guest Cluster CRDs for SPI/CSPI

### DIFF
--- a/manifests/guestcluster/1.34/pvcsi.yaml
+++ b/manifests/guestcluster/1.34/pvcsi.yaml
@@ -746,6 +746,7 @@ data:
   "vsan-file-volume-service-support": "false"
   "CSI_Backup_API": "false"
   "improved-volume-visibility": "false"
+  "supports_exposing_storage_policy_attributes": "false" # same name as supervisor capability; effective only when supervisor capability is also enabled
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.35/pvcsi.yaml
+++ b/manifests/guestcluster/1.35/pvcsi.yaml
@@ -747,6 +747,7 @@ data:
   "vsan-file-volume-service-support": "false"
   "CSI_Backup_API": "false"
   "improved-volume-visibility": "false"
+  "supports_exposing_storage_policy_attributes": "false" # same name as supervisor capability; effective only when supervisor capability is also enabled
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.36/pvcsi.yaml
+++ b/manifests/guestcluster/1.36/pvcsi.yaml
@@ -748,6 +748,7 @@ data:
   "CSI_Backup_API": "false"
   "improved-volume-visibility": "false"
   "host-local-storage-support": "false"
+  "supports_exposing_storage_policy_attributes": "false" # same name as supervisor capability; effective only when supervisor capability is also enabled
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -627,7 +627,10 @@ const (
 	// CSI_Backup_API_FSS is an FSS for Changed Block Tracking(CBT) support in pvCSI
 	CSI_Backup_API_FSS = "CSI_Backup_API"
 	// SupportsExposingStoragePolicyAttributes is the supervisor capability that gates exposing
-	// storage policy attributes to devops users.
+	// storage policy attributes to devops users. The same name is reused as the pvCSI FSS in
+	// guest clusters (see WCPFeatureStateAssociatedWithPVCSI), so the guest installs the
+	// ClusterStoragePolicyInfo and StoragePolicyInfo CRDs only when both the pvCSI FSS and this
+	// supervisor capability are enabled. InfraStoragePolicyInfo is not used in guest clusters.
 	SupportsExposingStoragePolicyAttributes = "supports_exposing_storage_policy_attributes"
 	// SupportsPerNamespaceNetworkProviders is a WCP capability indicating that network provider
 	// is resolved per namespace (NetworkSettings CR) rather than from the global wcp-network-config.
@@ -744,10 +747,11 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 // on supervisor cluster. If PVCSI feature is enabled, then we need to check if associated Capability is enabled
 // or not on the supervisor cluster to decide if effective value of this FSS is enabled or disabled.
 var WCPFeatureStateAssociatedWithPVCSI = map[string]string{
-	WorkloadDomainIsolationFSS:      WorkloadDomainIsolation,
-	LinkedCloneSupportFSS:           LinkedCloneSupport,
-	VsanFileVolumeServiceSupportFSS: VsanFileVolumeService,
-	CSI_Backup_API_FSS:              CSI_Backup_API,
-	VMPVCStoragePolicyMutabilityFSS: VMPVCStoragePolicyMutability,
-	HostLocalStorageSupportFSS:      HostLocalStorageSupport,
+	WorkloadDomainIsolationFSS:              WorkloadDomainIsolation,
+	LinkedCloneSupportFSS:                   LinkedCloneSupport,
+	VsanFileVolumeServiceSupportFSS:         VsanFileVolumeService,
+	CSI_Backup_API_FSS:                      CSI_Backup_API,
+	VMPVCStoragePolicyMutabilityFSS:         VMPVCStoragePolicyMutability,
+	HostLocalStorageSupportFSS:              HostLocalStorageSupport,
+	SupportsExposingStoragePolicyAttributes: SupportsExposingStoragePolicyAttributes,
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -522,6 +522,23 @@ func CreateCustomResourceDefinitionFromManifest(ctx context.Context, embedFiles 
 	return createCustomResourceDefinition(ctx, manifestcrd)
 }
 
+// CreateCustomResourceDefinitionFromManifestWithScope creates a custom resource
+// definition from a manifest file, overriding its scope before creation. This is
+// used when the same CRD manifest is installed with a different scope in different
+// clusters. For example, StoragePolicyInfo is Namespaced on the Supervisor but is
+// installed as Cluster-scoped in guest clusters (which are single-tenant).
+func CreateCustomResourceDefinitionFromManifestWithScope(ctx context.Context, embedFiles embed.FS,
+	fileName string, scope apiextensionsv1.ResourceScope) error {
+	log := logger.GetLogger(ctx)
+	manifestcrd, err := getCRDFromManifest(ctx, embedFiles, fileName)
+	if err != nil {
+		log.Errorf("Failed to read the CRD spec from manifest file: %s with err: %+v", fileName, err)
+		return err
+	}
+	manifestcrd.Spec.Scope = scope
+	return createCustomResourceDefinition(ctx, manifestcrd)
+}
+
 // GetNodeIdFromCSINode gets the UUID from CSINode object
 func GetNodeIdFromCSINode(csiNode *storagev1.CSINode) string {
 	drivers := csiNode.Spec.Drivers

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -381,10 +382,15 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 				return err
 			}
 
-			// Create StoragePolicyInfo CRD in the guest cluster.
-			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx,
+			// Create StoragePolicyInfo CRD in the guest cluster as Cluster-scoped.
+			// StoragePolicyInfo is Namespaced on the Supervisor (one per tenant namespace),
+			// but a guest cluster is provisioned inside a single Supervisor namespace and is
+			// therefore single-tenant, so the guest gets one Cluster-scoped StoragePolicyInfo
+			// per policy. The same manifest is reused with its scope overridden here.
+			err = k8s.CreateCustomResourceDefinitionFromManifestWithScope(ctx,
 				cnsoperatorconfig.EmbedStoragePolicyInfoCRFile,
-				cnsoperatorconfig.EmbedStoragePolicyInfoCRFileName)
+				cnsoperatorconfig.EmbedStoragePolicyInfoCRFileName,
+				apiextensionsv1.ClusterScoped)
 			if err != nil {
 				crdName := cnsoperatorv1alpha1.StoragePolicyInfoPlural +
 					"." + cnsoperatorv1alpha1.SchemeGroupVersion.Group

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -368,6 +368,30 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 				return err
 			}
 		}
+
+		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.SupportsExposingStoragePolicyAttributes) {
+			// Create ClusterStoragePolicyInfo CRD in the guest cluster.
+			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx,
+				cnsoperatorconfig.EmbedClusterStoragePolicyInfoCRFile,
+				cnsoperatorconfig.EmbedClusterStoragePolicyInfoCRFileName)
+			if err != nil {
+				crdName := cnsoperatorv1alpha1.ClusterStoragePolicyInfoPlural +
+					"." + cnsoperatorv1alpha1.SchemeGroupVersion.Group
+				log.Errorf("failed to create %q CRD. Err: %+v", crdName, err)
+				return err
+			}
+
+			// Create StoragePolicyInfo CRD in the guest cluster.
+			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx,
+				cnsoperatorconfig.EmbedStoragePolicyInfoCRFile,
+				cnsoperatorconfig.EmbedStoragePolicyInfoCRFileName)
+			if err != nil {
+				crdName := cnsoperatorv1alpha1.StoragePolicyInfoPlural +
+					"." + cnsoperatorv1alpha1.SchemeGroupVersion.Group
+				log.Errorf("failed to create %q CRD. Err: %+v", crdName, err)
+				return err
+			}
+		}
 	}
 
 	// Initialize the global scheme once before creating the manager


### PR DESCRIPTION

**What this PR does / why we need it:**
This PR adds guest-cluster support for the supports_exposing_storage_policy_attributes capability by installing the ClusterStoragePolicyInfo and StoragePolicyInfo CRDs in the guest cluster's cnsoperator manager, gated on the corresponding pvCSI FSS being enabled (and effectively enabled only when the associated supervisor capability is also on, via WCPFeatureStateAssociatedWithPVCSI).

Since StoragePolicyInfo is Namespaced on the Supervisor (one per tenant namespace) but a guest cluster lives inside a single Supervisor namespace and is therefore single-tenant, the guest installs StoragePolicyInfo as Cluster-scoped instead of Namespaced. A new helper, CreateCustomResourceDefinitionFromManifestWithScope, was added to pkg/kubernetes/kubernetes.go to override the CRD's scope at creation time so the same manifest can be reused with a different scope in guest vs. supervisor clusters. InfraStoragePolicyInfo is intentionally not installed in guest clusters.

Also adds the supports_exposing_storage_policy_attributes FSS entry to the guest cluster pvCSI feature-states ConfigMap (1.34/1.35/1.36 manifests), defaulted to false.




**Testing done:**

<details>

<summary>Logs from testing</summary>

```bash

NAME                                                       CREATED AT
clusterstoragepolicyinfos.cns.vmware.com                   2026-07-15T12:27:02Z
storagepolicyinfos.cns.vmware.com                          2026-07-15T12:27:07Z

> k describe crds clusterstoragepolicyinfos.cns.vmware.com

Name:         clusterstoragepolicyinfos.cns.vmware.com
Namespace:
Labels:       <none>
Annotations:  controller-gen.kubebuilder.io/version: v0.19.0
API Version:  apiextensions.k8s.io/v1
Kind:         CustomResourceDefinition
Metadata:
  Creation Timestamp:  2026-07-15T12:27:02Z
  Generation:          1
  Resource Version:    13973
  UID:                 06c1d8f1-87e6-469d-bef8-5ddd808be843
Spec:
  Conversion:
    Strategy:  None
  Group:       cns.vmware.com
  Names:
    Kind:       ClusterStoragePolicyInfo
    List Kind:  ClusterStoragePolicyInfoList
    Plural:     clusterstoragepolicyinfos
    Short Names:
      clusterspi
    Singular:  clusterstoragepolicyinfo
  Scope:       Cluster
  Versions:
    Name:  v1alpha1
    Schema:
      openAPIV3Schema:
        Description:  ClusterStoragePolicyInfo is the Schema for the clusterstoragepolicyinfos API.
Name of this CR is same as the unique and immutable K8sCompliantName of the storage policy.
        Properties:
          API Version:
            Description:  APIVersion defines the versioned schema of this representation of an object.
Servers should convert recognized schemas to the latest internal value, and
may reject unrecognized values.
More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
            Type:  string
          Kind:
            Description:  Kind is a string value representing the REST resource this object represents.
Servers may infer this from the endpoint the client submits requests to.
Cannot be updated.
In CamelCase.
More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
            Type:  string
          Metadata:
            Type:  object
          Status:
            Description:  ClusterStoragePolicyInfoStatus defines the observed state of ClusterStoragePolicyInfo.
            Properties:
              Encryption:
                Description:  Encryption describes encryption-related status for the storage policy.
                Properties:
                  Encryption Types:
                    Description:  EncryptionTypes indicates the types of encryption.
                    Items:
                      Description:  EncryptionType describes the type of encryption supported by the storage policy.
                      Enum:
                        vm-encryption
                        vsan-encryption
                      Type:  string
                    Type:    array
                  Supports Encryption:
                    Description:  SupportsEncryption indicates whether the storage policy supports encryption.
                    Type:         boolean
                Type:             object
              Error:
                Description:  Error describes a failure observed while reconciling the ClusterStoragePolicyInfo resource.
Empty string indicates no error.
                Type:  string
              Performance:
                Description:  Performance describes performance characteristics (vSAN only).
                Properties:
                  Iops Limit:
                    Description:  IopsLimit is the IOPS limit for volumes created from this storage policy.
                    Format:       int64
                    Type:         integer
                Type:             object
              Storage Policy Deleted:
                Description:  StoragePolicyDeleted indicates whether the underlying storagepolicy is deleted or not on the VC.
                Type:         boolean
            Type:             object
        Type:                 object
    Served:                   true
    Storage:                  true
    Subresources:
      Status:
Status:
  Accepted Names:
    Kind:       ClusterStoragePolicyInfo
    List Kind:  ClusterStoragePolicyInfoList
    Plural:     clusterstoragepolicyinfos
    Short Names:
      clusterspi
    Singular:  clusterstoragepolicyinfo
  Conditions:
    Last Transition Time:  2026-07-15T12:27:02Z
    Message:               no conflicts found
    Reason:                NoConflicts
    Status:                True
    Type:                  NamesAccepted
    Last Transition Time:  2026-07-15T12:27:02Z
    Message:               the initial names have been accepted
    Reason:                InitialNamesAccepted
    Status:                True
    Type:                  Established
  Stored Versions:
    v1alpha1
Events:  <none>

> k describe crds storagepolicyinfos.cns.vmware.com

Name:         storagepolicyinfos.cns.vmware.com
Namespace:
Labels:       <none>
Annotations:  controller-gen.kubebuilder.io/version: v0.21.0
API Version:  apiextensions.k8s.io/v1
Kind:         CustomResourceDefinition
Metadata:
  Creation Timestamp:  2026-07-15T12:27:07Z
  Generation:          1
  Resource Version:    13987
  UID:                 e01b8bb0-4da4-47f3-9024-e7c1d373ce26
Spec:
  Conversion:
    Strategy:  None
  Group:       cns.vmware.com
  Names:
    Kind:       StoragePolicyInfo
    List Kind:  StoragePolicyInfoList
    Plural:     storagepolicyinfos
    Short Names:
      spi
    Singular:  storagepolicyinfo
  Scope:       Cluster
  Versions:
    Name:  v1alpha1
    Schema:
      openAPIV3Schema:
        Description:  StoragePolicyInfo is the Schema for the storagepolicyinfos API.
Name of this CR is the same as the unique and immutable K8sCompliantName of the
storage policy. One instance is created per namespace per storage policy that is
assigned to that namespace.
        Properties:
          API Version:
            Description:  APIVersion defines the versioned schema of this representation of an object.
Servers should convert recognized schemas to the latest internal value, and
may reject unrecognized values.
More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
            Type:  string
          Kind:
            Description:  Kind is a string value representing the REST resource this object represents.
Servers may infer this from the endpoint the client submits requests to.
Cannot be updated.
In CamelCase.
More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
            Type:  string
          Metadata:
            Type:  object
          Status:
            Description:  StoragePolicyInfoStatus defines the observed state of StoragePolicyInfo.
            Properties:
              Error:
                Description:  Error describes a failure condition when resolving topology for this
storage policy. Empty string indicates no error.
                Type:  string
              Topology Info:
                Description:  TopologyInfo contains observed topology for this storage policy filtered
to the zones accessible within this namespace.
                Properties:
                  Accessible Zones:
                    Description:  AccessibleZones lists zones where the policy is accessible for this namespace.
For a marker policy (e.g. vSAN File Service), zones are shown even if they are
not assigned to the namespace.
                    Items:
                      Min Length:                  1
                      Type:                        string
                    Type:                          array
                    X - Kubernetes - List - Type:  set
                  Topology Type:
                    Description:  TopologyType describes the type of topology for the storage policy.
Valid values are empty string (no topology) or "zonal" (zone-based topology).
                    Enum:

                      zonal
                    Type:  string
                Required:
                  accessibleZones
                  topologyType
                Type:  object
              Volume Capabilities:
                Additional Properties:
                  Type:       boolean
                Description:  VolumeCapabilities describes the supported volume capabilities.
                Type:         object
            Type:             object
        Type:                 object
    Served:                   true
    Storage:                  true
    Subresources:
      Status:
Status:
  Accepted Names:
    Kind:       StoragePolicyInfo
    List Kind:  StoragePolicyInfoList
    Plural:     storagepolicyinfos
    Short Names:
      spi
    Singular:  storagepolicyinfo
  Conditions:
    Last Transition Time:  2026-07-15T12:27:07Z
    Message:               no conflicts found
    Reason:                NoConflicts
    Status:                True
    Type:                  NamesAccepted
    Last Transition Time:  2026-07-15T12:27:07Z
    Message:               the initial names have been accepted
    Reason:                InitialNamesAccepted
    Status:                True
    Type:                  Established
  Stored Versions:
    v1alpha1
Events:  <none>
```

</details>
