### PR TITLE
Refactor compatible zones code for clusterSPI and populate volume capabilities for namespace scoped SPI CRs

### DIFF
--- a/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1/storagepolicyinfo_types.go
+++ b/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1/storagepolicyinfo_types.go
@@ -30,6 +30,18 @@ import (
 // +kubebuilder:validation:Enum=SupportsPersistentVolumeBlock;SupportsPersistentVolumeFilesystem;SupportsHighPerformanceLinkedClone;SupportsLinkedClone
 type VolumeCapability string
 
+const (
+	// SupportsVolumeModeBlock indicates that the policy supports PersistentVolume with Block volume mode.
+	SupportsVolumeModeBlock VolumeCapability = "SupportsPersistentVolumeBlock"
+	// SupportsVolumeModeFilesystem indicates that the policy supports PersistentVolume with Filesystem volume mode.
+	SupportsVolumeModeFilesystem VolumeCapability = "SupportsPersistentVolumeFilesystem"
+	// SupportsHighPerformanceLinkedClone indicates that the policy supports high-performance linked clones
+	// on vSAN ESA clusters with ESXi 9.1 or above hosts.
+	SupportsHighPerformanceLinkedClone VolumeCapability = "SupportsHighPerformanceLinkedClone"
+	// SupportsLinkedClone indicates that the policy supports linked clones with at least one ESXi 9.1+ host.
+	SupportsLinkedClone VolumeCapability = "SupportsLinkedClone"
+)
+
 // Topology describes topology accessibility for the storage policy within a namespace.
 type Topology struct {
 	// TopologyType describes the type of topology for the storage policy.

--- a/pkg/common/cns-lib/vsphere/pbm.go
+++ b/pkg/common/cns-lib/vsphere/pbm.go
@@ -169,6 +169,46 @@ func (vc *VirtualCenter) PbmQueryMatchingHub(ctx context.Context,
 	return res.Returnval, nil
 }
 
+// PbmCheckRequirementsForZoneTopology performs an SPBM placement compatibility check for
+// profileID using a PbmPlacementZoneTopologyRequirement scoped to clusterMoIDs.
+// For each datastore that is both policy-compatible and
+// mounted on at least one of the clusterMoIDs, the result's
+// HubInfo.ZoneClusters field indicates which of clusterMoIDs it is mounted on.
+func (vc *VirtualCenter) PbmCheckRequirementsForZoneTopology(ctx context.Context,
+	profileID string, clusterMoIDs []string) (pbm.PlacementCompatibilityResult, error) {
+	log := logger.GetLogger(ctx)
+	err := vc.ConnectPbm(ctx)
+	if err != nil {
+		log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
+		return nil, err
+	}
+
+	clusters := make([]pbmtypes.PbmServerObjectRef, 0, len(clusterMoIDs))
+	for _, moID := range clusterMoIDs {
+		clusters = append(clusters, pbmtypes.PbmServerObjectRef{
+			ObjectType: string(pbmtypes.PbmObjectTypeCluster),
+			Key:        moID,
+		})
+	}
+
+	requirement := &pbmtypes.PbmPlacementZoneTopologyRequirement{
+		PbmPlacementCapabilityProfileRequirement: pbmtypes.PbmPlacementCapabilityProfileRequirement{
+			ProfileId: pbmtypes.PbmProfileId{UniqueId: profileID},
+		},
+		Clusters: clusters,
+	}
+
+	res, err := vc.PbmClient.CheckRequirements(ctx, nil, nil,
+		[]pbmtypes.BasePbmPlacementRequirement{requirement})
+	if err != nil {
+		log.Errorf("failed to check zone topology placement requirements for profile %s: %v", profileID, err)
+		return nil, err
+	}
+
+	log.Infof("Found %d placement results for profile %s across %d clusters", len(res), profileID, len(clusterMoIDs))
+	return res, nil
+}
+
 // PbmRetrieveContent fetches the policy content of all given policies from SPBM.
 func (vc *VirtualCenter) PbmRetrieveContent(ctx context.Context, policyIds []string) ([]SpbmPolicyContent, error) {
 

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -859,19 +859,15 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 
 	var overallErr error
 
-	// Create a cache for datastore information to be shared across capability calculations
-	// This avoids redundant vCenter calls when populating both topology and volume capabilities
-	clusterDatastoreCache := make(map[string][]*cnsvsphere.DatastoreInfo)
-
 	// Populate topology capabilities for InfraSPI.
-	if err := r.populateTopologyCapabilities(ctx, instance, infraSPI, profile.ID, vc,
-		clusterDatastoreCache, policyContent); err != nil {
+	zoneCompatibleDS, err := r.populateTopologyCapabilities(ctx, instance, infraSPI, profile.ID, vc, policyContent)
+	if err != nil {
 		log.Errorf("Failed to populate topology capabilities for profile %s: %v", profile.ID, err)
 		overallErr = errors.Join(overallErr, err)
 	}
 
 	// Populate volume capabilities.
-	if err := populateVolumeCapabilities(ctx, infraSPI, vc, profile.ID, r.topologyMgr, clusterDatastoreCache); err != nil {
+	if err := populateVolumeCapabilities(ctx, infraSPI, vc, profile.ID, zoneCompatibleDS); err != nil {
 		log.Errorf("Failed to populate volume capabilities for profile %s: %v", profile.ID, err)
 		overallErr = errors.Join(overallErr, err)
 	}
@@ -879,13 +875,14 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 	return overallErr
 }
 
-// populateTopologyCapabilities populates topology information for the storage policy in InfraSPI.
+// populateTopologyCapabilities populates topology information for the storage policy in InfraSPI,
+// and returns the zone->compatible-datastore map computed along the way (nil for marker
+// policies).
 func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx context.Context,
 	clusterSPI *clusterspiv1alpha1.ClusterStoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo, profileID string,
 	vc *cnsvsphere.VirtualCenter,
-	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo,
-	clusterSPIPolicyContent []cnsvsphere.SpbmPolicyContent) error {
+	clusterSPIPolicyContent []cnsvsphere.SpbmPolicyContent) (map[string][]*cnsvsphere.DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
 
 	// Marker policies (e.g. vSAN File Service) derive their cluster-wide accessible zones from
@@ -898,14 +895,15 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 		}
 		zones, err := cnsoperatorutil.GetZonesForvSANFileServiceMarkerPolicy(ctx, r.k8sClient, zonesFn)
 		if err != nil {
-			return fmt.Errorf("failed to compute cluster zones for vSAN File Service marker policy %q: %w", clusterSPI.Name, err)
+			return nil, fmt.Errorf("failed to compute cluster zones for vSAN File Service marker policy %q: %w",
+				clusterSPI.Name, err)
 		}
 		infraSPI.Status.Topology = &infraspiv1alpha1.Topology{
 			TopologyType:    "zonal",
 			AccessibleZones: zones,
 		}
 		log.Infof("vSAN File Service marker policy %q accessible zones: %v", clusterSPI.Name, zones)
-		return nil
+		return nil, nil
 	}
 
 	// Determine the topology type for this policy. Prefer the StorageClass's StorageTopologyType
@@ -914,7 +912,7 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 	// were created ahead of any StorageClass (see full sync).
 	storageClass, err := getStorageClassForPolicy(ctx, r.client, profileID)
 	if err != nil {
-		return fmt.Errorf("failed to get StorageClass for policy: %w", err)
+		return nil, fmt.Errorf("failed to get StorageClass for policy: %w", err)
 	}
 
 	var topologyType string
@@ -924,7 +922,7 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 		if err != nil {
 			log.Errorf("Storage policy %s does not have a valid StorageTopologyType parameter: %v",
 				profileID, err)
-			return err
+			return nil, err
 		}
 		log.Infof("Storage policy %s has topology type %q from StorageClass %q", profileID, topologyType,
 			storageClass.Name)
@@ -943,13 +941,13 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 
 	log.Infof("Storage policy %s: populating accessible zones", profileID)
 
-	// GetAccessibleZonesAndDatastoresForPolicy returns the flat set of
-	// compatible datastore morefs needed for the DsToPolicy cache update
-	// below alongside the accessible zones, from the same PBM query.
-	accessibleZones, dsIDs, err := cnsoperatorutil.GetAccessibleZonesAndDatastoresForPolicy(ctx, r.topologyMgr, vc,
-		profileID, clusterDatastoreCache)
+	// GetZoneCompatibleDatastoresForPolicy makes SPBM CheckRequirements call, scoped to
+	// every cluster registered to a vSphere AvailabilityZone, to determine both the accessible
+	// zones and the compatible datastores within each zone.
+	accessibleZones, zoneCompatibleDS, dsIDs, err := cnsoperatorutil.GetZoneCompatibleDatastoresForPolicy(ctx,
+		r.topologyMgr, vc, profileID)
 	if err != nil {
-		return fmt.Errorf("failed to get accessible zones: %w", err)
+		return nil, fmt.Errorf("failed to get accessible zones: %w", err)
 	}
 
 	// Record which datastores this policy is compatible with, so the shared
@@ -958,10 +956,24 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 	// without a separate vCenter round trip.
 	vsphereinfra.GetCache().SetDatastoresForPolicy(clusterSPI.Name, dsIDs)
 
+	// Record, per zone, which datastores are compatible with this policy, so the
+	// namespace-scoped storagepolicyinfo controller can determine SupportsLinkedClone/
+	// SupportsHighPerformanceLinkedClone for a given zone without any additional vCenter or
+	// PBM call.
+	zoneDsIDs := make(map[string][]string, len(zoneCompatibleDS))
+	for zone, datastores := range zoneCompatibleDS {
+		ids := make([]string, 0, len(datastores))
+		for _, ds := range datastores {
+			ids = append(ids, ds.Reference().Value)
+		}
+		zoneDsIDs[zone] = ids
+	}
+	vsphereinfra.GetCache().SetDatastoresForPolicyZones(clusterSPI.Name, zoneDsIDs)
+
 	// Update InfraSPI with topology information including accessible zones
 	infraSPI.Status.Topology.AccessibleZones = accessibleZones
 
-	return nil
+	return zoneCompatibleDS, nil
 }
 
 // setClusterSPIError sets error and records an event on the ClusterStoragePolicyInfo instance.
@@ -1004,28 +1016,16 @@ func (r *ReconcileClusterStoragePolicyInfo) setClusterSPISuccess(ctx context.Con
 	return nil
 }
 
-// recordEvent records events and handles backoff duration management
+// recordEvent records events for clusterSPI instance.
 func (r *ReconcileClusterStoragePolicyInfo) recordEvent(ctx context.Context,
 	instance *clusterspiv1alpha1.ClusterStoragePolicyInfo, eventtype string, msg string) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("Event type is %s", eventtype)
-	namespacedName := apitypes.NamespacedName{
-		Name: instance.Name,
-	}
 	switch eventtype {
 	case v1.EventTypeWarning:
-		// Double backOff duration.
-		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
-			types.MaxBackOffDurationForReconciler)
 		r.recorder.Event(instance, v1.EventTypeWarning, "ClusterStoragePolicyInfoFailed", msg)
-		backOffDurationMapMutex.Unlock()
 	case v1.EventTypeNormal:
-		// Reset backOff duration to 1 second on success.
-		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = time.Second
 		r.recorder.Event(instance, v1.EventTypeNormal, "ClusterStoragePolicyInfoSynced", msg)
-		backOffDurationMapMutex.Unlock()
 	}
 }
 
@@ -1069,27 +1069,15 @@ func (r *ReconcileClusterStoragePolicyInfo) setInfraSPISuccess(ctx context.Conte
 	return nil
 }
 
-// recordInfraSPIEvent records events for InfraStoragePolicyInfo instances and handles backoff duration management
+// recordInfraSPIEvent records events for InfraStoragePolicyInfo instances.
 func (r *ReconcileClusterStoragePolicyInfo) recordInfraSPIEvent(ctx context.Context,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo, eventtype string, msg string) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("InfraSPI Event type is %s", eventtype)
