### PR TITLE
Surface FileVolume backend error conditions on CreateVolume/ExpandVoume failures

### DIFF
--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -344,6 +344,34 @@ func fvsAccessibleTopology(pvcNamespace, instanceNS string) ([]*csi.Topology, er
 	return topologyListFromZoneMap(shared), nil
 }
 
+// summarizeFileVolumeConditions renders the FileVolume's not-True status conditions as a compact
+// "Type=Reason: Message" list so the underlying backend failure (e.g. BackendReady=VdfsConnectionFailed)
+// surfaces in the CSI error and on the consuming PVC event, rather than only the generic "entered Error
+// phase". Returns "no conditions reported" when status.conditions is empty.
+func summarizeFileVolumeConditions(fv *fvv1alpha1.FileVolume) string {
+	if len(fv.Status.Conditions) == 0 {
+		return "no conditions reported"
+	}
+	var parts []string
+	for _, cond := range fv.Status.Conditions {
+		if cond.Status == metav1.ConditionTrue {
+			continue
+		}
+		part := cond.Type
+		if cond.Reason != "" {
+			part += "=" + cond.Reason
+		}
+		if cond.Message != "" {
+			part += ": " + cond.Message
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) == 0 {
+		return "no failing conditions reported"
+	}
+	return strings.Join(parts, "; ")
+}
+
 // createFileVolumeViaFVS provisions a file volume by creating a FileVolume CR in the FVS instance namespace.
 func (c *controller) createFileVolumeViaFVS(ctx context.Context, req *csi.CreateVolumeRequest) (
 	*csi.CreateVolumeResponse, string, error) {
@@ -468,7 +496,8 @@ func (c *controller) createFileVolumeViaFVS(ctx context.Context, req *csi.Create
 			return false, nil
 		}
 		if strings.EqualFold(string(phase), string(fvv1alpha1.FileVolumePhaseError)) {
-			return false, fmt.Errorf("FileVolume %s/%s entered Error phase", instanceNS, fvName)
+			return false, fmt.Errorf("FileVolume %s/%s entered Error phase: %s",
+				instanceNS, fvName, summarizeFileVolumeConditions(fv))
 		}
 		if !strings.EqualFold(string(phase), string(fvv1alpha1.FileVolumePhaseReady)) {
 			return false, nil
@@ -670,7 +699,8 @@ func (c *controller) expandFileVolumeViaFVS(ctx context.Context, req *csi.Contro
 			return false, getErr
 		}
 		if strings.EqualFold(string(cur.Status.Phase), string(fvv1alpha1.FileVolumePhaseError)) {
-			return false, fmt.Errorf("FileVolume %s/%s entered Error phase during expansion", instanceNS, fvName)
+			return false, fmt.Errorf("FileVolume %s/%s entered Error phase during expansion: %s",
+				instanceNS, fvName, summarizeFileVolumeConditions(cur))
 		}
 		if cur.Status.LastAppliedSize.Cmp(*desired) >= 0 {
 			return true, nil

--- a/pkg/csi/service/wcp/fvs_filevolume_test.go
+++ b/pkg/csi/service/wcp/fvs_filevolume_test.go
@@ -1280,6 +1280,14 @@ func TestExpandFileVolumeViaFVS_ErrorPhase(t *testing.T) {
 					opts ...ctrlclient.UpdateOption) error {
 					if fv, ok := obj.(*fvv1alpha1.FileVolume); ok {
 						fv.Status.Phase = fvv1alpha1.FileVolumePhaseError
+						fv.Status.Conditions = []metav1.Condition{
+							{
+								Type:    "BackendReady",
+								Status:  metav1.ConditionFalse,
+								Reason:  "VdfsConnectionFailed",
+								Message: "resize: vdfs grpc dial vsock:2:1570: context deadline exceeded",
+							},
+						}
 					}
 					return w.Update(ctx, obj, opts...)
 				},
@@ -1292,6 +1300,9 @@ func TestExpandFileVolumeViaFVS_ErrorPhase(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, csifault.CSIInternalFault, fault)
 	require.Contains(t, err.Error(), "Error phase")
+	// The FileVolume's failing condition must surface so the resize event names the backend cause.
+	require.Contains(t, err.Error(), "VdfsConnectionFailed")
+	require.Contains(t, err.Error(), "vdfs grpc dial")
 }
 
 // TestDeleteFileVolumeViaFVS_StuckFinalizer simulates an FVS controller that has not yet drained
@@ -1403,6 +1414,155 @@ func TestCreateFileVolumeViaFVS_ExistingFVGetError(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, csifault.CSIInternalFault, fault)
 	require.Contains(t, err.Error(), "failed to check for existing FileVolume")
+}
+
+// TestSummarizeFileVolumeConditions verifies that only not-True conditions are rendered, with their
+// reason and message, so the underlying backend failure surfaces in the CSI error.
+func TestSummarizeFileVolumeConditions(t *testing.T) {
+	cases := []struct {
+		name        string
+		conditions  []metav1.Condition
+		wantExact   string
+		wantContain []string
+	}{
+		{
+			name:      "no conditions",
+			wantExact: "no conditions reported",
+		},
+		{
+			name: "only true conditions are excluded",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Provisioned", Message: "all good"},
+			},
+			wantExact: "no failing conditions reported",
+		},
+		{
+			name: "single failing backend condition",
+			conditions: []metav1.Condition{
+				{
+					Type:    "BackendReady",
+					Status:  metav1.ConditionFalse,
+					Reason:  "VdfsConnectionFailed",
+					Message: "create: vdfs grpc dial vsock:2:1570: context deadline exceeded",
+				},
+			},
+			wantContain: []string{"BackendReady=VdfsConnectionFailed", "vdfs grpc dial vsock:2:1570"},
+		},
+		{
+			name: "multiple failing conditions joined",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: metav1.ConditionFalse, Reason: "BackendVolumeAssignmentNotReady",
+					Message: "One or more required conditions are not ready"},
+				{Type: "BackendReady", Status: metav1.ConditionFalse, Reason: "VdfsConnectionFailed",
+					Message: "context deadline exceeded"},
+			},
+			wantContain: []string{
+				"Ready=BackendVolumeAssignmentNotReady",
+				"BackendReady=VdfsConnectionFailed",
+				"; ",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fv := &fvv1alpha1.FileVolume{Status: fvv1alpha1.FileVolumeStatus{Conditions: tc.conditions}}
+			got := summarizeFileVolumeConditions(fv)
+			if tc.wantExact != "" {
+				require.Equal(t, tc.wantExact, got)
+			}
+			for _, sub := range tc.wantContain {
+				require.Contains(t, got, sub)
+			}
+		})
+	}
+}
+
+// TestCreateFileVolumeViaFVS_ErrorPhasePropagatesCondition verifies that when an existing FileVolume
+// is in Error phase, createFileVolumeViaFVS surfaces the failing condition (reason + message) in the
+// returned error so the consuming PVC event names the backend cause rather than only "Error phase".
+func TestCreateFileVolumeViaFVS_ErrorPhasePropagatesCondition(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+	consumerAnn := "pvc-ns-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	instAnn := "inst-ns-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	sameVPCPath := "/orgs/default/projects/default/vpcs/same-vpc"
+	pvcUID := "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+	k8s := k8sfake.NewClientset(
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "pvc-ns",
+				Annotations: map[string]string{AnnotationVPCNetworkConfig: consumerAnn},
+			},
+		},
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "inst-ns",
+				Labels:      map[string]string{NamespaceLabelFVSInstance: "true"},
+				Annotations: map[string]string{AnnotationVPCNetworkConfig: instAnn},
+			},
+		},
+	)
+	dyn := newTestDynamicClient(t,
+		testVPCNetworkConfigurationCR(consumerAnn, sameVPCPath),
+		testVPCNetworkConfigurationCR(instAnn, sameVPCPath),
+	)
+
+	origZones := fvsZonesForNamespace
+	defer func() { fvsZonesForNamespace = origZones }()
+	fvsZonesForNamespace = func(ns string) map[string]struct{} {
+		if ns == "pvc-ns" || ns == "inst-ns" {
+			return map[string]struct{}{"zone-a": {}}
+		}
+		return nil
+	}
+
+	// Existing FileVolume already in Error phase carrying the backend failure condition. This exercises
+	// the Phase 1 reuse path, so no healthy FileVolumeService is required.
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcUID, Namespace: "inst-ns"},
+		Status: fvv1alpha1.FileVolumeStatus{
+			Phase: fvv1alpha1.FileVolumePhaseError,
+			Conditions: []metav1.Condition{
+				{
+					Type:    "BackendReady",
+					Status:  metav1.ConditionFalse,
+					Reason:  "VdfsConnectionFailed",
+					Message: "create: vdfs grpc dial vsock:2:1570: context deadline exceeded",
+				},
+			},
+		},
+	}
+	fvClient := ctrlfake.NewClientBuilder().
+		WithScheme(newFileVolumeSchemeForTest(t)).
+		WithObjects(existing).
+		Build()
+
+	c := &controller{
+		k8sClient:        k8s,
+		dynamicClient:    dyn,
+		namespaceLister:  testNamespaceLister(t, k8s),
+		fileVolumeClient: fvClient,
+	}
+
+	req := &csi.CreateVolumeRequest{
+		Name: "pvc-" + pvcUID,
+		Parameters: map[string]string{
+			common.AttributePvcNamespace: "pvc-ns",
+			common.AttributePvcName:      "my-pvc",
+		},
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Preferred: []*csi.Topology{{Segments: map[string]string{v1.LabelTopologyZone: "zone-a"}}},
+		},
+	}
+
+	resp, fault, err := c.createFileVolumeViaFVS(ctx, req)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Equal(t, csifault.CSIInternalFault, fault)
+	require.Contains(t, err.Error(), "Error phase")
+	require.Contains(t, err.Error(), "VdfsConnectionFailed")
+	require.Contains(t, err.Error(), "vdfs grpc dial")
 }
 
 // TestReservedFVSStorageClassGuard documents the invariant the new CreateVolume guard relies on:


