### PR TITLE
Add hostlocal capability

### DIFF
--- a/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1/infrastoragepolicyinfo_types.go
+++ b/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1/infrastoragepolicyinfo_types.go
@@ -26,8 +26,9 @@ import (
 //   - SupportsPersistentVolumeFilesystem: Volume Mode Filesystem is supported.
 //   - SupportsHighPerformanceLinkedClone: LinkedClone on vSAN ESA is supported.
 //   - SupportsLinkedClone: LinkedClone is supported.
+//   - SupportsHostLocal: the policy is a host-local storage policy.
 //
-// +kubebuilder:validation:Enum=SupportsPersistentVolumeBlock;SupportsPersistentVolumeFilesystem;SupportsHighPerformanceLinkedClone;SupportsLinkedClone
+// +kubebuilder:validation:Enum=SupportsPersistentVolumeBlock;SupportsPersistentVolumeFilesystem;SupportsHighPerformanceLinkedClone;SupportsLinkedClone;SupportsHostLocal
 type VolumeCapability string
 
 const (
@@ -40,6 +41,8 @@ const (
 	SupportsHighPerformanceLinkedClone VolumeCapability = "SupportsHighPerformanceLinkedClone"
 	// SupportsLinkedClone indicates that the policy supports linked clones with at least one ESXi 9.1+ host.
 	SupportsLinkedClone VolumeCapability = "SupportsLinkedClone"
+	// SupportsHostLocal indicates that the policy carries the host-local storage capability.
+	SupportsHostLocal VolumeCapability = "SupportsHostLocal"
 )
 
 // Topology describes topology accessibility for the storage policy within the cluster.

--- a/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1/storagepolicyinfo_types.go
+++ b/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1/storagepolicyinfo_types.go
@@ -26,8 +26,9 @@ import (
 //   - SupportsPersistentVolumeFilesystem: Volume Mode Filesystem is supported.
 //   - SupportsHighPerformanceLinkedClone: LinkedClone on vSAN ESA is supported.
 //   - SupportsLinkedClone: LinkedClone is supported.
+//   - SupportsHostLocal: the policy is a host-local storage policy.
 //
-// +kubebuilder:validation:Enum=SupportsPersistentVolumeBlock;SupportsPersistentVolumeFilesystem;SupportsHighPerformanceLinkedClone;SupportsLinkedClone
+// +kubebuilder:validation:Enum=SupportsPersistentVolumeBlock;SupportsPersistentVolumeFilesystem;SupportsHighPerformanceLinkedClone;SupportsLinkedClone;SupportsHostLocal
 type VolumeCapability string
 
 const (
@@ -40,6 +41,8 @@ const (
 	SupportsHighPerformanceLinkedClone VolumeCapability = "SupportsHighPerformanceLinkedClone"
 	// SupportsLinkedClone indicates that the policy supports linked clones with at least one ESXi 9.1+ host.
 	SupportsLinkedClone VolumeCapability = "SupportsLinkedClone"
+	// SupportsHostLocal indicates that the policy carries the host-local storage capability.
+	SupportsHostLocal VolumeCapability = "SupportsHostLocal"
 )
 
 // Topology describes topology accessibility for the storage policy within a namespace.

--- a/pkg/common/cns-lib/vsphere/pbm.go
+++ b/pkg/common/cns-lib/vsphere/pbm.go
@@ -211,22 +211,32 @@ func (vc *VirtualCenter) PbmCheckRequirementsForZoneTopology(ctx context.Context
 
 // PbmRetrieveContent fetches the policy content of all given policies from SPBM.
 func (vc *VirtualCenter) PbmRetrieveContent(ctx context.Context, policyIds []string) ([]SpbmPolicyContent, error) {
+	profiles, err := vc.PbmRetrieveContentRaw(ctx, policyIds)
+	return PbmSimplifyProfileContent(ctx, profiles), err
+}
 
+// PbmRetrieveContentRaw connects to PBM and fetches the raw SPBM profile content for the given
+// policy IDs, with no post-processing.
+func (vc *VirtualCenter) PbmRetrieveContentRaw(ctx context.Context,
+	policyIds []string) ([]pbmtypes.BasePbmProfile, error) {
 	log := logger.GetLogger(ctx)
-	err := vc.ConnectPbm(ctx)
-	if err != nil {
+	if err := vc.ConnectPbm(ctx); err != nil {
 		log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
 		return nil, err
 	}
-	pbmPolicyIds := make([]pbmtypes.PbmProfileId, 0)
+	pbmPolicyIds := make([]pbmtypes.PbmProfileId, 0, len(policyIds))
 	for _, policyID := range policyIds {
 		pbmPolicyIds = append(pbmPolicyIds, pbmtypes.PbmProfileId{
 			UniqueId: policyID,
 		})
 	}
-	profiles, err := vc.PbmClient.RetrieveContent(ctx, pbmPolicyIds)
+	return vc.PbmClient.RetrieveContent(ctx, pbmPolicyIds)
+}
 
-	return simplifyProfileStructs(ctx, profiles), err
+// PbmSimplifyProfileContent converts raw PBM profiles (e.g. from PbmRetrieveContentRaw) into
+// SpbmPolicyContent.
+func PbmSimplifyProfileContent(ctx context.Context, profiles []pbmtypes.BasePbmProfile) []SpbmPolicyContent {
+	return simplifyProfileStructs(ctx, profiles)
 }
 
 const (
@@ -264,15 +274,23 @@ func (vc *VirtualCenter) IsHostLocalStoragePolicy(ctx context.Context, policyID 
 	if policyID == "" {
 		return false, nil
 	}
-	if err := vc.ConnectPbm(ctx); err != nil {
-		log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
-		return false, err
-	}
-	profiles, err := vc.PbmClient.RetrieveContent(ctx, []pbmtypes.PbmProfileId{{UniqueId: policyID}})
+	profiles, err := vc.PbmRetrieveContentRaw(ctx, []string{policyID})
 	if err != nil {
 		log.Errorf("failed to retrieve SPBM profile for policy %q: %v", policyID, err)
 		return false, err
 	}
+	isHostLocal := ProfilesContainHostLocal(profiles)
+	if !isHostLocal {
+		log.Infof("storage policy %q does not carry the host-local storage capability", policyID)
+	}
+	return isHostLocal, nil
+}
+
+// ProfilesContainHostLocal reports whether any profile in a raw PbmRetrieveContentRaw result
+// carries the host-local storage capability. Callers that already hold raw profiles
+// can use this directly instead of issuing a second PBM RetrieveContent call
+// through IsHostLocalStoragePolicy.
+func ProfilesContainHostLocal(profiles []pbmtypes.BasePbmProfile) bool {
 	for _, baseProfile := range profiles {
 		profile, ok := baseProfile.(*pbmtypes.PbmCapabilityProfile)
 		if !ok {
@@ -283,11 +301,10 @@ func (vc *VirtualCenter) IsHostLocalStoragePolicy(ctx context.Context, policyID 
 			continue
 		}
 		if IsHostLocalStorageCapabilityPolicy(constraints) {
-			return true, nil
+			return true
 		}
 	}
-	log.Infof("storage policy %q does not carry the host-local storage capability", policyID)
-	return false, nil
+	return false
 }
 
 // QueryAllProfileDetails queries all profiles of a specific category from vCenter SPBM.

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -36,7 +36,6 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -180,7 +179,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 			Interface: k8sclient.CoreV1().Events(""),
 		},
 	)
-	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: apis.GroupName})
+	recorder := eventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: apis.GroupName})
 	return add(mgr, newReconciler(mgr, configInfo, topologyMgr, k8sclient, dynamicClient, recorder))
 }
 
@@ -572,7 +571,7 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 		return r.completeReconciliationWithSuccess(ctx, request.NamespacedName, timeout)
 	}
 
