### PR TITLE
Fix no-op merge patch when adding/removing CNS PVC finalizer

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -817,10 +817,14 @@ func removeFinalizerFromCRDInstance(ctx context.Context,
 func addFinalizerToPVC(ctx context.Context, client client.Client,
 	pvc *v1.PersistentVolumeClaim) (string, error) {
 	log := logger.GetLogger(ctx)
+	// original must be captured before mutating pvc.Finalizers below, otherwise
+	// the merge patch computed in updateSVPVC would diff two identical objects
+	// and produce a no-op patch, silently failing to persist the finalizer.
+	original := pvc.DeepCopy()
 	pvc.Finalizers = append(pvc.Finalizers, cnsoptypes.CNSPvcFinalizer)
 	log.Infof("Adding %q finalizer on PersistentVolumeClaim: %q on namespace: %q",
 		cnsoptypes.CNSPvcFinalizer, pvc.Name, pvc.Namespace)
-	faulttype, err := updateSVPVC(ctx, client, pvc, false)
+	faulttype, err := updateSVPVC(ctx, client, original, pvc, false)
 	if err != nil {
 		log.Errorf("failed to update PersistentVolumeClaim: %q on namespace: %q. Error: %+v",
 			pvc.Name, pvc.Namespace, err)
@@ -861,6 +865,10 @@ func removeFinalizerFromPVC(ctx context.Context, client client.Client,
 	}
 
 	finalizerFound := false
+	// original must be captured before mutating pvc.Finalizers below, otherwise
+	// the merge patch computed in updateSVPVC would diff two identical objects
+	// and produce a no-op patch, silently failing to remove the finalizer.
+	original := pvc.DeepCopy()
 	for i, finalizer := range pvc.Finalizers {
 		if finalizer == cnsoptypes.CNSPvcFinalizer {
 			log.Infof("Removing %q finalizer from PersistentVolumeClaim: %q on namespace: %q",
@@ -875,7 +883,7 @@ func removeFinalizerFromPVC(ctx context.Context, client client.Client,
 			cnsoptypes.CNSPvcFinalizer, pvc.Name, pvc.Namespace)
 		return "", nil
 	}
-	faulttype, err := updateSVPVC(ctx, client, pvc, true)
+	faulttype, err := updateSVPVC(ctx, client, original, pvc, true)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Infof("PersistentVolumeClaim: %q on namespace: %q not found. Returning nil", pvc.Name, pvc.Namespace)
@@ -888,10 +896,13 @@ func removeFinalizerFromPVC(ctx context.Context, client client.Client,
 
 }
 
+// updateSVPVC patches the finalizer change made to pvc onto the API server.
+// original must be a copy of pvc taken before the caller mutated its
+// Finalizers, so that the merge patch computed against pvc actually reflects
+// the finalizer add/remove.
 func updateSVPVC(ctx context.Context, client client.Client,
-	pvc *v1.PersistentVolumeClaim, removeCnsPvcFinalizer bool) (string, error) {
+	original, pvc *v1.PersistentVolumeClaim, removeCnsPvcFinalizer bool) (string, error) {
 	log := logger.GetLogger(ctx)
-	original := pvc.DeepCopy()
 	err := k8s.PatchObject(ctx, client, original, pvc)
 	if err != nil {
 		if apierrors.IsConflict(err) {
@@ -909,6 +920,10 @@ func updateSVPVC(ctx context.Context, client client.Client,
 
 			// The callers of updateSVPVC are only updating the instance finalizers
 			// Hence we add/remove the finalizers on the latest PVC object from API server.
+			// originalLatest is captured before mutating latestPVCObject.Finalizers
+			// below, otherwise the merge patch would diff two identical objects and
+			// produce a no-op patch, silently failing to persist the finalizer change.
+			originalLatest := latestPVCObject.DeepCopy()
 			if removeCnsPvcFinalizer {
 				for i, finalizer := range latestPVCObject.Finalizers {
 					if finalizer == cnsoptypes.CNSPvcFinalizer {
@@ -921,7 +936,6 @@ func updateSVPVC(ctx context.Context, client client.Client,
 			} else {
 				latestPVCObject.Finalizers = append(latestPVCObject.Finalizers, cnsoptypes.CNSPvcFinalizer)
 			}
-			originalLatest := latestPVCObject.DeepCopy()
 			err := k8s.PatchObject(ctx, client, originalLatest, latestPVCObject)
 			if err != nil {
 				if apierrors.IsConflict(err) {

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
@@ -956,11 +956,92 @@ func TestRemoveFinalizerFromPVCWithUsedByAnnotations(t *testing.T) {
 				assert.Contains(t, updatedPVC.Finalizers, cnsoptypes.CNSPvcFinalizer,
 					"Expected finalizer to be preserved when used-by annotations are present")
 			} else {
-				// For cases where finalizer should be removed, log the attempt
-				t.Logf("Finalizer removal attempted for PVC without used-by annotations")
+				// The finalizer must actually be persisted as removed on the object
+				// fetched fresh from the API server, not just on the in-memory pvc
+				// pointer passed into removeFinalizerFromPVC.
+				assert.NotContains(t, updatedPVC.Finalizers, cnsoptypes.CNSPvcFinalizer,
+					"Expected finalizer to be removed from the persisted PVC")
 			}
 		})
 	}
+}
+
+// TestRemoveFinalizerFromPVCPersistsToAPIServer is a regression test for a bug
+// where updateSVPVC took its DeepCopy of the "original" object after the
+// caller had already mutated pvc.Finalizers in place. Since both the
+// "original" and "modified" objects were then identical, CreateMergePatch
+// produced an empty ({}) patch, which the fake (and real) API server applies
+// as a silent no-op: err is nil, but the finalizer is never actually removed
+// from the stored object. This test fetches a fresh copy of the PVC from the
+// client after the call to catch exactly that failure mode.
+func TestRemoveFinalizerFromPVCPersistsToAPIServer(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	err := v1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc-remove-persist",
+			Namespace: "test-ns",
+			Finalizers: []string{
+				cnsoptypes.CNSPvcFinalizer,
+				"other-finalizer",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc).
+		Build()
+
+	faultType, err := removeFinalizerFromPVC(ctx, fakeClient, pvc)
+	require.NoError(t, err)
+	assert.Empty(t, faultType)
+
+	// Fetch a fresh object from the API server; do not rely on the mutated
+	// in-memory pvc pointer, which would mask a no-op patch.
+	persisted := &v1.PersistentVolumeClaim{}
+	err = fakeClient.Get(ctx, client.ObjectKey{Name: pvc.Name, Namespace: pvc.Namespace}, persisted)
+	require.NoError(t, err)
+	assert.NotContains(t, persisted.Finalizers, cnsoptypes.CNSPvcFinalizer,
+		"finalizer must be removed on the API server, not just on the in-memory object")
+	assert.Contains(t, persisted.Finalizers, "other-finalizer")
+}
+
+// TestAddFinalizerToPVCPersistsToAPIServer is the add-path counterpart of
+// TestRemoveFinalizerFromPVCPersistsToAPIServer: it guards against the same
+// no-op merge patch bug when addFinalizerToPVC adds the CNS finalizer.
+func TestAddFinalizerToPVCPersistsToAPIServer(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	err := v1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-pvc-add-persist",
+			Namespace:  "test-ns",
+			Finalizers: []string{"other-finalizer"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc).
+		Build()
+
+	faultType, err := addFinalizerToPVC(ctx, fakeClient, pvc)
+	require.NoError(t, err)
+	assert.Empty(t, faultType)
+
+	persisted := &v1.PersistentVolumeClaim{}
+	err = fakeClient.Get(ctx, client.ObjectKey{Name: pvc.Name, Namespace: pvc.Namespace}, persisted)
+	require.NoError(t, err)
+	assert.Contains(t, persisted.Finalizers, cnsoptypes.CNSPvcFinalizer,
+		"finalizer must be added on the API server, not just on the in-memory object")
+	assert.Contains(t, persisted.Finalizers, "other-finalizer")
 }
 
 // TestPvcHasUsedByAnnotaion tests the helper function that checks for used-by annotations.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We were switching PVC finalizer updates from Update calls to Patch calls (merge patches). The problem: the code computed the patch by comparing an "original" copy of the PVC against the "modified" one — but the original copy was taken after the finalizer had already been added or removed in memory. So the two copies looked identical, the computed patch was empty, and an empty patch is a no-op as far as the API server is concerned.

The result: the PATCH call returns success, no error anywhere, but the finalizer never actually changes on the real object. Depending on which path this hit, that means either a PVC delete could hang forever waiting on a finalizer that was supposedly removed, or the protection finalizer never gets attached to the PVC in the first place.

Fixed by moving the "take a copy before mutating" step to happen at the right time, in both the add-finalizer and remove-finalizer code paths, plus a similar spot that only runs during a retry after a conflict.


**Testing done**:
<br> PR 4175<br>
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix no-op merge patch when adding/removing CNS PVC finalizer
```