-	namespacedName := apitypes.NamespacedName{
-		Name: infraSPI.Name,
-	}
 	switch eventtype {
 	case v1.EventTypeWarning:
-		// Double backOff duration.
-		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = min(backOffDuration[namespacedName]*2,
-			types.MaxBackOffDurationForReconciler)
 		r.recorder.Event(infraSPI, v1.EventTypeWarning, "InfraStoragePolicyInfoFailed", msg)
-		backOffDurationMapMutex.Unlock()
 	case v1.EventTypeNormal:
-		// Reset backOff duration to 1 second on success.
-		backOffDurationMapMutex.Lock()
-		backOffDuration[namespacedName] = time.Second
 		r.recorder.Event(infraSPI, v1.EventTypeNormal, "InfraStoragePolicyInfoSynced", msg)
-		backOffDurationMapMutex.Unlock()
 	}
 }

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -34,6 +34,7 @@ import (
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -57,6 +58,7 @@ import (
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
@@ -1141,50 +1143,110 @@ func TestValidateStoragePolicyExistsOnVcenter_WithRealVCenter(t *testing.T) {
 	t.Skip("Skipping real vCenter test - requires connection, fault handling tested separately")
 }
 
-func TestRecordEvent_Warning(t *testing.T) {
+// TestRecordEvent_DoesNotMutateBackOffDuration verifies that recordEvent only emits a
+// Kubernetes Event and never touches backOffDuration. That map's sole writers must be
+// completeReconciliationWithError/completeReconciliationWithSuccess (the overall outcome of one
+// Reconcile call) — if recordEvent also reset/doubled it, a ClusterStoragePolicyInfo status
+// success recorded here would clobber the shared counter before a later failure within the same
+// Reconcile call (e.g. the InfraStoragePolicyInfo status update) got a chance to compound it,
+// which is exactly what previously kept a repeatedly-failing instance stuck oscillating between
+// a 1s and 2s backoff instead of growing exponentially.
+func TestRecordEvent_DoesNotMutateBackOffDuration(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
-
 	cspi := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cspi"},
 	}
-
-	// Initialize backoff map for testing
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
 	namespacedName := types.NamespacedName{Name: "test-cspi"}
-	backOffDuration[namespacedName] = time.Second
-
 	r := &ReconcileClusterStoragePolicyInfo{recorder: record.NewFakeRecorder(10)}
-	r.recordEvent(ctx, cspi, v1.EventTypeWarning, "test warning")
 
-	// Verify backoff duration was doubled
-	backOffDurationMapMutex.Lock()
-	duration := backOffDuration[namespacedName]
-	backOffDurationMapMutex.Unlock()
+	for _, tt := range []struct {
+		name      string
+		eventType string
+		msg       string
+	}{
+		{"warning", v1.EventTypeWarning, "test warning"},
+		{"normal", v1.EventTypeNormal, "test success"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			backOffDuration = make(map[types.NamespacedName]time.Duration)
+			backOffDuration[namespacedName] = 4 * time.Second
 
-	assert.Equal(t, 2*time.Second, duration, "expected backoff duration to be doubled")
+			r.recordEvent(ctx, cspi, tt.eventType, tt.msg)
+
+			backOffDurationMapMutex.Lock()
+			duration := backOffDuration[namespacedName]
+			backOffDurationMapMutex.Unlock()
+			assert.Equal(t, 4*time.Second, duration, "recordEvent must not modify backOffDuration")
+		})
+	}
 }
 
-func TestRecordEvent_Normal(t *testing.T) {
+// TestBackOffDuration_GrowsAcrossRepeatedClusterSuccessInfraFailure is a regression test for the
+// real-world sequence that used to defeat exponential backoff: on every Reconcile,
+// ClusterStoragePolicyInfo's own status update succeeds (recordEvent Normal) but
+// InfraStoragePolicyInfo's fails (completeReconciliationWithError), over and over. Before
+// recordEvent stopped touching backOffDuration, the per-reconcile success reset it to 1s right
+// before the failure doubled it once to 2s, so it could never climb past 2s no matter how many
+// consecutive failures occurred. It must now double on every iteration instead.
+func TestBackOffDuration_GrowsAcrossRepeatedClusterSuccessInfraFailure(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
+	namespacedName := types.NamespacedName{Name: "test-cspi"}
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+	backOffDuration[namespacedName] = time.Second
 
 	cspi := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-cspi"},
+		ObjectMeta: metav1.ObjectMeta{Name: namespacedName.Name},
 	}
-
-	// Initialize backoff map for testing with higher duration
-	backOffDuration = make(map[types.NamespacedName]time.Duration)
-	namespacedName := types.NamespacedName{Name: "test-cspi"}
-	backOffDuration[namespacedName] = 30 * time.Second
-
 	r := &ReconcileClusterStoragePolicyInfo{recorder: record.NewFakeRecorder(10)}
-	r.recordEvent(ctx, cspi, v1.EventTypeNormal, "test success")
 
-	// Verify backoff duration was reset to 1 second
-	backOffDurationMapMutex.Lock()
-	duration := backOffDuration[namespacedName]
-	backOffDurationMapMutex.Unlock()
+	want := time.Second
+	for i := 0; i < 4; i++ {
+		// ClusterStoragePolicyInfo's own status update succeeds every time.
+		r.recordEvent(ctx, cspi, v1.EventTypeNormal, "cluster spi synced")
+		// But InfraStoragePolicyInfo's status update fails every time, so the overall
+		// Reconcile call ends in completeReconciliationWithError.
+		_, _ = r.completeReconciliationWithError(ctx, namespacedName, backOffDuration[namespacedName],
+			assert.AnError)
 
-	assert.Equal(t, time.Second, duration, "expected backoff duration to be reset to 1 second")
+		want = min(want*2, cnsoperatortypes.MaxBackOffDurationForReconciler)
+		backOffDurationMapMutex.Lock()
+		got := backOffDuration[namespacedName]
+		backOffDurationMapMutex.Unlock()
+		assert.Equal(t, want, got, "iteration %d: backoff must keep doubling despite the "+
+			"per-reconcile ClusterStoragePolicyInfo success", i)
+	}
+}
+
+// TestRecordInfraSPIEvent_DoesNotMutateBackOffDuration is the InfraStoragePolicyInfo-side
+// counterpart of TestRecordEvent_DoesNotMutateBackOffDuration; see its doc comment.
+func TestRecordInfraSPIEvent_DoesNotMutateBackOffDuration(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-infraspi"},
+	}
+	namespacedName := types.NamespacedName{Name: "test-infraspi"}
+	r := &ReconcileClusterStoragePolicyInfo{recorder: record.NewFakeRecorder(10)}
+
+	for _, tt := range []struct {
+		name      string
+		eventType string
+		msg       string
+	}{
+		{"warning", v1.EventTypeWarning, "test warning"},
+		{"normal", v1.EventTypeNormal, "test success"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			backOffDuration = make(map[types.NamespacedName]time.Duration)
+			backOffDuration[namespacedName] = 4 * time.Second
+
+			r.recordInfraSPIEvent(ctx, infraSPI, tt.eventType, tt.msg)
+
+			backOffDurationMapMutex.Lock()
+			duration := backOffDuration[namespacedName]
+			backOffDurationMapMutex.Unlock()
+			assert.Equal(t, 4*time.Second, duration, "recordInfraSPIEvent must not modify backOffDuration")
+		})
+	}
 }
 
 // Helper function to simulate the policy existence check logic for testing