### PR DESCRIPTION
**What this PR does / why we need it**:
<!-- Thanks for sending a pull request! -->
When a FileVolume CR enters Error phase, the WCP CSI controller returned a generic "FileVolume <ns>/<name> entered Error phase" error without reading status.conditions[]. The real backend cause (e.g. BackendReady= VdfsConnectionFailed with the vdfs vsock dial timeout) was dropped, so the consuming PVC ProvisioningFailed/resize event never showed why provisioning failed.

Add summarizeFileVolumeConditions to render the FileVolume's not-True conditions as a compact "Type=Reason: Message" list and include it in the error returned from both createFileVolumeViaFVS and expandFileVolumeViaFVS so the backend reason surfaces directly on the PVC.

Behavior is otherwise unchanged: still fail fast on the first Error phase so external-provisioner retries drive recovery for transient backend failures.

**Testing done**:
Manul testing done.

After this fix

```
k describe pvc -name rwx-pvc -n test-ws
Name:          rwx-pvc
Namespace:     test-ws
StorageClass:  vsan-file-service-policy
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age                   From                                                                                          Message
  ----     ------                ----                  ----                                                                                          -------
csi.vsphere.vmware.com_42145430cbf8aaf2aa40857a877703bf_24ae321c-413c-4a7f-98a2-ee6a7f7a0b1e  External provisioner is provisioning volume for claim "test-ws/rwx-pvc"
  Warning  ProvisioningFailed    1s (x2 over 2s)       csi.vsphere.vmware.com_42145430cbf8aaf2aa40857a877703bf_24ae321c-413c-4a7f-98a2-ee6a7f7a0b1e  rpc error: code = DeadlineExceeded desc = timeout or error waiting for FileVolume test-fvs-ns/7c849d53-77af-4821-a7f9-f8fe3245d83d to become Ready with export path and endpoint: FileVolume test-fvs-ns/7c849d53-77af-4821-a7f9-f8fe3245d83d entered Error phase: Ready=BackendVolumeAssignmentNotReady: One or more required conditions are not ready; BackendReady=VdfsConnectionFailed: create: vdfs grpc dial vsock:2:1570: dial vsock:2:1570: context deadline exceeded
```


