### PR TITLE
[VKSRegisterVolume] Reconcile: guest PV creation + direct bind + Registered

### DIFF
--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/pvspec.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/pvspec.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vksregistervolume
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vksregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/vksregistervolume/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
+)
+
+// Labels stamped on the guest PV created by this controller.
+const (
+	labelVKSRegVolCreatedBy      = "cns.vmware.com/created-by"
+	labelVKSRegVolCreatedByValue = "vksregistervolume"
+	labelVKSRegVolCRNamespace    = "cns.vmware.com/vksregistervolume-namespace"
+	labelVKSRegVolCRName         = "cns.vmware.com/vksregistervolume-name"
+)
+
+// buildGuestPV constructs the guest PersistentVolume for a VKSRegisterVolume CR.
+//
+// supervisorPVCName and accessibleTopology are taken as plain arguments rather than fetched
+// here, so this builder stays independently unit-testable against literals. Reconcile() supplies
+// the real values once the referenced Supervisor CnsRegisterVolume reports Registered and its
+// Supervisor PVC reaches Bound (see waitForSupervisorRegistration/waitForSupervisorBinding in
+// supervisor_watch.go):
+//   - supervisorPVCName comes from CnsRegisterVolume.Spec.PvcName.
+//   - accessibleTopology is parsed from the Supervisor PVC's common.AnnVolumeAccessibleTopology
+//     annotation, falling back to the Supervisor PV's spec.nodeAffinity when the annotation is
+//     absent. nil is a valid input (single-zone, or topology genuinely unavailable) and yields a
+//     guest PV with no nodeAffinity — full-sync's AddNodeAffinityRulesOnPV backfills it later.
+//
+// All other fields — name, capacity, accessModes, volumeMode, storageClassName — are copied from
+// the pre-created guest PVC (pvc) and never recomputed.
+func buildGuestPV(
+	pvc *v1.PersistentVolumeClaim,
+	guestPVName string,
+	supervisorPVCName string,
+	volumeMode v1.PersistentVolumeMode,
+	accessibleTopology []map[string]string,
+	instance *vksregistervolumev1alpha1.VKSRegisterVolume,
+) *v1.PersistentVolume {
+	storageClassName := ""
+	if pvc.Spec.StorageClassName != nil {
+		storageClassName = *pvc.Spec.StorageClassName
+	}
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: guestPVName,
+			Labels: map[string]string{
+				labelVKSRegVolCreatedBy:   labelVKSRegVolCreatedByValue,
+				labelVKSRegVolCRNamespace: instance.Namespace,
+				labelVKSRegVolCRName:      instance.Name,
+			},
+			Annotations: map[string]string{
+				"pv.kubernetes.io/provisioned-by": cnsoperatortypes.VSphereCSIDriverName,
+			},
+		},
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: pvc.Spec.Resources.Requests[v1.ResourceStorage],
+			},
+			AccessModes:                   pvc.Spec.AccessModes,
+			PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+			StorageClassName:              storageClassName,
+			VolumeMode:                    &volumeMode,
+			ClaimRef: &v1.ObjectReference{
+				Kind:       "PersistentVolumeClaim",
+				APIVersion: "v1",
+				Namespace:  instance.Namespace,
+				Name:       instance.Spec.PVCName,
+			},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       cnsoperatortypes.VSphereCSIDriverName,
+					VolumeHandle: supervisorPVCName,
+					ReadOnly:     false,
+				},
+			},
+			NodeAffinity: syncer.GenerateVolumeNodeAffinity(toCSITopology(accessibleTopology)),
+		},
+	}
+
+	// FSType applies only to Filesystem volumes (mirrors getPersistentVolumeSpec in cnsregistervolume).
+	if volumeMode == v1.PersistentVolumeFilesystem {
+		pv.Spec.PersistentVolumeSource.CSI.FSType = "ext4"
+	}
+
+	return pv
+}
+
+// toCSITopology converts the []map[string]string accessible-topology shape (as parsed off the
+// Supervisor PVC's AnnVolumeAccessibleTopology annotation) into the []*csi.Topology shape consumed
+// by syncer.GenerateVolumeNodeAffinity. Returns nil for a nil/empty input.
+func toCSITopology(accessibleTopology []map[string]string) []*csi.Topology {
+	if len(accessibleTopology) == 0 {
+		return nil
+	}
+	topologies := make([]*csi.Topology, 0, len(accessibleTopology))
+	for _, segment := range accessibleTopology {
+		topologies = append(topologies, &csi.Topology{Segments: segment})
+	}
+	return topologies
+}
+
+// guestPVMatchesExpected reports whether an already-existing guest PV (found on the
+// GET-before-CREATE check in the CreatingGuestPV phase) still correctly points at supervisorPVCName
+// and is claimed by the CR's referenced PVC. Called from Reconcile's CreatingGuestPV step to decide
+// between "idempotent no-op" and terminal Failed when a guest PV with the expected name already
+// exists but disagrees with the current CR/Supervisor state.
+func guestPVMatchesExpected(pv *v1.PersistentVolume, supervisorPVCName string,
+	instance *vksregistervolumev1alpha1.VKSRegisterVolume) bool {
+	if pv == nil || pv.Spec.CSI == nil {
+		return false
+	}
+	if pv.Spec.CSI.VolumeHandle != supervisorPVCName {
+		return false
+	}
+	if pv.Spec.ClaimRef == nil {
+		return false
+	}
+	return pv.Spec.ClaimRef.Namespace == instance.Namespace && pv.Spec.ClaimRef.Name == instance.Spec.PVCName
+}

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/pvspec_test.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/pvspec_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vksregistervolume
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vksregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/vksregistervolume/v1alpha1"
+	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
+)
+
+const (
+	testNamespace         = "my-app"
+	testCRName            = "restore-db-vol"
+	testPVCName           = "db-data-pvc"
+	testGuestPVName       = "pv-restore-db-vol"
+	testSupervisorPVCName = "tkc-uid-reg-deadbeef12345678"
+)
+
+func testInstance() *vksregistervolumev1alpha1.VKSRegisterVolume {
+	return &vksregistervolumev1alpha1.VKSRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testCRName},
+		Spec: vksregistervolumev1alpha1.VKSRegisterVolumeSpec{
+			PVCName:               testPVCName,
+			CnsRegisterVolumeName: "tkc-uid-reg-deadbeef12345678",
+		},
+	}
+}
+
+// ── TestBuildGuestPV ──────────────────────────────────────────────────────────────────────────
+
+func TestBuildGuestPV(t *testing.T) {
+	instance := testInstance()
+
+	cases := []struct {
+		name                string
+		pvc                 *corev1.PersistentVolumeClaim
+		volumeMode          corev1.PersistentVolumeMode
+		accessibleTopology  []map[string]string
+		wantFSType          string
+		wantNodeAffinityNil bool
+	}{
+		{
+			name:                "Filesystem volume, no topology → nodeAffinity nil, fsType ext4",
+			pvc:                 pendingPVC(testNamespace, testPVCName, "guest-sc"),
+			volumeMode:          corev1.PersistentVolumeFilesystem,
+			accessibleTopology:  nil,
+			wantFSType:          "ext4",
+			wantNodeAffinityNil: true,
+		},
+		{
+			name:       "Filesystem volume, with topology → nodeAffinity populated",
+			pvc:        pendingPVC(testNamespace, testPVCName, "guest-sc"),
+			volumeMode: corev1.PersistentVolumeFilesystem,
+			accessibleTopology: []map[string]string{
+				{"topology.kubernetes.io/zone": "zone-a"},
+			},
+			wantFSType:          "ext4",
+			wantNodeAffinityNil: false,
+		},
+		{
+			name:                "Block volume → no fsType, nodeAffinity nil",
+			pvc:                 pendingPVC(testNamespace, testPVCName, "guest-sc"),
+			volumeMode:          corev1.PersistentVolumeBlock,
+			accessibleTopology:  nil,
+			wantFSType:          "",
+			wantNodeAffinityNil: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			pv := buildGuestPV(tc.pvc, testGuestPVName, testSupervisorPVCName, tc.volumeMode,
+				tc.accessibleTopology, instance)
+
+			if pv.Name != testGuestPVName {
+				t.Errorf("PV name = %q, want %q", pv.Name, testGuestPVName)
+			}
+			if pv.Spec.CSI == nil {
+				t.Fatal("expected non-nil CSI source")
+			}
+			if pv.Spec.CSI.Driver != cnsoperatortypes.VSphereCSIDriverName {
+				t.Errorf("CSI.Driver = %q, want %q", pv.Spec.CSI.Driver, cnsoperatortypes.VSphereCSIDriverName)
+			}
+			// The most important invariant: volumeHandle is the Supervisor PVC name, NOT the FCD
+			// UUID and NOT the guest PV name — this is what the pvCSI syncer resolves guest volume
+			// ops against (pkg/syncer/pvcsi_fullsync.go:365).
+			if pv.Spec.CSI.VolumeHandle != testSupervisorPVCName {
+				t.Errorf("CSI.VolumeHandle = %q, want %q", pv.Spec.CSI.VolumeHandle, testSupervisorPVCName)
+			}
+			if pv.Spec.CSI.FSType != tc.wantFSType {
+				t.Errorf("CSI.FSType = %q, want %q", pv.Spec.CSI.FSType, tc.wantFSType)
+			}
+			if pv.Spec.ClaimRef == nil {
+				t.Fatal("expected non-nil claimRef")
+			}
+			if pv.Spec.ClaimRef.Namespace != instance.Namespace || pv.Spec.ClaimRef.Name != instance.Spec.PVCName {
+				t.Errorf("claimRef = %s/%s, want %s/%s",
+					pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name, instance.Namespace, instance.Spec.PVCName)
+			}
+			if pv.Spec.VolumeMode == nil || *pv.Spec.VolumeMode != tc.volumeMode {
+				t.Errorf("volumeMode = %v, want %v", pv.Spec.VolumeMode, tc.volumeMode)
+			}
+			if !reflect.DeepEqual(pv.Spec.AccessModes, tc.pvc.Spec.AccessModes) {
+				t.Errorf("accessModes = %v, want %v", pv.Spec.AccessModes, tc.pvc.Spec.AccessModes)
+			}
+			wantCapacity := tc.pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+			if gotCapacity := pv.Spec.Capacity[corev1.ResourceStorage]; gotCapacity.Cmp(wantCapacity) != 0 {
+				t.Errorf("capacity = %s, want %s", gotCapacity.String(), wantCapacity.String())
+			}
+			if pv.Spec.StorageClassName != *tc.pvc.Spec.StorageClassName {
+				t.Errorf("storageClassName = %q, want %q", pv.Spec.StorageClassName, *tc.pvc.Spec.StorageClassName)
+			}
+			if pv.Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimDelete {
+				t.Errorf("reclaimPolicy = %q, want %q", pv.Spec.PersistentVolumeReclaimPolicy, corev1.PersistentVolumeReclaimDelete)
+			}
+			if pv.Annotations["pv.kubernetes.io/provisioned-by"] != cnsoperatortypes.VSphereCSIDriverName {
+				t.Errorf("provisioned-by annotation = %q, want %q",
+					pv.Annotations["pv.kubernetes.io/provisioned-by"], cnsoperatortypes.VSphereCSIDriverName)
+			}
+			if pv.Labels[labelVKSRegVolCreatedBy] != labelVKSRegVolCreatedByValue {
+				t.Errorf("created-by label = %q, want %q", pv.Labels[labelVKSRegVolCreatedBy], labelVKSRegVolCreatedByValue)
+			}
+			if pv.Labels[labelVKSRegVolCRNamespace] != instance.Namespace {
+				t.Errorf("CR namespace label = %q, want %q", pv.Labels[labelVKSRegVolCRNamespace], instance.Namespace)
+			}
+			if pv.Labels[labelVKSRegVolCRName] != instance.Name {
+				t.Errorf("CR name label = %q, want %q", pv.Labels[labelVKSRegVolCRName], instance.Name)
+			}
+
+			gotNil := pv.Spec.NodeAffinity == nil
+			if gotNil != tc.wantNodeAffinityNil {
+				t.Errorf("nodeAffinity nil = %v, want %v (nodeAffinity=%+v)",
+					gotNil, tc.wantNodeAffinityNil, pv.Spec.NodeAffinity)
+			}
+		})
+	}
+}
+
+// ── TestToCSITopology ─────────────────────────────────────────────────────────────────────────
+
+func TestToCSITopology(t *testing.T) {
+	if got := toCSITopology(nil); got != nil {
+		t.Errorf("toCSITopology(nil) = %v, want nil", got)
+	}
+	if got := toCSITopology([]map[string]string{}); got != nil {
+		t.Errorf("toCSITopology(empty) = %v, want nil", got)
+	}
+
+	segments := []map[string]string{
+		{"topology.kubernetes.io/zone": "zone-a"},
+		{"topology.kubernetes.io/zone": "zone-b"},
+	}
+	got := toCSITopology(segments)
+	if len(got) != 2 {
+		t.Fatalf("len(toCSITopology(segments)) = %d, want 2", len(got))
+	}
+	for i, top := range got {
+		if !reflect.DeepEqual(top.Segments, segments[i]) {
+			t.Errorf("topology[%d].Segments = %v, want %v", i, top.Segments, segments[i])
+		}
+	}
+}
+
+// ── TestGuestPVMatchesExpected ────────────────────────────────────────────────────────────────
+
+func TestGuestPVMatchesExpected(t *testing.T) {
+	instance := testInstance()
+
+	matchingPV := &corev1.PersistentVolume{
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{VolumeHandle: testSupervisorPVCName},
+			},
+			ClaimRef: &corev1.ObjectReference{Namespace: instance.Namespace, Name: instance.Spec.PVCName},
+		},
+	}
+
+	cases := []struct {
+		name string
+		pv   *corev1.PersistentVolume
+		want bool
+	}{
+		{"nil PV", nil, false},
+		{"matching PV", matchingPV, true},
+		{
+			name: "wrong volumeHandle (e.g. FCD UUID leaked in) → mismatch",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{VolumeHandle: "42-fake-fcd-uuid"},
+					},
+					ClaimRef: &corev1.ObjectReference{Namespace: instance.Namespace, Name: instance.Spec.PVCName},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "claimRef points at a different PVC → mismatch",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{VolumeHandle: testSupervisorPVCName},
+					},
+					ClaimRef: &corev1.ObjectReference{Namespace: instance.Namespace, Name: "some-other-pvc"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil claimRef → mismatch",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{VolumeHandle: testSupervisorPVCName},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil CSI source → mismatch",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					ClaimRef: &corev1.ObjectReference{Namespace: instance.Namespace, Name: instance.Spec.PVCName},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := guestPVMatchesExpected(tc.pv, testSupervisorPVCName, instance)
+			if got != tc.want {
+				t.Errorf("guestPVMatchesExpected() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/supervisor_watch.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/supervisor_watch.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vksregistervolume
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
+	vksregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/vksregistervolume/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+const (
+	// supervisorCRMissingTimeout is the bounded window during which a missing Supervisor
+	// CnsRegisterVolume is treated as transient. The caller may create the guest CR and the
+	// Supervisor CR concurrently, or the CR may not yet be visible through the local informer
+	// cache; after this window the reference is assumed to be permanently broken.
+	supervisorCRMissingTimeout = 10 * time.Minute
+)
+
+// waitForSupervisorRegistration resolves the Supervisor CnsRegisterVolume referenced by the
+// VKSRegisterVolume instance and checks whether it has completed registration.
+//
+// Return semantics (mirrors resolveGuestPVC):
+//   - (pvcName, false, nil) – Supervisor CR reports Registered==true; pvcName is its spec.pvcName,
+//     which becomes the guest PV's csi.volumeHandle. Caller may proceed to WaitingForSupervisorBinding.
+//   - ("", false, err)      – transient; caller should requeue with backoff.
+//   - ("", true,  err)      – terminal; caller should set Phase=Failed with no requeue.
+//
+// A VKS cluster can only ever access resources in its own Supervisor namespace (r.supervisorNamespace),
+// so instance.Spec.CnsRegisterVolumeName is looked up there without a separate namespace field.
+func waitForSupervisorRegistration(
+	ctx context.Context,
+	supervisorCnsOperatorClient client.Client,
+	supervisorNamespace string,
+	instance *vksregistervolumev1alpha1.VKSRegisterVolume,
+) (string, bool, error) {
+	log := logger.GetLogger(ctx)
+
+	crKey := types.NamespacedName{
+		Namespace: supervisorNamespace,
+		Name:      instance.Spec.CnsRegisterVolumeName,
+	}
+	supervisorCR := &cnsregistervolumev1alpha1.CnsRegisterVolume{}
+	if err := supervisorCnsOperatorClient.Get(ctx, crKey, supervisorCR); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return "", false, fmt.Errorf("failed to GET supervisor CnsRegisterVolume %s/%s: %w",
+				supervisorNamespace, instance.Spec.CnsRegisterVolumeName, err)
+		}
+		// Supervisor CR not found — transient if within the bounded window, terminal otherwise.
+		age := crAge(instance)
+		if age <= supervisorCRMissingTimeout {
+			log.Infof("Supervisor CnsRegisterVolume %s/%s not found after %v (within %v window); will retry",
+				supervisorNamespace, instance.Spec.CnsRegisterVolumeName, age.Truncate(time.Second),
+				supervisorCRMissingTimeout)
+			return "", false, fmt.Errorf("supervisor CnsRegisterVolume %s/%s not found (waited %v)",
+				supervisorNamespace, instance.Spec.CnsRegisterVolumeName, age.Truncate(time.Second))
+		}
+		return "", true, fmt.Errorf("supervisor CnsRegisterVolume %s/%s not found after %v (exceeded %v timeout); "+
+			"the referenced CnsRegisterVolume must exist before the VKSRegisterVolume CR is created",
+			supervisorNamespace, instance.Spec.CnsRegisterVolumeName, age.Truncate(time.Second),
+			supervisorCRMissingTimeout)
+	}
+
+	if supervisorCR.Status.Error != "" {
+		return "", true, fmt.Errorf("supervisor CnsRegisterVolume %s/%s failed registration: %s",
+			supervisorNamespace, instance.Spec.CnsRegisterVolumeName, supervisorCR.Status.Error)
+	}
+
+	if !supervisorCR.Status.Registered {
+		log.Infof("Supervisor CnsRegisterVolume %s/%s not yet registered; will retry",
+			supervisorNamespace, instance.Spec.CnsRegisterVolumeName)
+		return "", false, fmt.Errorf("supervisor CnsRegisterVolume %s/%s not yet registered",
+			supervisorNamespace, instance.Spec.CnsRegisterVolumeName)
+	}
+
+	if supervisorCR.Spec.PvcName == "" {
+		return "", true, fmt.Errorf("supervisor CnsRegisterVolume %s/%s reports Registered=true "+
+			"but spec.pvcName is empty", supervisorNamespace, instance.Spec.CnsRegisterVolumeName)
+	}
+
+	log.Infof("Supervisor CnsRegisterVolume %s/%s registered: supervisorPVCName=%q",
+		supervisorNamespace, instance.Spec.CnsRegisterVolumeName, supervisorCR.Spec.PvcName)
+	return supervisorCR.Spec.PvcName, false, nil
+}
+
+// waitForSupervisorBinding resolves the Supervisor PVC (named supervisorPVCName, the future guest
+// PV's csi.volumeHandle) and waits for it to reach Bound. Once Bound it also derives the volume's
+// accessible topology, used by T7 to set node affinity on the guest PV it creates.
+//
+// Return semantics:
+//   - (topology, false, nil) – Supervisor PVC is Bound; topology may be nil if the volume is not
+//     zone-restricted (single-zone/non-stretched Supervisor) or the annotation has not yet
+//     propagated — a nil topology is not an error, since the guest-side fullsync backfill
+//     (AddNodeAffinityRulesOnPV) later corrects a guest PV created with no node affinity.
+//   - (nil, false, err)      – transient; caller should requeue with backoff.
+//   - (nil, true,  err)      – terminal; caller should set Phase=Failed with no requeue.
+func waitForSupervisorBinding(
+	ctx context.Context,
+	supervisorClient clientset.Interface,
+	supervisorNamespace string,
+	supervisorPVCName string,
+) ([]*csi.Topology, bool, error) {
+	log := logger.GetLogger(ctx)
+
+	supervisorPVC, err := supervisorClient.CoreV1().PersistentVolumeClaims(supervisorNamespace).
+		Get(ctx, supervisorPVCName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// The Supervisor CnsRegisterVolume already reported Registered==true, so its PVC
+			// must exist; a NotFound here is unexpected and not a "just hasn't been created yet"
+			// race — treat as terminal rather than retrying indefinitely.
+			return nil, true, fmt.Errorf("supervisor PVC %s/%s not found even though its "+
+				"CnsRegisterVolume reported Registered=true", supervisorNamespace, supervisorPVCName)
+		}
+		return nil, false, fmt.Errorf("failed to GET supervisor PVC %s/%s: %w",
+			supervisorNamespace, supervisorPVCName, err)
+	}
+
+	if supervisorPVC.Status.Phase != corev1.ClaimBound {
+		log.Infof("Supervisor PVC %s/%s not yet Bound (phase=%q); will retry",
+			supervisorNamespace, supervisorPVCName, supervisorPVC.Status.Phase)
+		return nil, false, fmt.Errorf("supervisor PVC %s/%s not yet Bound",
+			supervisorNamespace, supervisorPVCName)
+	}
+
+	topology, err := accessibleTopologyFromSupervisorPVC(ctx, supervisorClient, supervisorPVC)
+	if err != nil {
+		// Topology is a best-effort read: log and proceed with nil rather than blocking
+		// registration on it. AddNodeAffinityRulesOnPV backfills node affinity later.
+		log.Warnf("Could not determine accessible topology for supervisor PVC %s/%s; "+
+			"guest PV will be created without node affinity and backfilled later. Err: %v",
+			supervisorNamespace, supervisorPVCName, err)
+		return nil, false, nil
+	}
+
+	return topology, false, nil
+}
+
+// accessibleTopologyFromSupervisorPVC returns the accessible topology for a Bound Supervisor PVC,
+// preferring the csi.vsphere.volume-accessible-topology annotation on the PVC itself and falling
+// back to the Supervisor PV's spec.nodeAffinity when the annotation is absent. Returns (nil, nil)
+// when neither source has topology information (single-zone/non-stretched Supervisor).
+func accessibleTopologyFromSupervisorPVC(
+	ctx context.Context,
+	supervisorClient clientset.Interface,
+	supervisorPVC *corev1.PersistentVolumeClaim,
+) ([]*csi.Topology, error) {
+	if annotation := supervisorPVC.Annotations[common.AnnVolumeAccessibleTopology]; annotation != "" {
+		segments, err := parseVolumeAccessibleTopologyAnnotation(annotation)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %q annotation on supervisor PVC %s/%s: %w",
+				common.AnnVolumeAccessibleTopology, supervisorPVC.Namespace, supervisorPVC.Name, err)
+		}
+		return toCSITopology(segments), nil
+	}
+
+	// Annotation absent — fall back to the Supervisor PV's node affinity, if any.
+	supervisorPV, err := supervisorClient.CoreV1().PersistentVolumes().
+		Get(ctx, supervisorPVC.Spec.VolumeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to GET supervisor PV %q: %w", supervisorPVC.Spec.VolumeName, err)
+	}
+	if supervisorPV.Spec.NodeAffinity == nil || supervisorPV.Spec.NodeAffinity.Required == nil {
+		return nil, nil
+	}
+
+	var topology []*csi.Topology
+	for _, term := range supervisorPV.Spec.NodeAffinity.Required.NodeSelectorTerms {
+		segments := make(map[string]string, len(term.MatchExpressions))
+		for _, expr := range term.MatchExpressions {
+			if len(expr.Values) > 0 {
+				segments[expr.Key] = expr.Values[0]
+			}
+		}
+		if len(segments) > 0 {
+			topology = append(topology, &csi.Topology{Segments: segments})
+		}
+	}
+	return topology, nil
+}
+
+// parseVolumeAccessibleTopologyAnnotation unmarshals the csi.vsphere.volume-accessible-topology
+// annotation value into its underlying segment-map form.
+func parseVolumeAccessibleTopologyAnnotation(annotation string) ([]map[string]string, error) {
+	var segments []map[string]string
+	if err := json.Unmarshal([]byte(annotation), &segments); err != nil {
+		return nil, err
+	}
+	return segments, nil
+}

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/supervisor_watch_test.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/supervisor_watch_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vksregistervolume
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+)
+
+// makeSupervisorScheme returns a runtime.Scheme with the cns.vmware.com group registered
+// (needed to GET a CnsRegisterVolume through the fake controller-runtime client).
+func makeSupervisorScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add clientgoscheme: %v", err)
+	}
+	if err := apis.SchemeBuilder.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add cnsoperator scheme: %v", err)
+	}
+	return s
+}
+
+// ── TestWaitForSupervisorRegistration ────────────────────────────────────────────────────────────
+
+func TestWaitForSupervisorRegistration(t *testing.T) {
+	const supervisorNS = "sv-ns"
+	const crName = "abc-reg-deadbeef12345678"
+
+	cases := []struct {
+		name         string
+		supervisorCR *cnsregistervolumev1alpha1.CnsRegisterVolume
+		instanceAge  time.Duration
+		wantPVCName  string
+		wantTerminal bool
+		wantErr      bool
+	}{
+		{
+			name: "registered",
+			supervisorCR: &cnsregistervolumev1alpha1.CnsRegisterVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: supervisorNS},
+				Spec:       cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{PvcName: "sv-pvc-1"},
+				Status:     cnsregistervolumev1alpha1.CnsRegisterVolumeStatus{Registered: true},
+			},
+			wantPVCName:  "sv-pvc-1",
+			wantTerminal: false,
+			wantErr:      false,
+		},
+		{
+			name: "not yet registered",
+			supervisorCR: &cnsregistervolumev1alpha1.CnsRegisterVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: supervisorNS},
+				Status:     cnsregistervolumev1alpha1.CnsRegisterVolumeStatus{Registered: false},
+			},
+			wantTerminal: false,
+			wantErr:      true,
+		},
+		{
+			name: "supervisor CR reports error",
+			supervisorCR: &cnsregistervolumev1alpha1.CnsRegisterVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: supervisorNS},
+				Status: cnsregistervolumev1alpha1.CnsRegisterVolumeStatus{
+					Registered: false,
+					Error:      "backing disk not found",
+				},
+			},
+			wantTerminal: true,
+			wantErr:      true,
+		},
+		{
+			name: "registered but empty pvcName is terminal",
+			supervisorCR: &cnsregistervolumev1alpha1.CnsRegisterVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: supervisorNS},
+				Status:     cnsregistervolumev1alpha1.CnsRegisterVolumeStatus{Registered: true},
+			},
+			wantTerminal: true,
+			wantErr:      true,
+		},
+		{
+			name:         "missing within timeout is transient",
+			supervisorCR: nil,
+			instanceAge:  time.Minute,
+			wantTerminal: false,
+			wantErr:      true,
+		},
+		{
+			name:         "missing past timeout is terminal",
+			supervisorCR: nil,
+			instanceAge:  supervisorCRMissingTimeout + time.Minute,
+			wantTerminal: true,
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := makeSupervisorScheme(t)
+			var objs []runtime.Object
+			if tc.supervisorCR != nil {
+				objs = append(objs, tc.supervisorCR)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+
+			instance := instanceWithAge("guest-ns", "restore-db-vol", "db-data-pvc", tc.instanceAge)
+			instance.Spec.CnsRegisterVolumeName = crName
+
+			pvcName, terminal, err := waitForSupervisorRegistration(context.Background(),
+				fakeClient, supervisorNS, instance)
+
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil (terminal=%v, pvcName=%q)", terminal, pvcName)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tc.wantTerminal != terminal {
+				t.Errorf("terminal: got %v, want %v (err=%v)", terminal, tc.wantTerminal, err)
+			}
+			if pvcName != tc.wantPVCName {
+				t.Errorf("pvcName: got %q, want %q", pvcName, tc.wantPVCName)
+			}
+		})
+	}
+}
+
+// ── TestWaitForSupervisorBinding ─────────────────────────────────────────────────────────────────
+
+func TestWaitForSupervisorBinding(t *testing.T) {
+	const supervisorNS = "sv-ns"
+	const pvcName = "sv-pvc-1"
+	const pvName = "sv-pv-1"
+
+	topologyAnnotation := `[{"topology.kubernetes.io/zone":"zone-a"}]`
+
+	cases := []struct {
+		name         string
+		pvc          *corev1.PersistentVolumeClaim
+		pv           *corev1.PersistentVolume
+		wantTopology bool
+		wantTerminal bool
+		wantErr      bool
+	}{
+		{
+			name: "bound with topology annotation",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: supervisorNS,
+					Annotations: map[string]string{
+						common.AnnVolumeAccessibleTopology: topologyAnnotation,
+					},
+				},
+				Spec:   corev1.PersistentVolumeClaimSpec{VolumeName: pvName},
+				Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+			},
+			wantTopology: true,
+			wantTerminal: false,
+			wantErr:      false,
+		},
+		{
+			name: "bound, no annotation, falls back to PV node affinity",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: supervisorNS},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: pvName},
+				Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+			},
+			pv: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: pvName},
+				Spec: corev1.PersistentVolumeSpec{
+					NodeAffinity: &corev1.VolumeNodeAffinity{
+						Required: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      "topology.kubernetes.io/zone",
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{"zone-b"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTopology: true,
+			wantTerminal: false,
+			wantErr:      false,
+		},
+		{
+			name: "bound, no annotation, no PV affinity — nil topology is not an error",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: supervisorNS},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: pvName},
+				Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+			},
+			pv: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: pvName},
+			},
+			wantTopology: false,
+			wantTerminal: false,
+			wantErr:      false,
+		},
+		{
+			name: "not yet bound is transient",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: supervisorNS},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: pvName},
+				Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+			},
+			wantTerminal: false,
+			wantErr:      true,
+		},
+		{
+			name:         "pvc missing after supervisor CR registered is terminal",
+			pvc:          nil,
+			wantTerminal: true,
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var objs []runtime.Object
+			if tc.pvc != nil {
+				objs = append(objs, tc.pvc)
+			}
+			if tc.pv != nil {
+				objs = append(objs, tc.pv)
+			}
+			fakeK8s := k8sfake.NewSimpleClientset(objs...)
+
+			topology, terminal, err := waitForSupervisorBinding(context.Background(),
+				fakeK8s, supervisorNS, pvcName)
+
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil (terminal=%v, topology=%v)", terminal, topology)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tc.wantTerminal != terminal {
+				t.Errorf("terminal: got %v, want %v (err=%v)", terminal, tc.wantTerminal, err)
+			}
+			gotTopology := len(topology) > 0
+			if gotTopology != tc.wantTopology {
+				t.Errorf("topology presence: got %v (%v), want %v", gotTopology, topology, tc.wantTopology)
+			}
+		})
+	}
+}
+
+// ── TestParseVolumeAccessibleTopologyAnnotation ──────────────────────────────────────────────────
+
+func TestParseVolumeAccessibleTopologyAnnotation(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation string
+		wantLen    int
+		wantErr    bool
+	}{
+		{
+			name:       "single zone",
+			annotation: `[{"topology.kubernetes.io/zone":"zone-a"}]`,
+			wantLen:    1,
+			wantErr:    false,
+		},
+		{
+			name:       "multiple zones",
+			annotation: `[{"topology.kubernetes.io/zone":"zone-a"},{"topology.kubernetes.io/zone":"zone-b"}]`,
+			wantLen:    2,
+			wantErr:    false,
+		},
+		{
+			name:       "malformed json",
+			annotation: `not-json`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			segments, err := parseVolumeAccessibleTopologyAnnotation(tc.annotation)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil (segments=%v)", segments)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !tc.wantErr && len(segments) != tc.wantLen {
+				t.Errorf("segments length: got %d, want %d", len(segments), tc.wantLen)
+			}
+		})
+	}
+}
+
+// toCSITopology itself is tested in pvspec_test.go (TestToCSITopology) — it's defined in pvspec.go,
+// shared by both the T6 (supervisor watch) and T7 (guest PV builder) call sites.

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/validation_test.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/validation_test.go
@@ -412,11 +412,11 @@ func TestDefaultVolumeMode(t *testing.T) {
 	}
 }
 