@@ -3840,8 +3902,8 @@ func TestPopulateVolumeCapabilities_MarkerPolicy(t *testing.T) {
 			infraSPI.Name = tt.k8sCompliantName
 
 			// Call populateVolumeCapabilities with minimal required parameters
-			// We pass nil for vc, topologyMgr, and clusterDatastoreCache since we only want to test the logic
-			err := populateVolumeCapabilities(ctx, infraSPI, nil, "test-profile-id", nil, nil)
+			// We pass nil for vc and zoneCompatibleDS since we only want to test the logic
+			err := populateVolumeCapabilities(ctx, infraSPI, nil, "test-profile-id", nil)
 
 			// For marker policies, there should be no error since we skip the HPLC check
 			// For non-marker policies, there may be an error due to nil parameters, but capabilities should still be set
@@ -3902,22 +3964,21 @@ func TestCheckHighPerformanceLinkedClone_ZonesWithNoHosts(t *testing.T) {
 }
 
 // TestCheckLinkedClone_NoZones verifies that checkLinkedClone returns
-// LC=false when the topology manager reports no zones (empty azClustersMap).
+// LC=false when there are no zones with compatible datastores (empty zoneCompatibleDS).
 func TestCheckLinkedClone_NoZones(t *testing.T) {
 	ctx := context.Background()
-	topoMgr := &mockControllerTopologyService{azClustersMap: map[string][]string{}}
 	stubVC := &cnsvsphere.VirtualCenter{Client: &govmomi.Client{}}
-	lc, perZone, err := checkLinkedClone(ctx, stubVC, "test-policy", topoMgr, nil)
+	lc, perZone, err := checkLinkedClone(ctx, stubVC, "test-policy", map[string][]*cnsvsphere.DatastoreInfo{})
 	assert.NoError(t, err)
 	assert.False(t, lc, "LC must be false when there are no zones")
 	assert.Empty(t, perZone)
 }
 
-// TestCheckLinkedClone_NilTopologyManager verifies that checkLinkedClone returns
-// an error when called without a topology manager.
-func TestCheckLinkedClone_NilTopologyManager(t *testing.T) {
+// TestCheckLinkedClone_NilVC verifies that checkLinkedClone returns an error when called
+// without a vCenter client.
+func TestCheckLinkedClone_NilVC(t *testing.T) {
 	ctx := context.Background()
-	lc, perZone, err := checkLinkedClone(ctx, nil, "test-policy", nil, nil)
+	lc, perZone, err := checkLinkedClone(ctx, nil, "test-policy", nil)
 	assert.Error(t, err)
 	assert.False(t, lc)
 	assert.Nil(t, perZone)
@@ -3985,6 +4046,74 @@ func setupLCSim(t *testing.T, numClusters, hostsPerCluster int) (
 	return
 }
 
+// setupLCSimIsolatedDatastores creates a VPX model with numClusters clusters (one host each) and
+// one datastore exclusively mounted per cluster. Unlike setupLCSim, whose single datastore is
+// shared by every host in the datacenter (the vcsim VPX default), this gives each cluster its
+// own datastore so a 9.1+ host in one cluster can't be mistaken for ESXi 9.1+ coverage of
+// another cluster's zone.
+func setupLCSimIsolatedDatastores(t *testing.T, numClusters int) (
+	ctx context.Context,
+	vc *cnsvsphere.VirtualCenter,
+	model *simulator.Model,
+	clusterRefs []vimtypes.ManagedObjectReference,
+	datastores []*cnsvsphere.DatastoreInfo,
+	stop func(),
+) {
+	t.Helper()
+	ctx = logger.NewContextWithLogger(context.Background())
+	model = simulator.VPX()
+	model.Datacenter = 1
+	model.Cluster = numClusters
+	model.ClusterHost = 1
+	model.Host = 0
+	model.Machine = 0
+	model.Datastore = numClusters
+	require.NoError(t, model.Create())
+	s := model.Service.NewServer()
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		s.Close()
+		model.Remove()
+		t.Fatalf("failed to create govmomi client: %v", err)
+	}
+	vc = &cnsvsphere.VirtualCenter{
+		Config:      &cnsvsphere.VirtualCenterConfig{Host: "127.0.0.1"},
+		Client:      c,
+		ClientMutex: &sync.Mutex{},
+	}
+	stop = func() { s.Close(); model.Remove() }
+
+	clusters := model.Map().All("ClusterComputeResource")
+	require.Len(t, clusters, numClusters)
+	dsObjs := model.Map().All("Datastore")
+	require.Len(t, dsObjs, numClusters)
+
+	clusterRefs = make([]vimtypes.ManagedObjectReference, numClusters)
+	datastores = make([]*cnsvsphere.DatastoreInfo, numClusters)
+	for i, cl := range clusters {
+		clusterRef := cl.Reference()
+		clusterRefs[i] = clusterRef
+		hostRefs := hostRefsInCluster(model, clusterRef)
+		hostSet := make(map[string]struct{}, len(hostRefs))
+		for _, h := range hostRefs {
+			hostSet[h.Value] = struct{}{}
+		}
+
+		// Restrict this datastore's mount list to only the current cluster's hosts; by
+		// default vcsim mounts every datastore on every host in the datacenter.
+		dsObj := dsObjs[i].(*simulator.Datastore)
+		var mounts []vimtypes.DatastoreHostMount
+		for _, m := range dsObj.Host {
+			if _, ok := hostSet[m.Key.Value]; ok {
+				mounts = append(mounts, m)
+			}
+		}
+		dsObj.Host = mounts
+		datastores[i] = dsInfoFromSim(c, dsObj.Reference())
+	}
+	return
+}
+
 // dsInfoFromSim wraps a simulator datastore reference in a cnsvsphere.DatastoreInfo.
 func dsInfoFromSim(c *govmomi.Client, ref vimtypes.ManagedObjectReference) *cnsvsphere.DatastoreInfo {
 	return &cnsvsphere.DatastoreInfo{
@@ -4017,6 +4146,31 @@ func hostRefsInCluster(model *simulator.Model, clusterRef vimtypes.ManagedObject
 ) []vimtypes.ManagedObjectReference {
 	c := model.Map().Get(clusterRef).(*simulator.ClusterComputeResource)
 	return c.Host
+}
+
+// datastoresForCluster returns the datastores mounted by hosts in the given cluster, via a
+// direct HostSystem.datastore property query. Deliberately not
+// cnsvsphere.GetCandidateDatastoresInCluster/VirtualCenter.GetHostsByCluster: those attempt to
+// (re)connect using VirtualCenterConfig, which the bare simulator-backed VC built by setupLCSim
+// doesn't have, and the call fails trying to read a real vSphere config file.
+func datastoresForCluster(t *testing.T, ctx context.Context, vc *cnsvsphere.VirtualCenter, model *simulator.Model,
+	clusterRef vimtypes.ManagedObjectReference) []*cnsvsphere.DatastoreInfo {
+	t.Helper()
+	pc := property.DefaultCollector(vc.Client.Client)
+	seen := make(map[string]struct{})
+	var datastores []*cnsvsphere.DatastoreInfo
+	for _, hostRef := range hostRefsInCluster(model, clusterRef) {
+		var hostMo mo.HostSystem
+		require.NoError(t, pc.RetrieveOne(ctx, hostRef, []string{"datastore"}, &hostMo))
+		for _, dsRef := range hostMo.Datastore {
+			if _, ok := seen[dsRef.Value]; ok {
+				continue
+			}
+			seen[dsRef.Value] = struct{}{}
+			datastores = append(datastores, dsInfoFromSim(vc.Client, dsRef))
+		}
+	}
+	return datastores
 }
 
 // --- fetchESXi91HostsForDatastore tests -----------------------------------------------
@@ -4091,6 +4245,54 @@ func TestFetchESXi91HostsForDatastore_AllESXi91(t *testing.T) {
 	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]bool))
 	require.NoError(t, err)
 	assert.Len(t, hosts, len(hostRefs), "all ESXi 9.1+ hosts should be returned")
+}
+
+// --- checkLinkedClone simulator tests --------------------------------------------------
+
+// TestCheckLinkedClone_SingleZoneAllHostsESXi91 verifies LC=true when the only zone's
+// compatible datastore is mounted only by ESXi 9.1+ hosts.
+func TestCheckLinkedClone_SingleZoneAllHostsESXi91(t *testing.T) {
+	ctx, vc, model, stop := setupLCSim(t, 1, 2)
+	defer stop()
+
+	clusterRef := model.Map().All("ClusterComputeResource")[0].Reference()
+	for _, hostRef := range hostRefsInCluster(model, clusterRef) {
+		setHostESXiVersion(model, hostRef, "9.1.0")
+	}
+
+	clusterDS := datastoresForCluster(t, ctx, vc, model, clusterRef)
+	require.NotEmpty(t, clusterDS)
+
+	zoneCompatibleDS := map[string][]*cnsvsphere.DatastoreInfo{"zone-a": clusterDS}
+
+	lc, perZone, err := checkLinkedClone(ctx, vc, "test-policy", zoneCompatibleDS)
+	require.NoError(t, err)
+	assert.True(t, lc, "LC should be true when the zone's datastore is mounted only by ESXi 9.1+ hosts")
+	assert.NotEmpty(t, perZone["zone-a"])
+}
+
+// TestCheckLinkedClone_OneZoneMissingESXi91Host verifies LC=false when only one of two
+// zones has a qualifying ESXi 9.1+ host (LC requires every zone with compatible
+// datastores to have at least one).
+func TestCheckLinkedClone_OneZoneMissingESXi91Host(t *testing.T) {
+	ctx, vc, model, clusters, datastores, stop := setupLCSimIsolatedDatastores(t, 2)
+	defer stop()
+
+	for _, hostRef := range hostRefsInCluster(model, clusters[0]) {
+		setHostESXiVersion(model, hostRef, "9.1.0")
+	}
+	for _, hostRef := range hostRefsInCluster(model, clusters[1]) {
+		setHostESXiVersion(model, hostRef, "7.0.3")
+	}
+
+	zoneCompatibleDS := map[string][]*cnsvsphere.DatastoreInfo{
+		"zone-a": {datastores[0]},
+		"zone-b": {datastores[1]},
+	}
+
+	lc, _, err := checkLinkedClone(ctx, vc, "test-policy", zoneCompatibleDS)
+	require.NoError(t, err)
+	assert.False(t, lc, "LC must be false when not every zone has a qualifying ESXi 9.1+ host")
 }
 
 // --- checkHighPerformanceLinkedClone simulator tests ----------------------------------

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
@@ -39,9 +39,8 @@ import (
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
-	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
-	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/vsphereinfra"
 )
 
 // ownerReferenceKey returns OwnerReference key which is concatenated from the APIVersion, Kind and Name.
@@ -522,8 +521,7 @@ func findStoragePolicyProfile(ctx context.Context,
 func populateVolumeCapabilities(ctx context.Context,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
 	vc *cnsvsphere.VirtualCenter, profileID string,
-	topologyMgr commoncotypes.ControllerTopologyService,
-	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) error {
+	zoneCompatibleDS map[string][]*cnsvsphere.DatastoreInfo) error {
 	log := logger.GetLogger(ctx)
 
 	caps := map[infraspiv1alpha1.VolumeCapability]bool{
@@ -551,11 +549,7 @@ func populateVolumeCapabilities(ctx context.Context,
 		return nil
 	}
 
-	if clusterDatastoreCache == nil {
-		clusterDatastoreCache = make(map[string][]*cnsvsphere.DatastoreInfo)
-	}
-
-	lc, esxi91HostsPerZone, err := checkLinkedClone(ctx, vc, profileID, topologyMgr, clusterDatastoreCache)
+	lc, esxi91HostsPerZone, err := checkLinkedClone(ctx, vc, profileID, zoneCompatibleDS)
 	if err != nil {
 		log.Errorf("Failed to check SupportsLinkedClone for policy %s: %v", profileID, err)
 		caps[infraspiv1alpha1.SupportsHighPerformanceLinkedClone] = false
@@ -596,24 +590,12 @@ func populateVolumeCapabilities(ctx context.Context,
 // least one ESXi 9.1+ host mounting those datastores.
 func checkLinkedClone(ctx context.Context,
 	vc *cnsvsphere.VirtualCenter, profileID string,
-	topologyMgr commoncotypes.ControllerTopologyService,
-	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo,
+	zoneCompatibleDS map[string][]*cnsvsphere.DatastoreInfo,
 ) (bool, map[string]map[string]vimtypes.ManagedObjectReference, error) {
 	log := logger.GetLogger(ctx)
 
-	if topologyMgr == nil {
-		log.Warnf("Topology manager unavailable; cannot determine SupportsLinkedClone")
-		return false, nil, fmt.Errorf("topology manager is not available")
-	}
-
 	if vc == nil || vc.Client == nil {
 		return false, nil, fmt.Errorf("virtual center client is not available")
-	}
-
-	zoneCompatibleDS, err := cnsoperatorutil.GetPolicyCompatibleDatastoresPerZone(ctx, topologyMgr, vc, profileID,
-		clusterDatastoreCache)
-	if err != nil {
-		return false, nil, err
 	}
 
 	if len(zoneCompatibleDS) == 0 {
@@ -850,5 +832,6 @@ func isClusterESAEnabled(ctx context.Context, pc *property.Collector,
 	esa := ok && cfgEx.VsanConfigInfo != nil &&
 		cfgEx.VsanConfigInfo.VsanEsaEnabled != nil && *cfgEx.VsanConfigInfo.VsanEsaEnabled
 	checkedClusters[clusterValue] = esa
+	vsphereinfra.GetCache().SetClusterESAEnabled(clusterValue, esa)
 	return esa, nil
 }

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/populate_topology_cache_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/populate_topology_cache_test.go
@@ -22,8 +22,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/vmware/govmomi/object"
-	vimtypes "github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/pbm"
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -37,33 +38,36 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/vsphereinfra"
 )
 
-// fakeDatastoreInfo builds a *cnsvsphere.DatastoreInfo whose Reference() is
-// dsID, without needing a real vCenter connection: object.NewDatastore's
-// Reference() only ever returns the moref it was constructed with.
-func fakeDatastoreInfo(dsID string) *cnsvsphere.DatastoreInfo {
-	return &cnsvsphere.DatastoreInfo{
-		Datastore: &cnsvsphere.Datastore{
-			Datastore: object.NewDatastore(nil, vimtypes.ManagedObjectReference{Type: "Datastore", Value: dsID}),
-		},
-	}
+// fakeVCForTopologyTests returns a VirtualCenter with just enough non-nil structure that
+// object.NewDatastore(vc.Client.Client, ...) doesn't panic while GetZoneCompatibleDatastoresForPolicy
+// builds DatastoreInfo results.
+func fakeVCForTopologyTests() *cnsvsphere.VirtualCenter {
+	return &cnsvsphere.VirtualCenter{Client: &govmomi.Client{}}
 }
 
-// withMockCompatibleDatastores replaces cnsoperatorutil.GetPolicyCompatibleDatastoresFn
-// for the duration of the test, so populateTopologyCapabilities's PBM query
-// resolves to a fixed set of datastore morefs without a real vCenter/PBM
-// connection.
-func withMockCompatibleDatastores(t *testing.T, dsIDs ...string) {
+// withMockCompatibleDatastores replaces cnsoperatorutil.PbmCheckRequirementsForZoneTopologyFn for
+// the duration of the test, so populateTopologyCapabilities's PBM query resolves to a fixed
+// datastore-to-cluster attribution without a real vCenter/PBM connection. dsToClusters maps each
+// compatible datastore moref to the cluster moref(s) it is mounted on.
+func withMockCompatibleDatastores(t *testing.T, dsToClusters map[string][]string) {
 	t.Helper()
-	orig := cnsoperatorutil.GetPolicyCompatibleDatastoresFn
-	cnsoperatorutil.GetPolicyCompatibleDatastoresFn = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
-		profileID string) (map[string]struct{}, error) {
-		ids := make(map[string]struct{}, len(dsIDs))
-		for _, id := range dsIDs {
-			ids[id] = struct{}{}
+	orig := cnsoperatorutil.PbmCheckRequirementsForZoneTopologyFn
+	cnsoperatorutil.PbmCheckRequirementsForZoneTopologyFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ string, _ []string) (pbm.PlacementCompatibilityResult, error) {
+		result := make(pbm.PlacementCompatibilityResult, 0, len(dsToClusters))
+		for dsID, clusters := range dsToClusters {
+			zoneClusters := make([]pbmtypes.PbmServerObjectRef, 0, len(clusters))
+			for _, c := range clusters {
+				zoneClusters = append(zoneClusters, pbmtypes.PbmServerObjectRef{Key: c})
+			}
+			result = append(result, pbmtypes.PbmPlacementCompatibilityResult{
+				Hub:     pbmtypes.PbmPlacementHub{HubType: "Datastore", HubId: dsID},
+				HubInfo: &pbmtypes.PbmPlacementHubInfo{ZoneClusters: zoneClusters},
+			})
 		}
-		return ids, nil
+		return result, nil
 	}
-	t.Cleanup(func() { cnsoperatorutil.GetPolicyCompatibleDatastoresFn = orig })
+	t.Cleanup(func() { cnsoperatorutil.PbmCheckRequirementsForZoneTopologyFn = orig })
 }
 
 func TestPopulateTopologyCapabilities_PopulatesDsToPolicyCache(t *testing.T) {
@@ -79,12 +83,8 @@ func TestPopulateTopologyCapabilities_PopulatesDsToPolicyCache(t *testing.T) {
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sc).Build()
 
-	withMockCompatibleDatastores(t, "ds-1")
-
-	clusterDatastoreCache := map[string][]*cnsvsphere.DatastoreInfo{
-		"cluster-1": {fakeDatastoreInfo("ds-1")},
-		"cluster-2": {fakeDatastoreInfo("ds-2")},
-	}
+	// ds-1 is compatible and mounted only on cluster-1 (zone-a); ds-2 is not compatible at all.
+	withMockCompatibleDatastores(t, map[string][]string{"ds-1": {"cluster-1"}})
 
 	r := &ReconcileClusterStoragePolicyInfo{
 		client: k8sClient,
@@ -108,7 +108,7 @@ func TestPopulateTopologyCapabilities_PopulatesDsToPolicyCache(t *testing.T) {
 	// that reuse the same datastore IDs.
 	t.Cleanup(func() { vsphereinfra.GetCache().SetDatastoresForPolicy(clusterSPI.Name, nil) })
 
-	err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil, clusterDatastoreCache, nil)
+	_, err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", fakeVCForTopologyTests(), nil)
 	require.NoError(t, err)
 
 	// Only zone-a's cluster mounts the compatible datastore (ds-1).
@@ -133,9 +133,6 @@ func TestPopulateTopologyCapabilities_CacheEntryClearedWhenNoLongerCompatible(t 
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sc).Build()
 
-	clusterDatastoreCache := map[string][]*cnsvsphere.DatastoreInfo{
-		"cluster-1": {fakeDatastoreInfo("ds-1")},
-	}
 	r := &ReconcileClusterStoragePolicyInfo{
 		client: k8sClient,
 		scheme: scheme,
@@ -150,17 +147,18 @@ func TestPopulateTopologyCapabilities_CacheEntryClearedWhenNoLongerCompatible(t 
 	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-policy-2"},
 	}
+	vc := fakeVCForTopologyTests()
 
-	// First reconcile: ds-1 is compatible.
-	withMockCompatibleDatastores(t, "ds-1")
-	require.NoError(t, r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil,
-		clusterDatastoreCache, nil))
+	// First reconcile: ds-1 is compatible, mounted on cluster-1.
+	withMockCompatibleDatastores(t, map[string][]string{"ds-1": {"cluster-1"}})
+	_, err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", vc, nil)
+	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"test-policy-2"}, vsphereinfra.GetCache().PoliciesForDatastore("ds-1"))
 
 	// Second reconcile: PBM now reports no compatible datastores at all.
-	withMockCompatibleDatastores(t)
-	require.NoError(t, r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", nil,
-		clusterDatastoreCache, nil))
+	withMockCompatibleDatastores(t, map[string][]string{})
+	_, err = r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", vc, nil)
+	require.NoError(t, err)
 
 	assert.Empty(t, vsphereinfra.GetCache().PoliciesForDatastore("ds-1"),
 		"stale cache entry must be cleared once the policy is no longer compatible with ds-1")

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -51,6 +52,7 @@ import (
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
 	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -58,6 +60,7 @@ import (
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/vsphereinfra"
 )
 
 // zonesProvider is the narrow slice of COCommonInterface that this controller
@@ -69,6 +72,12 @@ type zonesProvider interface {
 	// dereference a nil informer and panic.
 	StartZonesInformer(ctx context.Context, restClientConfig *restclient.Config, namespace string) error
 	GetZonesForNamespace(ns string) map[string]struct{}
+	// GetActiveClustersForNamespaceInRequestedZones returns the cluster morefs the namespace
+	// is actually active on within the given zones (from the namespace-scoped Zone CR's
+	// spec.namespace.clusterMoIDs), as opposed to GetZonesForNamespace, which only reports
+	// zone-name assignment. A zone can span multiple clusters, and a namespace may be active
+	// on only a subset of them.
+	GetActiveClustersForNamespaceInRequestedZones(ctx context.Context, ns string, zones []string) ([]string, error)
 }
 
 const (
@@ -492,6 +501,18 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
+	// Populate VolumeCapabilities from InfraStoragePolicyInfo.
+	if err := syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI); err != nil {
+		log.Errorf("Failed to sync volume capabilities for StoragePolicyInfo %q: %v",
+			request.NamespacedName, err)
+		if setErr := r.setSPIError(ctx, instance, origStatus,
+			fmt.Sprintf("Failed to sync volume capabilities: %v", err)); setErr != nil {
+			log.Errorf("Failed to update StoragePolicyInfo %q status: %v",
+				request.NamespacedName, setErr)
+		}
+		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
+	}
+
 	if setErr := r.setSPISuccess(ctx, instance, origStatus, "Successfully synced topology"); setErr != nil {
 		log.Errorf("Failed to update StoragePolicyInfo %q status: %v",
 			request.NamespacedName, setErr)
@@ -640,6 +661,192 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 	return nil
 }
 
+// syncVolumeCapabilitiesFromInfraSPI populates the namespace-scoped
+// StoragePolicyInfo volume capabilities from the cluster-scoped
+// InfraStoragePolicyInfo, with no additional vCenter calls.
+// SupportsVolumeModeFilesystem is always true, independent of InfraSPI.
+// SupportsVolumeModeBlock is copied as-is from InfraSPI.
+// SupportsLinkedClone and SupportsHighPerformanceLinkedClone are recomputed for just the zones accessible
+// to this namespace.
+func syncVolumeCapabilitiesFromInfraSPI(ctx context.Context, instance *spiv1alpha1.StoragePolicyInfo,
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) error {
+	infraCaps := infraSPI.Status.VolumeCapabilities
+
+	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, instance, infraSPI)
+	if err != nil {
+		return err
+	}
+
+	instance.Status.VolumeCapabilities = map[spiv1alpha1.VolumeCapability]bool{
+		spiv1alpha1.SupportsVolumeModeFilesystem:       true,
+		spiv1alpha1.SupportsVolumeModeBlock:            infraCaps[infraspiv1alpha1.SupportsVolumeModeBlock],
+		spiv1alpha1.SupportsLinkedClone:                lc,
+		spiv1alpha1.SupportsHighPerformanceLinkedClone: hplc,
+	}
+	return nil
+}
+
+// linkedCloneCapabilitiesForNamespace determines SupportsLinkedClone and
+// SupportsHighPerformanceLinkedClone for this namespace's StoragePolicyInfo, recomputed over
+// just the namespace's accessible zones (already namespace-filtered by
+// syncTopologyFromInfraSPI) via computeLinkedCloneForNamespace/computeHPLCForNamespace.
+//
+// instance.Status.TopologyInfo is nil only when InfraStoragePolicyInfo itself has no
+// Topology, which happens exclusively when the cluster-scoped reconcile failed to resolve the
+// policy's StorageClass or StorageTopologyType (see populateTopologyCapabilities) — never as a
+// legitimate "non-zonal" state, since a genuinely non-zonal policy still gets a non-nil
+// Topology with an empty TopologyType. That's an upstream failure, not an absence of
+// applicable zones, so it's surfaced as an error here rather than silently falling back to
+// infraCaps (which was computed from that same failed reconcile and can't be trusted either).
+func linkedCloneCapabilitiesForNamespace(ctx context.Context, instance *spiv1alpha1.StoragePolicyInfo,
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) (lc bool, hplc bool, err error) {
+	if instance.Status.TopologyInfo == nil {
+		return false, false, fmt.Errorf(
+			"cannot determine LinkedClone capabilities for namespace %q: InfraStoragePolicyInfo %q "+
+				"has not resolved its topology yet", instance.Namespace, infraSPI.Name)
+	}
+
+	nsZones := instance.Status.TopologyInfo.AccessibleZones
+	lc, err = computeLinkedCloneForNamespace(ctx, infraSPI.Name, nsZones)
+	if err != nil {
+		return false, false, err
+	}
+	hplc, err = computeHPLCForNamespace(ctx, infraSPI.Name, nsZones, lc)
+	if err != nil {
+		return false, false, err
+	}
+	return lc, hplc, nil
+}
+
+// computeLinkedCloneForNamespace determines whether the storage policy identified by
+// policyName (its K8s-compliant name) supports LinkedClone within nsZones, using
+// data already cached by vsphereinfra.StoragePolicyInfoCache.
+// LinkedClone is supported for the namespace if any host mounting a
+// datastore compatible with policyName within one of nsZones is running ESXi 9.1 or
+// above.
+func computeLinkedCloneForNamespace(ctx context.Context, policyName string, nsZones []string) (bool, error) {
+	return anyQualifyingHostForNamespace(ctx, "LinkedClone", policyName, nsZones, hostSupportsLinkedClone)
+}
+
+// computeHPLCForNamespace determines whether SupportsHighPerformanceLinkedClone is true
+// for nsZones. HPLC requires LinkedClone support first — if lcSupported is false, HPLC is
+// false without evaluating the vSAN-ESA condition. Otherwise it looks for a qualifying
+// host (ESXi 9.1+) whose cluster has vSAN-ESA enabled
+// (hostSupportsHighPerformanceLinkedClone).
+func computeHPLCForNamespace(ctx context.Context, policyName string, nsZones []string,
+	lcSupported bool) (bool, error) {
+	if !lcSupported {
+		return false, nil
+	}
+	return anyQualifyingHostForNamespace(ctx, "HighPerformanceLinkedClone", policyName, nsZones,
+		hostSupportsHighPerformanceLinkedClone)
+}
+
+// anyQualifyingHostForNamespace walks every host mounting a datastore compatible with
+// policyName within one of nsZones to find out if LC or HPLC are supported or not.
+// checkName ("LinkedClone" or "HPLC") identifies which check is running in the logs, since
+// both checks walk the same hosts/datastores/zones and would otherwise be indistinguishable.
+func anyQualifyingHostForNamespace(ctx context.Context, operation string, policyName string, nsZones []string,
+	qualifies func(ctx context.Context, hostID string) (bool, error)) (bool, error) {
+	log := logger.GetLogger(ctx)
+	for _, zone := range nsZones {
+		zoneDS, ok := vsphereinfra.GetCache().GetDatastoresForPolicyZone(ctx, policyName, zone)
+		if !ok {
+			continue
+		}
+		log.Debugf("anyQualifyingHostForNamespace[%s]: policy %q has %d compatible datastore(s) cached "+
+			"in zone %q", operation, policyName, len(zoneDS), zone)
+
+		for dsID := range zoneDS {
+			hosts, ok := vsphereinfra.GetCache().GetDsHosts(dsID)
+			if !ok {
+				log.Debugf("anyQualifyingHostForNamespace[%s]: no hosts cached yet for datastore %s "+
+					"(policy %q, zone %q); skipping", operation, dsID, policyName, zone)
+				continue
+			}
+			log.Infof("anyQualifyingHostForNamespace[%s]: found hosts %+v for datastore %s", operation, hosts, dsID)
+			for hostID := range hosts {
+				qualified, err := qualifies(ctx, hostID)
+				if err != nil {
+					return false, fmt.Errorf("failed to check host %s (datastore %s, zone %q): %w",
+						hostID, dsID, zone, err)
+				}
+				if qualified {
+					log.Infof("anyQualifyingHostForNamespace[%s]: host %s qualifies for policy %q via "+
+						"datastore %s in zone %q", operation, hostID, policyName, dsID, zone)
+					return true, nil
+				}
+				log.Debugf("anyQualifyingHostForNamespace[%s]: host %s does not qualify for policy %q "+
+					"(datastore %s, zone %q)", operation, hostID, policyName, dsID, zone)
+			}
+		}
+	}
+	log.Infof("anyQualifyingHostForNamespace[%s]: no qualifying host found for policy %q across zones %v",
+		operation, policyName, nsZones)
+	return false, nil
+}
+
+// hostSupportsLinkedClone reports whether a host cached by the inventory watcher is
+// running ESXi 9.1 or above. Returns false if the host's version has not been observed
+// yet; returns an error if the cached version string can't be parsed.
+func hostSupportsLinkedClone(ctx context.Context, hostID string) (bool, error) {
+	log := logger.GetLogger(ctx)
+
+	version, found := vsphereinfra.GetCache().GetHostVersion(hostID)
+	if !found {
+		log.Infof("Version for Host %s not found", hostID)
+		return false, nil
+	}
+	supported, err := cnsvsphere.IsvSphereVersion91orAbove(ctx, vimtypes.AboutInfo{Version: version})
+	if err != nil {
+		return false, fmt.Errorf("failed to parse ESXi version %q for host %q: %w", version, hostID, err)
+	}
+	return supported, nil
+}
+
+// hostSupportsHighPerformanceLinkedClone reports whether a host cached by the inventory
+// watcher both is ESXi 9.1+ and belongs to a cluster with vSAN-ESA enabled
+// (ClusterForHost/GetClusterESAEnabled, populated by the clusterstoragepolicyinfo
+// controller's isClusterESAEnabled check while reconciling InfraSPI). Returns false if
+// the host's cluster, or that cluster's vSAN-ESA state, has not been observed/computed
+// yet.
+func hostSupportsHighPerformanceLinkedClone(ctx context.Context, hostID string) (bool, error) {
+	log := logger.GetLogger(ctx)
+
+	lc, err := hostSupportsLinkedClone(ctx, hostID)
+	if err != nil {
+		return false, err
+	}
+	if !lc {
+		log.Debugf("hostSupportsHighPerformanceLinkedClone: host %s does not support LinkedClone; HPLC=false",
+			hostID)
+		return false, nil
+	}
+
+	clusterID, ok := vsphereinfra.GetCache().ClusterForHost(hostID)
+	if !ok {
+		log.Debugf("hostSupportsHighPerformanceLinkedClone: cluster for host %s not yet known; HPLC=false",
+			hostID)
+		return false, nil
+	}
+
+	esa, found := vsphereinfra.GetCache().GetClusterESAEnabled(clusterID)
+	if !found {
+		log.Debugf("hostSupportsHighPerformanceLinkedClone: vSAN-ESA state for cluster %s (host %s) not "+
+			"yet known; HPLC=false", clusterID, hostID)
+		return false, nil
+	}
+	if !esa {
+		log.Debugf("hostSupportsHighPerformanceLinkedClone: cluster %s (host %s) does not have vSAN-ESA "+
+			"enabled; HPLC=false", clusterID, hostID)
+		return false, nil
+	}
+
+	log.Debugf("hostSupportsHighPerformanceLinkedClone: host %s in cluster %s qualifies for HPLC",
+		hostID, clusterID)
+	return true, nil
+}
+
 // syncMarkerPolicyTopology populates the namespace-scoped StoragePolicyInfo
 // topology for a marker policy by deriving accessible zones from FVS instance
 // namespaces that share the consumer namespace's VPC path, bypassing the
@@ -693,13 +900,32 @@ func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 	}
 
 	// Intersect cluster-accessible zones with namespace-assigned zones.
-	filtered := make([]string, 0, len(clusterZones))
+	assignedZones := make([]string, 0, len(clusterZones))
 	for _, zone := range clusterZones {
 		if _, assigned := nsZones[zone]; assigned {
-			filtered = append(filtered, zone)
+			assignedZones = append(assignedZones, zone)
 		}
 	}
-	log.Debugf("Namespace %q has zone assignments %v; filtered %d cluster zones → %d namespace-accessible zones",
+
+	// A zone can span multiple clusters, and this namespace may only be active on a subset
+	// of them (or, in an edge case, on none). Confirm each zone-assigned zone actually has an
+	// active cluster for this namespace before exposing it — otherwise a policy's datastores
+	// attributed to that zone (via PolicyZoneDatastores, computed over every cluster in the
+	// zone) could be reported as accessible even though this namespace's volumes could never
+	// actually land there.
+	// GetActiveClustersForNamespaceInRequestedZones does a full informer-store scan internally,
+	// calling it once per zone is fine for typical zone counts.
+	filtered := make([]string, 0, len(assignedZones))
+	for _, zone := range assignedZones {
+		activeClusters, err := r.zonesProvider.GetActiveClustersForNamespaceInRequestedZones(ctx, namespace, []string{zone})
+		if err != nil || len(activeClusters) == 0 {
+			log.Debugf("Namespace %q is assigned zone %q but has no active cluster within it; excluding: %v",
+				namespace, zone, err)
+			continue
+		}
+		filtered = append(filtered, zone)
+	}
+	log.Infof("Namespace %q has zone assignments %v; filtered %d cluster zones → %d namespace-accessible zones",
 		namespace, nsZones, len(clusterZones), len(filtered))
 	return filtered
 }
@@ -740,13 +966,11 @@ func (r *ReconcileStoragePolicyInfo) setSPISuccess(ctx context.Context,
 // and records a successful reconciliation.
 func (r *ReconcileStoragePolicyInfo) completeReconciliationWithSuccess(ctx context.Context,
 	namespacedName apitypes.NamespacedName) (reconcile.Result, error) {
-	log := logger.GetLogger(ctx).With("name", namespacedName)
 
 	r.backOffDurationMapMutex.Lock()
 	delete(r.backOffDuration, namespacedName)
 	r.backOffDurationMapMutex.Unlock()
 
-	log.Infof("Successfully reconciled StoragePolicyInfo")
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -18,6 +18,7 @@ package storagepolicyinfo
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -57,10 +58,15 @@ func testScheme(t *testing.T) *runtime.Scheme {
 }
 
 // mockZonesProvider is a minimal test double for the zonesProvider interface.
-// Only GetZonesForNamespace carries real behaviour; tests set zonesForNamespace
-// to control which zones are returned per namespace.
+// zonesForNamespace controls which zones GetZonesForNamespace reports per namespace.
+// GetActiveClustersForNamespaceInRequestedZones defaults to treating every zone in
+// zonesForNamespace as having an active cluster (returning a synthetic cluster moref for it),
+// so existing tests that only care about zone-name assignment don't need to opt into the
+// active-cluster check explicitly. Tests exercising that check set inactiveZones to mark
+// specific assigned zones as having no active cluster for the namespace.
 type mockZonesProvider struct {
 	zonesForNamespace map[string]map[string]struct{}
+	inactiveZones     map[string]map[string]struct{}
 }
 
 func (m *mockZonesProvider) StartZonesInformer(_ context.Context, _ *restclient.Config, _ string) error {
@@ -72,6 +78,26 @@ func (m *mockZonesProvider) GetZonesForNamespace(ns string) map[string]struct{} 
 		return m.zonesForNamespace[ns]
 	}
 	return nil
+}
+
+func (m *mockZonesProvider) GetActiveClustersForNamespaceInRequestedZones(_ context.Context,
+	ns string, zones []string) ([]string, error) {
+	nsZones := m.zonesForNamespace[ns]
+	inactive := m.inactiveZones[ns]
+	var activeClusters []string
+	for _, zone := range zones {
+		if _, assigned := nsZones[zone]; !assigned {
+			continue
+		}
+		if _, isInactive := inactive[zone]; isInactive {
+			continue
+		}
+		activeClusters = append(activeClusters, "cluster-for-"+zone)
+	}
+	if len(activeClusters) == 0 {
+		return nil, fmt.Errorf("could not find active cluster for the namespace %q in requested zones: %v", ns, zones)
+	}
+	return activeClusters, nil
 }
 
 var _ zonesProvider = &mockZonesProvider{}
@@ -468,6 +494,7 @@ func TestNamespaceFilteredZones(t *testing.T) {
 	tests := []struct {
 		name          string
 		nsZones       map[string]struct{} // zones for "ns1"; nil = no constraint
+		inactiveZones map[string]struct{} // subset of nsZones with no active cluster for ns1
 		clusterZones  []string
 		expectedZones []string
 	}{
@@ -495,18 +522,38 @@ func TestNamespaceFilteredZones(t *testing.T) {
 			clusterZones:  nil,
 			expectedZones: nil,
 		},
+		{
+			name:          "zone assigned to namespace but with no active cluster is excluded",
+			nsZones:       map[string]struct{}{"az1": {}, "az2": {}},
+			inactiveZones: map[string]struct{}{"az2": {}},
+			clusterZones:  []string{"az1", "az2"},
+			expectedZones: []string{"az1"},
+		},
+		{
+			name:          "namespace assigned to zone but active on no cluster in any zone returns empty",
+			nsZones:       map[string]struct{}{"az1": {}},
+			inactiveZones: map[string]struct{}{"az1": {}},
+			clusterZones:  []string{"az1"},
+			expectedZones: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var zonesMap map[string]map[string]struct{}
+			var zonesMap, inactiveMap map[string]map[string]struct{}
 			if tt.nsZones != nil {
 				zonesMap = map[string]map[string]struct{}{"ns1": tt.nsZones}
 			}
+			if tt.inactiveZones != nil {
+				inactiveMap = map[string]map[string]struct{}{"ns1": tt.inactiveZones}
+			}
 			r := &ReconcileStoragePolicyInfo{
-				client:        fake.NewClientBuilder().WithScheme(scheme).Build(),
-				scheme:        scheme,
-				zonesProvider: &mockZonesProvider{zonesForNamespace: zonesMap},
+				client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+				scheme: scheme,
+				zonesProvider: &mockZonesProvider{
+					zonesForNamespace: zonesMap,
+					inactiveZones:     inactiveMap,
+				},
 			}
 
 			got := r.namespaceFilteredZones(ctx, "ns1", tt.clusterZones)

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/volume_capabilities_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/volume_capabilities_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepolicyinfo
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
+	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/vsphereinfra"
+)
+
+// clearPolicyZoneCache clears the process-wide vsphereinfra cache entries this test wrote,
+// so cases in this file can't leak state into each other or into other packages' tests
+// sharing the same singleton.
+func clearPolicyZoneCache(t *testing.T, policyName string) {
+	t.Helper()
+	t.Cleanup(func() { vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, nil) })
+}
+
+func TestAnyQualifyingHostForNamespace_NoZones(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", "policy-1", nil,
+		func(context.Context, string) (bool, error) { return true, nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAnyQualifyingHostForNamespace_ZoneNotCached(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", "policy-never-cached", []string{"zone-a"},
+		func(context.Context, string) (bool, error) { return true, nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAnyQualifyingHostForNamespace_DatastoreNotInDsToHosts(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const policyName = "policy-anqhfn-1"
+	clearPolicyZoneCache(t, policyName)
+
+	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-1"}})
+	// Deliberately not populating DsToHosts for ds-1.
+
+	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", policyName, []string{"zone-a"},
+		func(context.Context, string) (bool, error) { return true, nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAnyQualifyingHostForNamespace_QualifyingHostFound(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const policyName = "policy-anqhfn-2"
+	clearPolicyZoneCache(t, policyName)
+	t.Cleanup(func() { vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-2", map[string]struct{}{}) })
+
+	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-anqhfn-2"}})
+	vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-2", map[string]struct{}{"host-1": {}, "host-2": {}})
+
+	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", policyName, []string{"zone-a"},
+		func(_ context.Context, hostID string) (bool, error) { return hostID == "host-2", nil })
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestAnyQualifyingHostForNamespace_NoQualifyingHost(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const policyName = "policy-anqhfn-3"
+	clearPolicyZoneCache(t, policyName)
+	t.Cleanup(func() { vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-3", map[string]struct{}{}) })
+
+	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-anqhfn-3"}})
+	vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-3", map[string]struct{}{"host-1": {}})
+
+	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", policyName, []string{"zone-a"},
+		func(context.Context, string) (bool, error) { return false, nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAnyQualifyingHostForNamespace_QualifiesErrorPropagates(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const policyName = "policy-anqhfn-4"
+	clearPolicyZoneCache(t, policyName)
+	t.Cleanup(func() { vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-4", map[string]struct{}{}) })
+
+	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-anqhfn-4"}})
+	vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-4", map[string]struct{}{"host-1": {}})
+
+	wantErr := errors.New("boom")
+	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", policyName, []string{"zone-a"},
+		func(context.Context, string) (bool, error) { return false, wantErr })
+	assert.ErrorIs(t, err, wantErr)
+	assert.False(t, ok)
+}
+
+func TestHostSupportsLinkedClone_NotObserved(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	ok, err := hostSupportsLinkedClone(ctx, "host-never-observed")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestHostSupportsLinkedClone_VersionBelow91(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateHostVersion("host-hslc-old") })
+	vsphereinfra.GetCache().UpdateHostVersion("host-hslc-old", "8.0.3")
+
+	ok, err := hostSupportsLinkedClone(ctx, "host-hslc-old")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestHostSupportsLinkedClone_VersionAtOrAbove91(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateHostVersion("host-hslc-new") })
+	vsphereinfra.GetCache().UpdateHostVersion("host-hslc-new", "9.1.0")
+
+	ok, err := hostSupportsLinkedClone(ctx, "host-hslc-new")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestHostSupportsHighPerformanceLinkedClone_RequiresLinkedCloneFirst(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateHostVersion("host-hphlc-old") })
+	// Below 9.1: hostSupportsLinkedClone is false, so HPLC must short-circuit to false without
+	// ever needing ClusterForHost/GetClusterESAEnabled to be populated.
+	vsphereinfra.GetCache().UpdateHostVersion("host-hphlc-old", "8.0.3")
+
+	ok, err := hostSupportsHighPerformanceLinkedClone(ctx, "host-hphlc-old")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestHostSupportsHighPerformanceLinkedClone_NoClusterMapping(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateHostVersion("host-hphlc-nocluster") })
+	vsphereinfra.GetCache().UpdateHostVersion("host-hphlc-nocluster", "9.1.0")
+	// Deliberately not populating ClusterToHosts for this host.
+
+	ok, err := hostSupportsHighPerformanceLinkedClone(ctx, "host-hphlc-nocluster")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestHostSupportsHighPerformanceLinkedClone_ESANotEnabled(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const hostID, clusterID = "host-hphlc-noesa", "cluster-hphlc-noesa"
+	t.Cleanup(func() {
+		vsphereinfra.GetCache().InvalidateHostVersion(hostID)
+		vsphereinfra.GetCache().InvalidateCluster(clusterID)
+	})
+	vsphereinfra.GetCache().UpdateHostVersion(hostID, "9.1.0")
+	vsphereinfra.GetCache().UpdateClusterHosts(clusterID, map[string]struct{}{hostID: {}})
+	vsphereinfra.GetCache().SetClusterESAEnabled(clusterID, false)
+
+	ok, err := hostSupportsHighPerformanceLinkedClone(ctx, hostID)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestHostSupportsHighPerformanceLinkedClone_ESAEnabled(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const hostID, clusterID = "host-hphlc-esa", "cluster-hphlc-esa"
+	t.Cleanup(func() {
+		vsphereinfra.GetCache().InvalidateHostVersion(hostID)
+		vsphereinfra.GetCache().InvalidateCluster(clusterID)
+	})
+	vsphereinfra.GetCache().UpdateHostVersion(hostID, "9.1.0")
+	vsphereinfra.GetCache().UpdateClusterHosts(clusterID, map[string]struct{}{hostID: {}})
+	vsphereinfra.GetCache().SetClusterESAEnabled(clusterID, true)
+
+	ok, err := hostSupportsHighPerformanceLinkedClone(ctx, hostID)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+// TestLinkedCloneCapabilitiesForNamespace_NilTopologyInfoReturnsError verifies that a nil
+// TopologyInfo — which only happens when InfraStoragePolicyInfo failed to resolve its own
+// topology, never as a legitimate non-zonal state — is surfaced as an error rather than
+// silently falling back to (equally untrustworthy) infraCaps.
+func TestLinkedCloneCapabilitiesForNamespace_NilTopologyInfoReturnsError(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-lccfn-notopology"},
+		// TopologyInfo is deliberately nil.
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "policy-lccfn-notopology"}}
+
+	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, instance, infraSPI)
+	assert.Error(t, err)
+	assert.False(t, lc)
+	assert.False(t, hplc)
+}
+
+func TestLinkedCloneCapabilitiesForNamespace_ZonalRecomputesFromCache(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const policyName = "policy-lccfn-zonal"
+	clearPolicyZoneCache(t, policyName)
+	t.Cleanup(func() { vsphereinfra.GetCache().UpdateDsHosts("ds-lccfn-zonal", map[string]struct{}{}) })
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateHostVersion("host-lccfn-zonal") })
+
+	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-lccfn-zonal"}})
+	vsphereinfra.GetCache().UpdateDsHosts("ds-lccfn-zonal", map[string]struct{}{"host-lccfn-zonal": {}})
+	vsphereinfra.GetCache().UpdateHostVersion("host-lccfn-zonal", "9.1.0")
+
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: policyName},
+		Status: spiv1alpha1.StoragePolicyInfoStatus{
+			TopologyInfo: &spiv1alpha1.Topology{TopologyType: "zonal", AccessibleZones: []string{"zone-a"}},
+		},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: policyName}}
+
+	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, instance, infraSPI)
+	require.NoError(t, err)
+	assert.True(t, lc, "zone-a has a compatible datastore mounted by an ESXi 9.1+ host")
+	assert.False(t, hplc, "no vSAN-ESA cluster was configured for this host")
+}
+
+func TestSyncVolumeCapabilitiesFromInfraSPI_CopiesBlockAndFilesystemCapabilities(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-svcfi"},
+		Status: spiv1alpha1.StoragePolicyInfoStatus{
+			// Non-nil but zoneless, as syncTopologyFromInfraSPI would set for a non-zonal
+			// policy; only nil TopologyInfo (an unresolved upstream topology) is an error.
+			TopologyInfo: &spiv1alpha1.Topology{},
+		},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-svcfi"},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			VolumeCapabilities: map[infraspiv1alpha1.VolumeCapability]bool{
+				infraspiv1alpha1.SupportsVolumeModeBlock: true,
+			},
+		},
+	}
+
+	err := syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI)
+	require.NoError(t, err)
+	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsVolumeModeFilesystem],
+		"SupportsVolumeModeFilesystem is always true, independent of InfraSPI")
+	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsVolumeModeBlock])
+	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsLinkedClone])
+	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsHighPerformanceLinkedClone])
+}

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -26,6 +26,7 @@ import (
 
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/pbm"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -542,59 +543,102 @@ func GetMaxWorkerThreads(ctx context.Context, key string, defaultVal int) int {
 	return workerThreads
 }
 