before this fix

```
k describe pvc -name rwx-pvc -n test-ws
Name:          rwx-pvc
Namespace:     test-ws
StorageClass:  vsan-file-service-policy
Status:        Pending
Volume:
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age                From                                                                                          Message
  ----     ------                ----               ----                                                                                          -------
  Normal   ExternalProvisioning  13s (x6 over 88s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal   Provisioning          9s (x7 over 88s)   csi.vsphere.vmware.com_42145430cbf8aaf2aa40857a877703bf_f4085871-c296-425f-9023-1af97fec62b4  External provisioner is provisioning volume for claim "test-ws/rwx-pvc"
  Warning  ProvisioningFailed    9s (x7 over 72s)   csi.vsphere.vmware.com_42145430cbf8aaf2aa40857a877703bf_f4085871-c296-425f-9023-1af97fec62b4  rpc error: code = DeadlineExceeded desc = timeout or error waiting for FileVolume test-fvs-ns/7c849d53-77af-4821-a7f9-f8fe3245d83d to become Ready with export path and endpoint: FileVolume test-fvs-ns/7c849d53-77af-4821-a7f9-f8fe3245d83d entered Error phase
[worker@lvn-dvm-10-161-230-127 tools]$

```

**Special notes for your reviewer**:
wcp pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1816/ - `SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked`
vks pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1375/ `SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked`


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Surface FileVolume backend error conditions on CreateVolume/ExpandVoume failures
```
