### PR TITLE
Fix flaky e2e tests: snapshot size/timeouts and concurrent pod creation race

### DIFF
--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -2420,7 +2420,8 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		}()
 
 		ginkgo.By("Create a volume snapshot - 1")
-		diskSize := "1Gi"
+		pvc1Storage := pvclaim1.Spec.Resources.Requests[v1.ResourceStorage]
+		diskSize := pvc1Storage.String()
 		volumeSnapshot1, snapshotContent1, snapshotCreated1,
 			snapshotContentCreated1, snapshotId1, _, err := createDynamicVolumeSnapshot(ctx, namespace, snapc,
 			volumeSnapshotClass, pvclaim1, volHandle1, diskSize, true)
@@ -2500,8 +2501,9 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		denied the request: Deleting volume with snapshots is not allowed */
 
 		ginkgo.By("Restoring a snapshot-1 to create a new volume and attach it to a new Pod")
+		restoreSize1 := volumeSnapshot1.Status.RestoreSize.String()
 		pvclaim3, persistentVolumes3, pod3 := verifyVolumeRestoreOperation(ctx, client,
-			namespace, storageclass, volumeSnapshot1, diskSize, true)
+			namespace, storageclass, volumeSnapshot1, restoreSize1, true)
 		volHandle3 := persistentVolumes3[0].Spec.CSI.VolumeHandle
 		if guestCluster {
 			volHandle3 = getVolumeIDFromSupervisorCluster(volHandle3)
@@ -3896,7 +3898,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.By("Done with reboot")
 			essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
-			checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
+			checkVcenterServicesRunning(ctx, vcAddress, essentialServices, vcRebootRecoveryTimeout)
 
 			// After reboot.
 			bootstrap()
@@ -3915,7 +3917,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
-		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices, vcRebootRecoveryTimeout)
 
 		// After reboot.
 		bootstrap()
@@ -4006,7 +4008,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		err = waitForHostToBeUp(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
-		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices, vcRebootRecoveryTimeout)
 
 		// After reboot.
 		bootstrap()
@@ -5801,7 +5803,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(strings.Contains(output, "Hello message from test into Pod")).NotTo(gomega.BeFalse())
 
 		wrtiecmd2 := []string{"exec", pod.Name, "--namespace=" + namespace, "--", "/bin/sh", "-c",
-			"echo 'fsync' "}
+			"sync"}
 		e2ekubectl.RunKubectlOrDie(namespace, wrtiecmd2...)
 
 		ginkgo.By("Get volume snapshot class")
@@ -6236,7 +6238,10 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			ginkgo.By(fmt.Sprintf("Deleting the pvc %s in namespace %s", pvclaim.Name, namespace))
 			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volHandle)
+			// This volume just had a snapshot created and deleted on it as part of this negative
+			// test; give CNS extra time beyond the default budget to settle before treating a
+			// slow deletion as a failure.
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volHandle, cnsVolumeDeleteTimeout*2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 