-// GetPolicyCompatibleDatastoresFn is the implementation used by GetPolicyCompatibleDatastoresPerZone;
-// tests may replace it to inject fake compatible datastore IDs without a real PBM connection.
-var GetPolicyCompatibleDatastoresFn = GetPolicyCompatibleDatastores
-
-// GetPolicyCompatibleDatastores gets all datastores compatible with a storage policy using PBM
-func GetPolicyCompatibleDatastores(ctx context.Context, vc *cnsvsphere.VirtualCenter,
-	profileID string) (map[string]struct{}, error) {
-	if vc == nil || vc.Client == nil {
-		return nil, fmt.Errorf("virtual center client is not available")
-	}
-	compatibleHubs, err := vc.PbmQueryMatchingHub(ctx, profileID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query compatible datastores for policy %s: %w", profileID, err)
-	}
-
-	compatibleDSIDs := make(map[string]struct{})
-	for _, hub := range compatibleHubs {
-		compatibleDSIDs[hub.HubId] = struct{}{}
-	}
-
-	return compatibleDSIDs, nil
+// PbmCheckRequirementsForZoneTopologyFn is the implementation used by
+// GetZoneCompatibleDatastoresForPolicy; tests may replace it to inject a fake placement
+// compatibility result without a real PBM connection.
+var PbmCheckRequirementsForZoneTopologyFn = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+	profileID string, clusterMoIDs []string) (pbm.PlacementCompatibilityResult, error) {
+	return vc.PbmCheckRequirementsForZoneTopology(ctx, profileID, clusterMoIDs)
 }
 