-// ── TODO(T4+): Reconcile-level tests (see T10) ───────────────────────────────────────────────
+// ── TODO: Reconcile-level tests ──────────────────────────────────────────────────────────────
 //
-// The following test cases require a fully wired Reconcile() loop (T4 complete) and fake
-// Supervisor clients (T6). Add them in validation_test.go or a dedicated
-// vksregistervolume_controller_test.go once T4 is done:
+// Add these end-to-end Reconcile() test cases in a fake-client-backed harness (fake guest client
+// + fake Supervisor clients), in validation_test.go or a dedicated
+// vksregistervolume_controller_test.go:
 //
 //  1. Happy path: Pending PVC + Registered Supervisor CR + Bound Supervisor PVC →
 //     controller creates only the guest PV, PVC binds, Phase=Registered.

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/vksregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/vksregistervolume_controller.go
@@ -63,10 +63,6 @@ const (
 	// On deletion the controller only removes this finalizer; it never deletes the guest PV/PVC
 	// or the Supervisor CnsRegisterVolume (both owned by the caller that drives this CR).
 	vksRegisterVolumeFinalizer = "cns.vmware.com/vks-register-volume"
-
-	// TODO(T7): add labels stamped on the guest PV created by this controller
-	// (cns.vmware.com/created-by, .../vksregistervolume-namespace, .../vksregistervolume-name)
-	// alongside the guest PV spec builder in pvspec.go.
 )
 
 var (
@@ -89,16 +85,13 @@ type ReconcileVKSRegisterVolume struct {
 	k8sclient clientset.Interface
 
 	// supervisorNamespace is the Supervisor namespace in which the VKS cluster is deployed.
-	// TODO(T4): populated in Add() from commonconfig.GetSupervisorNamespace.
 	supervisorNamespace string
 
 	// supervisorClient is a CoreV1 client for the Supervisor cluster (Supervisor PVCs/PVs).
-	// TODO(T4): populated in Add() via k8s.NewSupervisorClient.
 	supervisorClient clientset.Interface
 
 	// supervisorCnsOperatorClient is a typed client for the Supervisor cluster restricted to
 	// read-only GET of CnsRegisterVolume CRs (get, list, watch; no create or delete).
-	// TODO(T4): populated in Add() via k8s.NewClientForGroup.
 	supervisorCnsOperatorClient client.Client
 }
 
@@ -109,15 +102,6 @@ var _ reconcile.Reconciler = &ReconcileVKSRegisterVolume{}
 //
 // Guard: only active when clusterFlavor == CnsClusterFlavorGuest AND the VKSRegisterVolume FSS
 // is enabled in both the guest PVCSI ConfigMap and the Supervisor csi-feature-states ConfigMap.
-//
-// TODO(T4): the Supervisor-side dependencies are not yet wired in:
-//   - build restConfig via k8s.GetRestClientConfigForSupervisor(ctx, cfg.GC.Endpoint, cfg.GC.Port)
-//   - create supervisorClient via k8s.NewSupervisorClient(ctx, restConfig)
-//   - create supervisorCnsOperatorClient via k8s.NewClientForGroup(ctx, restConfig, cnsoperatorv1alpha1.GroupName)
-//   - read supervisorNamespace via commonconfig.GetSupervisorNamespace(ctx)
-//
-// Until T4 lands, the reconciler is registered with nil Supervisor clients; this is safe because
-// Reconcile() does not yet dereference them (the T6/T7 steps that will are still TODO stubs).
 func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	configInfo *commonconfig.ConfigurationInfo, volumeManager volumes.Manager) error {
 	ctx, log := logger.GetNewContextWithLogger()
@@ -131,12 +115,41 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 			common.VKSRegisterVolume)
 		return nil
 	}
