### PR TITLE
Updated error message in case of WCP testbed

### DIFF
--- a/tests/e2e/storagepolicy.go
+++ b/tests/e2e/storagepolicy.go
@@ -130,6 +130,7 @@ var _ = ginkgo.Describe("Storage Policy Based Volume Provisioning", func() {
 			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
 			scParameters[scParamStoragePolicyName] = storagePolicyNameForNonSharedDatastores
 		} else if supervisorCluster {
+			expectedErrorMsg = "failed to create volume"
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyNameForNonSharedDatastores)
 			scParameters[scParamStoragePolicyID] = profileID


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: In case of WCP testbed Expected error message is changed 

**Testing done**: Yes 

Verify dynamic volume provisioning fails when storage policy specified in the storageclass is compliant for non-shared datastores

In case of WCP testbed Expected error message is "failed to create volume"
Where as in case of GC it is "failed to provision volume"