--- a/tests/e2e/csi_snapshot_utils.go
+++ b/tests/e2e/csi_snapshot_utils.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -130,6 +131,12 @@ func waitForVolumeSnapshotContentToBeDeleted(client snapclient.Clientset, ctx co
 				if apierrors.IsNotFound(err) {
 					framework.Logf("VolumeSnapshotContent: %s is deleted", name)
 					return true, nil
+				} else if errors.Is(err, context.DeadlineExceeded) {
+					// transient client-side throttling/rate-limiter timeout, retry within
+					// the overall poll timeout instead of failing the test immediately
+					framework.Logf("transient error fetching volumesnapshotcontent %s details, "+
+						"retrying: %v", name, err)
+					return false, nil
 				} else {
 					return false, fmt.Errorf("error fetching volumesnapshotcontent details : %v", err)
 				}
@@ -192,6 +199,12 @@ func waitForVolumeSnapshotContentToBeDeletedWithPandoraWait(ctx context.Context,
 					ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow CNS to sync with pandora", pandoraSyncWaitTime))
 					time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
 					return true, nil
+				} else if errors.Is(err, context.DeadlineExceeded) {
+					// transient client-side throttling/rate-limiter timeout, retry within
+					// the overall poll timeout instead of failing the test immediately
+					framework.Logf("transient error fetching volumesnapshotcontent %s details, "+
+						"retrying: %v", name, err)
+					return false, nil
 				} else {
 					return false, fmt.Errorf("error fetching volumesnapshotcontent details : %v", err)
 				}
@@ -738,8 +751,18 @@ func verifyVolumeRestoreOperation(ctx context.Context, client clientset.Interfac
 			cmd = []string{"exec", pod.Name, "--namespace=" + namespace, "--", "/bin/sh", "-c",
 				"cat ", filePathPod1}
 		}
-		output := e2ekubectl.RunKubectlOrDie(namespace, cmd...)
-		gomega.Expect(strings.Contains(output, "Hello message from Pod1")).NotTo(gomega.BeFalse())
+		// The pod's container is marked Running as soon as its entrypoint process starts,
+		// which can race ahead of the entrypoint's own "echo ... > Pod1.html" write completing,
+		// especially on higher-latency datastores (e.g. VVOL, VMFS, NFS, VSAN2). Poll briefly
+		// instead of a single immediate read to tolerate that startup race.
+		var output string
+		waitErr := wait.PollUntilContextTimeout(ctx, poll, pollTimeoutShort, true,
+			func(ctx context.Context) (bool, error) {
+				output = e2ekubectl.RunKubectlOrDie(namespace, cmd...)
+				return strings.Contains(output, "Hello message from Pod1"), nil
+			})
+		gomega.Expect(waitErr).NotTo(gomega.HaveOccurred(),
+			fmt.Sprintf("file content mismatch, expected \"Hello message from Pod1\" got: %q", output))
 
 		var wrtiecmd []string
 		if windowsEnv {

--- a/tests/e2e/csisnapshot/util.go
+++ b/tests/e2e/csisnapshot/util.go
@@ -18,6 +18,7 @@ package csisnapshot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -251,6 +252,12 @@ func WaitForVolumeSnapshotContentToBeDeletedWithPandoraWait(ctx context.Context,
 					ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow CNS to sync with pandora", pandoraSyncWaitTime))
 					time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
 					return true, nil
+				} else if errors.Is(err, context.DeadlineExceeded) {
+					// transient client-side throttling/rate-limiter timeout, retry within
+					// the overall poll timeout instead of failing the test immediately
+					framework.Logf("transient error fetching volumesnapshotcontent %s details, "+
+						"retrying: %v", name, err)
+					return false, nil
 				} else {
 					return false, fmt.Errorf("error fetching volumesnapshotcontent details : %v", err)
 				}
@@ -388,6 +395,12 @@ func WaitForVolumeSnapshotContentToBeDeleted(client snapclient.Clientset, ctx co
 				if apierrors.IsNotFound(err) {
 					framework.Logf("VolumeSnapshotContent: %s is deleted", name)
 					return true, nil
+				} else if errors.Is(err, context.DeadlineExceeded) {
+					// transient client-side throttling/rate-limiter timeout, retry within
+					// the overall poll timeout instead of failing the test immediately
+					framework.Logf("transient error fetching volumesnapshotcontent %s details, "+
+						"retrying: %v", name, err)
+					return false, nil
 				} else {
 					return false, fmt.Errorf("error fetching volumesnapshotcontent details : %v", err)
 				}

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -171,6 +171,7 @@ const (
 	pollTimeout                               = 10 * time.Minute
 	pollTimeoutShort                          = 1 * time.Minute
 	pollTimeoutSixMin                         = 6 * time.Minute
+	vcRebootRecoveryTimeout                   = 90 * time.Minute
 	healthStatusPollTimeout                   = 20 * time.Minute
 	healthStatusPollInterval                  = 30 * time.Second
 	psodTime                                  = "120"

--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -243,8 +244,14 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 		}()
 
 		ginkgo.By("Create 2 Pods concurrently with these PVCs mounted as volumes")
-		go verifyPodCreation(ctx, f, client, namespace, pvc1, pv1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			verifyPodCreation(ctx, f, client, namespace, pvc1, pv1)
+		}()
 		verifyPodCreation(ctx, f, client, namespace, pvc2, pv2)
+		wg.Wait()
 
 	})
 

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -3963,6 +3963,12 @@ func waitForEvent(ctx context.Context, client clientset.Interface,
 			eventList, err := client.CoreV1().Events(namespace).List(ctx,
 				metav1.ListOptions{FieldSelector: "involvedObject.name=" + name})
 			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					// transient client-side throttling/rate-limiter timeout, retry within
+					// the overall poll timeout instead of failing the test immediately
+					framework.Logf("transient error listing events for %s, retrying: %v", name, err)
+					return false, nil
+				}
 				return false, err
 			}
 			for _, item := range eventList.Items {

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -465,9 +465,14 @@ func (vs *vSphere) waitForMetadataToBeDeleted(volumeID string, entityType string
 }
 
 // waitForCNSVolumeToBeDeleted executes QueryVolume API on vCenter and verifies
-// volume entries are deleted from vCenter Database
-func (vs *vSphere) waitForCNSVolumeToBeDeleted(volumeID string) error {
-	err := wait.PollUntilContextTimeout(context.Background(), poll, cnsVolumeDeleteTimeout, true,
+// volume entries are deleted from vCenter Database. An optional timeout can be
+// passed to override the default cnsVolumeDeleteTimeout.
+func (vs *vSphere) waitForCNSVolumeToBeDeleted(volumeID string, timeout ...time.Duration) error {
+	deleteTimeout := cnsVolumeDeleteTimeout
+	if len(timeout) > 0 {
+		deleteTimeout = timeout[0]
+	}
+	err := wait.PollUntilContextTimeout(context.Background(), poll, deleteTimeout, true,
 		func(ctx context.Context) (bool, error) {
 			queryResult, err := vs.queryCNSVolumeWithResult(volumeID)
 			if err != nil {


### PR DESCRIPTION
- Fix concurrent CnsNodeVmAttachment pod creation test racing its own shared context cancellation, which caused spurious AfterEach failures when the async pod's readiness wait outlived the It block.
- Use actual PVC/snapshot restore sizes instead of hardcoded values, and extend VC reboot recovery and CNS volume deletion timeouts to reduce snapshot test flakiness.


**Testing done**:
InProgress