-	policyContent, err := vc.PbmRetrieveContent(ctx, []string{profile.ID})
+	rawProfiles, err := vc.PbmRetrieveContentRaw(ctx, []string{profile.ID})
 	if err != nil {
 		log.Errorf("Failed to retrieve policy content for profile %s: %v", profile.ID, err)
 		errorMsg := fmt.Sprintf("Failed to retrieve policy content: %v", err)
@@ -581,6 +580,8 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 		}
 		return r.completeReconciliationWithError(ctx, request.NamespacedName, timeout, err)
 	}
+	policyContent := cnsvsphere.PbmSimplifyProfileContent(ctx, rawProfiles)
+	isHostLocal := cnsvsphere.ProfilesContainHostLocal(rawProfiles)
 
 	// Sync storage policy attributes for ClusterSPI instance.
 	err = r.syncClusterSPIAttributes(ctx, instance, profile, vc, policyContent)
@@ -600,7 +601,7 @@ func (r *ReconcileClusterStoragePolicyInfo) Reconcile(ctx context.Context,
 	}
 
 	// Sync InfraSPI attributes for InfraSPI instance.
-	err = r.syncInfraSPIAttributes(ctx, instance, infraSPI, vc, profile, policyContent)
+	err = r.syncInfraSPIAttributes(ctx, instance, infraSPI, vc, profile, policyContent, isHostLocal)
 	if err != nil {
 		log.Errorf("Failed to sync InfraSPI attributes for %q: %v.", request.Name, err)
 		errorMsg := fmt.Sprintf("Failed to sync InfraSPI attributes: %v", err)
@@ -940,7 +941,7 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 	instance *clusterspiv1alpha1.ClusterStoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
 	vc *cnsvsphere.VirtualCenter, profile *cnsvsphere.ProfileDetail,
-	policyContent []cnsvsphere.SpbmPolicyContent) error {
+	policyContent []cnsvsphere.SpbmPolicyContent, isHostLocal bool) error {
 	log := logger.GetLogger(ctx)
 
 	log.Infof("Syncing InfraSPI attributes for %q (policy ID: %s, name: %s)",
@@ -949,7 +950,8 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 	var overallErr error
 
 	// Populate topology capabilities for InfraSPI.
-	zoneCompatibleDS, err := r.populateTopologyCapabilities(ctx, instance, infraSPI, profile.ID, vc, policyContent)
+	zoneCompatibleDS, err := r.populateTopologyCapabilities(ctx, instance, infraSPI, profile.ID, vc, policyContent,
+		isHostLocal)
 	if err != nil {
 		log.Errorf("Failed to populate topology capabilities for profile %s: %v", profile.ID, err)
 		overallErr = errors.Join(overallErr, err)
@@ -961,7 +963,8 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 	zoneClusters := r.topologyMgr.GetAZClustersMap(ctx)
 
 	// Populate volume capabilities.
-	if err := populateVolumeCapabilities(ctx, infraSPI, vc, profile.ID, zoneCompatibleDS, zoneClusters); err != nil {
+	if err := populateVolumeCapabilities(ctx, infraSPI, vc, profile.ID, zoneCompatibleDS, zoneClusters,
+		isHostLocal); err != nil {
 		log.Errorf("Failed to populate volume capabilities for profile %s: %v", profile.ID, err)
 		overallErr = errors.Join(overallErr, err)
 	}
@@ -970,13 +973,16 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 }
 
 // populateTopologyCapabilities populates topology information for the storage policy in InfraSPI,
-// and returns the zone->compatible-datastore map computed along the way (nil for marker
-// policies).
+// and returns the zone->compatible-datastore map computed along the way (nil for marker policies,
+// which derive zones from FVS instance namespaces rather than datastore/PBM compatibility; for
+// host-local policies, this map still gets populated by GetHostLocalAccessibleZones, so
+// LinkedClone/HighPerformanceLinkedClone are computed normally).
 func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx context.Context,
 	clusterSPI *clusterspiv1alpha1.ClusterStoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo, profileID string,
 	vc *cnsvsphere.VirtualCenter,
-	clusterSPIPolicyContent []cnsvsphere.SpbmPolicyContent) (map[string][]*cnsvsphere.DatastoreInfo, error) {
+	clusterSPIPolicyContent []cnsvsphere.SpbmPolicyContent, isHostLocal bool) (
+	map[string][]*cnsvsphere.DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
 
 	// Marker policies (e.g. vSAN File Service) derive their cluster-wide accessible zones from
@@ -1028,20 +1034,39 @@ func (r *ReconcileClusterStoragePolicyInfo) populateTopologyCapabilities(ctx con
 			profileID, topologyType)
 	}
 
-	// Initialize topology status with the topology type
+	// Initialize topology status with the topology type and empty accessibleZones.
 	infraSPI.Status.Topology = &infraspiv1alpha1.Topology{
-		TopologyType: topologyType,
+		TopologyType:    topologyType,
+		AccessibleZones: []string{},
 	}
 
 	log.Infof("Storage policy %s: populating accessible zones", profileID)
 
-	// GetZoneCompatibleDatastoresForPolicy makes SPBM CheckRequirements call, scoped to
-	// every cluster registered to a vSphere AvailabilityZone, to determine both the accessible
-	// zones and the compatible datastores within each zone.
-	accessibleZones, zoneCompatibleDS, dsIDs, err := cnsoperatorutil.GetZoneCompatibleDatastoresForPolicy(ctx,
-		r.topologyMgr, vc, profileID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get accessible zones: %w", err)
+	var accessibleZones, dsIDs []string
+	var zoneCompatibleDS map[string][]*cnsvsphere.DatastoreInfo
+	if isHostLocal {
+		// A host-local datastore is mounted on exactly one host, so it can never be
+		// attributed to a zone via PbmPlacementHubInfo.ZoneClusters (populated by PBM only when a
+		// datastore is mounted on every host in a cluster).
+		//
+		// Resolve accessible zones by walking each PBM-compatible datastore's mounting host
+		// directly instead. GetHostLocalAccessibleZones also returns a zoneCompatibleDS map (one
+		// entry per host-local datastore's zone) so LinkedClone/HighPerformanceLinkedClone are
+		// still computed for host-local policies via the same checkLinkedClone path below.
+		accessibleZones, zoneCompatibleDS, dsIDs, err = cnsoperatorutil.GetHostLocalAccessibleZones(ctx,
+			r.topologyMgr, vc, profileID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get accessible zones for host-local policy: %w", err)
+		}
+	} else {
+		// GetZoneCompatibleDatastoresForPolicy makes SPBM CheckRequirements call, scoped to
+		// every cluster registered to a vSphere AvailabilityZone, to determine both the accessible
+		// zones and the compatible datastores within each zone.
+		accessibleZones, zoneCompatibleDS, dsIDs, err = cnsoperatorutil.GetZoneCompatibleDatastoresForPolicy(ctx,
+			r.topologyMgr, vc, profileID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get accessible zones: %w", err)
+		}
 	}
 
 	// Record which datastores this policy is compatible with, so the shared

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -3906,7 +3906,7 @@ func TestPopulateVolumeCapabilities_MarkerPolicy(t *testing.T) {
 
 			// Call populateVolumeCapabilities with minimal required parameters
 			// We pass nil for vc, zoneCompatibleDS and zoneClusters since we only want to test the logic
-			err := populateVolumeCapabilities(ctx, infraSPI, nil, "test-profile-id", nil, nil)
+			err := populateVolumeCapabilities(ctx, infraSPI, nil, "test-profile-id", nil, nil, false)
 
 			// For marker policies, there should be no error since we skip the HPLC check
 			// For non-marker policies, there may be an error due to nil parameters, but capabilities should still be set
@@ -3940,6 +3940,46 @@ func TestPopulateVolumeCapabilities_MarkerPolicy(t *testing.T) {
 			assert.Equal(t, tt.expectedSupportsHPLinkedClone, actualHPLC,
 				"SupportsHighPerformanceLinkedClone should be %v for k8sCompliantName %s",
 				tt.expectedSupportsHPLinkedClone, tt.k8sCompliantName)
+		})
+	}
+}
+
+// TestPopulateVolumeCapabilities_HostLocal verifies that SupportsHostLocal is populated
+// from the isHostLocal argument for non-marker policies. isHostLocal is resolved once by the
+// caller (syncInfraSPIAttributes, via PbmRetrieveContentRaw + ProfilesContainHostLocal) and passed
+// straight through here — no PBM call is made inside populateVolumeCapabilities itself.
+func TestPopulateVolumeCapabilities_HostLocal(t *testing.T) {
+	ctx := context.Background()
+	stubVC := &cnsvsphere.VirtualCenter{Client: &govmomi.Client{}}
+
+	tests := []struct {
+		name             string
+		isHostLocal      bool
+		expectedSupports bool
+	}{
+		{
+			name:             "policy carries host-local capability",
+			isHostLocal:      true,
+			expectedSupports: true,
+		},
+		{
+			name:             "policy does not carry host-local capability",
+			isHostLocal:      false,
+			expectedSupports: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{}
+			infraSPI.Name = "some-regular-policy"
+
+			err := populateVolumeCapabilities(ctx, infraSPI, stubVC, "test-policy", nil, nil, tt.isHostLocal)
+			assert.NoError(t, err)
+
+			actual, exists := infraSPI.Status.VolumeCapabilities[infraspiv1alpha1.SupportsHostLocal]
+			assert.True(t, exists, "SupportsHostLocal should be set")
+			assert.Equal(t, tt.expectedSupports, actual)
 		})
 	}
 }

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
@@ -509,7 +509,8 @@ func findStoragePolicyProfile(ctx context.Context,
 //
 // SupportsVolumeModeBlock is always true except when the policy is a marker policy
 // (k8scompliantname is "vsan-file-service-policy").
-// For marker policies, SupportsHighPerformanceLinkedClone and SupportsLinkedClone are also false.
+// For marker policies, SupportsHighPerformanceLinkedClone, SupportsLinkedClone and
+// SupportsHostLocal are also false.
 //
 // SupportsLinkedClone is true only if every zone with compatible datastores has at least one
 // mounting host running ESXi 9.1 or above.
@@ -517,12 +518,16 @@ func findStoragePolicyProfile(ctx context.Context,
 // SupportsHighPerformanceLinkedClone is true only if SupportsLinkedClone is true AND every zone
 // has at least one ESXi 9.1+ host in a cluster with vSAN-ESA enabled.
 //
+// SupportsHostLocal is passed in by the caller (isHostLocal), already derived from the same raw
+// SPBM profile fetched for policyContent (via VirtualCenter.PbmRetrieveContentRaw and
+// ProfilesContainHostLocal), so no separate PBM call is made here to determine it.
+//
 // This function accepts an optional cache from topology calculation to avoid redundant vCenter calls.
 func populateVolumeCapabilities(ctx context.Context,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
 	vc *cnsvsphere.VirtualCenter, profileID string,
 	zoneCompatibleDS map[string][]*cnsvsphere.DatastoreInfo,
-	zoneClusters map[string][]string) error {
+	zoneClusters map[string][]string, isHostLocal bool) error {
 	log := logger.GetLogger(ctx)
 
 	caps := map[infraspiv1alpha1.VolumeCapability]bool{
@@ -539,12 +544,13 @@ func populateVolumeCapabilities(ctx context.Context,
 	log.Infof("Storage policy %s SupportsVolumeModeBlock=%v (isMarkerPolicy=%v)",
 		profileID, !isMarkerPolicy, isMarkerPolicy)
 
-	// For marker policies, linked clone capabilities are always false
+	// For marker policies, linked clone and host-local capabilities are always false.
 	if isMarkerPolicy {
 		caps[infraspiv1alpha1.SupportsHighPerformanceLinkedClone] = false
 		caps[infraspiv1alpha1.SupportsLinkedClone] = false
+		caps[infraspiv1alpha1.SupportsHostLocal] = false
 		log.Infof("Storage policy %s is a marker policy - SupportsHighPerformanceLinkedClone=false, "+
-			"SupportsLinkedClone=false", profileID)
+			"SupportsLinkedClone=false, SupportsHostLocal=false", profileID)
 
 		infraSPI.Status.VolumeCapabilities = caps
 		return nil
@@ -581,6 +587,9 @@ func populateVolumeCapabilities(ctx context.Context,
 	caps[infraspiv1alpha1.SupportsHighPerformanceLinkedClone] = hplc
 	log.Infof("Storage policy %s SupportsLinkedClone=%v, SupportsHighPerformanceLinkedClone=%v",
 		profileID, lc, hplc)
+
+	caps[infraspiv1alpha1.SupportsHostLocal] = isHostLocal
+	log.Infof("Storage policy %s SupportsHostLocal=%v", profileID, isHostLocal)
 
 	infraSPI.Status.VolumeCapabilities = caps
 	return nil

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/populate_topology_cache_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/populate_topology_cache_test.go
@@ -108,7 +108,7 @@ func TestPopulateTopologyCapabilities_PopulatesDsToPolicyCache(t *testing.T) {
 	// that reuse the same datastore IDs.
 	t.Cleanup(func() { vsphereinfra.GetCache().SetDatastoresForPolicy(clusterSPI.Name, nil) })
 
-	_, err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", fakeVCForTopologyTests(), nil)
+	_, err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", fakeVCForTopologyTests(), nil, false)
 	require.NoError(t, err)
 
 	// Only zone-a's cluster mounts the compatible datastore (ds-1).
@@ -151,13 +151,13 @@ func TestPopulateTopologyCapabilities_CacheEntryClearedWhenNoLongerCompatible(t 
 
 	// First reconcile: ds-1 is compatible, mounted on cluster-1.
 	withMockCompatibleDatastores(t, map[string][]string{"ds-1": {"cluster-1"}})
-	_, err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", vc, nil)
+	_, err := r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", vc, nil, false)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"test-policy-2"}, vsphereinfra.GetCache().PoliciesForDatastore("ds-1"))
 
 	// Second reconcile: PBM now reports no compatible datastores at all.
 	withMockCompatibleDatastores(t, map[string][]string{})
-	_, err = r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", vc, nil)
+	_, err = r.populateTopologyCapabilities(ctx, clusterSPI, infraSPI, "profile-1", vc, nil, false)
 	require.NoError(t, err)
 
 	assert.Empty(t, vsphereinfra.GetCache().PoliciesForDatastore("ds-1"),

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -35,7 +35,6 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -153,7 +152,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 			Interface: k8sclient.CoreV1().Events(""),
 		},
 	)
-	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: apis.GroupName})
+	recorder := eventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: apis.GroupName})
 
 	// Marker-policy topology support (the marker field index, the FVS-namespace
 	// watch, and the syncMarkerPolicyTopology branch) is a distinct feature gated
@@ -814,7 +813,8 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 // StoragePolicyInfo volume capabilities from the cluster-scoped
 // InfraStoragePolicyInfo, with no additional vCenter calls.
 // SupportsVolumeModeFilesystem is always true, independent of InfraSPI.
-// SupportsVolumeModeBlock is copied as-is from InfraSPI.
+// SupportsVolumeModeBlock and SupportsHostLocal are copied as-is from InfraSPI, since neither
+// varies by namespace.
 // SupportsLinkedClone and SupportsHighPerformanceLinkedClone are recomputed for just the zones accessible
 // to this namespace, except for the marker policy, which is file-only and forces
 // SupportsVolumeModeBlock, SupportsLinkedClone and SupportsHighPerformanceLinkedClone all false.
@@ -845,6 +845,7 @@ func (r *ReconcileStoragePolicyInfo) syncVolumeCapabilitiesFromInfraSPI(ctx cont
 		spiv1alpha1.SupportsVolumeModeBlock:            infraCaps[infraspiv1alpha1.SupportsVolumeModeBlock],
 		spiv1alpha1.SupportsLinkedClone:                lc,
 		spiv1alpha1.SupportsHighPerformanceLinkedClone: hplc,
+		spiv1alpha1.SupportsHostLocal:                  infraCaps[infraspiv1alpha1.SupportsHostLocal],
 	}
 	return nil
 }

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/volume_capabilities_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/volume_capabilities_test.go
@@ -339,6 +339,33 @@ func TestSyncVolumeCapabilitiesFromInfraSPI_CopiesBlockAndFilesystemCapabilities
 	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsVolumeModeBlock])
 	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsLinkedClone])
 	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsHighPerformanceLinkedClone])
+	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsHostLocal],
+		"SupportsHostLocal is copied as-is from InfraSPI, which did not set it here")
+}
+
+// TestSyncVolumeCapabilitiesFromInfraSPI_CopiesHostLocalCapability verifies that
+// SupportsHostLocal is copied directly from InfraSPI, with no per-namespace recomputation.
+func TestSyncVolumeCapabilitiesFromInfraSPI_CopiesHostLocalCapability(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-svcfi-hostlocal"},
+		Status: spiv1alpha1.StoragePolicyInfoStatus{
+			TopologyInfo: &spiv1alpha1.Topology{},
+		},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-svcfi-hostlocal"},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			VolumeCapabilities: map[infraspiv1alpha1.VolumeCapability]bool{
+				infraspiv1alpha1.SupportsHostLocal: true,
+			},
+		},
+	}
+
+	r := &ReconcileStoragePolicyInfo{zonesProvider: &mockZonesProvider{}}
+	err := r.syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI, nil)
+	require.NoError(t, err)
+	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsHostLocal])
 }
 
 // setupPolicyZoneWithHPLCHost primes the cache so LC/HPLC over zone-a would compute true.

--- a/pkg/syncer/cnsoperator/util/hostlocal_zones_test.go
+++ b/pkg/syncer/cnsoperator/util/hostlocal_zones_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
+	"github.com/vmware/govmomi/simulator"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+)
+
+// --- helpers for GetHostLocalAccessibleZones --------------------------------------------
+
+// setupHostLocalSim creates a VPX model with numClusters clusters, one host each, and one
+// datastore exclusively mounted by that cluster's single host — mirroring a host-local vSAN
+// datastore, which is by definition mounted on exactly one host. Returns, per cluster in order,
+// the cluster moref, its single host moref, and its exclusively-mounted datastore moref, plus the
+// model itself so tests can mutate simulator state directly (e.g. clearing a datastore's mounts,
+// or mounting an extra datastore on an existing host).
+func setupHostLocalSim(t *testing.T, numClusters int) (
+	ctx context.Context,
+	vc *cnsvsphere.VirtualCenter,
+	model *simulator.Model,
+	clusterRefs []vimtypes.ManagedObjectReference,
+	hostRefs []vimtypes.ManagedObjectReference,
+	dsRefs []vimtypes.ManagedObjectReference,
+	stop func(),
+) {
+	t.Helper()
+	ctx = context.Background()
+	model = simulator.VPX()
+	model.Datacenter = 1
+	model.Cluster = numClusters
+	model.ClusterHost = 1
+	model.Host = 0
+	model.Machine = 0
+	model.Datastore = numClusters
+	require.NoError(t, model.Create())
+	s := model.Service.NewServer()
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		s.Close()
+		model.Remove()
+		t.Fatalf("failed to create govmomi client: %v", err)
+	}
+	vc = &cnsvsphere.VirtualCenter{
+		Config:      &cnsvsphere.VirtualCenterConfig{Host: "127.0.0.1"},
+		Client:      c,
+		ClientMutex: &sync.Mutex{},
+	}
+	stop = func() { s.Close(); model.Remove() }
+
+	clusters := model.Map().All("ClusterComputeResource")
+	require.Len(t, clusters, numClusters)
+	dsObjs := model.Map().All("Datastore")
+	require.Len(t, dsObjs, numClusters)
+
+	clusterRefs = make([]vimtypes.ManagedObjectReference, numClusters)
+	hostRefs = make([]vimtypes.ManagedObjectReference, numClusters)
+	dsRefs = make([]vimtypes.ManagedObjectReference, numClusters)
+	for i, cl := range clusters {
+		clusterRef := cl.Reference()
+		clusterRefs[i] = clusterRef
+
+		clusterObj := model.Map().Get(clusterRef).(*simulator.ClusterComputeResource)
+		require.Len(t, clusterObj.Host, 1, "setupHostLocalSim expects exactly one host per cluster")
+		hostRefs[i] = clusterObj.Host[0]
+
+		// Restrict this datastore's mount list to only this cluster's single host; by default
+		// vcsim mounts every datastore on every host in the datacenter.
+		dsObj := dsObjs[i].(*simulator.Datastore)
+		dsObj.Host = []vimtypes.DatastoreHostMount{{Key: hostRefs[i]}}
+		dsRefs[i] = dsObj.Reference()
+	}
+	return
+}
+
+// hubFor builds a PbmPlacementHub for a datastore moref, as PbmQueryMatchingHub would return.
+func hubFor(dsRef vimtypes.ManagedObjectReference) pbmtypes.PbmPlacementHub {
+	return pbmtypes.PbmPlacementHub{HubType: "Datastore", HubId: dsRef.Value}
+}
+
+// withFakeMatchingHubs replaces PbmQueryMatchingHubFn for the duration of fn, returning
+// hubs/err without a real PBM connection. If called is non-nil, it's set to true iff the fake
+// was actually invoked.
+func withFakeMatchingHubs(hubs []pbmtypes.PbmPlacementHub, err error, called *bool, fn func()) {
+	orig := PbmQueryMatchingHubFn
+	PbmQueryMatchingHubFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ string) ([]pbmtypes.PbmPlacementHub, error) {
+		if called != nil {
+			*called = true
+		}
+		return hubs, err
+	}
+	defer func() { PbmQueryMatchingHubFn = orig }()
+	fn()
+}
+
+// --- GetHostLocalAccessibleZones tests ---------------------------------------------------
+
+// TestGetHostLocalAccessibleZones_NilTopologyManager verifies that a nil topology manager
+// returns an error immediately, without ever calling PBM.
+func TestGetHostLocalAccessibleZones_NilTopologyManager(t *testing.T) {
+	ctx := context.Background()
+	var called bool
+	withFakeMatchingHubs(nil, nil, &called, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, nil, nil, "policy-1")
+		assert.Error(t, err)
+		assert.Nil(t, zones)
+		assert.Nil(t, zoneCompatibleDS)
+		assert.Nil(t, dsIDs)
+	})
+	assert.False(t, called, "PBM should not be queried when the topology manager is nil")
+}
+
+// TestGetHostLocalAccessibleZones_NilVirtualCenter verifies that a nil (or not-yet-connected)
+// vCenter returns an error instead of panicking.
+func TestGetHostLocalAccessibleZones_NilVirtualCenter(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {"cluster-1"}}}
+
+	zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, topo, nil, "policy-1")
+	assert.Error(t, err)
+	assert.Nil(t, zones)
+	assert.Nil(t, zoneCompatibleDS)
+	assert.Nil(t, dsIDs)
+
+	zones, zoneCompatibleDS, dsIDs, err = GetHostLocalAccessibleZones(ctx, topo, &cnsvsphere.VirtualCenter{}, "policy-1")
+	assert.Error(t, err)
+	assert.Nil(t, zones)
+	assert.Nil(t, zoneCompatibleDS)
+	assert.Nil(t, dsIDs)
+}
+
+// TestGetHostLocalAccessibleZones_PbmError verifies that a PBM error is propagated.
+func TestGetHostLocalAccessibleZones_PbmError(t *testing.T) {
+	ctx := context.Background()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {"cluster-1"}}}
+
+	withFakeMatchingHubs(nil, errors.New("pbm unavailable"), nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, topo, fakeVC(), "policy-1")
+		assert.Error(t, err)
+		assert.Nil(t, zones)
+		assert.Nil(t, zoneCompatibleDS)
+		assert.Nil(t, dsIDs)
+	})
+}
+
+// TestGetHostLocalAccessibleZones_NoHubs verifies that no compatible datastores yields an empty,
+// non-nil result without error.
+func TestGetHostLocalAccessibleZones_NoHubs(t *testing.T) {
+	_, vc, _, _, _, _, stop := setupHostLocalSim(t, 1)
+	defer stop()
+	ctx := context.Background()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {"cluster-1"}}}
+
+	withFakeMatchingHubs(nil, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, topo, vc, "policy-1")
+		require.NoError(t, err)
+		assert.NotNil(t, zones, "zones must be a non-nil empty slice, not nil: it's assigned straight into "+
+			"InfraStoragePolicyInfo.Status.Topology.AccessibleZones, which the CRD requires to be present")
+		assert.Empty(t, zones)
+		assert.Empty(t, zoneCompatibleDS)
+		assert.Empty(t, dsIDs)
+	})
+}
+
+// TestGetHostLocalAccessibleZones_SingleZoneSingleHost verifies the basic success path: one
+// host-local datastore, mounted on one host, whose cluster is part of one zone.
+func TestGetHostLocalAccessibleZones_SingleZoneSingleHost(t *testing.T) {
+	ctx, vc, _, clusterRefs, _, dsRefs, stop := setupHostLocalSim(t, 1)
+	defer stop()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {clusterRefs[0].Value}}}
+
+	withFakeMatchingHubs([]pbmtypes.PbmPlacementHub{hubFor(dsRefs[0])}, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, topo, vc, "policy-1")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"zone-a"}, zones)
+		require.Contains(t, zoneCompatibleDS, "zone-a")
+		require.Len(t, zoneCompatibleDS["zone-a"], 1)
+		assert.Equal(t, dsRefs[0].Value, zoneCompatibleDS["zone-a"][0].Reference().Value)
+		assert.Equal(t, []string{dsRefs[0].Value}, dsIDs)
+	})
+}
+
+// TestGetHostLocalAccessibleZones_MultipleZonesUnioned verifies that host-local datastores in
+// different zones are all attributed and unioned into the result.
+func TestGetHostLocalAccessibleZones_MultipleZonesUnioned(t *testing.T) {
+	ctx, vc, _, clusterRefs, _, dsRefs, stop := setupHostLocalSim(t, 2)
+	defer stop()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{
+		"zone-a": {clusterRefs[0].Value},
+		"zone-b": {clusterRefs[1].Value},
+	}}
+
+	withFakeMatchingHubs([]pbmtypes.PbmPlacementHub{hubFor(dsRefs[0]), hubFor(dsRefs[1])}, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, topo, vc, "policy-1")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"zone-a", "zone-b"}, zones)
+		require.Len(t, zoneCompatibleDS["zone-a"], 1)
+		require.Len(t, zoneCompatibleDS["zone-b"], 1)
+		assert.Equal(t, dsRefs[0].Value, zoneCompatibleDS["zone-a"][0].Reference().Value)
+		assert.Equal(t, dsRefs[1].Value, zoneCompatibleDS["zone-b"][0].Reference().Value)
+		assert.ElementsMatch(t, []string{dsRefs[0].Value, dsRefs[1].Value}, dsIDs)
+	})
+}
+
+// TestGetHostLocalAccessibleZones_InaccessibleDatastore_SkippedNotFatal verifies that a
+// PBM-compatible datastore the property collector can't read (e.g. NoPermission, or here a
+// moref vCenter doesn't recognize) is skipped rather than failing the whole policy's zone
+// computation — other, readable datastores are still processed normally. Regression test for a
+// live failure where PbmQueryMatchingHub returned a datastore outside the service account's
+// permitted inventory subtree and aborted accessible-zone computation for the entire policy.
+func TestGetHostLocalAccessibleZones_InaccessibleDatastore_SkippedNotFatal(t *testing.T) {
+	ctx, vc, _, clusterRefs, _, dsRefs, stop := setupHostLocalSim(t, 1)
+	defer stop()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {clusterRefs[0].Value}}}
+
+	unreadableDS := vimtypes.ManagedObjectReference{Type: "Datastore", Value: "datastore-does-not-exist"}
+	withFakeMatchingHubs([]pbmtypes.PbmPlacementHub{hubFor(unreadableDS), hubFor(dsRefs[0])}, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, topo, vc, "policy-1")
+		require.NoError(t, err, "an unreadable datastore must be skipped, not surfaced as an error")
+		assert.Equal(t, []string{"zone-a"}, zones)
+		require.Len(t, zoneCompatibleDS["zone-a"], 1)
+		assert.Equal(t, dsRefs[0].Value, zoneCompatibleDS["zone-a"][0].Reference().Value)
+		assert.ElementsMatch(t, []string{unreadableDS.Value, dsRefs[0].Value}, dsIDs,
+			"dsIDs still records the unreadable datastore as policy-compatible")
+	})
+}
+
+// TestGetHostLocalAccessibleZones_ClusterNotInAnyZone_Skipped verifies that a host-local
+// datastore whose host's cluster isn't part of any zone is skipped: it's still recorded in
+// dsIDs (it's still policy-compatible) but contributes no zone.
+func TestGetHostLocalAccessibleZones_ClusterNotInAnyZone_Skipped(t *testing.T) {
+	ctx, vc, _, _, _, dsRefs, stop := setupHostLocalSim(t, 1)
+	defer stop()
+	// No zone maps to this cluster at all.
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {"some-other-cluster"}}}
+
+	withFakeMatchingHubs([]pbmtypes.PbmPlacementHub{hubFor(dsRefs[0])}, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, topo, vc, "policy-1")
+		require.NoError(t, err)
+		assert.Empty(t, zones)
+		assert.Empty(t, zoneCompatibleDS)
+		assert.Equal(t, []string{dsRefs[0].Value}, dsIDs)
+	})
+}
+
+// TestGetHostLocalAccessibleZones_NoHostMounts_Skipped verifies that a compatible datastore with
+// no host mounts (e.g. detached) is skipped for zone purposes but still recorded in dsIDs.
+func TestGetHostLocalAccessibleZones_NoHostMounts_Skipped(t *testing.T) {
+	ctx, vc, model, clusterRefs, _, dsRefs, stop := setupHostLocalSim(t, 1)
+	defer stop()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {clusterRefs[0].Value}}}
+
+	// Clear the datastore's host mounts entirely.
+	dsObj := model.Map().Get(dsRefs[0]).(*simulator.Datastore)
+	dsObj.Host = nil
+
+	withFakeMatchingHubs([]pbmtypes.PbmPlacementHub{hubFor(dsRefs[0])}, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, topo, vc, "policy-1")
+		require.NoError(t, err)
+		assert.Empty(t, zones)
+		assert.Empty(t, zoneCompatibleDS)
+		assert.Equal(t, []string{dsRefs[0].Value}, dsIDs, "an unmounted datastore is still policy-compatible")
+	})
+}
+
+// TestGetHostLocalAccessibleZones_SameHostMultipleDatastores verifies that two host-local
+// datastores mounted on the same host are both attributed to that host's zone — deduped once in
+// zones, but each recorded separately in zoneCompatibleDS and dsIDs — exercising the
+// hostClusterCache reuse path (the host's parent cluster is only looked up once).
+func TestGetHostLocalAccessibleZones_SameHostMultipleDatastores(t *testing.T) {
+	// setupHostLocalSim(t, 2) gives two independent clusters/hosts/datastores; remount the second
+	// cluster's datastore onto the first cluster's host so both datastores end up mounted on the
+	// same single host, as if that host had two local disk groups.
+	ctx, vc, model, clusterRefs, hostRefs, dsRefs, stop := setupHostLocalSim(t, 2)
+	defer stop()
+	topo := &mockTopologyService{azClustersMap: map[string][]string{"zone-a": {clusterRefs[0].Value}}}
+
+	secondDSObj := model.Map().Get(dsRefs[1]).(*simulator.Datastore)
+	secondDSObj.Host = []vimtypes.DatastoreHostMount{{Key: hostRefs[0]}}
+
+	withFakeMatchingHubs([]pbmtypes.PbmPlacementHub{hubFor(dsRefs[0]), hubFor(dsRefs[1])}, nil, nil, func() {
+		zones, zoneCompatibleDS, dsIDs, err := GetHostLocalAccessibleZones(ctx, topo, vc, "policy-1")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"zone-a"}, zones, "the zone must appear once even though two hubs map to it")
+		require.Len(t, zoneCompatibleDS["zone-a"], 2, "both hub entries should still be recorded")
+		assert.ElementsMatch(t, []string{dsRefs[0].Value, dsRefs[1].Value}, dsIDs)
+	})
+}

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -27,6 +27,9 @@ import (
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/pbm"
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -648,5 +651,131 @@ func GetZoneCompatibleDatastoresForPolicy(ctx context.Context, topologyMgr commo
 		log.Infof("Storage policy %s is accessible from zones: %v", profileID, zones)
 	}
 
+	return zones, zoneCompatibleDS, dsIDs, nil
+}
+
+// PbmQueryMatchingHubFn is the implementation used by GetHostLocalAccessibleZones; tests may
+// replace it to inject a fake result without a real PBM connection.
+var PbmQueryMatchingHubFn = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+	profileID string) ([]pbmtypes.PbmPlacementHub, error) {
+	return vc.PbmQueryMatchingHub(ctx, profileID)
+}
+
+// GetHostLocalAccessibleZones determines which zones have at least one host whose local
+// datastore is compatible with the given host-local storage policy, and which datastores are
+// compatible within each such zone.
+//
+// It walks every datastore PBM reports as compatible with the policy and, for each, resolves the
+// single host mounting it and that host's parent cluster, then maps the cluster to its zone(s) via
+// topologyMgr.GetAZClustersMap(). A host whose cluster isn't part of any zone is skipped.
+//
+// Unlike GetZoneCompatibleDatastoresForPolicy's zoneCompatibleDS — where each entry is a shared
+// datastore genuinely mounted across a zone's cluster — the entries returned here are
+// single-host-local datastores merely attributed to the zone their one mounting host happens to
+// belong to; they are not "zonal" in that sense. The map is still built and returned in this shape
+// solely so checkLinkedClone (called next, via populateVolumeCapabilities) can compute
+// SupportsLinkedClone/SupportsHighPerformanceLinkedClone for host-local policies through the same
+// code path used for regular policies, without having to special-case host-local there too.
+func GetHostLocalAccessibleZones(ctx context.Context, topologyMgr commoncotypes.ControllerTopologyService,
+	vc *cnsvsphere.VirtualCenter, profileID string) (
+	zones []string, zoneCompatibleDS map[string][]*cnsvsphere.DatastoreInfo, dsIDs []string, err error) {
+	log := logger.GetLogger(ctx)
+
+	if topologyMgr == nil {
+		return nil, nil, nil, fmt.Errorf("topology manager is not available")
+	}
+	if vc == nil || vc.Client == nil {
+		return nil, nil, nil, fmt.Errorf("vCenter is not available")
+	}
+
+	azClustersMap := topologyMgr.GetAZClustersMap(ctx)
+	clusterToZones := make(map[string][]string)
+	for zone, clusters := range azClustersMap {
+		for _, clusterMoref := range clusters {
+			clusterToZones[clusterMoref] = append(clusterToZones[clusterMoref], zone)
+		}
+	}
+
+	hubs, err := PbmQueryMatchingHubFn(ctx, vc, profileID)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to query matching hubs for policy %s: %w", profileID, err)
+	}
+
+	// zones/zoneCompatibleDS must never be nil on a successful (err == nil) return: zones is
+	// assigned straight into InfraStoragePolicyInfo.Status.Topology.AccessibleZones, which the CRD
+	// schema requires to be present — a nil slice serializes to JSON null and the status update is
+	// rejected.
+	zones = make([]string, 0)
+	zoneCompatibleDS = make(map[string][]*cnsvsphere.DatastoreInfo)
+	dsIDs = make([]string, 0, len(hubs))
+	pc := property.DefaultCollector(vc.Client.Client)
+	// hostClusterCache maps host MoID -> parent cluster MoID ("" if the host has none), avoiding
+	// repeat vCenter calls for a host mounting multiple policy-compatible datastores.
+	hostClusterCache := make(map[string]string)
+
+	for _, hub := range hubs {
+		dsIDs = append(dsIDs, hub.HubId)
+
+		dsRef := vimtypes.ManagedObjectReference{Type: "Datastore", Value: hub.HubId}
+		var dsMo mo.Datastore
+		if err := pc.RetrieveOne(ctx, dsRef, []string{"host"}, &dsMo); err != nil {
+			// PbmQueryMatchingHub is unscoped by cluster/inventory ACLs, so it can legitimately
+			// return a datastore the vCenter service account can't read via the property
+			// collector (e.g. NoPermission on a datastore outside this Supervisor's permitted
+			// inventory subtree). Skip it rather than failing the whole policy's zone computation.
+			log.Warnf("Failed to retrieve host mounts for datastore %s (policy %s); skipping: %v",
+				hub.HubId, profileID, err)
+			continue
+		}
+		if len(dsMo.Host) == 0 {
+			log.Debugf("Datastore %s (policy %s) has no host mounts; skipping", hub.HubId, profileID)
+			continue
+		}
+		// A host-local datastore is mounted on exactly one host; take the first mount.
+		hostRef := dsMo.Host[0].Key
+
+		clusterValue, cached := hostClusterCache[hostRef.Value]
+		if !cached {
+			var hostMo mo.HostSystem
+			if err := pc.RetrieveOne(ctx, hostRef, []string{"parent"}, &hostMo); err != nil {
+				log.Warnf("Failed to retrieve parent cluster for host %s (datastore %s, policy %s); skipping: %v",
+					hostRef.Value, hub.HubId, profileID, err)
+				continue
+			}
+			if hostMo.Parent != nil {
+				clusterValue = hostMo.Parent.Value
+			}
+			hostClusterCache[hostRef.Value] = clusterValue
+		}
+		if clusterValue == "" {
+			log.Debugf("Host %s (datastore %s) has no parent cluster; skipping", hostRef.Value, hub.HubId)
+			continue
+		}
+
+		zonesForCluster, ok := clusterToZones[clusterValue]
+		if !ok {
+			log.Debugf("Cluster %s (host %s, datastore %s) is not part of any zone; skipping",
+				clusterValue, hostRef.Value, hub.HubId)
+			continue
+		}
+
+		dsInfo := &cnsvsphere.DatastoreInfo{
+			Datastore: &cnsvsphere.Datastore{
+				Datastore: object.NewDatastore(vc.Client.Client, dsRef),
+			},
+		}
+		for _, zone := range zonesForCluster {
+			if _, exists := zoneCompatibleDS[zone]; !exists {
+				zones = append(zones, zone)
+			}
+			zoneCompatibleDS[zone] = append(zoneCompatibleDS[zone], dsInfo)
+		}
+	}
+
+	if len(zones) == 0 {
+		log.Warnf("No accessible zones found for host-local storage policy %s", profileID)
+	} else {
+		log.Infof("Host-local storage policy %s is accessible from zones: %v", profileID, zones)
+	}
 	return zones, zoneCompatibleDS, dsIDs, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add Supportshostlocal volume capability to Infra SPI CR as well as namespace scoped SPI CR.