-	_ = configInfo
 	_ = volumeManager
 
 	k8sclient, err := k8s.NewClient(ctx)
 	if err != nil {
 		log.Errorf("Creating Kubernetes client failed. Err: %v", err)
+		return err
+	}
+
+	supervisorNamespace, err := commonconfig.GetSupervisorNamespace(ctx)
+	if err != nil {
+		log.Errorf("Failed to get supervisor namespace. Err: %v", err)
+		return err
+	}
+
+	if configInfo == nil {
+		log.Errorf("configInfo is nil")
+		return fmt.Errorf("configInfo is nil")
+	}
+
+	restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx,
+		configInfo.Cfg.GC.Endpoint, configInfo.Cfg.GC.Port)
+	if restClientConfig == nil {
+		log.Errorf("Failed to build rest client config for supervisor")
+		return fmt.Errorf("failed to build rest client config for supervisor")
+	}
+
+	supervisorClient, err := k8s.NewSupervisorClient(ctx, restClientConfig)
+	if err != nil {
+		log.Errorf("Failed to create supervisorClient. Err: %v", err)
+		return err
+	}
+
+	supervisorCnsOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, apis.GroupName)
+	if err != nil {
+		log.Errorf("Failed to create supervisorCnsOperatorClient. Err: %v", err)
 		return err
 	}
 
