### PR TITLE
Add a Zone CR watch to the StoragePolicyInfo controller so namespace zone assignment/unassignment reactively recomputes topology.

### DIFF
--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -84,6 +86,17 @@ const (
 	// StoragePolicyInfo objects in mapFVSNamespaceToMarkerSPIs.
 	spiMarkerIndexField = "isMarkerPolicy"
 )
+
+// zoneGVK identifies the namespace-scoped Zone custom resource
+// (topology.tanzu.vmware.com/v1alpha1) that the controller watches so a
+// namespace's StoragePolicyInfo topology recomputes when its zone assignments
+// change. It is watched as an unstructured object because no typed Go client is
+// registered for this CRD.
+var zoneGVK = schema.GroupVersionKind{
+	Group:   "topology.tanzu.vmware.com",
+	Version: "v1alpha1",
+	Kind:    "Zone",
+}
 
 // Add registers the StoragePolicyInfo controller with the Manager (WCP / Workload only).
 func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
@@ -258,6 +271,28 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 		},
 	}
 
+	// zonePredicate admits only Zone events that can change a namespace's accessible
+	// zone set: create, or a deletionTimestamp-set update. Delete is disabled — Zone
+	// deletion is finalizer-gated, so the deletionTimestamp update already triggers
+	// the re-reconcile; the later terminal Delete would just repeat it.
+	zonePredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object != nil
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			return (e.ObjectOld.GetDeletionTimestamp() == nil) != (e.ObjectNew.GetDeletionTimestamp() == nil)
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return false
+		},
+	}
+
+	zoneObj := &unstructured.Unstructured{}
+	zoneObj.SetGroupVersionKind(zoneGVK)
+
 	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).Named("storagepolicyinfo-controller").
 		For(&spiv1alpha1.StoragePolicyInfo{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
@@ -270,6 +305,11 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 			&infraspiv1alpha1.InfraStoragePolicyInfo{},
 			handler.EnqueueRequestsFromMapFunc(r.mapInfraSPItoSPI),
 			builder.WithPredicates(infraSPIPredicates),
+		).
+		Watches(
+			zoneObj,
+			handler.EnqueueRequestsFromMapFunc(r.mapZoneToSPIs),
+			builder.WithPredicates(zonePredicate),
 		).
 		WatchesRawSource(source.Channel(resyncCh, &handler.EnqueueRequestForObject{}))
 
@@ -388,6 +428,41 @@ func (r *ReconcileStoragePolicyInfo) mapFVSNamespaceToMarkerSPIs(ctx context.Con
 			},
 		}
 	}
+	return reqs
+}
+
+// mapZoneToSPIs maps a Zone CR event to reconcile requests for every
+// StoragePolicyInfo in the Zone's namespace, so their namespace-filtered
+// accessible zones are recomputed when the namespace's zone assignments change.
+// The Zone is namespace-scoped, so a plain InNamespace list suffices and no
+// field index is required. If the list fails the event is dropped, but the
+// periodic slow-sync reconcile independently re-syncs topology.
+func (r *ReconcileStoragePolicyInfo) mapZoneToSPIs(ctx context.Context,
+	obj client.Object) []reconcile.Request {
+	if obj == nil || obj.GetNamespace() == "" {
+		return nil
+	}
+	log := logger.GetLogger(ctx)
+	namespace := obj.GetNamespace()
+
+	spiList := &spiv1alpha1.StoragePolicyInfoList{}
+	if err := r.client.List(ctx, spiList, client.InNamespace(namespace)); err != nil {
+		log.Errorf("mapZoneToSPIs: failed to list StoragePolicyInfo in namespace %q: %v",
+			namespace, err)
+		return nil
+	}
+
+	reqs := make([]reconcile.Request, 0, len(spiList.Items))
+	for i := range spiList.Items {
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: apitypes.NamespacedName{
+				Namespace: spiList.Items[i].Namespace,
+				Name:      spiList.Items[i].Name,
+			},
+		})
+	}
+	log.Infof("Zone change in namespace %q enqueued %d StoragePolicyInfo reconcile request(s)",
+		namespace, len(reqs))
 	return reqs
 }
 
@@ -682,11 +757,13 @@ func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 
 	nsZones := r.zonesProvider.GetZonesForNamespace(namespace)
 	if len(nsZones) == 0 {
-		// Non-zonal deployment or namespace has no zone constraints; expose all
-		// cluster-accessible zones.
-		log.Debugf("Namespace %q has no zone assignments; using all %d cluster-accessible zones",
-			namespace, len(clusterZones))
-		return clusterZones
+		// No Zone CRs assigned to this namespace means no zone has been assigned to
+		// it yet. Return empty rather than falling back to all cluster zones —
+		// exposing all zones for an unassigned namespace is incorrect in a
+		// WDI/zonal deployment.
+		log.Debugf("Namespace %q has no zone assignments; accessibleZones will be empty",
+			namespace)
+		return []string{}
 	}
 
 	// Intersect cluster-accessible zones with namespace-assigned zones.

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -203,6 +203,82 @@ func TestMapInfraSPItoSPI_NoMatchingStoragePolicyInfos(t *testing.T) {
 	assert.Empty(t, reqs)
 }
 