Also implemented a function to fetch accessible zones for hostlocal policies by checking each compatible datastore and its associated hosts.

**Testing done**:

Hostlocal infraSPI:

```
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
metadata:
  creationTimestamp: "2026-07-31T08:55:29Z"
  generation: 1
  name: hostlocal
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: hostlocal
    uid: e0c0be33-4d4c-48a3-be3f-3590f4be0377
  resourceVersion: "2720385"
  uid: a785072b-af64-4670-847b-3eb4b8bbda9b
spec:
  clusterStoragePolicyInfoRef:
    apiGroup: cns.vmware.com/v1alpha1
    kind: ClusterStoragePolicyInfo
    name: hostlocal
status:
  topology:
    accessibleZones:
    - az1
    topologyType: ""
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsHostLocal: true
    SupportsLinkedClone: true
    SupportsPersistentVolumeBlock: true
    SupportsPersistentVolumeFilesystem: true
```

Namespace scoped SPI:

```
k get spi -n test -oyaml hostlocal
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyInfo
metadata:
  creationTimestamp: "2026-07-31T09:00:25Z"
  generation: 1
  name: hostlocal
  namespace: test
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha2
    blockOwnerDeletion: false
    controller: false
    kind: StoragePolicyQuota
    name: hostlocal-storagepolicyquota
    uid: c22a1a6b-e266-4edd-ad21-506c59e660df
  resourceVersion: "2723457"
  uid: b81b934b-e534-48d5-8e95-3c230313adf5
spec:
  clusterStoragePolicyInfoRef:
    apiGroup: cns.vmware.com/v1alpha1
    kind: ClusterStoragePolicyInfo
    name: hostlocal
status:
  topologyInfo:
    accessibleZones:
    - az1
    topologyType: ""
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsHostLocal: true
    SupportsLinkedClone: true
    SupportsPersistentVolumeBlock: true
    SupportsPersistentVolumeFilesystem: true
```

