### PR TITLE
Fix ControllerUnpublishVolume misclassifying file volumes on GC

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1302,19 +1302,10 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
 
-		// Determine whether this is a file volume from the guest PVC's access modes,
-		// not the Supervisor PVC's. A statically provisioned guest PVC can carry RWX/ROX
-		// access modes while the underlying Supervisor PVC (and CNS volume) is RWO block -
-		// e.g. when a block FCD is mistakenly registered as a static RWX volume on the guest
-		// cluster. ControllerPublishVolume already keys off the guest-side capability
-		// (req.GetVolumeCapability()), so unpublish must be consistent with that decision or
-		// the CnsFileAccessConfig CR created on publish is never cleaned up.
-		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, req.VolumeId)
+		isFileVolume, err := c.isFileVolumeAttachment(ctx, req)
 		if err != nil {
-			msg := fmt.Sprintf("failed to determine volume type for volume %q from guest PVC. Error: %+v",
-				req.VolumeId, err)
-			log.Error(msg)
-			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+			log.Error(err.Error())
+			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 		}
 		if isFileVolume {
 			volumeType = prometheus.PrometheusFileVolumeType
@@ -2310,28 +2301,48 @@ func (c *controller) ControllerModifyVolume(ctx context.Context, req *csi.Contro
 	return &csi.ControllerModifyVolumeResponse{}, nil
 }
 
-// isFileVolumeFromGuestPVC determines whether volumeID is a file volume by inspecting the
-// guest PVC's access modes, mirroring how ControllerPublishVolume classifies the volume from
-// the CSI request's guest-side VolumeCapability. It uses the in-memory volumeID->PVC cache
-// (maintained by the PV informer) to resolve the guest PVC, matching getTargetVACForVolume.
-func (c *controller) isFileVolumeFromGuestPVC(ctx context.Context, volumeID string) (bool, error) {
-	pvcName, pvcNamespace, exists := commonco.ContainerOrchestratorUtility.GetPVCNameFromCSIVolumeID(volumeID)
-	if !exists {
-		return false, fmt.Errorf("no guest PVC found for volume %q", volumeID)
-	}
-
-	pvc, err := c.guestClient.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(
-		ctx, pvcName, metav1.GetOptions{})
+// isFileVolumeAttachment determines whether the (req.NodeId, req.VolumeId) attachment that
+// ControllerUnpublishVolume is being asked to tear down was published as a file volume. It
+// checks two independent, unambiguous signals instead of inferring file-vs-block from any
+// PVC's overall access mode:
+//  1. Whether the Supervisor PVC is FVS-backed (a Supervisor-volume-level property; FVS
+//     volumes never get a CnsFileAccessConfig CR, so they must be special-cased here).
+//  2. Whether the CnsFileAccessConfig CR that ControllerPublishVolume would have created for
+//     this exact (node, volume) pair exists.
+//
+// A PVC's access mode is not a reliable signal here: a block FCD mistakenly registered as a
+// second, static RWX PV/PVC on the guest cluster shares its volumeHandle with the real,
+// dynamically-provisioned RWO PV, so any volumeID-keyed lookup (guest or Supervisor) can
+// resolve to either PVC. The CnsFileAccessConfig CR's existence has no such ambiguity: it is
+// the exact artifact Publish created (or didn't) for this specific req.NodeId/req.VolumeId
+// pair.
+func (c *controller) isFileVolumeAttachment(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (
+	bool, error) {
+	svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+		ctx, req.VolumeId, metav1.GetOptions{})
 	if err != nil {
-		return false, fmt.Errorf("failed to get guest PVC %s/%s: %v", pvcNamespace, pvcName, err)
+		return false, fmt.Errorf("failed to retrieve supervisor PVC %q in %q namespace: %v",
+			req.VolumeId, c.supervisorNamespace, err)
+	}
+	if IsVsanFileVolumeServiceEnabled && common.IsFVSPersistentVolumeClaim(svPVC) {
+		return true, nil
 	}
 
-	for _, accessMode := range pvc.Spec.AccessModes {
-		if accessMode == corev1.ReadWriteMany || accessMode == corev1.ReadOnlyMany {
-			return true, nil
-		}
+	cnsFileAccessConfigInstanceName := req.NodeId + "-" + req.VolumeId
+	existingInstance := &cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
+	err = c.cnsOperatorClient.Get(ctx, types.NamespacedName{
+		Namespace: c.supervisorNamespace,
+		Name:      cnsFileAccessConfigInstanceName,
+	}, existingInstance)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.IsNotFound(err):
+		return false, nil
+	default:
+		return false, fmt.Errorf("failed to get CnsFileAccessConfig instance %q/%q: %v",
+			c.supervisorNamespace, cnsFileAccessConfigInstanceName, err)
 	}
-	return false, nil
 }
 
 // getTargetVACForVolume resolves the target VolumeAttributesClass name from the guest PVC.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1302,20 +1302,19 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
 
-		// Retrieve Supervisor PVC
-		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
-			ctx, req.VolumeId, metav1.GetOptions{})
+		// Determine whether this is a file volume from the guest PVC's access modes,
+		// not the Supervisor PVC's. A statically provisioned guest PVC can carry RWX/ROX
+		// access modes while the underlying Supervisor PVC (and CNS volume) is RWO block -
+		// e.g. when a block FCD is mistakenly registered as a static RWX volume on the guest
+		// cluster. ControllerPublishVolume already keys off the guest-side capability
+		// (req.GetVolumeCapability()), so unpublish must be consistent with that decision or
+		// the CnsFileAccessConfig CR created on publish is never cleaned up.
+		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, req.VolumeId)
 		if err != nil {
-			msg := fmt.Sprintf("failed to retrieve supervisor PVC %q in %q namespace. Error: %+v",
-				req.VolumeId, c.supervisorNamespace, err)
+			msg := fmt.Sprintf("failed to determine volume type for volume %q from guest PVC. Error: %+v",
+				req.VolumeId, err)
 			log.Error(msg)
 			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
-		}
-		var isFileVolume bool
-		for _, accessMode := range svPVC.Spec.AccessModes {
-			if accessMode == corev1.ReadWriteMany || accessMode == corev1.ReadOnlyMany {
-				isFileVolume = true
-			}
 		}
 		if isFileVolume {
 			volumeType = prometheus.PrometheusFileVolumeType
@@ -2309,6 +2308,30 @@ func (c *controller) ControllerModifyVolume(ctx context.Context, req *csi.Contro
 
 	log.Infof("Volume %s successfully modified to VAC %q", volumeID, targetVAC)
 	return &csi.ControllerModifyVolumeResponse{}, nil
+}
+
+// isFileVolumeFromGuestPVC determines whether volumeID is a file volume by inspecting the
+// guest PVC's access modes, mirroring how ControllerPublishVolume classifies the volume from
+// the CSI request's guest-side VolumeCapability. It uses the in-memory volumeID->PVC cache
+// (maintained by the PV informer) to resolve the guest PVC, matching getTargetVACForVolume.
+func (c *controller) isFileVolumeFromGuestPVC(ctx context.Context, volumeID string) (bool, error) {
+	pvcName, pvcNamespace, exists := commonco.ContainerOrchestratorUtility.GetPVCNameFromCSIVolumeID(volumeID)
+	if !exists {
+		return false, fmt.Errorf("no guest PVC found for volume %q", volumeID)
+	}
+
+	pvc, err := c.guestClient.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(
+		ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get guest PVC %s/%s: %v", pvcNamespace, pvcName, err)
+	}
+
+	for _, accessMode := range pvc.Spec.AccessModes {
+		if accessMode == corev1.ReadWriteMany || accessMode == corev1.ReadOnlyMany {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // getTargetVACForVolume resolves the target VolumeAttributesClass name from the guest PVC.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1435,7 +1435,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			log.Error(err.Error())
 			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 		}
-		log.Infof("DEBUG ControllerUnpublishVolume: volumeId=%q nodeId=%q isFileVolume=%v",
+		log.Debugf("ControllerUnpublishVolume: volumeId=%q nodeId=%q isFileVolume=%v",
 			req.VolumeId, req.NodeId, isFileVolume)
 
 		if isFileVolume {
@@ -1449,7 +1449,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 					"exists for volumeId=%q on node %q; cleaning it up anyway to avoid leaking the "+
 					"pvc-protection finalizer", req.VolumeId, req.NodeId)
 			}
-			log.Infof("DEBUG ControllerUnpublishVolume: running file-volume teardown for volumeId=%q", req.VolumeId)
+			log.Debugf("ControllerUnpublishVolume: running file-volume teardown for volumeId=%q", req.VolumeId)
 			resp, faultType, err := controllerUnpublishForFileVolume(ctx, req, c)
 			if err != nil {
 				return resp, faultType, err
@@ -1461,7 +1461,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		// Always follow with the block teardown. For a genuine file volume the guest driver never
 		// adds the volume to the VM spec, so this is a no-op; for the shared-volumeHandle case it
 		// is what actually detaches the disk.
-		log.Infof("DEBUG ControllerUnpublishVolume: running block-volume teardown for volumeId=%q", req.VolumeId)
+		log.Debugf("ControllerUnpublishVolume: running block-volume teardown for volumeId=%q", req.VolumeId)
 		return controllerUnpublishForBlockVolume(ctx, req, c)
 	}
 	resp, faultType, err := controllerUnpublishVolumeInternal()
@@ -1620,7 +1620,7 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 func controllerUnpublishForFileVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest, c *controller) (
 	*csi.ControllerUnpublishVolumeResponse, string, error) {
 	log := logger.GetLogger(ctx)
-	log.Infof("DEBUG controllerUnpublishForFileVolume: entered for volumeId=%q nodeId=%q", req.VolumeId, req.NodeId)
+	log.Debugf("controllerUnpublishForFileVolume: entered for volumeId=%q nodeId=%q", req.VolumeId, req.NodeId)
 
 	if IsVsanFileVolumeServiceEnabled {
 		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
@@ -1679,7 +1679,7 @@ func controllerUnpublishForFileVolume(ctx context.Context, req *csi.ControllerUn
 		log.Error(msg)
 		return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
 	}
-	log.Infof("DEBUG controllerUnpublishForFileVolume: issuing Delete on CnsFileAccessConfig %q/%q",
+	log.Debugf("controllerUnpublishForFileVolume: issuing Delete on CnsFileAccessConfig %q/%q",
 		c.supervisorNamespace, cnsFileAccessConfigInstanceName)
 	if err := c.cnsOperatorClient.Delete(ctx, &cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1697,7 +1697,7 @@ func controllerUnpublishForFileVolume(ctx context.Context, req *csi.ControllerUn
 		log.Error(msg)
 		return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
 	}
-	log.Infof("DEBUG controllerUnpublishForFileVolume: Delete call for CnsFileAccessConfig %q/%q accepted, "+
+	log.Debugf("controllerUnpublishForFileVolume: Delete call for CnsFileAccessConfig %q/%q accepted, "+
 		"now waiting for the DELETED watch event", c.supervisorNamespace, cnsFileAccessConfigInstanceName)
 	defer watchCnsFileAccessConfig.Stop()
 	var cnsFileAccessConfigInstanceErr string
@@ -2474,7 +2474,7 @@ func (c *controller) ControllerModifyVolume(ctx context.Context, req *csi.Contro
 func (c *controller) isFileVolumeAttachment(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (
 	bool, error) {
 	log := logger.GetLogger(ctx)
-	log.Infof("DEBUG isFileVolumeAttachment: checking volumeId=%q nodeId=%q in supervisorNamespace=%q",
+	log.Debugf("isFileVolumeAttachment: checking volumeId=%q nodeId=%q in supervisorNamespace=%q",
 		req.VolumeId, req.NodeId, c.supervisorNamespace)
 
 	// The Supervisor PVC is consulted only for the FVS check, so it is fetched only when FVS
@@ -2490,10 +2490,10 @@ func (c *controller) isFileVolumeAttachment(ctx context.Context, req *csi.Contro
 			ctx, req.VolumeId, metav1.GetOptions{})
 		switch {
 		case err == nil:
-			log.Infof("DEBUG isFileVolumeAttachment: supervisor PVC %q accessModes=%v storageClass=%v",
+			log.Debugf("isFileVolumeAttachment: supervisor PVC %q accessModes=%v storageClass=%v",
 				req.VolumeId, svPVC.Spec.AccessModes, svPVC.Spec.StorageClassName)
 			if common.IsFVSPersistentVolumeClaim(svPVC) {
-				log.Infof("DEBUG isFileVolumeAttachment: volumeId=%q is FVS-backed, treating as file volume",
+				log.Debugf("isFileVolumeAttachment: volumeId=%q is FVS-backed, treating as file volume",
 					req.VolumeId)
 				return true, nil
 			}
@@ -2501,17 +2501,17 @@ func (c *controller) isFileVolumeAttachment(ctx context.Context, req *csi.Contro
 			// Not fatal: fall through to the CnsFileAccessConfig check so an orphaned CR can
 			// still be cleaned up. An FVS volume never has a CR, so it correctly reports block
 			// here and its teardown is a no-op.
-			log.Infof("DEBUG isFileVolumeAttachment: supervisor PVC %q not found; skipping FVS check "+
+			log.Debugf("isFileVolumeAttachment: supervisor PVC %q not found; skipping FVS check "+
 				"and falling through to the CnsFileAccessConfig lookup", req.VolumeId)
 		default:
-			log.Errorf("DEBUG isFileVolumeAttachment: failed to get supervisor PVC %q: %v", req.VolumeId, err)
+			log.Debugf("isFileVolumeAttachment: failed to get supervisor PVC %q: %v", req.VolumeId, err)
 			return false, fmt.Errorf("failed to retrieve supervisor PVC %q in %q namespace: %v",
 				req.VolumeId, c.supervisorNamespace, err)
 		}
 	}
 
 	cnsFileAccessConfigInstanceName := req.NodeId + "-" + req.VolumeId
-	log.Infof("DEBUG isFileVolumeAttachment: looking up CnsFileAccessConfig %q/%q",
+	log.Debugf("isFileVolumeAttachment: looking up CnsFileAccessConfig %q/%q",
 		c.supervisorNamespace, cnsFileAccessConfigInstanceName)
 	existingInstance := &cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
 	err := c.cnsOperatorClient.Get(ctx, types.NamespacedName{
@@ -2520,18 +2520,18 @@ func (c *controller) isFileVolumeAttachment(ctx context.Context, req *csi.Contro
 	}, existingInstance)
 	switch {
 	case err == nil:
-		log.Infof("DEBUG isFileVolumeAttachment: found CnsFileAccessConfig %q/%q (status.done=%v status.error=%q); "+
+		log.Debugf("isFileVolumeAttachment: found CnsFileAccessConfig %q/%q (status.done=%v status.error=%q); "+
 			"treating volumeId=%q as file volume",
 			c.supervisorNamespace, cnsFileAccessConfigInstanceName, existingInstance.Status.Done,
 			existingInstance.Status.Error, req.VolumeId)
 		return true, nil
 	case errors.IsNotFound(err):
-		log.Infof("DEBUG isFileVolumeAttachment: CnsFileAccessConfig %q/%q not found; "+
+		log.Debugf("isFileVolumeAttachment: CnsFileAccessConfig %q/%q not found; "+
 			"treating volumeId=%q as block volume",
 			c.supervisorNamespace, cnsFileAccessConfigInstanceName, req.VolumeId)
 		return false, nil
 	default:
-		log.Errorf("DEBUG isFileVolumeAttachment: failed to get CnsFileAccessConfig %q/%q: %v",
+		log.Debugf("isFileVolumeAttachment: failed to get CnsFileAccessConfig %q/%q: %v",
 			c.supervisorNamespace, cnsFileAccessConfigInstanceName, err)
 		return false, fmt.Errorf("failed to get CnsFileAccessConfig instance %q/%q: %v",
 			c.supervisorNamespace, cnsFileAccessConfigInstanceName, err)

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1421,15 +1421,22 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			log.Error(err.Error())
 			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 		}
+		log.Infof("DEBUG ControllerUnpublishVolume: dispatch decision for volumeId=%q nodeId=%q: isFileVolume=%v",
+			req.VolumeId, req.NodeId, isFileVolume)
 		if isFileVolume {
 			volumeType = prometheus.PrometheusFileVolumeType
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) {
+				log.Infof("DEBUG ControllerUnpublishVolume: routing volumeId=%q to controllerUnpublishForFileVolume",
+					req.VolumeId)
 				return controllerUnpublishForFileVolume(ctx, req, c)
 			}
 			// Feature is disabled on the cluster
+			log.Infof("DEBUG ControllerUnpublishVolume: FileVolume FSS disabled, failing volumeId=%q", req.VolumeId)
 			return nil, csifault.CSIInvalidArgumentFault, status.Error(codes.InvalidArgument, "File volume not supported.")
 		}
 		volumeType = prometheus.PrometheusBlockVolumeType
+		log.Infof("DEBUG ControllerUnpublishVolume: routing volumeId=%q to controllerUnpublishForBlockVolume",
+			req.VolumeId)
 		return controllerUnpublishForBlockVolume(ctx, req, c)
 	}
 	resp, faultType, err := controllerUnpublishVolumeInternal()
@@ -1588,6 +1595,7 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 func controllerUnpublishForFileVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest, c *controller) (
 	*csi.ControllerUnpublishVolumeResponse, string, error) {
 	log := logger.GetLogger(ctx)
+	log.Infof("DEBUG controllerUnpublishForFileVolume: entered for volumeId=%q nodeId=%q", req.VolumeId, req.NodeId)
 
 	if IsVsanFileVolumeServiceEnabled {
 		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
@@ -1646,6 +1654,8 @@ func controllerUnpublishForFileVolume(ctx context.Context, req *csi.ControllerUn
 		log.Error(msg)
 		return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
 	}
+	log.Infof("DEBUG controllerUnpublishForFileVolume: issuing Delete on CnsFileAccessConfig %q/%q",
+		c.supervisorNamespace, cnsFileAccessConfigInstanceName)
 	if err := c.cnsOperatorClient.Delete(ctx, &cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cnsFileAccessConfigInstanceName,
@@ -1662,6 +1672,8 @@ func controllerUnpublishForFileVolume(ctx context.Context, req *csi.ControllerUn
 		log.Error(msg)
 		return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
 	}
+	log.Infof("DEBUG controllerUnpublishForFileVolume: Delete call for CnsFileAccessConfig %q/%q accepted, "+
+		"now waiting for the DELETED watch event", c.supervisorNamespace, cnsFileAccessConfigInstanceName)
 	defer watchCnsFileAccessConfig.Stop()
 	var cnsFileAccessConfigInstanceErr string
 	isCnsFileAccessConfigInstanceDeleted := false
@@ -2436,17 +2448,28 @@ func (c *controller) ControllerModifyVolume(ctx context.Context, req *csi.Contro
 // pair.
 func (c *controller) isFileVolumeAttachment(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (
 	bool, error) {
+	log := logger.GetLogger(ctx)
+	log.Infof("DEBUG isFileVolumeAttachment: checking volumeId=%q nodeId=%q in supervisorNamespace=%q",
+		req.VolumeId, req.NodeId, c.supervisorNamespace)
+
 	svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
 		ctx, req.VolumeId, metav1.GetOptions{})
 	if err != nil {
+		log.Errorf("DEBUG isFileVolumeAttachment: failed to get supervisor PVC %q: %v", req.VolumeId, err)
 		return false, fmt.Errorf("failed to retrieve supervisor PVC %q in %q namespace: %v",
 			req.VolumeId, c.supervisorNamespace, err)
 	}
+	log.Infof("DEBUG isFileVolumeAttachment: supervisor PVC %q accessModes=%v storageClass=%v "+
+		"IsVsanFileVolumeServiceEnabled=%v",
+		req.VolumeId, svPVC.Spec.AccessModes, svPVC.Spec.StorageClassName, IsVsanFileVolumeServiceEnabled)
 	if IsVsanFileVolumeServiceEnabled && common.IsFVSPersistentVolumeClaim(svPVC) {
+		log.Infof("DEBUG isFileVolumeAttachment: volumeId=%q is FVS-backed, treating as file volume", req.VolumeId)
 		return true, nil
 	}
 
 	cnsFileAccessConfigInstanceName := req.NodeId + "-" + req.VolumeId
+	log.Infof("DEBUG isFileVolumeAttachment: looking up CnsFileAccessConfig %q/%q",
+		c.supervisorNamespace, cnsFileAccessConfigInstanceName)
 	existingInstance := &cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
 	err = c.cnsOperatorClient.Get(ctx, types.NamespacedName{
 		Namespace: c.supervisorNamespace,
@@ -2454,10 +2477,19 @@ func (c *controller) isFileVolumeAttachment(ctx context.Context, req *csi.Contro
 	}, existingInstance)
 	switch {
 	case err == nil:
+		log.Infof("DEBUG isFileVolumeAttachment: found CnsFileAccessConfig %q/%q (status.done=%v status.error=%q); "+
+			"treating volumeId=%q as file volume",
+			c.supervisorNamespace, cnsFileAccessConfigInstanceName, existingInstance.Status.Done,
+			existingInstance.Status.Error, req.VolumeId)
 		return true, nil
 	case errors.IsNotFound(err):
+		log.Infof("DEBUG isFileVolumeAttachment: CnsFileAccessConfig %q/%q not found; "+
+			"treating volumeId=%q as block volume",
+			c.supervisorNamespace, cnsFileAccessConfigInstanceName, req.VolumeId)
 		return false, nil
 	default:
+		log.Errorf("DEBUG isFileVolumeAttachment: failed to get CnsFileAccessConfig %q/%q: %v",
+			c.supervisorNamespace, cnsFileAccessConfigInstanceName, err)
 		return false, fmt.Errorf("failed to get CnsFileAccessConfig instance %q/%q: %v",
 			c.supervisorNamespace, cnsFileAccessConfigInstanceName, err)
 	}

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1416,20 +1416,19 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
 
-		// Retrieve Supervisor PVC
-		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
-			ctx, req.VolumeId, metav1.GetOptions{})
+		// Determine whether this is a file volume from the guest PVC's access modes,
+		// not the Supervisor PVC's. A statically provisioned guest PVC can carry RWX/ROX
+		// access modes while the underlying Supervisor PVC (and CNS volume) is RWO block -
+		// e.g. when a block FCD is mistakenly registered as a static RWX volume on the guest
+		// cluster. ControllerPublishVolume already keys off the guest-side capability
+		// (req.GetVolumeCapability()), so unpublish must be consistent with that decision or
+		// the CnsFileAccessConfig CR created on publish is never cleaned up.
+		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, req.VolumeId)
 		if err != nil {
-			msg := fmt.Sprintf("failed to retrieve supervisor PVC %q in %q namespace. Error: %+v",
-				req.VolumeId, c.supervisorNamespace, err)
+			msg := fmt.Sprintf("failed to determine volume type for volume %q from guest PVC. Error: %+v",
+				req.VolumeId, err)
 			log.Error(msg)
 			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
-		}
-		var isFileVolume bool
-		for _, accessMode := range svPVC.Spec.AccessModes {
-			if accessMode == corev1.ReadWriteMany || accessMode == corev1.ReadOnlyMany {
-				isFileVolume = true
-			}
 		}
 		if isFileVolume {
 			volumeType = prometheus.PrometheusFileVolumeType
@@ -2427,6 +2426,30 @@ func (c *controller) ControllerModifyVolume(ctx context.Context, req *csi.Contro
 
 	log.Infof("Volume %s successfully modified to VAC %q", volumeID, targetVAC)
 	return &csi.ControllerModifyVolumeResponse{}, nil
+}
+
+// isFileVolumeFromGuestPVC determines whether volumeID is a file volume by inspecting the
+// guest PVC's access modes, mirroring how ControllerPublishVolume classifies the volume from
+// the CSI request's guest-side VolumeCapability. It uses the in-memory volumeID->PVC cache
+// (maintained by the PV informer) to resolve the guest PVC, matching getTargetVACForVolume.
+func (c *controller) isFileVolumeFromGuestPVC(ctx context.Context, volumeID string) (bool, error) {
+	pvcName, pvcNamespace, exists := commonco.ContainerOrchestratorUtility.GetPVCNameFromCSIVolumeID(volumeID)
+	if !exists {
+		return false, fmt.Errorf("no guest PVC found for volume %q", volumeID)
+	}
+
+	pvc, err := c.guestClient.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(
+		ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get guest PVC %s/%s: %v", pvcNamespace, pvcName, err)
+	}
+
+	for _, accessMode := range pvc.Spec.AccessModes {
+		if accessMode == corev1.ReadWriteMany || accessMode == corev1.ReadOnlyMany {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // getTargetVACForVolume resolves the target VolumeAttributesClass name from the guest PVC.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1416,19 +1416,10 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
 
-		// Determine whether this is a file volume from the guest PVC's access modes,
-		// not the Supervisor PVC's. A statically provisioned guest PVC can carry RWX/ROX
-		// access modes while the underlying Supervisor PVC (and CNS volume) is RWO block -
-		// e.g. when a block FCD is mistakenly registered as a static RWX volume on the guest
-		// cluster. ControllerPublishVolume already keys off the guest-side capability
-		// (req.GetVolumeCapability()), so unpublish must be consistent with that decision or
-		// the CnsFileAccessConfig CR created on publish is never cleaned up.
-		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, req.VolumeId)
+		isFileVolume, err := c.isFileVolumeAttachment(ctx, req)
 		if err != nil {
-			msg := fmt.Sprintf("failed to determine volume type for volume %q from guest PVC. Error: %+v",
-				req.VolumeId, err)
-			log.Error(msg)
-			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+			log.Error(err.Error())
+			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 		}
 		if isFileVolume {
 			volumeType = prometheus.PrometheusFileVolumeType
@@ -2428,28 +2419,48 @@ func (c *controller) ControllerModifyVolume(ctx context.Context, req *csi.Contro
 	return &csi.ControllerModifyVolumeResponse{}, nil
 }
 
-// isFileVolumeFromGuestPVC determines whether volumeID is a file volume by inspecting the
-// guest PVC's access modes, mirroring how ControllerPublishVolume classifies the volume from
-// the CSI request's guest-side VolumeCapability. It uses the in-memory volumeID->PVC cache
-// (maintained by the PV informer) to resolve the guest PVC, matching getTargetVACForVolume.
-func (c *controller) isFileVolumeFromGuestPVC(ctx context.Context, volumeID string) (bool, error) {
-	pvcName, pvcNamespace, exists := commonco.ContainerOrchestratorUtility.GetPVCNameFromCSIVolumeID(volumeID)
-	if !exists {
-		return false, fmt.Errorf("no guest PVC found for volume %q", volumeID)
-	}
-
-	pvc, err := c.guestClient.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(
-		ctx, pvcName, metav1.GetOptions{})
+// isFileVolumeAttachment determines whether the (req.NodeId, req.VolumeId) attachment that
+// ControllerUnpublishVolume is being asked to tear down was published as a file volume. It
+// checks two independent, unambiguous signals instead of inferring file-vs-block from any
+// PVC's overall access mode:
+//  1. Whether the Supervisor PVC is FVS-backed (a Supervisor-volume-level property; FVS
+//     volumes never get a CnsFileAccessConfig CR, so they must be special-cased here).
+//  2. Whether the CnsFileAccessConfig CR that ControllerPublishVolume would have created for
+//     this exact (node, volume) pair exists.
+//
+// A PVC's access mode is not a reliable signal here: a block FCD mistakenly registered as a
+// second, static RWX PV/PVC on the guest cluster shares its volumeHandle with the real,
+// dynamically-provisioned RWO PV, so any volumeID-keyed lookup (guest or Supervisor) can
+// resolve to either PVC. The CnsFileAccessConfig CR's existence has no such ambiguity: it is
+// the exact artifact Publish created (or didn't) for this specific req.NodeId/req.VolumeId
+// pair.
+func (c *controller) isFileVolumeAttachment(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (
+	bool, error) {
+	svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+		ctx, req.VolumeId, metav1.GetOptions{})
 	if err != nil {
-		return false, fmt.Errorf("failed to get guest PVC %s/%s: %v", pvcNamespace, pvcName, err)
+		return false, fmt.Errorf("failed to retrieve supervisor PVC %q in %q namespace: %v",
+			req.VolumeId, c.supervisorNamespace, err)
+	}
+	if IsVsanFileVolumeServiceEnabled && common.IsFVSPersistentVolumeClaim(svPVC) {
+		return true, nil
 	}
 
-	for _, accessMode := range pvc.Spec.AccessModes {
-		if accessMode == corev1.ReadWriteMany || accessMode == corev1.ReadOnlyMany {
-			return true, nil
-		}
+	cnsFileAccessConfigInstanceName := req.NodeId + "-" + req.VolumeId
+	existingInstance := &cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
+	err = c.cnsOperatorClient.Get(ctx, types.NamespacedName{
+		Namespace: c.supervisorNamespace,
+		Name:      cnsFileAccessConfigInstanceName,
+	}, existingInstance)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.IsNotFound(err):
+		return false, nil
+	default:
+		return false, fmt.Errorf("failed to get CnsFileAccessConfig instance %q/%q: %v",
+			c.supervisorNamespace, cnsFileAccessConfigInstanceName, err)
 	}
-	return false, nil
 }
 
 // getTargetVACForVolume resolves the target VolumeAttributesClass name from the guest PVC.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1416,27 +1416,52 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
 
+		// Publish can leave behind two INDEPENDENT artifacts for a single (NodeId, VolumeId):
+		// a CnsFileAccessConfig CR (file path) and an entry in the VirtualMachine's volume spec
+		// (block path). They are not mutually exclusive, because two guest PVs can share one
+		// volumeHandle - the real dynamically-provisioned RWO PV plus a mis-registered static
+		// RWX PV pointing at the same FCD. Pods using each can land on the same node, so both
+		// attachments arrive here under identical CSI identifiers and neither the request nor
+		// any PVC access mode can tell them apart.
+		//
+		// Therefore tear down BOTH artifacts rather than choosing one: each teardown is a no-op
+		// when its artifact is absent (controllerUnpublishForFileVolume returns success when the
+		// CR is not found; controllerUnpublishForBlockVolume returns success when the volume is
+		// not in the VM spec/status). Choosing only one is what let the CnsFileAccessConfig CR
+		// leak, and choosing the file path alone for a block attachment would leave the disk
+		// attached to the VM.
 		isFileVolume, err := c.isFileVolumeAttachment(ctx, req)
 		if err != nil {
 			log.Error(err.Error())
 			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, err.Error())
 		}
-		log.Infof("DEBUG ControllerUnpublishVolume: dispatch decision for volumeId=%q nodeId=%q: isFileVolume=%v",
+		log.Infof("DEBUG ControllerUnpublishVolume: volumeId=%q nodeId=%q isFileVolume=%v",
 			req.VolumeId, req.NodeId, isFileVolume)
+
 		if isFileVolume {
 			volumeType = prometheus.PrometheusFileVolumeType
-			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) {
-				log.Infof("DEBUG ControllerUnpublishVolume: routing volumeId=%q to controllerUnpublishForFileVolume",
-					req.VolumeId)
-				return controllerUnpublishForFileVolume(ctx, req, c)
+			// Deliberately not gated on the FileVolume FSS. A CnsFileAccessConfig CR only exists
+			// because a publish created it, and it holds a pvc-protection finalizer on the
+			// Supervisor PVC. Refusing to remove it when the FSS is off (as this used to do)
+			// wedges the PVC in Terminating forever, so always clean it up.
+			if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) {
+				log.Warnf("ControllerUnpublishVolume: FileVolume FSS is disabled but a CnsFileAccessConfig "+
+					"exists for volumeId=%q on node %q; cleaning it up anyway to avoid leaking the "+
+					"pvc-protection finalizer", req.VolumeId, req.NodeId)
 			}
-			// Feature is disabled on the cluster
-			log.Infof("DEBUG ControllerUnpublishVolume: FileVolume FSS disabled, failing volumeId=%q", req.VolumeId)
-			return nil, csifault.CSIInvalidArgumentFault, status.Error(codes.InvalidArgument, "File volume not supported.")
+			log.Infof("DEBUG ControllerUnpublishVolume: running file-volume teardown for volumeId=%q", req.VolumeId)
+			resp, faultType, err := controllerUnpublishForFileVolume(ctx, req, c)
+			if err != nil {
+				return resp, faultType, err
+			}
+		} else {
+			volumeType = prometheus.PrometheusBlockVolumeType
 		}
-		volumeType = prometheus.PrometheusBlockVolumeType
-		log.Infof("DEBUG ControllerUnpublishVolume: routing volumeId=%q to controllerUnpublishForBlockVolume",
-			req.VolumeId)
+
+		// Always follow with the block teardown. For a genuine file volume the guest driver never
+		// adds the volume to the VM spec, so this is a no-op; for the shared-volumeHandle case it
+		// is what actually detaches the disk.
+		log.Infof("DEBUG ControllerUnpublishVolume: running block-volume teardown for volumeId=%q", req.VolumeId)
 		return controllerUnpublishForBlockVolume(ctx, req, c)
 	}
 	resp, faultType, err := controllerUnpublishVolumeInternal()
@@ -2452,26 +2477,44 @@ func (c *controller) isFileVolumeAttachment(ctx context.Context, req *csi.Contro
 	log.Infof("DEBUG isFileVolumeAttachment: checking volumeId=%q nodeId=%q in supervisorNamespace=%q",
 		req.VolumeId, req.NodeId, c.supervisorNamespace)
 
-	svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
-		ctx, req.VolumeId, metav1.GetOptions{})
-	if err != nil {
-		log.Errorf("DEBUG isFileVolumeAttachment: failed to get supervisor PVC %q: %v", req.VolumeId, err)
-		return false, fmt.Errorf("failed to retrieve supervisor PVC %q in %q namespace: %v",
-			req.VolumeId, c.supervisorNamespace, err)
-	}
-	log.Infof("DEBUG isFileVolumeAttachment: supervisor PVC %q accessModes=%v storageClass=%v "+
-		"IsVsanFileVolumeServiceEnabled=%v",
-		req.VolumeId, svPVC.Spec.AccessModes, svPVC.Spec.StorageClassName, IsVsanFileVolumeServiceEnabled)
-	if IsVsanFileVolumeServiceEnabled && common.IsFVSPersistentVolumeClaim(svPVC) {
-		log.Infof("DEBUG isFileVolumeAttachment: volumeId=%q is FVS-backed, treating as file volume", req.VolumeId)
-		return true, nil
+	// The Supervisor PVC is consulted only for the FVS check, so it is fetched only when FVS
+	// is enabled and a NotFound is tolerated. It must never gate the CnsFileAccessConfig lookup
+	// below: a CR can outlive its Supervisor PVC (the PVC is deleted cleanly whenever the
+	// pvc-protection finalizer had not been added yet - see addPvcFinalizer, which the
+	// CnsFileAccessConfig reconciler only reaches after adding its own finalizer and setting the
+	// VM ownerRef). Failing here on a missing PVC would leave precisely those orphaned CRs
+	// unremovable, since external-attacher would retry this RPC forever and the Delete below
+	// would never be issued.
+	if IsVsanFileVolumeServiceEnabled {
+		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+			ctx, req.VolumeId, metav1.GetOptions{})
+		switch {
+		case err == nil:
+			log.Infof("DEBUG isFileVolumeAttachment: supervisor PVC %q accessModes=%v storageClass=%v",
+				req.VolumeId, svPVC.Spec.AccessModes, svPVC.Spec.StorageClassName)
+			if common.IsFVSPersistentVolumeClaim(svPVC) {
+				log.Infof("DEBUG isFileVolumeAttachment: volumeId=%q is FVS-backed, treating as file volume",
+					req.VolumeId)
+				return true, nil
+			}
+		case errors.IsNotFound(err):
+			// Not fatal: fall through to the CnsFileAccessConfig check so an orphaned CR can
+			// still be cleaned up. An FVS volume never has a CR, so it correctly reports block
+			// here and its teardown is a no-op.
+			log.Infof("DEBUG isFileVolumeAttachment: supervisor PVC %q not found; skipping FVS check "+
+				"and falling through to the CnsFileAccessConfig lookup", req.VolumeId)
+		default:
+			log.Errorf("DEBUG isFileVolumeAttachment: failed to get supervisor PVC %q: %v", req.VolumeId, err)
+			return false, fmt.Errorf("failed to retrieve supervisor PVC %q in %q namespace: %v",
+				req.VolumeId, c.supervisorNamespace, err)
+		}
 	}
 
 	cnsFileAccessConfigInstanceName := req.NodeId + "-" + req.VolumeId
 	log.Infof("DEBUG isFileVolumeAttachment: looking up CnsFileAccessConfig %q/%q",
 		c.supervisorNamespace, cnsFileAccessConfigInstanceName)
 	existingInstance := &cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
-	err = c.cnsOperatorClient.Get(ctx, types.NamespacedName{
+	err := c.cnsOperatorClient.Get(ctx, types.NamespacedName{
 		Namespace: c.supervisorNamespace,
 		Name:      cnsFileAccessConfigInstanceName,
 	}, existingInstance)

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -45,6 +45,8 @@ import (
 	ktesting "k8s.io/client-go/testing"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
 	fakesnapshotclient "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fakesnapshot"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -1771,89 +1773,154 @@ func TestGetTargetVACForVolume(t *testing.T) {
 	})
 }
 
-// TestIsFileVolumeFromGuestPVC tests the isFileVolumeFromGuestPVC helper function.
-// The implementation uses commonco.ContainerOrchestratorUtility.GetPVCNameFromCSIVolumeID
-// (the in-memory PV informer cache) to resolve volumeID → guest PVC, then inspects the guest
-// PVC's access modes - this must be guest-side, since a statically provisioned guest PVC can
-// have RWX/ROX access modes while the underlying Supervisor PVC/CNS volume is RWO block.
-func TestIsFileVolumeFromGuestPVC(t *testing.T) {
+// TestIsFileVolumeAttachment tests the isFileVolumeAttachment helper function used by
+// ControllerUnpublishVolume to decide between the file and block volume teardown paths.
+// It must key off the CnsFileAccessConfig CR (or FVS storage class) for the specific
+// (node, volume) attachment rather than any PVC's overall access mode, since a block FCD
+// mistakenly registered as a second, static RWX PV/PVC on the guest cluster shares its
+// volumeHandle with the real, dynamically-provisioned RWO PV.
+func TestIsFileVolumeAttachment(t *testing.T) {
 	ctx := context.Background()
-	// Ensure commonco.ContainerOrchestratorUtility is initialised with the fake orchestrator.
-	getControllerTest(t)
 
-	const mockPVC = "mock-pvc"
-	const mockNS = "mock-namespace"
+	const (
+		mockSupervisorNamespace = "mock-namespace"
+		mockVolumeID            = "test-volume-123"
+		mockNodeID              = "test-node"
+	)
 
-	makePVC := func(guestClient *testclient.Clientset, accessModes ...v1.PersistentVolumeAccessMode) {
+	newReq := func() *csi.ControllerUnpublishVolumeRequest {
+		return &csi.ControllerUnpublishVolumeRequest{VolumeId: mockVolumeID, NodeId: mockNodeID}
+	}
+
+	makeSupervisorPVC := func(supervisorClient *testclient.Clientset, storageClassName string) {
 		pvc := &v1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: mockPVC, Namespace: mockNS},
-			Spec:       v1.PersistentVolumeClaimSpec{AccessModes: accessModes},
+			ObjectMeta: metav1.ObjectMeta{Name: mockVolumeID, Namespace: mockSupervisorNamespace},
 		}
-		_, err := guestClient.CoreV1().PersistentVolumeClaims(mockNS).Create(ctx, pvc, metav1.CreateOptions{})
+		if storageClassName != "" {
+			pvc.Spec.StorageClassName = &storageClassName
+		}
+		_, err := supervisorClient.CoreV1().PersistentVolumeClaims(mockSupervisorNamespace).Create(
+			ctx, pvc, metav1.CreateOptions{})
 		require.NoError(t, err)
 	}
 
-	t.Run("guest PVC with ReadWriteMany is a file volume", func(t *testing.T) {
-		guestClient := testclient.NewClientset()
-		makePVC(guestClient, v1.ReadWriteMany)
+	cnsOperatorScheme := runtime.NewScheme()
+	require.NoError(t, cnsoperatorv1alpha1.AddToScheme(cnsOperatorScheme))
 
-		c := &controller{guestClient: guestClient}
-		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+	t.Run("FVS-backed supervisor PVC is a file volume, regardless of CnsFileAccessConfig", func(t *testing.T) {
+		origFVSEnabled := IsVsanFileVolumeServiceEnabled
+		IsVsanFileVolumeServiceEnabled = true
+		defer func() { IsVsanFileVolumeServiceEnabled = origFVSEnabled }()
+
+		supervisorClient := testclient.NewClientset()
+		makeSupervisorPVC(supervisorClient, common.StorageClassVsanFileServicePolicy)
+		cnsOperatorClient := ctrlclientfake.NewClientBuilder().WithScheme(cnsOperatorScheme).Build()
+
+		c := &controller{
+			supervisorClient:    supervisorClient,
+			supervisorNamespace: mockSupervisorNamespace,
+			cnsOperatorClient:   cnsOperatorClient,
+		}
+		isFileVolume, err := c.isFileVolumeAttachment(ctx, newReq())
 		assert.NoError(t, err)
 		assert.True(t, isFileVolume)
 	})
 
-	t.Run("guest PVC with ReadOnlyMany is a file volume", func(t *testing.T) {
-		guestClient := testclient.NewClientset()
-		makePVC(guestClient, v1.ReadOnlyMany)
+	t.Run("CnsFileAccessConfig CR exists for this node/volume is a file volume", func(t *testing.T) {
+		supervisorClient := testclient.NewClientset()
+		makeSupervisorPVC(supervisorClient, "")
+		cnsOperatorClient := ctrlclientfake.NewClientBuilder().WithScheme(cnsOperatorScheme).WithObjects(
+			&cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mockNodeID + "-" + mockVolumeID,
+					Namespace: mockSupervisorNamespace,
+				},
+			},
+		).Build()
 
-		c := &controller{guestClient: guestClient}
-		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+		c := &controller{
+			supervisorClient:    supervisorClient,
+			supervisorNamespace: mockSupervisorNamespace,
+			cnsOperatorClient:   cnsOperatorClient,
+		}
+		isFileVolume, err := c.isFileVolumeAttachment(ctx, newReq())
 		assert.NoError(t, err)
 		assert.True(t, isFileVolume)
 	})
 
-	t.Run("guest PVC with ReadWriteOnce is a block volume", func(t *testing.T) {
-		guestClient := testclient.NewClientset()
-		makePVC(guestClient, v1.ReadWriteOnce)
+	t.Run("no CnsFileAccessConfig CR and non-FVS PVC is a block volume", func(t *testing.T) {
+		supervisorClient := testclient.NewClientset()
+		makeSupervisorPVC(supervisorClient, "")
+		cnsOperatorClient := ctrlclientfake.NewClientBuilder().WithScheme(cnsOperatorScheme).Build()
 
-		c := &controller{guestClient: guestClient}
-		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+		c := &controller{
+			supervisorClient:    supervisorClient,
+			supervisorNamespace: mockSupervisorNamespace,
+			cnsOperatorClient:   cnsOperatorClient,
+		}
+		isFileVolume, err := c.isFileVolumeAttachment(ctx, newReq())
 		assert.NoError(t, err)
 		assert.False(t, isFileVolume)
 	})
 
-	t.Run("volume not in cache", func(t *testing.T) {
-		// volumeID containing "invalid" causes FakeK8SOrchestrator to return exists=false
-		c := &controller{guestClient: testclient.NewClientset()}
-		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "invalid-volume")
-		assert.Error(t, err)
+	t.Run("mis-registered static RWX PV sharing a volumeHandle with the real RWO PV "+
+		"is still a block volume when no CnsFileAccessConfig CR exists for this attachment", func(t *testing.T) {
+		// Regression test: the underlying Supervisor PVC/CNS volume is block, and no
+		// CnsFileAccessConfig CR was ever created for this (node, volume) pair (e.g. attach
+		// never reached the file-volume publish path), so unpublish must take the block path
+		// regardless of what access mode any guest PV/PVC referencing this volumeHandle has.
+		supervisorClient := testclient.NewClientset()
+		makeSupervisorPVC(supervisorClient, "")
+		cnsOperatorClient := ctrlclientfake.NewClientBuilder().WithScheme(cnsOperatorScheme).Build()
+
+		c := &controller{
+			supervisorClient:    supervisorClient,
+			supervisorNamespace: mockSupervisorNamespace,
+			cnsOperatorClient:   cnsOperatorClient,
+		}
+		isFileVolume, err := c.isFileVolumeAttachment(ctx, newReq())
+		assert.NoError(t, err)
 		assert.False(t, isFileVolume)
-		assert.Contains(t, err.Error(), "no guest PVC found")
 	})
 
-	t.Run("guest PVC not found", func(t *testing.T) {
-		// Cache returns mock-pvc/mock-namespace but PVC does not exist in the API
-		c := &controller{guestClient: testclient.NewClientset()}
-		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+	t.Run("supervisor PVC not found returns an error", func(t *testing.T) {
+		c := &controller{
+			supervisorClient:    testclient.NewClientset(),
+			supervisorNamespace: mockSupervisorNamespace,
+			cnsOperatorClient:   ctrlclientfake.NewClientBuilder().WithScheme(cnsOperatorScheme).Build(),
+		}
+		isFileVolume, err := c.isFileVolumeAttachment(ctx, newReq())
 		assert.Error(t, err)
 		assert.False(t, isFileVolume)
-		assert.Contains(t, err.Error(), "failed to get guest PVC")
+		assert.Contains(t, err.Error(), "failed to retrieve supervisor PVC")
 	})
 
-	t.Run("guest client API failure on get", func(t *testing.T) {
-		guestClient := testclient.NewClientset()
-		guestClient.PrependReactor("get", "persistentvolumeclaims",
-			func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-				return true, nil, errors.NewInternalError(assert.AnError)
-			})
+	t.Run("CnsFileAccessConfig Get API failure returns an error", func(t *testing.T) {
+		supervisorClient := testclient.NewClientset()
+		makeSupervisorPVC(supervisorClient, "")
+		cnsOperatorClient := ctrlclientfake.NewClientBuilder().WithScheme(cnsOperatorScheme).Build()
 
-		c := &controller{guestClient: guestClient}
-		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+		c := &controller{
+			supervisorClient:    supervisorClient,
+			supervisorNamespace: mockSupervisorNamespace,
+			cnsOperatorClient:   errorInjectingClient{Client: cnsOperatorClient},
+		}
+		isFileVolume, err := c.isFileVolumeAttachment(ctx, newReq())
 		assert.Error(t, err)
 		assert.False(t, isFileVolume)
-		assert.Contains(t, err.Error(), "failed to get guest PVC")
+		assert.Contains(t, err.Error(), "failed to get CnsFileAccessConfig instance")
 	})
+}
+
+// errorInjectingClient wraps a controller-runtime client and forces every Get call to fail
+// with a non-NotFound error, used to exercise isFileVolumeAttachment's generic error path.
+type errorInjectingClient struct {
+	ctrlclient.Client
+}
+
+func (errorInjectingClient) Get(ctx context.Context, key ctrlclient.ObjectKey, obj ctrlclient.Object,
+	opts ...ctrlclient.GetOption) error {
+	return errors.NewInternalError(assert.AnError)
 }
 
 // TestWaitForSupervisorPVCModifyVolume tests the waitForSupervisorPVCModifyVolume helper function

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -1771,6 +1771,91 @@ func TestGetTargetVACForVolume(t *testing.T) {
 	})
 }
 
+// TestIsFileVolumeFromGuestPVC tests the isFileVolumeFromGuestPVC helper function.
+// The implementation uses commonco.ContainerOrchestratorUtility.GetPVCNameFromCSIVolumeID
+// (the in-memory PV informer cache) to resolve volumeID → guest PVC, then inspects the guest
+// PVC's access modes - this must be guest-side, since a statically provisioned guest PVC can
+// have RWX/ROX access modes while the underlying Supervisor PVC/CNS volume is RWO block.
+func TestIsFileVolumeFromGuestPVC(t *testing.T) {
+	ctx := context.Background()
+	// Ensure commonco.ContainerOrchestratorUtility is initialised with the fake orchestrator.
+	getControllerTest(t)
+
+	const mockPVC = "mock-pvc"
+	const mockNS = "mock-namespace"
+
+	makePVC := func(guestClient *testclient.Clientset, accessModes ...v1.PersistentVolumeAccessMode) {
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: mockPVC, Namespace: mockNS},
+			Spec:       v1.PersistentVolumeClaimSpec{AccessModes: accessModes},
+		}
+		_, err := guestClient.CoreV1().PersistentVolumeClaims(mockNS).Create(ctx, pvc, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	t.Run("guest PVC with ReadWriteMany is a file volume", func(t *testing.T) {
+		guestClient := testclient.NewClientset()
+		makePVC(guestClient, v1.ReadWriteMany)
+
+		c := &controller{guestClient: guestClient}
+		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+		assert.NoError(t, err)
+		assert.True(t, isFileVolume)
+	})
+
+	t.Run("guest PVC with ReadOnlyMany is a file volume", func(t *testing.T) {
+		guestClient := testclient.NewClientset()
+		makePVC(guestClient, v1.ReadOnlyMany)
+
+		c := &controller{guestClient: guestClient}
+		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+		assert.NoError(t, err)
+		assert.True(t, isFileVolume)
+	})
+
+	t.Run("guest PVC with ReadWriteOnce is a block volume", func(t *testing.T) {
+		guestClient := testclient.NewClientset()
+		makePVC(guestClient, v1.ReadWriteOnce)
+
+		c := &controller{guestClient: guestClient}
+		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+		assert.NoError(t, err)
+		assert.False(t, isFileVolume)
+	})
+
+	t.Run("volume not in cache", func(t *testing.T) {
+		// volumeID containing "invalid" causes FakeK8SOrchestrator to return exists=false
+		c := &controller{guestClient: testclient.NewClientset()}
+		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "invalid-volume")
+		assert.Error(t, err)
+		assert.False(t, isFileVolume)
+		assert.Contains(t, err.Error(), "no guest PVC found")
+	})
+
+	t.Run("guest PVC not found", func(t *testing.T) {
+		// Cache returns mock-pvc/mock-namespace but PVC does not exist in the API
+		c := &controller{guestClient: testclient.NewClientset()}
+		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+		assert.Error(t, err)
+		assert.False(t, isFileVolume)
+		assert.Contains(t, err.Error(), "failed to get guest PVC")
+	})
+
+	t.Run("guest client API failure on get", func(t *testing.T) {
+		guestClient := testclient.NewClientset()
+		guestClient.PrependReactor("get", "persistentvolumeclaims",
+			func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, errors.NewInternalError(assert.AnError)
+			})
+
+		c := &controller{guestClient: guestClient}
+		isFileVolume, err := c.isFileVolumeFromGuestPVC(ctx, "test-volume-123")
+		assert.Error(t, err)
+		assert.False(t, isFileVolume)
+		assert.Contains(t, err.Error(), "failed to get guest PVC")
+	})
+}
+
 // TestWaitForSupervisorPVCModifyVolume tests the waitForSupervisorPVCModifyVolume helper function
 func TestWaitForSupervisorPVCModifyVolume(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -1883,9 +1883,55 @@ func TestIsFileVolumeAttachment(t *testing.T) {
 		assert.False(t, isFileVolume)
 	})
 
-	t.Run("supervisor PVC not found returns an error", func(t *testing.T) {
+	t.Run("orphaned CnsFileAccessConfig CR is still a file volume when the supervisor PVC is gone",
+		func(t *testing.T) {
+			// Regression test: a CR can outlive its Supervisor PVC (the PVC deletes cleanly
+			// whenever the pvc-protection finalizer was never added). Such an orphaned CR is
+			// exactly what unpublish has to remove, so a missing Supervisor PVC must not abort
+			// the lookup - otherwise external-attacher retries forever and the CR leaks.
+			cnsOperatorClient := ctrlclientfake.NewClientBuilder().WithScheme(cnsOperatorScheme).WithObjects(
+				&cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      mockNodeID + "-" + mockVolumeID,
+						Namespace: mockSupervisorNamespace,
+					},
+				},
+			).Build()
+
+			c := &controller{
+				supervisorClient:    testclient.NewClientset(), // no Supervisor PVC at all
+				supervisorNamespace: mockSupervisorNamespace,
+				cnsOperatorClient:   cnsOperatorClient,
+			}
+			isFileVolume, err := c.isFileVolumeAttachment(ctx, newReq())
+			assert.NoError(t, err)
+			assert.True(t, isFileVolume)
+		})
+
+	t.Run("supervisor PVC gone and no CR is a block volume", func(t *testing.T) {
 		c := &controller{
 			supervisorClient:    testclient.NewClientset(),
+			supervisorNamespace: mockSupervisorNamespace,
+			cnsOperatorClient:   ctrlclientfake.NewClientBuilder().WithScheme(cnsOperatorScheme).Build(),
+		}
+		isFileVolume, err := c.isFileVolumeAttachment(ctx, newReq())
+		assert.NoError(t, err)
+		assert.False(t, isFileVolume)
+	})
+
+	t.Run("supervisor PVC API failure under FVS returns an error", func(t *testing.T) {
+		origFVSEnabled := IsVsanFileVolumeServiceEnabled
+		IsVsanFileVolumeServiceEnabled = true
+		defer func() { IsVsanFileVolumeServiceEnabled = origFVSEnabled }()
+
+		supervisorClient := testclient.NewClientset()
+		supervisorClient.PrependReactor("get", "persistentvolumeclaims",
+			func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, errors.NewInternalError(assert.AnError)
+			})
+
+		c := &controller{
+			supervisorClient:    supervisorClient,
 			supervisorNamespace: mockSupervisorNamespace,
 			cnsOperatorClient:   ctrlclientfake.NewClientBuilder().WithScheme(cnsOperatorScheme).Build(),
 		}


### PR DESCRIPTION
Fix ControllerUnpublishVolume misclassifying file volumes on guest cluster

ControllerUnpublishVolume determined file-vs-block by inspecting the Supervisor PVC's access modes, while ControllerPublishVolume determines it from the guest-side CSI request capability. When a block FCD is mistakenly statically provisioned as an RWX volume on the guest cluster (guest PVC is RWX, Supervisor PVC stays RWO), unpublish took the block path and never deleted the CnsFileAccessConfig CR created on publish. Resolve the file/block determination from the guest PVC instead, using the same PV-informer cache lookup already used by getTargetVACForVolume.

Testing Done: Done
Affected tests is passed now
https://gist.github.com/anuj087/b0161846168aa5c82551405bc9462d6b
PASSED: csi.tanzucluster.filevolume.RwoVolumeNotUsableAsRwxTest.test
        ReadWriteOnce Volume Not Usable As ReadWriteMany
vks precheck tests are passed :
https://gist.github.com/anuj087/1f4f070524ae830dec5a56723f27d26c#file-gistfile1-txt