@@ -146,13 +159,13 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	)
 	recorder := eventBroadcaster.NewRecorder(k8sscheme.Scheme, corev1.EventSource{Component: apis.GroupName})
 
-	// TODO(T4): pass real supervisorNamespace/supervisorClient/supervisorCnsOperatorClient here.
-	reconciler := newReconciler(mgr, recorder, k8sclient, "", nil, nil)
+	reconciler := newReconciler(mgr, recorder, k8sclient, supervisorNamespace,
+		supervisorClient, supervisorCnsOperatorClient)
 	return add(mgr, reconciler)
 }
 
 // add wires the reconciler into the controller-runtime manager.
-// Called from Add() once all dependencies are initialised (T4).
+// Called from Add() once all dependencies are initialised.
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	ctx, log := logger.GetNewContextWithLogger()
 
@@ -171,7 +184,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
-// newReconciler constructs the reconciler once all Supervisor clients are available (T4).
+// newReconciler constructs the reconciler once all Supervisor clients are available.
 // Kept separate from Add() so tests can construct ReconcileVKSRegisterVolume directly.
 func newReconciler(
 	mgr manager.Manager,
@@ -194,18 +207,19 @@ func newReconciler(
 
 // Reconcile implements the reconcile.Reconciler interface.
 //
-// Phase state machine (T5 wires steps 1–3; T6 wires steps 4–5; T7 wires steps 6–8):
+// Phase state machine:
 //  1. Finalizer — add vksRegisterVolumeFinalizer; requeue if absent.
 //  2. Validate spec fields (terminal Failed on any missing field).
 //  3. Resolve guest PVC: GET + validate (Pending, volumeName set, accessModes, storage>0,
 //     storageClass w/ svstorageclass); transient requeue if PVC not yet created (bounded window),
 //     terminal Failed otherwise.
 //     3b. VolumeMode default — Filesystem if nil/empty.
-//  4. [TODO T6] WaitingForSupervisorRegistration — GET Supervisor CnsRegisterVolume; wait Registered==true.
-//  5. [TODO T6] WaitingForSupervisorBinding — GET Supervisor PVC; wait Bound; read topology.
-//  6. [TODO T7] CreatingGuestPV — GET-before-CREATE guest PV with volumeHandle, claimRef, nodeAffinity.
-//  7. [TODO T7] WaitingForGuestPVCBound — poll until guest PVC↔PV are Bound.
-//  8. [TODO T7] Registered — set Phase=Registered, Registered=true.
+//  4. WaitingForSupervisorRegistration — GET Supervisor CnsRegisterVolume; wait Registered==true.
+//  5. WaitingForSupervisorBinding — GET Supervisor PVC; wait Bound; read topology.
+//  6. CreatingGuestPV — GET-before-CREATE guest PV via buildGuestPV/guestPVMatchesExpected
+//     (pvspec.go), using supervisorPVCName/accessibleTopology from step 5.
+//  7. WaitingForGuestPVCBound — poll until guest PVC↔PV are Bound.
+//  8. Registered — call setStatusRegistered.
 func (r *ReconcileVKSRegisterVolume) Reconcile(ctx context.Context,
 	request reconcile.Request) (reconcile.Result, error) {
 	ctx = logger.NewContextWithLogger(ctx)
@@ -284,11 +298,6 @@ func (r *ReconcileVKSRegisterVolume) Reconcile(ctx context.Context,
 
 	// ── Step 3b: Default VolumeMode to Filesystem if unset ────────────────────────────────────
 	volumeMode := defaultVolumeMode(pvc.Spec.VolumeMode)
-	// volumeMode is forwarded to buildGuestPV in T7.  Suppress unused-var until then.
-	_ = volumeMode
-
-	// pvc is used by T6 (topology read) and T7 (PV spec build).  Suppress until then.
-	_ = pvc
 
 	// ── Advance phase to WaitingForSupervisorRegistration ────────────────────────────────────
 	if err := r.setStatusPhase(ctx, instance,
@@ -298,42 +307,129 @@ func (r *ReconcileVKSRegisterVolume) Reconcile(ctx context.Context,
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 
-	// ── TODO(T6): WaitingForSupervisorRegistration ────────────────────────────────────────────
-	// GET Supervisor CnsRegisterVolume instance.Spec.CnsRegisterVolumeName in
-	// r.supervisorNamespace (the VKS cluster's own Supervisor namespace; a VKS cluster
-	// can only ever access resources there, so it is not repeated on the spec) via
-	// r.supervisorCnsOperatorClient.
-	// If NotFound and CR has not yet reached Registered, treat as transient (bounded window).
-	// If already past WaitingForSupervisorRegistration (CR reached Registered before), skip.
-	// When CnsRegisterVolume.Status.Registered == true:
-	//   supervisorPVCName = CnsRegisterVolume.Spec.PvcName
-	//   advance phase to WaitingForSupervisorBinding.
+	// ── Step 4: WaitingForSupervisorRegistration ──────────────────────────────────────────────
+	supervisorPVCName, terminal, err := waitForSupervisorRegistration(ctx,
+		r.supervisorCnsOperatorClient, r.supervisorNamespace, instance)
+	if err != nil {
+		log.Errorf("VKSRegisterVolume %s/%s waiting for supervisor registration failed (terminal=%v): %v",
+			instance.Namespace, instance.Name, terminal, err)
+		if terminal {
+			r.setStatusFailed(ctx, instance, err.Error())
+			return reconcile.Result{}, nil // no requeue — terminal
+		}
+		r.setStatusError(ctx, instance, err.Error())
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
 
-	// ── TODO(T6): WaitingForSupervisorBinding ─────────────────────────────────────────────────
-	// GET Supervisor PVC supervisorPVCName in r.supervisorNamespace via r.supervisorClient.
-	// Wait until its Phase == Bound.
-	// Read topology from PVC annotation common.AnnVolumeAccessibleTopology
-	//   (via generateVolumeAccessibleTopologyFromPVCAnnotation).
-	// Fall back to Supervisor PV spec.nodeAffinity if annotation absent.
-	// Proceed to CreatingGuestPV with (supervisorPVCName, accessibleTopology).
+	// ── Advance phase to WaitingForSupervisorBinding ──────────────────────────────────────────
+	if err := r.setStatusPhase(ctx, instance,
+		vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorBinding); err != nil {
+		log.Errorf("VKSRegisterVolume %s/%s: failed to advance phase: %v",
+			instance.Namespace, instance.Name, err)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
 
-	// ── TODO(T7): CreatingGuestPV ─────────────────────────────────────────────────────────────
-	// guestPVName = pvc.Spec.VolumeName
-	// GET-before-CREATE guest PV via r.client (idempotent).
-	// If not found: call buildGuestPV(pvc, supervisorPVCName, volumeMode, accessibleTopology, instance)
-	//   then r.client.Create.
-	// If found: validate volumeHandle == supervisorPVCName AND claimRef → {instance.Namespace, pvcName};
-	//   if wrong claimRef (bound to a different PVC) → terminal Failed.
+	// ── Step 5: WaitingForSupervisorBinding ───────────────────────────────────────────────────
+	accessibleTopology, terminal, err := waitForSupervisorBinding(ctx,
+		r.supervisorClient, r.supervisorNamespace, supervisorPVCName)
+	if err != nil {
+		log.Errorf("VKSRegisterVolume %s/%s waiting for supervisor binding failed (terminal=%v): %v",
+			instance.Namespace, instance.Name, terminal, err)
+		if terminal {
+			r.setStatusFailed(ctx, instance, err.Error())
+			return reconcile.Result{}, nil // no requeue — terminal
+		}
+		r.setStatusError(ctx, instance, err.Error())
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
 
-	// ── TODO(T7): WaitingForGuestPVCBound ────────────────────────────────────────────────────
-	// GET guest PVC; if Bound to guestPVName → advance.
-	// If Bound to a different PV → terminal Failed.
-	// If still Pending → requeue.
+	// ── Advance phase to CreatingGuestPV ───────────────────────────────────────────────────────
+	if err := r.setStatusPhase(ctx, instance,
+		vksregistervolumev1alpha1.VKSRegisterVolumePhaseCreatingGuestPV); err != nil {
+		log.Errorf("VKSRegisterVolume %s/%s: failed to advance phase: %v",
+			instance.Namespace, instance.Name, err)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
 
-	// ── TODO(T7): Registered ─────────────────────────────────────────────────────────────────
-	// setStatusRegistered(ctx, instance)
+	// waitForSupervisorBinding returns the CSI-shaped []*csi.Topology, but buildGuestPV takes the
+	// raw []map[string]string segment form (it does its own toCSITopology conversion) so that it
+	// stays independently unit-testable against plain literals. Convert back at this seam.
+	var accessibleTopologySegments []map[string]string
+	for _, t := range accessibleTopology {
+		if t != nil {
+			accessibleTopologySegments = append(accessibleTopologySegments, t.Segments)
+		}
+	}
 
-	return reconcile.Result{RequeueAfter: timeout}, nil
+	// ── Step 6: CreatingGuestPV — GET-before-CREATE the guest PV ──────────────────────────────
+	guestPVName := pvc.Spec.VolumeName
+	existingPV := &corev1.PersistentVolume{}
+	err = r.client.Get(ctx, apitypes.NamespacedName{Name: guestPVName}, existingPV)
+	switch {
+	case apierrors.IsNotFound(err):
+		pv := buildGuestPV(pvc, guestPVName, supervisorPVCName, volumeMode, accessibleTopologySegments, instance)
+		if err := r.client.Create(ctx, pv); err != nil {
+			log.Errorf("VKSRegisterVolume %s/%s: failed to create guest PV %q: %v",
+				instance.Namespace, instance.Name, guestPVName, err)
+			r.setStatusError(ctx, instance, fmt.Sprintf("failed to create guest PV %q: %v", guestPVName, err))
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+	case err == nil:
+		if !guestPVMatchesExpected(existingPV, supervisorPVCName, instance) {
+			msg := fmt.Sprintf("existing guest PV %q does not match expected volumeHandle/claimRef",
+				guestPVName)
+			log.Errorf("VKSRegisterVolume %s/%s: %s", instance.Namespace, instance.Name, msg)
+			r.setStatusFailed(ctx, instance, msg)
+			return reconcile.Result{}, nil // no requeue — terminal
+		}
+		// idempotent no-op — PV already correct.
+	default:
+		log.Errorf("VKSRegisterVolume %s/%s: failed to GET guest PV %q: %v",
+			instance.Namespace, instance.Name, guestPVName, err)
+		r.setStatusError(ctx, instance, fmt.Sprintf("failed to GET guest PV %q: %v", guestPVName, err))
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
+	// ── Advance phase to WaitingForGuestPVCBound ──────────────────────────────────────────────
+	if err := r.setStatusPhase(ctx, instance,
+		vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForGuestPVCBound); err != nil {
+		log.Errorf("VKSRegisterVolume %s/%s: failed to advance phase: %v",
+			instance.Namespace, instance.Name, err)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
+	// ── Step 7: WaitingForGuestPVCBound ────────────────────────────────────────────────────────
+	guestPVC := &corev1.PersistentVolumeClaim{}
+	if err := r.client.Get(ctx, apitypes.NamespacedName{Namespace: instance.Namespace,
+		Name: instance.Spec.PVCName}, guestPVC); err != nil {
+		log.Errorf("VKSRegisterVolume %s/%s: failed to GET guest PVC %s/%s: %v",
+			instance.Namespace, instance.Name, instance.Namespace, instance.Spec.PVCName, err)
+		r.setStatusError(ctx, instance, fmt.Sprintf("failed to GET guest PVC %s/%s: %v",
+			instance.Namespace, instance.Spec.PVCName, err))
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
+	if guestPVC.Status.Phase != corev1.ClaimBound {
+		msg := fmt.Sprintf("guest PVC %s/%s not yet Bound (phase=%q)",
+			instance.Namespace, instance.Spec.PVCName, guestPVC.Status.Phase)
+		log.Infof("VKSRegisterVolume %s/%s: %s; will retry", instance.Namespace, instance.Name, msg)
+		r.setStatusError(ctx, instance, msg)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
+	if guestPVC.Spec.VolumeName != guestPVName {
+		msg := fmt.Sprintf("guest PVC %s/%s is Bound to PV %q, not the expected %q",
+			instance.Namespace, instance.Spec.PVCName, guestPVC.Spec.VolumeName, guestPVName)
+		log.Errorf("VKSRegisterVolume %s/%s: %s", instance.Namespace, instance.Name, msg)
+		r.setStatusFailed(ctx, instance, msg)
+		return reconcile.Result{}, nil // no requeue — terminal
+	}
+
+	// ── Step 8: Registered ─────────────────────────────────────────────────────────────────────
+	if err := r.setStatusRegistered(ctx, instance); err != nil {
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+	return reconcile.Result{}, nil
 }
 
 // reconcileDelete handles VKSRegisterVolume CR deletion.
@@ -408,8 +504,24 @@ func (r *ReconcileVKSRegisterVolume) setStatusPhase(ctx context.Context,
 	return patchVKSRegisterVolumeStatus(ctx, r.client, orig, instance)
 }
 
-// TODO(T7): add setStatusRegistered(ctx, instance) — sets Phase=Registered, Registered=true,
-// clears Error, and records a Normal event — and wire it into the Registered step of Reconcile.
+// setStatusRegistered sets Phase=Registered, Registered=true, clears Error.
+// Called from Reconcile's Registered step (step 8) once the guest PVC↔PV direct bind completes.
+func (r *ReconcileVKSRegisterVolume) setStatusRegistered(ctx context.Context,
+	instance *vksregistervolumev1alpha1.VKSRegisterVolume) error {
+	log := logger.GetLogger(ctx)
+	orig := instance.DeepCopy()
+	instance.Status.Phase = vksregistervolumev1alpha1.VKSRegisterVolumePhaseRegistered
+	instance.Status.Registered = true
+	instance.Status.Error = ""
+	if err := patchVKSRegisterVolumeStatus(ctx, r.client, orig, instance); err != nil {
+		log.Errorf("patchVKSRegisterVolumeStatus failed while setting Registered: %v", err)
+		return err
+	}
+	msg := fmt.Sprintf("VKSRegisterVolume %s/%s: guest PVC successfully bound to registered volume",
+		instance.Namespace, instance.Name)
+	recordEvent(ctx, r, instance, corev1.EventTypeNormal, msg)
+	return nil
+}
 
 // patchVKSRegisterVolumeStatus sends a merge-patch for the status subresource.
 // Mirrors patchCnsRegisterVolumeStatus: always includes "registered" (required field),

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/vksregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/vksregistervolume_controller_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vksregistervolume
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	vksregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/vksregistervolume/v1alpha1"
+)
+
+// vksRegisterVolumeTestScheme returns a runtime.Scheme with core/v1 and VKSRegisterVolume registered,
+// for tests that need a controller-runtime fake client backing a ReconcileVKSRegisterVolume.
+func vksRegisterVolumeTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add clientgoscheme: %v", err)
+	}
+	s.AddKnownTypes(schema.GroupVersion{Group: "cns.vmware.com", Version: "v1alpha1"},
+		&vksregistervolumev1alpha1.VKSRegisterVolume{}, &vksregistervolumev1alpha1.VKSRegisterVolumeList{})
+	return s
+}
+
+// ── TestSetStatusRegistered ──────────────────────────────────────────────────────────────────────
+//
+// setStatusRegistered implements the plan's Registered terminal phase (Part 4d step 8): once the
+// guest PVC↔PV direct bind completes, it sets Phase=Registered, Registered=true, clears any prior
+// Error, and records a Normal event. This test exercises the status-setting logic directly.
+func TestSetStatusRegistered(t *testing.T) {
+	instance := &vksregistervolumev1alpha1.VKSRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testCRName},
+		Spec: vksregistervolumev1alpha1.VKSRegisterVolumeSpec{
+			PVCName:               testPVCName,
+			CnsRegisterVolumeName: testSupervisorPVCName,
+		},
+		Status: vksregistervolumev1alpha1.VKSRegisterVolumeStatus{
+			Phase: vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForGuestPVCBound,
+			Error: "PVC not yet Bound",
+		},
+	}
+
+	s := vksRegisterVolumeTestScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	backOffDuration = make(map[apitypes.NamespacedName]time.Duration)
+	recorder := record.NewFakeRecorder(10)
+	r := &ReconcileVKSRegisterVolume{client: fakeClient, recorder: recorder}
+
+	if err := r.setStatusRegistered(context.Background(), instance); err != nil {
+		t.Fatalf("setStatusRegistered returned unexpected error: %v", err)
+	}
+
+	got := &vksregistervolumev1alpha1.VKSRegisterVolume{}
+	if err := fakeClient.Get(context.Background(),
+		apitypes.NamespacedName{Namespace: testNamespace, Name: testCRName}, got); err != nil {
+		t.Fatalf("failed to GET VKSRegisterVolume after setStatusRegistered: %v", err)
+	}
+
+	if got.Status.Phase != vksregistervolumev1alpha1.VKSRegisterVolumePhaseRegistered {
+		t.Errorf("Status.Phase = %q, want %q", got.Status.Phase, vksregistervolumev1alpha1.VKSRegisterVolumePhaseRegistered)
+	}
+	if !got.Status.Registered {
+		t.Error("Status.Registered = false, want true")
+	}
+	if got.Status.Error != "" {
+		t.Errorf("Status.Error = %q, want empty (cleared on success)", got.Status.Error)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if event == "" {
+			t.Error("expected a non-empty Normal event to be recorded")
+		}
+	default:
+		t.Error("expected a Normal event to be recorded, got none")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements T7 — guest PV creation, direct bind, and `Registered` for `VKSRegisterVolume`.

- `pvspec.go`: `buildGuestPV()` builds the guest PV (`csi.volumeHandle` = Supervisor PVC name,
  `claimRef` locked to the guest PVC, `nodeAffinity` from topology). `guestPVMatchesExpected()`
  backs an idempotent GET-before-CREATE check.
- `vksregistervolume_controller.go`: `Reconcile()` now wires `CreatingGuestPV` →
  `WaitingForGuestPVCBound` → `Registered` end to end.
- Fixed two small integration bugs found while wiring against T6: a duplicate `toCSITopology`
  helper (T6 and T7 each wrote one independently — removed the dupe) and a topology type
  mismatch between T6's output and T7's input (added a conversion at the call site).

**Depends on T6** (not merged yet, so included here for T7 to compile/review against — will
shrink out on rebase once T6 merges). Diff is otherwise clean: rebased onto current `master`,
confined to `pkg/syncer/cnsoperator/controller/vksregistervolume/`.

**Testing done**:
- `go build`, `go vet`, `staticcheck`, `gofmt` clean. Full `go test ./...` passes.
- New unit tests: `TestBuildGuestPV`, `TestToCSITopology`, `TestGuestPVMatchesExpected`,
  `TestSetStatusRegistered`.
- Manual E2E on a real Supervisor + guest cluster: drove a `VKSRegisterVolume` CR through every
  phase to `Registered`,TBD.
- Reconcile-level fake-client tests are T10's scope, not included here.

Pre-checkin pipeline passed:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1408/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1852/

**Release note**:
```release-note
NONE

