### PR TITLE
Use nfs4.1 protocol version for FVS PVC

### DIFF
--- a/pkg/apis/filevolume/v1alpha1/types.go
+++ b/pkg/apis/filevolume/v1alpha1/types.go
@@ -34,12 +34,12 @@ const (
 	FileVolumePhaseError        FileVolumePhase = "Error"
 )
 
-// FileVolumeProtocol defines the file sharing protocol supported by a FileVolume (e.g., nfs3, nfs4)
+// FileVolumeProtocol defines the file sharing protocol supported by a FileVolume (e.g., nfs3, nfs4.1)
 type FileVolumeProtocol string
 
 const (
-	FileVolumeProtocolNFSv3 FileVolumeProtocol = "nfs3"
-	FileVolumeProtocolNFSv4 FileVolumeProtocol = "nfs4"
+	FileVolumeProtocolNFSv3  FileVolumeProtocol = "nfs3"
+	FileVolumeProtocolNFSv41 FileVolumeProtocol = "nfs4.1"
 )
 
 // FileVolumeSpec defines the desired state of FileVolume.
@@ -66,9 +66,9 @@ type FileVolumeSpec struct {
 
 	// *Optional*
 	// Protocols defines the file sharing protocols supported by this volume.
-	// If not specified, defaults to nfs4 (set by mutating webhook). Immutable after creation.
+	// If not specified, defaults to nfs4.1 (set by mutating webhook). Immutable after creation.
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:Items:Enum=nfs3;nfs4
+	// +kubebuilder:validation:Items:Enum=nfs3;nfs4.1
 	// +optional
 	Protocols []FileVolumeProtocol `json:"protocols,omitempty"`
 

--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -439,7 +439,7 @@ func (c *controller) createFileVolumeViaFVS(ctx context.Context, req *csi.Create
 			Spec: fvv1alpha1.FileVolumeSpec{
 				PvcUID:    pvcUID,
 				Size:      *qty,
-				Protocols: []fvv1alpha1.FileVolumeProtocol{fvv1alpha1.FileVolumeProtocolNFSv4},
+				Protocols: []fvv1alpha1.FileVolumeProtocol{fvv1alpha1.FileVolumeProtocolNFSv41},
 			},
 		}
 		log.Infof("Creating FileVolume CR for PVC %s/%s: %+v", pvcNamespace, pvcName, fvTyped)


### PR DESCRIPTION
**What this PR does / why we need it**:
Use nfs4.1 protocol version, instead of deprecated version nfs4 for FVS PVC

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
in-progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use nfs4.1 protocol version for FVS PVC
```