Non host local policies:

```
k get spi -n test -oyaml vsan-default-storage-policy
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyInfo
metadata:
  creationTimestamp: "2026-07-23T08:25:06Z"
  generation: 3
  name: vsan-default-storage-policy
  namespace: test
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: InfraStoragePolicyInfo
    name: vsan-default-storage-policy
    uid: ae22899e-eb99-4857-b8d4-925e3da08e4e
  resourceVersion: "576824"
  uid: 42f16538-5a39-4522-b48a-9e22bbc9cc93
spec:
  clusterStoragePolicyInfoRef:
    apiGroup: cns.vmware.com/v1alpha1
    kind: ClusterStoragePolicyInfo
    name: vsan-default-storage-policy
status:
  topologyInfo:
    accessibleZones:
    - az1
    topologyType: ""
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsHostLocal: false
    SupportsLinkedClone: true
    SupportsPersistentVolumeBlock: true
    SupportsPersistentVolumeFilesystem: true
```

Namespace scoped hostlocal:

```
k get infraspi -oyaml vsan-default-storage-policy
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
metadata:
  creationTimestamp: "2026-07-23T08:07:45Z"
  generation: 3
  name: vsan-default-storage-policy
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: vsan-default-storage-policy
    uid: 333235a6-5e63-4bae-ab90-aff24a357f4e
  resourceVersion: "576818"
  uid: ae22899e-eb99-4857-b8d4-925e3da08e4e
spec:
  clusterStoragePolicyInfoRef:
    apiGroup: cns.vmware.com/v1alpha1
    kind: ClusterStoragePolicyInfo
    name: vsan-default-storage-policy
status:
  topology:
    accessibleZones:
    - az1
    topologyType: ""
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsHostLocal: false
    SupportsLinkedClone: true
    SupportsPersistentVolumeBlock: true
    SupportsPersistentVolumeFilesystem: true
```

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1835/
VKS precheckin (pssed): https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1395/