+// newZone builds an unstructured Zone CR in the given namespace, matching the
+// object the Zone watch delivers to mapZoneToSPIs.
+func newZone(namespace, name string) *unstructured.Unstructured {
+	z := &unstructured.Unstructured{}
+	z.SetGroupVersionKind(zoneGVK)
+	z.SetNamespace(namespace)
+	z.SetName(name)
+	return z
+}
+
+// TestMapZoneToSPIs_NilObject verifies that mapZoneToSPIs returns nil for nil input.
+func TestMapZoneToSPIs_NilObject(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme: scheme,
+	}
+	assert.Nil(t, r.mapZoneToSPIs(ctx, nil))
+}
+
+// TestMapZoneToSPIs_EmptyNamespace verifies that a Zone with no namespace is skipped.
+func TestMapZoneToSPIs_EmptyNamespace(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme: scheme,
+	}
+	assert.Nil(t, r.mapZoneToSPIs(ctx, newZone("", "az1")))
+}
+
+// TestMapZoneToSPIs_EnqueuesNamespaceSPIs verifies that a Zone event enqueues every
+// StoragePolicyInfo in the Zone's namespace and none from other namespaces.
+func TestMapZoneToSPIs_EnqueuesNamespaceSPIs(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	gold := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	silver := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "silver", Namespace: "ns1"},
+	}
+	// A StoragePolicyInfo in a different namespace must not be enqueued.
+	other := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns2"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gold, silver, other).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	reqs := r.mapZoneToSPIs(ctx, newZone("ns1", "az1"))
+	require.Len(t, reqs, 2)
+	names := []string{
+		reqs[0].Namespace + "/" + reqs[0].Name,
+		reqs[1].Namespace + "/" + reqs[1].Name,
+	}
+	assert.ElementsMatch(t, []string{"ns1/gold", "ns1/silver"}, names)
+}
+
+// TestMapZoneToSPIs_NoSPIsInNamespace verifies an empty result when the Zone's
+// namespace has no StoragePolicyInfo CRs.
+func TestMapZoneToSPIs_NoSPIsInNamespace(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+
+	other := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns2"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(other).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme}
+
+	assert.Empty(t, r.mapZoneToSPIs(ctx, newZone("ns1", "az1")))
+}
+
 // TestMergeOwnerReference exercises the four cases of the mergeOwnerReference helper.
 func TestMergeOwnerReference(t *testing.T) {
 	controllerFalse := false
@@ -407,9 +483,13 @@ func TestSyncTopologyFromInfraSPI_CopiesTopology(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
 	r := &ReconcileStoragePolicyInfo{
-		client:        fake.NewClientBuilder().WithScheme(scheme).Build(),
-		scheme:        scheme,
-		zonesProvider: &mockZonesProvider{},
+		client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme: scheme,
+		// ns1 is assigned to both zones so the copy path is exercised rather than
+		// the unassigned-namespace clear path.
+		zonesProvider: &mockZonesProvider{zonesForNamespace: map[string]map[string]struct{}{
+			"ns1": {"az1": {}, "az2": {}},
+		}},
 	}
 
 	inst := &spiv1alpha1.StoragePolicyInfo{
@@ -458,6 +538,41 @@ func TestSyncTopologyFromInfraSPI_ClearsWhenNilTopology(t *testing.T) {
 	assert.Nil(t, inst.Status.TopologyInfo)
 }
 
+// TestSyncTopologyFromInfraSPI_NoAccessibleZonesKeepsTopologyType verifies that when the
+// namespace has no Zone CRs assigned, TopologyInfo is still populated with the InfraSPI's
+// TopologyType and an empty (non-nil) AccessibleZones slice, rather than being cleared
+// entirely — distinguishing "zonal policy, no zones currently accessible" from "no topology
+// at all".
+func TestSyncTopologyFromInfraSPI_NoAccessibleZonesKeepsTopologyType(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	r := &ReconcileStoragePolicyInfo{
+		client:        fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:        scheme,
+		zonesProvider: &mockZonesProvider{},
+	}
+
+	inst := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			Topology: &infraspiv1alpha1.Topology{
+				TopologyType:    "zonal",
+				AccessibleZones: []string{"az1", "az2"},
+			},
+		},
+	}
+
+	err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
+	require.NoError(t, err)
+	require.NotNil(t, inst.Status.TopologyInfo)
+	assert.Equal(t, "zonal", inst.Status.TopologyInfo.TopologyType)
+	assert.NotNil(t, inst.Status.TopologyInfo.AccessibleZones)
+	assert.Empty(t, inst.Status.TopologyInfo.AccessibleZones)
+}
+
 // TestNamespaceFilteredZones exercises the zone-intersection logic used by
 // namespaceFilteredZones with a table of representative inputs.
 func TestNamespaceFilteredZones(t *testing.T) {
@@ -471,10 +586,10 @@ func TestNamespaceFilteredZones(t *testing.T) {
 		expectedZones []string
 	}{
 		{
-			name:          "no namespace zone constraints returns all cluster zones",
+			name:          "no namespace zone assignments returns empty",
 			nsZones:       nil,
 			clusterZones:  []string{"az1", "az2", "az3"},
-			expectedZones: []string{"az1", "az2", "az3"},
+			expectedZones: nil,
 		},
 		{
 			name:          "namespace zones intersect cluster zones",
@@ -831,10 +946,10 @@ func TestReconcile_ZoneFilteringApplied(t *testing.T) {
 		"az2 should be filtered out because ns1 is not assigned to it")
 }
 
-// TestReconcile_NoNamespaceZonesReturnsAll verifies that when a namespace has
-// no zone assignments (non-zonal or unconstrained namespace), all
-// cluster-accessible zones are exposed.
-func TestReconcile_NoNamespaceZonesReturnsAll(t *testing.T) {
+// TestReconcile_NoNamespaceZonesYieldsEmptyAccessibleZones verifies that when a namespace has
+// no Zone CRs assigned, TopologyInfo keeps the InfraSPI's TopologyType but yields an empty
+// AccessibleZones slice (rather than falling back to all cluster-accessible zones).
+func TestReconcile_NoNamespaceZonesYieldsEmptyAccessibleZones(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	scheme := testScheme(t)
 
@@ -868,9 +983,11 @@ func TestReconcile_NoNamespaceZonesReturnsAll(t *testing.T) {
 
 	got := &spiv1alpha1.StoragePolicyInfo{}
 	require.NoError(t, cli.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "gold"}, got))
-	require.NotNil(t, got.Status.TopologyInfo)
-	assert.ElementsMatch(t, []string{"az1", "az2"}, got.Status.TopologyInfo.AccessibleZones,
-		"all cluster zones should be exposed when namespace has no zone constraints")
+	require.NotNil(t, got.Status.TopologyInfo,
+		"TopologyInfo should still be populated (with TopologyType) when namespace has no Zone CRs assigned")
+	assert.Equal(t, "zonal", got.Status.TopologyInfo.TopologyType)
+	assert.Empty(t, got.Status.TopologyInfo.AccessibleZones,
+		"AccessibleZones should be an empty slice, not omitted, when no zones are accessible")
 }
 
 // TestReconcile_InfraSPITopologyUpdated verifies the scenario where an InfraStoragePolicyInfo
@@ -903,10 +1020,14 @@ func TestReconcile_InfraSPITopologyUpdated(t *testing.T) {
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).
 		WithObjects(spi, infraSPI).Build()
 	r := &ReconcileStoragePolicyInfo{
-		client:          cli,
-		scheme:          scheme,
-		recorder:        recorder,
-		zonesProvider:   &mockZonesProvider{},
+		client:   cli,
+		scheme:   scheme,
+		recorder: recorder,
+		// ns1 is assigned to both zones so the InfraSPI update flows through the
+		// namespace filter rather than being cleared as an unassigned namespace.
+		zonesProvider: &mockZonesProvider{zonesForNamespace: map[string]map[string]struct{}{
+			"ns1": {"az1": {}, "az2": {}},
+		}},
 		backOffDuration: make(map[types.NamespacedName]time.Duration)}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{


### PR DESCRIPTION
This wires a native controller-runtime .Watches() on the namespace-scoped Zone CR (topology.tanzu.vmware.com/v1alpha1) into the StoragePolicyInfo controller. Previously, a namespace's Zone assignments were only read during Reconcile (via GetZonesForNamespace), with no trigger to re-reconcile when they changed, so zone assignment/unassignment relied entirely on the periodic slow-sync to eventually pick it up.

mapZoneToSPIs lists all StoragePolicyInfo CRs in the changed Zone's namespace and enqueues one reconcile request per CR. zonePredicate fires on Zone Create/Delete, and on Update only when deletionTimestamp transitions, matching exactly what GetZonesForNamespace/namespaceFilteredZones consider. Other Zone spec/status changes are filtered out as irrelevant to topology.

Note: the reconcile still reads zone membership via commonco's separate dynamic informer (GetZonesForNamespace), while this new watch triggers off the controller-runtime manager's own cache.

Testing Done:
Pipeline results:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1379/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1820/ - Passed

Verified on a WCP/Supervisor cluster. Namespace svc-velero-7nzum has 7 StoragePolicyInfo (SPI) CRs.

1. Zone assignment reactively populates topology
```
# Before: no Zone CR assigned → topology empty
$ kubectl get storagepolicyinfo -n svc-velero-7nzum -o yaml | grep -A3 topologyInfo
  status: {}

# Assign a zone
$ kubectl apply -f - <<EOF
apiVersion: topology.tanzu.vmware.com/v1alpha1
kind: Zone
metadata:
  name: az1
  namespace: svc-velero-7nzum
spec:
  availabilityZoneReference:
    apiVersion: v1alpha1
    name: az1
  disallowUnreservedDirectPathUsage: false
EOF
zone.topology.tanzu.vmware.com/az1 created
```
Watch fired within ~1s:
```
{"level":"info","time":"2026-07-17T14:54:18.769539233Z","caller":"storagepolicyinfo/controller.go:472","msg":"Zone change in namespace \"svc-velero-7nzum\" enqueued 7 StoragePolicyInfo reconcile request(s)"}
```

All 7 SPIs updated to include az1:
```
$ kubectl get storagepolicyinfo -n svc-velero-7nzum -o yaml | grep -A3 topologyInfo
    topologyInfo:
      accessibleZones:
      - az1
      topologyType: ""
   ... (×7)
```

2. Zone unassignment reactively clears topology
```
$ kubectl delete zone az1 -n svc-velero-7nzum
zone.topology.tanzu.vmware.com "az1" deleted from svc-velero-7nzum namespace
```

Watch fired on deletion:

```
{"level":"info","time":"2026-07-17T15:01:07.563163875Z","caller":"storagepolicyinfo/controller.go:472","msg":"Zone change in namespace \"svc-velero-7nzum\" enqueued 7 StoragePolicyInfo reconcile request(s)"}
{"level":"info","time":"2026-07-17T15:01:07.571053253Z","caller":"storagepolicyinfo/controller.go:472","msg":"Zone change in namespace \"svc-velero-7nzum\" enqueued 7 StoragePolicyInfo reconcile request(s)"}
{"level":"info","time":"2026-07-17T15:01:07.628527696Z","caller":"storagepolicyinfo/controller.go:472","msg":"Zone change in namespace \"svc-velero-7nzum\" enqueued 7 StoragePolicyInfo reconcile request(s)"}
```
All 7 SPIs updated to empty accessible zones, confirming accessible zones were cleared rather than left with a stale zone information):

```
$ kubectl get storagepolicyinfo -n svc-velero-7nzum -o yaml | grep -A3 topologyInfo
    topologyInfo:
      accessibleZones: []
      topologyType: ""
- apiVersion: cns.vmware.com/v1alpha1
```


3. Fan-out matches SPI count in the namespace

```
$ kubectl apply -f - <<EOF
apiVersion: topology.tanzu.vmware.com/v1alpha1
kind: Zone
metadata:
  name: az1
  namespace: svc-velero-7nzum
spec:
  availabilityZoneReference:
    apiVersion: v1alpha1
    name: az1
  disallowUnreservedDirectPathUsage: false
EOF
zone.topology.tanzu.vmware.com/az1 created

{"level":"info","time":"2026-07-17T15:05:48.214822402Z","caller":"storagepolicyinfo/controller.go:472","msg":"Zone change in namespace \"svc-velero-7nzum\" enqueued 7 StoragePolicyInfo reconcile request(s)"}
```

Enqueued count (7) == SPI count in the namespace (7), every SPI reflects the zone:

```
$ kubectl get storagepolicyinfo -n svc-velero-7nzum -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.topologyInfo.accessibleZones}{"\n"}{end}'
management-storage-policy-encryption: ["az1"]
management-storage-policy-regular: ["az1"]
management-storage-policy-single-node: ["az1"]
management-storage-policy-stretched-lite: ["az1"]
management-storage-policy-thin: ["az1"]
vm-encryption-policy: ["az1"]
vsan-default-storage-policy: ["az1"]
```

4. Cross-namespace isolation A Zone change in svc-velero-7nzum produced only that namespace's log line ("no other logs"); SPIs in other namespaces were not enqueued.

5. Irrelevant Zone updates are filtered An annotation-only update (no deletionTimestamp change) produced no reconcile trigger, confirming the predicate ignores updates that can't affect namespace topology:
```
$ kubectl annotate zone az1 -n svc-velero-7nzum test-annotation=noop --overwrite
zone.topology.tanzu.vmware.com/az1 annotated
$   # no "Zone change in namespace" log line emitted
```