### PR TITLE
Skip redundant status updates on StoragePolicyInfo, ClusterStoragePolicyInfo, and InfraStoragePolicyInfo when there is no actual change.

### DIFF
--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -436,23 +436,29 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName, timeout)
 	}
 
+	// Snapshot the status so setters below can skip the write if unchanged.
+	origClusterStatus := instance.Status.DeepCopy()
+
 	// Ensure InfraStoragePolicyInfo CR exists with the same name
 	infraSPI, err := r.ensureInfraSPIExists(ctx, instance)
 	if err != nil {
 		log.Errorf("Failed to ensure InfraStoragePolicyInfo exists for %q: %v", request.Name, err)
 		errorMsg := fmt.Sprintf("Failed to ensure InfraStoragePolicyInfo exists: %v", err)
-		if setErr := r.setClusterSPIError(ctx, instance, errorMsg); setErr != nil {
+		if setErr := r.setClusterSPIError(ctx, instance, origClusterStatus, errorMsg); setErr != nil {
 			log.Errorf("Failed to set error status: %v", setErr)
 		}
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
+
+	// Snapshot the status so setters below can skip the write if unchanged.
+	origInfraStatus := infraSPI.Status.DeepCopy()
 
 	// Connect to vCenter.
 	vc, err := cnsvsphere.GetVirtualCenterInstance(ctx, r.configInfo, false)
 	if err != nil {
 		log.Errorf("Failed to get vCenter instance for %q: %v", request.Name, err)
 		errorMsg := fmt.Sprintf("Failed to get vCenter instance: %v", err)
-		if setErr := r.setClusterSPIError(ctx, instance, errorMsg); setErr != nil {
+		if setErr := r.setClusterSPIError(ctx, instance, origClusterStatus, errorMsg); setErr != nil {
 			log.Errorf("Failed to set error status: %v", setErr)
 		}
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
@@ -462,14 +468,15 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 	profile, policyDeleted, err := findStoragePolicyProfile(ctx, instance, vc)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to lookup storage policy: %v", err)
-		if setErr := r.setClusterSPIError(ctx, instance, errorMsg); setErr != nil {
+		if setErr := r.setClusterSPIError(ctx, instance, origClusterStatus, errorMsg); setErr != nil {
 			log.Errorf("Failed to set error status: %v", setErr)
 		}
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 	if policyDeleted {
 		// Policy was deleted - update status and return success
-		if statusErr := r.setClusterSPISuccess(ctx, instance, "Storage policy deleted from vCenter"); statusErr != nil {
+		if statusErr := r.setClusterSPISuccess(ctx, instance, origClusterStatus,
+			"Storage policy deleted from vCenter"); statusErr != nil {
 			log.Errorf("failed to update status for ClusterStoragePolicyInfo %q: %v", request.Name, statusErr)
 			return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, statusErr)
 		}
@@ -480,7 +487,7 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 	if err != nil {
 		log.Errorf("Failed to retrieve policy content for profile %s: %v", profile.ID, err)
 		errorMsg := fmt.Sprintf("Failed to retrieve policy content: %v", err)
-		if setErr := r.setClusterSPIError(ctx, instance, errorMsg); setErr != nil {
+		if setErr := r.setClusterSPIError(ctx, instance, origClusterStatus, errorMsg); setErr != nil {
 			log.Errorf("Failed to set error status: %v", setErr)
 		}
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
@@ -491,13 +498,13 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 	if err != nil {
 		log.Errorf("Failed to sync storage policy attributes for %q: %v.", request.Name, err)
 		errorMsg := fmt.Sprintf("Failed to sync storage policy attributes: %v", err)
-		if setErr := r.setClusterSPIError(ctx, instance, errorMsg); setErr != nil {
+		if setErr := r.setClusterSPIError(ctx, instance, origClusterStatus, errorMsg); setErr != nil {
 			log.Errorf("Failed to set error status: %v", setErr)
 		}
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
-	statusErr := r.setClusterSPISuccess(ctx, instance, "Successfully synced storage policy attributes")
+	statusErr := r.setClusterSPISuccess(ctx, instance, origClusterStatus, "Successfully synced storage policy attributes")
 	if statusErr != nil {
 		log.Errorf("failed to update status for ClusterStoragePolicyInfo %q: %v", request.Name, statusErr)
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, statusErr)
@@ -508,13 +515,13 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 	if err != nil {
 		log.Errorf("Failed to sync InfraSPI attributes for %q: %v.", request.Name, err)
 		errorMsg := fmt.Sprintf("Failed to sync InfraSPI attributes: %v", err)
-		if setErr := r.setInfraSPIError(ctx, infraSPI, errorMsg); setErr != nil {
+		if setErr := r.setInfraSPIError(ctx, infraSPI, origInfraStatus, errorMsg); setErr != nil {
 			log.Errorf("Failed to set infraSPI error status: %v", setErr)
 		}
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
-	infraSPIStatusErr := r.setInfraSPISuccess(ctx, infraSPI, "Successfully synced InfraSPI attributes")
+	infraSPIStatusErr := r.setInfraSPISuccess(ctx, infraSPI, origInfraStatus, "Successfully synced InfraSPI attributes")
 	if infraSPIStatusErr != nil {
 		log.Errorf("failed to update status for InfraStoragePolicyInfo %q: %v", request.Name, infraSPIStatusErr)
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, infraSPIStatusErr)
@@ -958,12 +965,18 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 }
 
 // setClusterSPIError sets error and records an event on the ClusterStoragePolicyInfo instance.
+// origStatus is the pre-reconcile status snapshot; written only if it changed.
 func (r *ReconcileClusterStoragePolicyInfo) setClusterSPIError(ctx context.Context,
-	instance *clusterspiv1alpha1.ClusterStoragePolicyInfo, errMsg string) error {
+	instance *clusterspiv1alpha1.ClusterStoragePolicyInfo,
+	origStatus *clusterspiv1alpha1.ClusterStoragePolicyInfoStatus, errMsg string) error {
 	instance.Status.Error = errMsg
-	err := k8s.UpdateStatus(ctx, r.client, instance)
-	if err != nil {
-		return err
+	if !equality.Semantic.DeepEqual(*origStatus, instance.Status) {
+		if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
+			return err
+		}
+	} else {
+		logger.GetLogger(ctx).Debugf("ClusterStoragePolicyInfo %q status unchanged, skipping status update",
+			instance.Name)
 	}
 
 	r.recordEvent(ctx, instance, v1.EventTypeWarning, errMsg)
@@ -971,14 +984,20 @@ func (r *ReconcileClusterStoragePolicyInfo) setClusterSPIError(ctx context.Conte
 }
 
 // setClusterSPISuccess sets instance to success and records an event on the
-// ClusterStoragePolicyInfo instance.
+// ClusterStoragePolicyInfo instance. origStatus is the pre-reconcile status snapshot;
+// written only if it changed.
 func (r *ReconcileClusterStoragePolicyInfo) setClusterSPISuccess(ctx context.Context,
-	instance *clusterspiv1alpha1.ClusterStoragePolicyInfo, msg string) error {
+	instance *clusterspiv1alpha1.ClusterStoragePolicyInfo,
+	origStatus *clusterspiv1alpha1.ClusterStoragePolicyInfoStatus, msg string) error {
 	// Clear error but preserve other status fields that were set during sync
 	instance.Status.Error = ""
-	err := k8s.UpdateStatus(ctx, r.client, instance)
-	if err != nil {
-		return err
+	if !equality.Semantic.DeepEqual(*origStatus, instance.Status) {
+		if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
+			return err
+		}
+	} else {
+		logger.GetLogger(ctx).Debugf("ClusterStoragePolicyInfo %q status unchanged, skipping status update",
+			instance.Name)
 	}
 
 	r.recordEvent(ctx, instance, v1.EventTypeNormal, msg)
@@ -1011,12 +1030,18 @@ func (r *ReconcileClusterStoragePolicyInfo) recordEvent(ctx context.Context,
 }
 
 // setInfraSPIError sets error and records an event on the InfraStoragePolicyInfo instance.
+// origStatus is the pre-reconcile status snapshot; written only if it changed.
 func (r *ReconcileClusterStoragePolicyInfo) setInfraSPIError(ctx context.Context,
-	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo, errMsg string) error {
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
+	origStatus *infraspiv1alpha1.InfraStoragePolicyInfoStatus, errMsg string) error {
 	infraSPI.Status.Error = errMsg
-	err := k8s.UpdateStatus(ctx, r.client, infraSPI)
-	if err != nil {
-		return err
+	if !equality.Semantic.DeepEqual(*origStatus, infraSPI.Status) {
+		if err := k8s.UpdateStatus(ctx, r.client, infraSPI); err != nil {
+			return err
+		}
+	} else {
+		logger.GetLogger(ctx).Debugf("InfraStoragePolicyInfo %q status unchanged, skipping status update",
+			infraSPI.Name)
 	}
 
 	r.recordInfraSPIEvent(ctx, infraSPI, v1.EventTypeWarning, errMsg)
@@ -1024,14 +1049,20 @@ func (r *ReconcileClusterStoragePolicyInfo) setInfraSPIError(ctx context.Context
 }
 
 // setInfraSPISuccess sets instance to success and records an event on the
-// InfraStoragePolicyInfo instance.
+// InfraStoragePolicyInfo instance. origStatus is the pre-reconcile status snapshot;
+// written only if it changed.
 func (r *ReconcileClusterStoragePolicyInfo) setInfraSPISuccess(ctx context.Context,
-	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo, msg string) error {
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
+	origStatus *infraspiv1alpha1.InfraStoragePolicyInfoStatus, msg string) error {
 	// Clear error but preserve other status fields that were set during sync
 	infraSPI.Status.Error = ""
-	err := k8s.UpdateStatus(ctx, r.client, infraSPI)
-	if err != nil {
-		return err
+	if !equality.Semantic.DeepEqual(*origStatus, infraSPI.Status) {
+		if err := k8s.UpdateStatus(ctx, r.client, infraSPI); err != nil {
+			return err
+		}
+	} else {
+		logger.GetLogger(ctx).Debugf("InfraStoragePolicyInfo %q status unchanged, skipping status update",
+			infraSPI.Name)
 	}
 
 	r.recordInfraSPIEvent(ctx, infraSPI, v1.EventTypeNormal, msg)

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
@@ -1012,6 +1013,120 @@ func TestUpdateStatus_PolicyDeleted(t *testing.T) {
 	// Verify the status was updated
 	assert.True(t, cspi.Status.StoragePolicyDeleted, "expected StoragePolicyDeleted to be true")
 	assert.Empty(t, cspi.Status.Error, "expected no error message")
+}
+
+// statusUpdateInterceptor returns interceptor.Funcs that record every Status().Update() call
+// while still performing the update against the underlying fake client.
+func statusUpdateInterceptor(called *bool) interceptor.Funcs {
+	return interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, cli client.Client, subResourceName string,
+			obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			*called = true
+			return cli.SubResource(subResourceName).Update(ctx, obj, opts...)
+		},
+	}
+}
+
+// TestSetClusterSPISuccess_SkipsNoOpStatusUpdate verifies that setClusterSPISuccess does not
+// call Status().Update() when the recomputed status is identical to origStatus, but still
+// records the event.
+func TestSetClusterSPISuccess_SkipsNoOpStatusUpdate(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	cspi := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
+	}
+	origStatus := cspi.Status.DeepCopy()
+	recorder := record.NewFakeRecorder(10)
+	statusUpdateCalled := false
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cspi).
+		WithStatusSubresource(&clusterspiv1alpha1.ClusterStoragePolicyInfo{}).
+		WithInterceptorFuncs(statusUpdateInterceptor(&statusUpdateCalled)).Build()
+	r := &ReconcileClusterStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	err := r.setClusterSPISuccess(ctx, cspi, origStatus, "all good")
+	require.NoError(t, err)
+	assert.False(t, statusUpdateCalled, "expected no Status().Update() call when status is unchanged")
+
+	select {
+	case <-recorder.Events:
+	default:
+		t.Error("expected a Normal ClusterStoragePolicyInfoSynced event even when the write was skipped")
+	}
+}
+
+// TestSetClusterSPIError_WritesWhenStatusChanged verifies that setClusterSPIError still calls
+// Status().Update() when the recomputed status differs from origStatus.
+func TestSetClusterSPIError_WritesWhenStatusChanged(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	cspi := &clusterspiv1alpha1.ClusterStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
+	}
+	origStatus := cspi.Status.DeepCopy()
+	recorder := record.NewFakeRecorder(10)
+	statusUpdateCalled := false
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cspi).
+		WithStatusSubresource(&clusterspiv1alpha1.ClusterStoragePolicyInfo{}).
+		WithInterceptorFuncs(statusUpdateInterceptor(&statusUpdateCalled)).Build()
+	r := &ReconcileClusterStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	err := r.setClusterSPIError(ctx, cspi, origStatus, "something failed")
+	require.NoError(t, err)
+	assert.True(t, statusUpdateCalled, "expected a Status().Update() call when status changed")
+}
+
+// TestSetInfraSPISuccess_SkipsNoOpStatusUpdate verifies that setInfraSPISuccess does not call
+// Status().Update() when the recomputed status is identical to origStatus, but still records
+// the event.
+func TestSetInfraSPISuccess_SkipsNoOpStatusUpdate(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
+	}
+	origStatus := infraSPI.Status.DeepCopy()
+	recorder := record.NewFakeRecorder(10)
+	statusUpdateCalled := false
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(infraSPI).
+		WithStatusSubresource(&infraspiv1alpha1.InfraStoragePolicyInfo{}).
+		WithInterceptorFuncs(statusUpdateInterceptor(&statusUpdateCalled)).Build()
+	r := &ReconcileClusterStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	err := r.setInfraSPISuccess(ctx, infraSPI, origStatus, "all good")
+	require.NoError(t, err)
+	assert.False(t, statusUpdateCalled, "expected no Status().Update() call when status is unchanged")
+
+	select {
+	case <-recorder.Events:
+	default:
+		t.Error("expected a Normal InfraStoragePolicyInfoSynced event even when the write was skipped")
+	}
+}
+
+// TestSetInfraSPIError_WritesWhenStatusChanged verifies that setInfraSPIError still calls
+// Status().Update() when the recomputed status differs from origStatus.
+func TestSetInfraSPIError_WritesWhenStatusChanged(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
+	}
+	origStatus := infraSPI.Status.DeepCopy()
+	recorder := record.NewFakeRecorder(10)
+	statusUpdateCalled := false
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(infraSPI).
+		WithStatusSubresource(&infraspiv1alpha1.InfraStoragePolicyInfo{}).
+		WithInterceptorFuncs(statusUpdateInterceptor(&statusUpdateCalled)).Build()
+	r := &ReconcileClusterStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	err := r.setInfraSPIError(ctx, infraSPI, origStatus, "something failed")
+	require.NoError(t, err)
+	assert.True(t, statusUpdateCalled, "expected a Status().Update() call when status changed")
 }
 
 func TestValidateStoragePolicyExistsOnVcenter_NilVCenter(t *testing.T) {

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -477,11 +477,14 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
+	// Snapshot the status so setters below can skip the write if unchanged.
+	origStatus := instance.Status.DeepCopy()
+
 	// Populate TopologyInfo from InfraStoragePolicyInfo.
 	if err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI); err != nil {
 		log.Errorf("Failed to sync topology for StoragePolicyInfo %q: %v",
 			request.NamespacedName, err)
-		if setErr := r.setSPIError(ctx, instance,
+		if setErr := r.setSPIError(ctx, instance, origStatus,
 			fmt.Sprintf("Failed to sync topology: %v", err)); setErr != nil {
 			log.Errorf("Failed to update StoragePolicyInfo %q status: %v",
 				request.NamespacedName, setErr)
@@ -489,7 +492,7 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
 
-	if setErr := r.setSPISuccess(ctx, instance, "Successfully synced topology"); setErr != nil {
+	if setErr := r.setSPISuccess(ctx, instance, origStatus, "Successfully synced topology"); setErr != nil {
 		log.Errorf("Failed to update StoragePolicyInfo %q status: %v",
 			request.NamespacedName, setErr)
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, setErr)
@@ -702,22 +705,32 @@ func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 }
 
 // setSPIError sets the error status and records a Warning event on the instance.
+// origStatus is the pre-reconcile status snapshot; written only if it changed.
 func (r *ReconcileStoragePolicyInfo) setSPIError(ctx context.Context,
-	instance *spiv1alpha1.StoragePolicyInfo, errMsg string) error {
+	instance *spiv1alpha1.StoragePolicyInfo, origStatus *spiv1alpha1.StoragePolicyInfoStatus, errMsg string) error {
 	instance.Status.Error = errMsg
-	if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
-		return err
+	if !equality.Semantic.DeepEqual(*origStatus, instance.Status) {
+		if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
+			return err
+		}
+	} else {
+		logger.GetLogger(ctx).Debugf("StoragePolicyInfo %q status unchanged, skipping status update", instance.Name)
 	}
 	r.recorder.Event(instance, v1.EventTypeWarning, "StoragePolicyInfoFailed", errMsg)
 	return nil
 }
 
 // setSPISuccess clears the error status and records a Normal event on the instance.
+// origStatus is the pre-reconcile status snapshot; written only if it changed.
 func (r *ReconcileStoragePolicyInfo) setSPISuccess(ctx context.Context,
-	instance *spiv1alpha1.StoragePolicyInfo, msg string) error {
+	instance *spiv1alpha1.StoragePolicyInfo, origStatus *spiv1alpha1.StoragePolicyInfoStatus, msg string) error {
 	instance.Status.Error = ""
-	if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
-		return err
+	if !equality.Semantic.DeepEqual(*origStatus, instance.Status) {
+		if err := k8s.UpdateStatus(ctx, r.client, instance); err != nil {
+			return err
+		}
+	} else {
+		logger.GetLogger(ctx).Debugf("StoragePolicyInfo %q status unchanged, skipping status update", instance.Name)
 	}
 	r.recorder.Event(instance, v1.EventTypeNormal, "StoragePolicyInfoSynced", msg)
 	return nil

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
@@ -676,12 +677,13 @@ func TestSetSPISuccess(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
 		Status:     spiv1alpha1.StoragePolicyInfoStatus{Error: "previous error"},
 	}
+	origStatus := spi.Status.DeepCopy()
 	recorder := record.NewFakeRecorder(10)
 	cli := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
 	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
 
-	err := r.setSPISuccess(ctx, spi, "all good")
+	err := r.setSPISuccess(ctx, spi, origStatus, "all good")
 	require.NoError(t, err)
 	assert.Empty(t, spi.Status.Error, "expected error field to be cleared")
 
@@ -702,12 +704,13 @@ func TestSetSPIError(t *testing.T) {
 	spi := &spiv1alpha1.StoragePolicyInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
 	}
+	origStatus := spi.Status.DeepCopy()
 	recorder := record.NewFakeRecorder(10)
 	cli := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).Build()
 	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
 
-	err := r.setSPIError(ctx, spi, "something failed")
+	err := r.setSPIError(ctx, spi, origStatus, "something failed")
 	require.NoError(t, err)
 	assert.Equal(t, "something failed", spi.Status.Error)
 
@@ -718,6 +721,67 @@ func TestSetSPIError(t *testing.T) {
 	default:
 		t.Error("expected a Warning StoragePolicyInfoFailed event")
 	}
+}
+
+// TestSetSPISuccess_SkipsNoOpStatusUpdate verifies that setSPISuccess does not call
+// Status().Update() when the recomputed status is identical to origStatus, but still
+// records the event.
+func TestSetSPISuccess_SkipsNoOpStatusUpdate(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	origStatus := spi.Status.DeepCopy()
+	recorder := record.NewFakeRecorder(10)
+	statusUpdateCalled := false
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, cli client.Client, subResourceName string,
+				obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				statusUpdateCalled = true
+				return cli.SubResource(subResourceName).Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
+
+	err := r.setSPISuccess(ctx, spi, origStatus, "all good")
+	require.NoError(t, err)
+	assert.False(t, statusUpdateCalled, "expected no Status().Update() call when status is unchanged")
+
+	select {
+	case <-recorder.Events:
+	default:
+		t.Error("expected a Normal StoragePolicyInfoSynced event even when the write was skipped")
+	}
+}
+
+// TestSetSPIError_WritesWhenStatusChanged verifies that setSPIError still calls
+// Status().Update() when the recomputed status differs from origStatus.
+func TestSetSPIError_WritesWhenStatusChanged(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	scheme := testScheme(t)
+	spi := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "gold", Namespace: "ns1"},
+	}
+	origStatus := spi.Status.DeepCopy()
+	recorder := record.NewFakeRecorder(10)
+	statusUpdateCalled := false
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&spiv1alpha1.StoragePolicyInfo{}).WithObjects(spi).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, cli client.Client, subResourceName string,
+				obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				statusUpdateCalled = true
+				return cli.SubResource(subResourceName).Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := &ReconcileStoragePolicyInfo{client: cli, scheme: scheme, recorder: recorder}
+
+	err := r.setSPIError(ctx, spi, origStatus, "something failed")
+	require.NoError(t, err)
+	assert.True(t, statusUpdateCalled, "expected a Status().Update() call when status changed")
 }
 
 // TestUpdateStatus_StatusFieldPersisted verifies that k8s.UpdateStatus correctly


### PR DESCRIPTION
The storagepolicyinfo and clusterstoragepolicyinfo controllers previously called k8s.UpdateStatus() (Status().Update()) unconditionally at the end of every reconcile pass, even when the recomputed status was identical to what was already stored.

Since these CRs reconcile frequently (periodic slow-sync, StorageClass/VolumeAttributesClass/Namespace watches, vCenter inventory-change forwarding), this caused needless API writes and resourceVersion churn, which in turn cascaded into unrelated downstream reconciles (e.g. namespace-scoped StoragePolicyInfo whenever InfraStoragePolicyInfo's resourceVersion changes).

This change snapshots each CR's Status before it's recomputed in a given reconcile pass, and only calls Status().Update() if the recomputed value actually differs from that snapshot. Event recording and backoff-duration bookkeeping remain unconditional; only the status subresource write itself is gated.

Testing done:
Pipelines:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1386/ 
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1829/ 


Deployed a custom vsphere-syncer build, shortened the periodic resync (STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES=1) and enabled LOGGER_LEVEL=DEVELOPMENT to observe reconciles in near real time. Verified against vsan-default-storage-policy and its three CRs.

Test 1. no-op reconciles do not write:

Baseline resourceVersion, then confirmed continuous reconciles for ~7 minutes without any status write:
```
$ kubectl get clusterstoragepolicyinfo vsan-default-storage-policy -o jsonpath='{.metadata.resourceVersion}'
892743
$ kubectl get infrastoragepolicyinfo vsan-default-storage-policy -o jsonpath='{.metadata.resourceVersion}'
6777510
$ kubectl get storagepolicyinfo vsan-default-storage-policy -n svc-velero-7nzum -o jsonpath='{.metadata.resourceVersion}'
6777530
```
Logs:
```
2026-07-21T08:45:09.996Z  INFO  clusterstoragepolicyinfo/controller.go:394  Reconciling ClusterStoragePolicyInfo  {"name": "/vsan-default-storage-policy"}
2026-07-21T08:46:10.255Z  INFO  clusterstoragepolicyinfo/controller.go:394  Reconciling ClusterStoragePolicyInfo  {"name": "/vsan-default-storage-policy"}
2026-07-21T08:47:16.905Z  INFO  clusterstoragepolicyinfo/controller.go:394  Reconciling ClusterStoragePolicyInfo  {"name": "/vsan-default-storage-policy"}
```

After ~7 minutes and multiple reconcile passes (~20 policies × once/minute), all three CRs' resourceVersion were unchanged (892743 / 6777510 / 6777530), and per-pass traces showed the event/backoff bookkeeping firing without the corresponding status write, e.g.:
```
DEBUG  clusterstoragepolicyinfo/controller.go:1010  Event type is Normal   {"TraceId": "8c9b1586-..."}
DEBUG  clusterstoragepolicyinfo/controller.go:1071  InfraSPI Event type is Normal  {"TraceId": "15c03fb3-..."}
INFO   clusterstoragepolicyinfo/controller.go:799   Successfully reconciled ClusterStoragePolicyInfo  {"TraceId": "15c03fb3-...", "name": "/management-storage-policy-stretched-esa"}
— no "Successfully updated status." (pkg/kubernetes/kubernetes.go:796) for any of these no-op passes.
```

Test 2. A real change still writes correctly:

Forced a real diff by patching the status subresource directly, twice, and confirmed each was detected and self-corrected:
```
$ kubectl patch clusterstoragepolicyinfo vsan-default-storage-policy --subresource=status --type=merge \
    -p '{"status":{"storagePolicyDeleted":true}}'
clusterstoragepolicyinfo.cns.vmware.com/vsan-default-storage-policy patched

$ kubectl get clusterstoragepolicyinfo vsan-default-storage-policy -o jsonpath='{.status.storagePolicyDeleted}'
false   # corrected back by the next reconcile
```
Logs:

```
2026-07-21T09:10:14.975Z  DEBUG  kubernetes/kubernetes.go:796  Successfully updated status.  {"kind": "ClusterStoragePolicyInfo", "name": "/vsan-default-storage-policy"}
2026-07-21T09:12:11.172Z  DEBUG  kubernetes/kubernetes.go:796  Successfully updated status.  {"kind": "ClusterStoragePolicyInfo", "name": "/vsan-default-storage-policy"}
```
Both injected changes were detected and written exactly once each — resourceVersion bumped only on ClusterStoragePolicyInfo (the CR whose status actually changed), while InfraStoragePolicyInfo and the namespace-scoped StoragePolicyInfo resourceVersion remained untouched throughout, confirming the fix gates writes precisely per-CR rather than broadly suppressing them.