-// GetAccessibleZonesAndDatastoresForPolicy determines which zones are
-// accessible to the datastores compatible with the given storage policy, and
-// returns the flat set of compatible datastore morefs behind those zones
-// (deduped across zones that share a datastore).
-func GetAccessibleZonesAndDatastoresForPolicy(ctx context.Context, topologyMgr commoncotypes.ControllerTopologyService,
-	vc *cnsvsphere.VirtualCenter, profileID string,
-	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) (zones []string, dsIDs []string, err error) {
+// GetZoneCompatibleDatastoresForPolicy determines, via a single SPBM CheckRequirements call
+// scoped to every cluster registered to a vSphere AvailabilityZone, which zones are accessible
+// for the given storage policy and which datastores are compatible within each zone. It also
+// returns the flat, deduped set of compatible datastore morefs across all zones.
+func GetZoneCompatibleDatastoresForPolicy(ctx context.Context, topologyMgr commoncotypes.ControllerTopologyService,
+	vc *cnsvsphere.VirtualCenter, profileID string) (
+	zones []string, zoneCompatibleDS map[string][]*cnsvsphere.DatastoreInfo, dsIDs []string, err error) {
 	log := logger.GetLogger(ctx)
 
-	zoneCompatibleDS, err := GetPolicyCompatibleDatastoresPerZone(ctx, topologyMgr, vc, profileID, clusterDatastoreCache)
-	if err != nil {
-		return nil, nil, err
+	if topologyMgr == nil {
+		return nil, nil, nil, fmt.Errorf("topology manager is not available")
 	}
 
-	// A zone is accessible if it has at least one compatible datastore.
-	zones = make([]string, 0, len(zoneCompatibleDS))
+	azClustersMap := topologyMgr.GetAZClustersMap(ctx)
+	if len(azClustersMap) == 0 {
+		log.Warnf("No zones found in topology service")
+		return make([]string, 0), make(map[string][]*cnsvsphere.DatastoreInfo), nil, nil
+	}
+
+	// Flatten every cluster across all zones into a single candidate list, and build the
+	// reverse cluster->zones lookup used to attribute each compatible datastore (returned per
+	// cluster by CheckRequirements via HubInfo.ZoneClusters) back to its zone(s).
+	clusterToZones := make(map[string][]string)
+	var allClusters []string
+	for zone, clusters := range azClustersMap {
+		for _, clusterMoref := range clusters {
+			clusterToZones[clusterMoref] = append(clusterToZones[clusterMoref], zone)
+			allClusters = append(allClusters, clusterMoref)
+		}
+	}
+	if len(allClusters) == 0 {
+		log.Warnf("No clusters found across any zone in topology service")
+		return make([]string, 0), make(map[string][]*cnsvsphere.DatastoreInfo), nil, nil
+	}
+
+	if vc == nil || vc.Client == nil {
+		return nil, nil, nil, fmt.Errorf("vCenter is not available")
+	}
+
+	result, err := PbmCheckRequirementsForZoneTopologyFn(ctx, vc, profileID, allClusters)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to check placement requirements for policy %s: %w", profileID, err)
+	}
+
+	// zones must never be nil on a successful (err == nil) return: it's assigned straight into
+	// InfraStoragePolicyInfo.Status.Topology.AccessibleZones, which the CRD schema requires to
+	// be present — a nil slice serializes to JSON null and the status update is rejected.
+	zones = make([]string, 0)
+	zoneCompatibleDS = make(map[string][]*cnsvsphere.DatastoreInfo)
 	seenDsIDs := make(map[string]struct{})
-	for zone, compatibleDS := range zoneCompatibleDS {
-		if len(compatibleDS) == 0 {
+
+	for _, res := range result {
+		if len(res.Error) > 0 {
+			// Incompatible with the policy, or not mounted on any of allClusters.
 			continue
 		}
-		zones = append(zones, zone)
-		for _, ds := range compatibleDS {
-			dsID := ds.Reference().Value
+		if res.HubInfo == nil || len(res.HubInfo.ZoneClusters) == 0 {
+			log.Debugf("Datastore %s is compatible with policy %s but is not attributable to any "+
+				"requested cluster; skipping", res.Hub.HubId, profileID)
+			continue
+		}
 
-			if _, ok := seenDsIDs[dsID]; ok {
-				continue
+		if _, seen := seenDsIDs[res.Hub.HubId]; !seen {
+			seenDsIDs[res.Hub.HubId] = struct{}{}
+			dsIDs = append(dsIDs, res.Hub.HubId)
+		}
+
+		dsInfo := &cnsvsphere.DatastoreInfo{
+			Datastore: &cnsvsphere.Datastore{
+				Datastore: object.NewDatastore(vc.Client.Client, vimtypes.ManagedObjectReference{
+					Type:  "Datastore",
+					Value: res.Hub.HubId,
+				}),
+			},
+		}
+
+		seenZones := make(map[string]struct{})
+		for _, clusterRef := range res.HubInfo.ZoneClusters {
+			for _, zone := range clusterToZones[clusterRef.Key] {
+				if _, done := seenZones[zone]; done {
+					continue
+				}
+				seenZones[zone] = struct{}{}
+				if _, exists := zoneCompatibleDS[zone]; !exists {
+					zones = append(zones, zone)
+				}
+				zoneCompatibleDS[zone] = append(zoneCompatibleDS[zone], dsInfo)
 			}
-			seenDsIDs[dsID] = struct{}{}
-			dsIDs = append(dsIDs, dsID)
 		}
 	}
 
@@ -604,76 +648,5 @@ func GetAccessibleZonesAndDatastoresForPolicy(ctx context.Context, topologyMgr c
 		log.Infof("Storage policy %s is accessible from zones: %v", profileID, zones)
 	}
 
-	return zones, dsIDs, nil
-}
-
-// GetPolicyCompatibleDatastoresPerZone returns compatible datastores grouped by zone.
-func GetPolicyCompatibleDatastoresPerZone(ctx context.Context, topologyMgr commoncotypes.ControllerTopologyService,
-	vc *cnsvsphere.VirtualCenter, profileID string,
-	clusterDatastoreCache map[string][]*cnsvsphere.DatastoreInfo) (map[string][]*cnsvsphere.DatastoreInfo, error) {
-	log := logger.GetLogger(ctx)
-
-	if topologyMgr == nil {
-		log.Warnf("Topology manager not available")
-		return nil, fmt.Errorf("topology manager is not available")
-	}
-
-	if clusterDatastoreCache == nil {
-		clusterDatastoreCache = make(map[string][]*cnsvsphere.DatastoreInfo)
-	}
-
-	azClustersMap := topologyMgr.GetAZClustersMap(ctx)
-	if len(azClustersMap) == 0 {
-		log.Warnf("No zones found in topology service")
-		return make(map[string][]*cnsvsphere.DatastoreInfo), nil
-	}
-
-	compatibleDSIDs, err := GetPolicyCompatibleDatastoresFn(ctx, vc, profileID)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Infof("Found %d compatible datastores for policy %s", len(compatibleDSIDs), profileID)
-
-	result := make(map[string][]*cnsvsphere.DatastoreInfo)
-
-	// For each zone, collect compatible datastores
-	for zone, clusters := range azClustersMap {
-		log.Debugf("Checking zone %s with clusters %v", zone, clusters)
-
-		// Collect all datastores for this zone
-		var zoneDS []*cnsvsphere.DatastoreInfo
-		for _, clusterMoref := range clusters {
-			// Check datastore cache first
-			var clusterDS []*cnsvsphere.DatastoreInfo
-			if cached, exists := clusterDatastoreCache[clusterMoref]; exists {
-				clusterDS = cached
-			} else {
-				// Cache miss - fetch from vCenter and cache the result
-				datastores, _, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterMoref, false)
-				if err != nil {
-					log.Warnf("Zone %s: failed to get datastores for cluster %s: %v", zone, clusterMoref, err)
-					continue
-				}
-				clusterDatastoreCache[clusterMoref] = datastores
-				clusterDS = datastores
-			}
-			zoneDS = append(zoneDS, clusterDS...)
-		}
-
-		// Filter to compatible datastores for this zone
-		var compatibleDatastores []*cnsvsphere.DatastoreInfo
-		for _, ds := range zoneDS {
-			if _, isCompatible := compatibleDSIDs[ds.Reference().Value]; isCompatible {
-				compatibleDatastores = append(compatibleDatastores, ds)
-			}
-		}
-
-		result[zone] = compatibleDatastores
-		if len(compatibleDatastores) > 0 {
-			log.Debugf("Zone %s has %d compatible datastores for policy %s", zone, len(compatibleDatastores), profileID)
-		}
-	}
-
-	return result, nil
+	return zones, zoneCompatibleDS, dsIDs, nil
 }

--- a/pkg/syncer/cnsoperator/util/util_test.go
+++ b/pkg/syncer/cnsoperator/util/util_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
-	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/pbm"
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -619,7 +621,7 @@ func TestGetTKGVMIP_PerNamespaceVDSUsesVMIP(t *testing.T) {
 	assert.Equal(t, "192.0.2.10", ip)
 }
 
-// --- helpers for GetPolicyCompatibleDatastoresPerZone / GetAccessibleZonesAndDatastoresForPolicy ----
+// --- helpers for GetZoneCompatibleDatastoresForPolicy -----------------------------------
 
 // mockTopologyService is a minimal ControllerTopologyService for unit tests.
 type mockTopologyService struct {
@@ -643,52 +645,177 @@ func (m *mockTopologyService) GetAccessibleZonesForDatastore(_ context.Context, 
 	return nil, nil
 }
 
-// fakeDS builds a DatastoreInfo whose Reference().Value equals the given id.
-// nil is safe for the govmomi client because only Reference() is called in tests.
-func fakeDS(id string) *cnsvsphere.DatastoreInfo {
-	ref := vimtypes.ManagedObjectReference{Type: "Datastore", Value: id}
-	return &cnsvsphere.DatastoreInfo{
-		Datastore: &cnsvsphere.Datastore{
-			Datastore: object.NewDatastore(nil, ref),
-		},
+// fakeVC returns a VirtualCenter with just enough non-nil structure that
+// object.NewDatastore(vc.Client.Client, ...) doesn't panic while building DatastoreInfo results.
+func fakeVC() *cnsvsphere.VirtualCenter {
+	return &cnsvsphere.VirtualCenter{Client: &govmomi.Client{}}
+}
+
+// compatibleResult builds a PbmPlacementCompatibilityResult for dsID that is compatible with the
+// policy and attributed (via HubInfo.ZoneClusters) to the given cluster morefs.
+func compatibleResult(dsID string, clusterMoIDs ...string) pbmtypes.PbmPlacementCompatibilityResult {
+	zoneClusters := make([]pbmtypes.PbmServerObjectRef, 0, len(clusterMoIDs))
+	for _, c := range clusterMoIDs {
+		zoneClusters = append(zoneClusters, pbmtypes.PbmServerObjectRef{Key: c})
+	}
+	return pbmtypes.PbmPlacementCompatibilityResult{
+		Hub:     pbmtypes.PbmPlacementHub{HubType: "Datastore", HubId: dsID},
+		HubInfo: &pbmtypes.PbmPlacementHubInfo{ZoneClusters: zoneClusters},
 	}
 }
 
-// withCompatibleDSIDs replaces GetPolicyCompatibleDatastoresFn for the duration of a test.
-func withCompatibleDSIDs(ids map[string]struct{}, fn func()) {
-	orig := GetPolicyCompatibleDatastoresFn
-	GetPolicyCompatibleDatastoresFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
-		_ string) (map[string]struct{}, error) {
-		return ids, nil
+// compatibleResultNoHubInfo builds a compatible result with no HubInfo at all, as CheckRequirements
+// would return without a PbmPlacementZoneTopologyRequirement (not expected in practice here, but
+// exercised as a defensive edge case).
+func compatibleResultNoHubInfo(dsID string) pbmtypes.PbmPlacementCompatibilityResult {
+	return pbmtypes.PbmPlacementCompatibilityResult{
+		Hub: pbmtypes.PbmPlacementHub{HubType: "Datastore", HubId: dsID},
 	}
-	defer func() { GetPolicyCompatibleDatastoresFn = orig }()
+}
+
+// incompatibleResult builds a result that failed the policy/zone-topology requirement.
+func incompatibleResult(dsID string) pbmtypes.PbmPlacementCompatibilityResult {
+	return pbmtypes.PbmPlacementCompatibilityResult{
+		Hub:   pbmtypes.PbmPlacementHub{HubType: "Datastore", HubId: dsID},
+		Error: []vimtypes.LocalizedMethodFault{{}},
+	}
+}
+
+// withFakePlacementResult replaces PbmCheckRequirementsForZoneTopologyFn for the duration of a
+// test, returning result/err without a real PBM connection. If capturedClusters is non-nil, the
+// clusterMoIDs actually requested are recorded into it.
+func withFakePlacementResult(result pbm.PlacementCompatibilityResult, err error,
+	capturedClusters *[]string, fn func()) {
+	orig := PbmCheckRequirementsForZoneTopologyFn
+	PbmCheckRequirementsForZoneTopologyFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ string, clusterMoIDs []string) (pbm.PlacementCompatibilityResult, error) {
+		if capturedClusters != nil {
+			*capturedClusters = clusterMoIDs
+		}
+		return result, err
+	}
+	defer func() { PbmCheckRequirementsForZoneTopologyFn = orig }()
 	fn()
 }
 
-// --- GetPolicyCompatibleDatastoresPerZone tests ---------------------------------------
+// --- GetZoneCompatibleDatastoresForPolicy tests -----------------------------------------
 
-// TestGetPolicyCompatibleDatastoresPerZone_NilTopologyManager verifies that a nil
-// topology manager returns an error immediately.
-func TestGetPolicyCompatibleDatastoresPerZone_NilTopologyManager(t *testing.T) {
+// TestGetZoneCompatibleDatastoresForPolicy_NilTopologyManager verifies that a nil topology
+// manager returns an error immediately, without ever calling PBM.
+func TestGetZoneCompatibleDatastoresForPolicy_NilTopologyManager(t *testing.T) {
 	ctx := context.Background()
-	result, err := GetPolicyCompatibleDatastoresPerZone(ctx, nil, nil, "policy-1", nil)
+	zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, nil, nil, "policy-1")
 	assert.Error(t, err)
-	assert.Nil(t, result)
+	assert.Nil(t, zones)
+	assert.Nil(t, zoneCompatibleDS)
+	assert.Nil(t, dsIDs)
 }
 
-// TestGetPolicyCompatibleDatastoresPerZone_NoZones verifies that an empty azClustersMap
-// returns an empty map without calling the VC.
-func TestGetPolicyCompatibleDatastoresPerZone_NoZones(t *testing.T) {
+// TestGetZoneCompatibleDatastoresForPolicy_NoZones verifies that an empty azClustersMap returns
+// an empty map without calling PBM.
+func TestGetZoneCompatibleDatastoresForPolicy_NoZones(t *testing.T) {
 	ctx := context.Background()
 	topo := &mockTopologyService{azClustersMap: map[string][]string{}}
-	result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", nil)
+	called := false
+	orig := PbmCheckRequirementsForZoneTopologyFn
+	PbmCheckRequirementsForZoneTopologyFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ string, _ []string) (pbm.PlacementCompatibilityResult, error) {
+		called = true
+		return nil, nil
+	}
+	defer func() { PbmCheckRequirementsForZoneTopologyFn = orig }()
+
+	zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, nil, "policy-1")
 	require.NoError(t, err)
-	assert.Empty(t, result)
+	assert.NotNil(t, zones, "zones must be a non-nil empty slice, not nil: it's assigned straight into "+
+		"InfraStoragePolicyInfo.Status.Topology.AccessibleZones, which the CRD requires to be present")
+	assert.Empty(t, zones)
+	assert.Empty(t, zoneCompatibleDS)
+	assert.Empty(t, dsIDs)
+	assert.False(t, called, "PBM should not be queried when there are no zones")
 }
 
-// TestGetPolicyCompatibleDatastoresPerZone_AllCompatible verifies that when every
-// datastore in the cache matches the compatible set, all are returned per zone.
-func TestGetPolicyCompatibleDatastoresPerZone_AllCompatible(t *testing.T) {
+// TestGetZoneCompatibleDatastoresForPolicy_NoClustersInAnyZone verifies that zones with no
+// clusters return an empty result without calling PBM, instead of issuing a CheckRequirements
+// call with an empty cluster list.
+func TestGetZoneCompatibleDatastoresForPolicy_NoClustersInAnyZone(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {}, "zone-b": {}}}
+	called := false
+	orig := PbmCheckRequirementsForZoneTopologyFn
+	PbmCheckRequirementsForZoneTopologyFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ string, _ []string) (pbm.PlacementCompatibilityResult, error) {
+		called = true
+		return nil, nil
+	}
+	defer func() { PbmCheckRequirementsForZoneTopologyFn = orig }()
+
+	zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, nil, "policy-1")
+	require.NoError(t, err)
+	assert.NotNil(t, zones)
+	assert.Empty(t, zones)
+	assert.Empty(t, zoneCompatibleDS)
+	assert.Empty(t, dsIDs)
+	assert.False(t, called, "PBM should not be queried with an empty cluster list")
+}
+
+// TestGetZoneCompatibleDatastoresForPolicy_NilVirtualCenter verifies that a nil (or
+// not-yet-connected) vCenter returns an error instead of panicking once there's at least one
+// zone/cluster to actually check against PBM.
+func TestGetZoneCompatibleDatastoresForPolicy_NilVirtualCenter(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {"cluster-1"}}}
+
+	zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, nil, "policy-1")
+	assert.Error(t, err)
+	assert.Nil(t, zones)
+	assert.Nil(t, zoneCompatibleDS)
+	assert.Nil(t, dsIDs)
+
+	zones, zoneCompatibleDS, dsIDs, err = GetZoneCompatibleDatastoresForPolicy(ctx, topo,
+		&cnsvsphere.VirtualCenter{}, "policy-1")
+	assert.Error(t, err)
+	assert.Nil(t, zones)
+	assert.Nil(t, zoneCompatibleDS)
+	assert.Nil(t, dsIDs)
+}
+
+// TestGetZoneCompatibleDatastoresForPolicy_PbmError verifies that a PBM error is propagated.
+func TestGetZoneCompatibleDatastoresForPolicy_PbmError(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {"cluster-1"}}}
+
+	withFakePlacementResult(nil, errors.New("pbm unavailable"), nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, fakeVC(), "policy-1")
+		assert.Error(t, err)
+		assert.Nil(t, zones)
+		assert.Nil(t, zoneCompatibleDS)
+		assert.Nil(t, dsIDs)
+	})
+}
+
+// TestGetZoneCompatibleDatastoresForPolicy_ClustersFlattenedAcrossZones verifies that every
+// cluster across every zone is flattened into the candidate list passed to PBM.
+func TestGetZoneCompatibleDatastoresForPolicy_ClustersFlattenedAcrossZones(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{
+		azClustersMap: map[string][]string{
+			"zone-a": {"cluster-1", "cluster-2"},
+			"zone-b": {"cluster-3"},
+		},
+	}
+	var captured []string
+	withFakePlacementResult(nil, nil, &captured, func() {
+		_, _, _, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, fakeVC(), "policy-1")
+		require.NoError(t, err)
+	})
+	sort.Strings(captured)
+	assert.Equal(t, []string{"cluster-1", "cluster-2", "cluster-3"}, captured)
+}
+
+// TestGetZoneCompatibleDatastoresForPolicy_AllCompatible verifies that a compatible datastore
+// attributed to a zone's cluster is placed in that zone's result, and is included in dsIDs.
+func TestGetZoneCompatibleDatastoresForPolicy_AllCompatible(t *testing.T) {
 	ctx := context.Background()
 	topo := &mockTopologyService{
 		azClustersMap: map[string][]string{
@@ -696,62 +823,92 @@ func TestGetPolicyCompatibleDatastoresPerZone_AllCompatible(t *testing.T) {
 			"zone-b": {"cluster-2"},
 		},
 	}
-	cache := map[string][]*cnsvsphere.DatastoreInfo{
-		"cluster-1": {fakeDS("ds-1"), fakeDS("ds-2")},
-		"cluster-2": {fakeDS("ds-3")},
+	result := pbm.PlacementCompatibilityResult{
+		compatibleResult("ds-1", "cluster-1"),
+		compatibleResult("ds-2", "cluster-2"),
 	}
-	compatible := map[string]struct{}{"ds-1": {}, "ds-2": {}, "ds-3": {}}
 
-	withCompatibleDSIDs(compatible, func() {
-		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+	withFakePlacementResult(result, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, fakeVC(), "policy-1")
 		require.NoError(t, err)
-		assert.Len(t, result["zone-a"], 2)
-		assert.Len(t, result["zone-b"], 1)
+		sort.Strings(zones)
+		assert.Equal(t, []string{"zone-a", "zone-b"}, zones)
+		require.Len(t, zoneCompatibleDS["zone-a"], 1)
+		assert.Equal(t, "ds-1", zoneCompatibleDS["zone-a"][0].Reference().Value)
+		require.Len(t, zoneCompatibleDS["zone-b"], 1)
+		assert.Equal(t, "ds-2", zoneCompatibleDS["zone-b"][0].Reference().Value)
+		sort.Strings(dsIDs)
+		assert.Equal(t, []string{"ds-1", "ds-2"}, dsIDs)
 	})
 }
 
-// TestGetPolicyCompatibleDatastoresPerZone_SomeCompatible verifies that only datastores
-// whose IDs are in the compatible set are included in the result.
-func TestGetPolicyCompatibleDatastoresPerZone_SomeCompatible(t *testing.T) {
+// TestGetZoneCompatibleDatastoresForPolicy_IncompatibleSkipped verifies that a result with a
+// non-empty Error (incompatible with the policy, or not mounted on any requested cluster) is
+// excluded.
+func TestGetZoneCompatibleDatastoresForPolicy_IncompatibleSkipped(t *testing.T) {
 	ctx := context.Background()
-	topo := &mockTopologyService{
-		azClustersMap: map[string][]string{"zone-a": {"cluster-1"}},
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {"cluster-1"}}}
+	result := pbm.PlacementCompatibilityResult{
+		compatibleResult("ds-match", "cluster-1"),
+		incompatibleResult("ds-skip"),
 	}
-	cache := map[string][]*cnsvsphere.DatastoreInfo{
-		"cluster-1": {fakeDS("ds-match"), fakeDS("ds-skip")},
-	}
-	compatible := map[string]struct{}{"ds-match": {}}
 
-	withCompatibleDSIDs(compatible, func() {
-		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+	withFakePlacementResult(result, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, fakeVC(), "policy-1")
 		require.NoError(t, err)
-		require.Len(t, result["zone-a"], 1)
-		assert.Equal(t, "ds-match", result["zone-a"][0].Reference().Value)
+		assert.Equal(t, []string{"zone-a"}, zones)
+		require.Len(t, zoneCompatibleDS["zone-a"], 1)
+		assert.Equal(t, "ds-match", zoneCompatibleDS["zone-a"][0].Reference().Value)
+		assert.Equal(t, []string{"ds-match"}, dsIDs)
 	})
 }
 
-// TestGetPolicyCompatibleDatastoresPerZone_NoneCompatible verifies that a zone entry
-// is still created with an empty slice when no datastores match.
-func TestGetPolicyCompatibleDatastoresPerZone_NoneCompatible(t *testing.T) {
+// TestGetZoneCompatibleDatastoresForPolicy_MissingHubInfoSkipped verifies that a compatible
+// result with no HubInfo (or an empty ZoneClusters) is not attributable to any zone and is
+// skipped, since there's no way to know which cluster it came from.
+func TestGetZoneCompatibleDatastoresForPolicy_MissingHubInfoSkipped(t *testing.T) {
 	ctx := context.Background()
-	topo := &mockTopologyService{
-		azClustersMap: map[string][]string{"zone-a": {"cluster-1"}},
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {"cluster-1"}}}
+	result := pbm.PlacementCompatibilityResult{
+		compatibleResultNoHubInfo("ds-no-hubinfo"),
+		compatibleResult("ds-empty-zoneclusters"),
 	}
-	cache := map[string][]*cnsvsphere.DatastoreInfo{
-		"cluster-1": {fakeDS("ds-1")},
-	}
-	compatible := map[string]struct{}{"ds-other": {}}
 
-	withCompatibleDSIDs(compatible, func() {
-		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+	withFakePlacementResult(result, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, fakeVC(), "policy-1")
 		require.NoError(t, err)
-		assert.Empty(t, result["zone-a"])
+		assert.NotNil(t, zones, "zones must be a non-nil empty slice, not nil, even when every "+
+			"PBM-compatible datastore is unattributable to any zone")
+		assert.Empty(t, zones)
+		assert.Empty(t, zoneCompatibleDS)
+		assert.Empty(t, dsIDs)
 	})
 }
 
-// TestGetPolicyCompatibleDatastoresPerZone_MultipleZonesSameDatastore verifies that a
-// datastore shared between two zones appears in the results for both.
-func TestGetPolicyCompatibleDatastoresPerZone_MultipleZonesSameDatastore(t *testing.T) {
+// TestGetZoneCompatibleDatastoresForPolicy_UnknownClusterSkipped verifies that a ZoneClusters
+// entry referencing a cluster outside the requested azClustersMap is not attributed to any zone.
+func TestGetZoneCompatibleDatastoresForPolicy_UnknownClusterSkipped(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {"cluster-1"}}}
+	result := pbm.PlacementCompatibilityResult{
+		compatibleResult("ds-1", "cluster-unknown"),
+	}
+
+	withFakePlacementResult(result, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, fakeVC(), "policy-1")
+		require.NoError(t, err)
+		assert.Empty(t, zones)
+		assert.Empty(t, zoneCompatibleDS)
+		// dsIDs still records every compatible datastore returned by PBM, regardless of whether
+		// it could be attributed to a zone.
+		assert.Equal(t, []string{"ds-1"}, dsIDs)
+	})
+}
+
+// TestGetZoneCompatibleDatastoresForPolicy_MultipleZonesSameDatastore verifies that a datastore
+// mounted on clusters in two different zones is attributed to both, but only counted once in
+// the deduped dsIDs list.
+func TestGetZoneCompatibleDatastoresForPolicy_MultipleZonesSameDatastore(t *testing.T) {
 	ctx := context.Background()
 	topo := &mockTopologyService{
 		azClustersMap: map[string][]string{
@@ -759,101 +916,69 @@ func TestGetPolicyCompatibleDatastoresPerZone_MultipleZonesSameDatastore(t *test
 			"zone-b": {"cluster-2"},
 		},
 	}
-	sharedDS := fakeDS("ds-shared")
-	cache := map[string][]*cnsvsphere.DatastoreInfo{
-		"cluster-1": {sharedDS},
-		"cluster-2": {sharedDS},
+	result := pbm.PlacementCompatibilityResult{
+		compatibleResult("ds-shared", "cluster-1", "cluster-2"),
 	}
-	compatible := map[string]struct{}{"ds-shared": {}}
 
-	withCompatibleDSIDs(compatible, func() {
-		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+	withFakePlacementResult(result, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, fakeVC(), "policy-1")
 		require.NoError(t, err)
-		assert.Len(t, result["zone-a"], 1)
-		assert.Len(t, result["zone-b"], 1)
+		sort.Strings(zones)
+		assert.Equal(t, []string{"zone-a", "zone-b"}, zones)
+		require.Len(t, zoneCompatibleDS["zone-a"], 1)
+		require.Len(t, zoneCompatibleDS["zone-b"], 1)
+		assert.Equal(t, []string{"ds-shared"}, dsIDs)
 	})
 }
 
-// TestGetPolicyCompatibleDatastoresPerZone_MultipleClustersPerZone verifies that
-// datastores from all clusters in a zone are aggregated before filtering.
-func TestGetPolicyCompatibleDatastoresPerZone_MultipleClustersPerZone(t *testing.T) {
+// TestGetZoneCompatibleDatastoresForPolicy_MultipleClustersPerZoneDeduped verifies that a
+// datastore mounted on two clusters within the SAME zone is only added to that zone once.
+func TestGetZoneCompatibleDatastoresForPolicy_MultipleClustersPerZoneDeduped(t *testing.T) {
 	ctx := context.Background()
 	topo := &mockTopologyService{
 		azClustersMap: map[string][]string{
 			"zone-a": {"cluster-1", "cluster-2"},
 		},
 	}
-	cache := map[string][]*cnsvsphere.DatastoreInfo{
-		"cluster-1": {fakeDS("ds-1")},
-		"cluster-2": {fakeDS("ds-2")},
+	result := pbm.PlacementCompatibilityResult{
+		compatibleResult("ds-1", "cluster-1", "cluster-2"),
 	}
-	compatible := map[string]struct{}{"ds-1": {}, "ds-2": {}}
 
-	withCompatibleDSIDs(compatible, func() {
-		result, err := GetPolicyCompatibleDatastoresPerZone(ctx, topo, nil, "policy-1", cache)
+	withFakePlacementResult(result, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, fakeVC(), "policy-1")
 		require.NoError(t, err)
-		assert.Len(t, result["zone-a"], 2)
+		assert.Equal(t, []string{"zone-a"}, zones)
+		assert.Len(t, zoneCompatibleDS["zone-a"], 1)
+		assert.Equal(t, []string{"ds-1"}, dsIDs)
 	})
 }
 
-// --- GetAccessibleZonesAndDatastoresForPolicy tests -----------------------------------
-
-// TestGetAccessibleZonesAndDatastoresForPolicy_NilTopologyManager verifies that a nil
-// topology manager returns an error.
-func TestGetAccessibleZonesAndDatastoresForPolicy_NilTopologyManager(t *testing.T) {
-	ctx := context.Background()
-	zones, dsIDs, err := GetAccessibleZonesAndDatastoresForPolicy(ctx, nil, nil, "policy-1", nil)
-	assert.Error(t, err)
-	assert.Nil(t, zones)
-	assert.Nil(t, dsIDs)
-}
-
-// TestGetAccessibleZonesAndDatastoresForPolicy_NoCompatibleDatastores verifies that
-// zones without any compatible datastores are excluded from the result, and no
-// datastore morefs are returned either.
-func TestGetAccessibleZonesAndDatastoresForPolicy_NoCompatibleDatastores(t *testing.T) {
-	ctx := context.Background()
-	topo := &mockTopologyService{
-		azClustersMap: map[string][]string{"zone-a": {"cluster-1"}},
-	}
-	cache := map[string][]*cnsvsphere.DatastoreInfo{
-		"cluster-1": {fakeDS("ds-1")},
-	}
-	// No compatible datastores → zone-a should not appear.
-	withCompatibleDSIDs(map[string]struct{}{}, func() {
-		zones, dsIDs, err := GetAccessibleZonesAndDatastoresForPolicy(ctx, topo, nil, "policy-1", cache)
-		require.NoError(t, err)
-		assert.Empty(t, zones)
-		assert.Empty(t, dsIDs)
-	})
-}
-
-// TestGetAccessibleZonesAndDatastoresForPolicy_OnlyZonesWithCompatibleDSReturned verifies
-// that only zones containing at least one compatible datastore are included in the
-// result, and that the returned datastore morefs are exactly the compatible ones,
-// deduped.
-func TestGetAccessibleZonesAndDatastoresForPolicy_OnlyZonesWithCompatibleDSReturned(t *testing.T) {
+// TestGetZoneCompatibleDatastoresForPolicy_ClusterInMultipleZones verifies that if the same
+// cluster moref is (incorrectly) listed under two different zones in azClustersMap, a datastore
+// attributed to that cluster is attributed to BOTH zones rather than silently dropped from one
+// of them. A cluster is expected to belong to at most one zone as an operational invariant of
+// how AvailabilityZone CRs are configured, but that invariant isn't enforced when azClustersMap
+// is built, so this must degrade safely rather than lose an attribution.
+func TestGetZoneCompatibleDatastoresForPolicy_ClusterInMultipleZones(t *testing.T) {
 	ctx := context.Background()
 	topo := &mockTopologyService{
 		azClustersMap: map[string][]string{
-			"zone-has-ds":   {"cluster-1"},
-			"zone-no-ds":    {"cluster-2"},
-			"zone-also-has": {"cluster-3"},
+			"zone-a": {"cluster-1"},
+			"zone-b": {"cluster-1"},
 		},
 	}
-	cache := map[string][]*cnsvsphere.DatastoreInfo{
-		"cluster-1": {fakeDS("ds-match")},
-		"cluster-2": {fakeDS("ds-other")},
-		"cluster-3": {fakeDS("ds-match2")},
+	result := pbm.PlacementCompatibilityResult{
+		compatibleResult("ds-1", "cluster-1"),
 	}
-	compatible := map[string]struct{}{"ds-match": {}, "ds-match2": {}}
 
-	withCompatibleDSIDs(compatible, func() {
-		zones, dsIDs, err := GetAccessibleZonesAndDatastoresForPolicy(ctx, topo, nil, "policy-1", cache)
+	withFakePlacementResult(result, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetZoneCompatibleDatastoresForPolicy(ctx, topo, fakeVC(), "policy-1")
 		require.NoError(t, err)
 		sort.Strings(zones)
-		assert.Equal(t, []string{"zone-also-has", "zone-has-ds"}, zones)
-		sort.Strings(dsIDs)
-		assert.Equal(t, []string{"ds-match", "ds-match2"}, dsIDs)
+		assert.Equal(t, []string{"zone-a", "zone-b"}, zones,
+			"a cluster shared across two zones must attribute the datastore to both, not just one")
+		assert.Len(t, zoneCompatibleDS["zone-a"], 1)
+		assert.Len(t, zoneCompatibleDS["zone-b"], 1)
+		assert.Equal(t, []string{"ds-1"}, dsIDs)
 	})
 }

--- a/pkg/syncer/cnsoperator/vsphereinfra/cache.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/cache.go
@@ -17,27 +17,33 @@ limitations under the License.
 package vsphereinfra
 
 import (
+	"context"
+	"maps"
 	"slices"
 	"sync"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
-// StoragePolicyInfoCache is a shared in-memory cache used by the
-// PropertyCollector watcher and the storage-policy-info
-// controllers.
+// StoragePolicyInfoCache is a shared in-memory cache written by two independent producers and
+// read by the namespace-scoped storagepolicyinfo controller to avoid extra vCenter round trips:
+//
+//   - The PropertyCollector inventory watcher (collector.go), which keeps live, topology-shaped
+//     facts about vCenter (which hosts mount a datastore, which hosts belong to a cluster, each
+//     host's ESXi version) fresh via a standing WaitForUpdatesEx session — independent of any
+//     storage policy.
+//   - The clusterstoragepolicyinfo controller (pkg/syncer/cnsoperator/controller/
+//     clusterstoragepolicyinfo), which writes policy-specific facts (which datastores/zones a
+//     policy is compatible with, which clusters have vSAN-ESA enabled) as a byproduct of each
+//     ClusterStoragePolicyInfo/InfraStoragePolicyInfo reconcile.
 type StoragePolicyInfoCache struct {
 	mu sync.RWMutex
+
+	// --- Populated by the PropertyCollector inventory watcher ---
 
 	// DsToHosts tracks the last-known set of hosts mounting each datastore.
 	// Written by the PropertyCollector on Datastore.host changes.
 	DsToHosts map[string]map[string]struct{}
-
-	// DsToPolicy records which storage policies a datastore is compatible
-	// with, keyed by datastore moref. Written by the clusterstoragepolicyinfo
-	// controller (SetDatastoresForPolicy) after each policy's PBM compatibility
-	// query, and read by OnInventoryChange (via PoliciesForDatastore) to
-	// resolve an inventory change to the policies it affects, without a
-	// separate vCenter round trip.
-	DsToPolicy map[string][]string
 
 	// HostToVersion tracks the last-known ESXi version string per host
 	// (e.g. "9.2.0"). key: host moref.
@@ -54,6 +60,21 @@ type StoragePolicyInfoCache struct {
 	// matches how InfraSPI itself queries hosts (GetHostsByCluster, per known
 	// zone-registered cluster).
 	ClusterToHosts map[string]map[string]struct{}
+
+	// --- Populated by the clusterstoragepolicyinfo controller ---
+
+	// DsToPolicy records which storage policies a datastore is compatible
+	// with, keyed by datastore moref.
+	DsToPolicy map[string][]string
+
+	// PolicyZoneDatastores tracks, per storage policy, the datastores compatible with that
+	// policy within each zone. key: policy K8s-compliant name; inner key: zone name;
+	// innermost key: datastore moref.
+	PolicyZoneDatastores map[string]map[string]map[string]struct{}
+
+	// ClusterToESAEnabled records whether a cluster has vSAN-ESA enabled, keyed by cluster
+	// moref.
+	ClusterToESAEnabled map[string]bool
 }
 
 var (
@@ -66,10 +87,14 @@ var (
 func GetCache() *StoragePolicyInfoCache {
 	cacheOnce.Do(func() {
 		defaultCache = &StoragePolicyInfoCache{
+			// Populated by the PropertyCollector inventory watcher.
 			DsToHosts:      make(map[string]map[string]struct{}),
-			DsToPolicy:     make(map[string][]string),
 			HostToVersion:  make(map[string]string),
 			ClusterToHosts: make(map[string]map[string]struct{}),
+			// Populated by the clusterstoragepolicyinfo controller.
+			DsToPolicy:           make(map[string][]string),
+			PolicyZoneDatastores: make(map[string]map[string]map[string]struct{}),
+			ClusterToESAEnabled:  make(map[string]bool),
 		}
 	})
 	return defaultCache
@@ -196,6 +221,65 @@ func (c *StoragePolicyInfoCache) SetDatastoresForPolicy(policyName string, dsIDs
 	}
 }
 
+// SetDatastoresForPolicyZones replaces the entire per-zone compatible-datastore map recorded
+// for policyName, so a zone the policy is no longer compatible with doesn't keep a stale
+// entry. zoneDatastores maps zone name to the datastore morefs compatible with policyName in
+// that zone. A nil zoneDatastores clears policyName's entry entirely; a non-nil-but-empty map
+// is recorded as-is, so PolicyDataAvailable can distinguish "policy reconciled, zero compatible
+// datastores in any zone" from "policy not reconciled yet".
+func (c *StoragePolicyInfoCache) SetDatastoresForPolicyZones(policyName string, zoneDatastores map[string][]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if zoneDatastores == nil {
+		delete(c.PolicyZoneDatastores, policyName)
+		return
+	}
+	zones := make(map[string]map[string]struct{}, len(zoneDatastores))
+	for zone, dsIDs := range zoneDatastores {
+		set := make(map[string]struct{}, len(dsIDs))
+		for _, dsID := range dsIDs {
+			set[dsID] = struct{}{}
+		}
+		zones[zone] = set
+	}
+	c.PolicyZoneDatastores[policyName] = zones
+}
+
+// GetDatastoresForPolicyZone returns a copy of the cached datastore set compatible with
+// policyName within zone, and whether the entry exists.
+func (c *StoragePolicyInfoCache) GetDatastoresForPolicyZone(ctx context.Context,
+	policyName, zone string) (map[string]struct{}, bool) {
+	log := logger.GetLogger(ctx)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	zones, ok := c.PolicyZoneDatastores[policyName]
+	if !ok {
+		log.Debugf("GetDatastoresForPolicyZone: no entry cached for policy %q; "+
+			"either it hasn't been reconciled yet, or it has no compatible datastores in any zone", policyName)
+		return nil, false
+	}
+	ds, ok := zones[zone]
+	if !ok {
+		log.Debugf("GetDatastoresForPolicyZone: policy %q is cached, but has no compatible datastores "+
+			"in zone %q; cached zones for this policy: %v", policyName, zone, slices.Collect(maps.Keys(zones)))
+		return nil, false
+	}
+	cp := make(map[string]struct{}, len(ds))
+	for id := range ds {
+		cp[id] = struct{}{}
+	}
+	return cp, true
+}
+
+// GetHostVersion returns the last-known ESXi version string for a host and
+// whether it has been observed yet.
+func (c *StoragePolicyInfoCache) GetHostVersion(hostID string) (version string, found bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	version, found = c.HostToVersion[hostID]
+	return version, found
+}
+
 // UpdateHostVersion compares newVersion against the cached ESXi version for a
 // host. Returns the previous value and whether it changed. On the first
 // sighting for a host (no previous entry) changed is false — there is nothing
@@ -262,11 +346,42 @@ func (c *StoragePolicyInfoCache) InvalidateCluster(clusterID string) []string {
 	defer c.mu.Unlock()
 	hosts := c.ClusterToHosts[clusterID]
 	delete(c.ClusterToHosts, clusterID)
+	delete(c.ClusterToESAEnabled, clusterID)
 	result := make([]string, 0, len(hosts))
 	for h := range hosts {
 		result = append(result, h)
 	}
 	return result
+}
+
+// ClusterForHost returns the moref of the cluster the given host currently
+// belongs to, by scanning ClusterToHosts for membership (mirrors
+// DatastoresForHost). A host belongs to at most one cluster at steady state.
+func (c *StoragePolicyInfoCache) ClusterForHost(hostID string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for clusterID, hosts := range c.ClusterToHosts {
+		if _, ok := hosts[hostID]; ok {
+			return clusterID, true
+		}
+	}
+	return "", false
+}
+
+// SetClusterESAEnabled records whether the given cluster has vSAN-ESA enabled.
+func (c *StoragePolicyInfoCache) SetClusterESAEnabled(clusterID string, esa bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ClusterToESAEnabled[clusterID] = esa
+}
+
+// GetClusterESAEnabled returns the last-known vSAN-ESA state for a cluster and
+// whether it has been observed/computed yet.
+func (c *StoragePolicyInfoCache) GetClusterESAEnabled(clusterID string) (esa bool, found bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	esa, found = c.ClusterToESAEnabled[clusterID]
+	return esa, found
 }
 
 // hostSetsEqual returns true if both sets contain the same host morefs.

--- a/pkg/syncer/cnsoperator/vsphereinfra/cache_test.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/cache_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package vsphereinfra
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestCache returns a fresh, independent StoragePolicyInfoCache instead of
@@ -28,9 +30,12 @@ import (
 func newTestCache() *StoragePolicyInfoCache {
 	return &StoragePolicyInfoCache{
 		DsToHosts:      make(map[string]map[string]struct{}),
-		DsToPolicy:     make(map[string][]string),
 		HostToVersion:  make(map[string]string),
 		ClusterToHosts: make(map[string]map[string]struct{}),
+
+		DsToPolicy:           make(map[string][]string),
+		PolicyZoneDatastores: make(map[string]map[string]map[string]struct{}),
+		ClusterToESAEnabled:  make(map[string]bool),
 	}
 }
 
@@ -202,6 +207,18 @@ func TestSetDatastoresForPolicy(t *testing.T) {
 	})
 }
 
+func TestGetHostVersion(t *testing.T) {
+	c := newTestCache()
+
+	_, found := c.GetHostVersion("host-1")
+	assert.False(t, found, "unpopulated host should not be found")
+
+	c.UpdateHostVersion("host-1", "9.2.0")
+	version, found := c.GetHostVersion("host-1")
+	assert.True(t, found)
+	assert.Equal(t, "9.2.0", version)
+}
+
 func TestUpdateHostVersion(t *testing.T) {
 	t.Run("first sighting is baseline, not a change", func(t *testing.T) {
 		c := newTestCache()
@@ -312,6 +329,126 @@ func TestInvalidateCluster_UnknownCluster(t *testing.T) {
 	c := newTestCache()
 	lastHosts := c.InvalidateCluster("cluster-never-seen")
 	assert.Empty(t, lastHosts)
+}
+
+func TestInvalidateCluster_ClearsESAState(t *testing.T) {
+	c := newTestCache()
+	c.UpdateClusterHosts("cluster-1", hostSet("host-1"))
+	c.SetClusterESAEnabled("cluster-1", true)
+
+	c.InvalidateCluster("cluster-1")
+
+	_, found := c.GetClusterESAEnabled("cluster-1")
+	assert.False(t, found, "ESA state must be cleared when its cluster is invalidated")
+}
+
+func TestClusterForHost(t *testing.T) {
+	c := newTestCache()
+
+	_, ok := c.ClusterForHost("host-1")
+	assert.False(t, ok, "unpopulated host should not resolve to a cluster")
+
+	c.UpdateClusterHosts("cluster-1", hostSet("host-1", "host-2"))
+	clusterID, ok := c.ClusterForHost("host-1")
+	assert.True(t, ok)
+	assert.Equal(t, "cluster-1", clusterID)
+
+	_, ok = c.ClusterForHost("host-never-seen")
+	assert.False(t, ok)
+}
+
+func TestClusterESAEnabled(t *testing.T) {
+	c := newTestCache()
+
+	_, found := c.GetClusterESAEnabled("cluster-1")
+	assert.False(t, found, "unpopulated cluster should not be found")
+
+	c.SetClusterESAEnabled("cluster-1", true)
+	esa, found := c.GetClusterESAEnabled("cluster-1")
+	assert.True(t, found)
+	assert.True(t, esa)
+
+	c.SetClusterESAEnabled("cluster-1", false)
+	esa, found = c.GetClusterESAEnabled("cluster-1")
+	assert.True(t, found)
+	assert.False(t, esa)
+}
+
+func TestSetDatastoresForPolicyZones(t *testing.T) {
+	t.Run("populates a fresh policy", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{
+			"zone-a": {"ds-1", "ds-2"},
+			"zone-b": {"ds-3"},
+		})
+
+		ds, ok := c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-a")
+		require.True(t, ok)
+		assert.Equal(t, map[string]struct{}{"ds-1": {}, "ds-2": {}}, ds)
+
+		ds, ok = c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-b")
+		require.True(t, ok)
+		assert.Equal(t, map[string]struct{}{"ds-3": {}}, ds)
+	})
+
+	t.Run("unpopulated policy or zone is not found", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{"zone-a": {"ds-1"}})
+
+		_, ok := c.GetDatastoresForPolicyZone(context.Background(), "policy-never-seen", "zone-a")
+		assert.False(t, ok)
+
+		_, ok = c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-never-seen")
+		assert.False(t, ok)
+	})
+
+	t.Run("re-setting replaces the entire per-zone map, dropping stale zones", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{
+			"zone-a": {"ds-1"},
+			"zone-b": {"ds-2"},
+		})
+
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{"zone-a": {"ds-1"}})
+
+		_, ok := c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-b")
+		assert.False(t, ok, "zone-b is no longer compatible, its entry must be removed")
+	})
+
+	t.Run("nil zone map clears the policy's entry entirely", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{"zone-a": {"ds-1"}})
+
+		c.SetDatastoresForPolicyZones("policy-1", nil)
+
+		_, ok := c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-a")
+		assert.False(t, ok)
+	})
+
+	t.Run("does not disturb other policies", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{"zone-a": {"ds-1"}})
+		c.SetDatastoresForPolicyZones("policy-2", map[string][]string{"zone-a": {"ds-2"}})
+
+		c.SetDatastoresForPolicyZones("policy-1", nil)
+
+		ds, ok := c.GetDatastoresForPolicyZone(context.Background(), "policy-2", "zone-a")
+		require.True(t, ok)
+		assert.Equal(t, map[string]struct{}{"ds-2": {}}, ds)
+	})
+
+	t.Run("returned map is a copy", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{"zone-a": {"ds-1"}})
+
+		ds, ok := c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-a")
+		require.True(t, ok)
+		ds["ds-injected"] = struct{}{}
+
+		internal, _ := c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-a")
+		assert.Equal(t, map[string]struct{}{"ds-1": {}}, internal,
+			"mutating the returned map must not leak into the cache")
+	})
 }
 
 func TestHostSetsEqual(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR targets 3 things:
1. Stat using SPBM' check requirements API to fetch compatible zones and datastores for a policy.
2. Populate volume capabilities for namespace scoped SPI CRs by using the caching already created by InfraSPI and property collector.
3. Remove the redundant backoffduration update in infraSPI which I found was resetting the backoff duration to 1sec causing very successive reconciles. It is already being done in completeReconciliationWithSuccess and completeReconciliationWithError.

**Testing done**:

Logs for the new SPBM API:

```
{"level":"info","time":"2026-07-16T14:22:27.90136083Z","caller":"clusterstoragepolicyinfo/controller.go:839","msg":"Storage policy 4d5f673c-536f-11e6-beb8-9e71128cae77: populating accessible zones","TraceId":"d684d40b-75cf-4735-88f8-7550708b4fd3"}
{"level":"info","time":"2026-07-16T14:22:30.502414063Z","caller":"vsphere/pbm.go:209","msg":"Found 3 placement results for profile 4d5f673c-536f-11e6-beb8-9e71128cae77 across 1 clusters","TraceId":"d684d40b-75cf-4735-88f8-7550708b4fd3"}
{"level":"info","time":"2026-07-16T14:22:30.502662203Z","caller":"util/util.go:640","msg":"Storage policy 4d5f673c-536f-11e6-beb8-9e71128cae77 is accessible from zones: [az1]","TraceId":"d684d40b-75cf-4735-88f8-7550708b4fd3"}
{"level":"info","time":"2026-07-16T14:22:30.502902688Z","caller":"clusterstoragepolicyinfo/helper.go:470","msg":"Storage policy 4d5f673c-536f-11e6-beb8-9e71128cae77 SupportsVolumeModeBlock=true (isMarkerPolicy=false)","TraceId":"d684d40b-75cf-4735-88f8-7550708b4fd3"}
```

Namespace scoped SPI CR gets populated correctly:

```
k get spi -n test -oyaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyInfo
  metadata:
    creationTimestamp: "2026-07-21T06:14:30Z"
    generation: 2
    name: vm-encryption-policy
    namespace: test
    ownerReferences:
    - apiVersion: cns.vmware.com/v1alpha1
      blockOwnerDeletion: false
      controller: false
      kind: InfraStoragePolicyInfo
      name: vm-encryption-policy
      uid: 5059a11b-4a32-4762-a317-1f669db7a2fa
    resourceVersion: "5248692"
    uid: e1f26c9f-f4f9-49e0-b6fc-6721cb358a05
  spec:
    clusterStoragePolicyInfoRef:
      apiGroup: cns.vmware.com/v1alpha1
      kind: ClusterStoragePolicyInfo
      name: vm-encryption-policy
  status:
    topologyInfo:
      accessibleZones:
      - az1
      topologyType: ""
    volumeCapabilities:
      SupportsHighPerformanceLinkedClone: false
      SupportsLinkedClone: true
      SupportsPersistentVolumeBlock: true
      SupportsPersistentVolumeFilesystem: true
kind: List
metadata:
  resourceVersion: ""
```

```
{"level":"info","time":"2026-07-21T07:25:35.629005407Z","caller":"storagepolicyinfo/controller.go:436","msg":"Reconciling StoragePolicyInfo","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560","name":"test/vm-encryption-policy"}
{"level":"info","time":"2026-07-21T07:25:35.630066542Z","caller":"k8sorchestrator/topology.go:1787","msg":"zone name=\"az1\" ns=\"test\" uid=\"d161dfef-d852-4e1b-bcdb-78e30fd0050c\" rv=\"5202021\" active clusters: [domain-c9]","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560"}
{"level":"info","time":"2026-07-21T07:25:35.630119135Z","caller":"k8sorchestrator/topology.go:1800","msg":"active clusters: [domain-c9] for namespace: \"test\" in requested zones: [az1]","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560"}
{"level":"info","time":"2026-07-21T07:25:35.630137551Z","caller":"storagepolicyinfo/controller.go:761","msg":"Found hosts map[host-19:{} host-25:{} host-31:{} host-37:{}] for datastore datastore-80","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560"}
{"level":"info","time":"2026-07-21T07:25:35.630148977Z","caller":"storagepolicyinfo/controller.go:769","msg":"anyQualifyingHostForNamespace: host host-25 qualifies for policy \"vm-encryption-policy\" via datastore datastore-80 in zone \"az1\"","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560"}
{"level":"info","time":"2026-07-21T07:25:35.630164358Z","caller":"storagepolicyinfo/controller.go:761","msg":"Found hosts map[host-19:{} host-25:{} host-31:{} host-37:{}] for datastore datastore-80","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560"}
{"level":"info","time":"2026-07-21T07:25:35.630175274Z","caller":"storagepolicyinfo/controller.go:761","msg":"Found hosts map[host-19:{} host-25:{} host-31:{} host-37:{}] for datastore datastore-111","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560"}
{"level":"info","time":"2026-07-21T07:25:35.630181643Z","caller":"storagepolicyinfo/controller.go:761","msg":"Found hosts map[host-19:{} host-25:{} host-31:{} host-37:{}] for datastore datastore-76","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560"}
{"level":"info","time":"2026-07-21T07:25:35.630246884Z","caller":"storagepolicyinfo/controller.go:778","msg":"anyQualifyingHostForNamespace: no qualifying host found for policy \"vm-encryption-policy\" across zones [az1]","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560"}
{"level":"info","time":"2026-07-21T07:25:35.743806345Z","caller":"storagepolicyinfo/controller.go:519","msg":"Successfully reconciled StoragePolicyInfo \"test/vm-encryption-policy\"","TraceId":"b18c4829-53d6-446e-8feb-227ca2a0e560","name":"test/vm-encryption-policy"}

```

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1823/
VKS precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1382/