### PR TITLE
Operator wiring in init.go

### DIFF
--- a/pkg/syncer/cnsoperator/controller/add_vksregistervolume.go
+++ b/pkg/syncer/cnsoperator/controller/add_vksregistervolume.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/vksregistervolume"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, vksregistervolume.Add)
+}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -398,6 +398,19 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 				return err
 			}
 		}
+
+		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.VKSRegisterVolume) {
+			// Create VKSRegisterVolume CRD in the guest cluster.
+			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx,
+				cnsoperatorconfig.EmbedVKSRegisterVolumeCRFile,
+				cnsoperatorconfig.EmbedVKSRegisterVolumeCRFileName)
+			if err != nil {
+				crdName := cnsoperatorv1alpha1.VKSRegisterVolumePlural +
+					"." + cnsoperatorv1alpha1.SchemeGroupVersion.Group
+				log.Errorf("failed to create %q CRD. Err: %+v", crdName, err)
+				return err
+			}
+		}
 	}
 
 	// Initialize the global scheme once before creating the manager


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Implements T8 — operator wiring for `VKSRegisterVolume` in `init.go`:
- `pkg/syncer/cnsoperator/manager/init.go`: in `InitCnsOperator`'s `CnsClusterFlavorGuest`
  branch, adds an `IsFSSEnabled(ctx, common.VKSRegisterVolume)`-gated call to
  `k8s.CreateCustomResourceDefinitionFromManifest` using the `EmbedVKSRegisterVolumeCRFile` /
  `EmbedVKSRegisterVolumeCRFileName` constants, so the CRD is created at syncer startup when the
  feature is on. Mirrors the existing `SupportsExposingStoragePolicyAttributes` block right above
  it (same namespaced-CRD, log-and-return-err pattern).
- No cleanup goroutine is added (unlike the Supervisor `CnsRegisterVolume` block elsewhere in this
  function) — ss-metadata-manager owns `VKSRegisterVolume` CR lifecycle end-to-end, confirmed with
  owners; the guest controller has nothing to clean up.

**Note:** this branch needs the CRD embed constants from T3, which isn't merged yet
(https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/4173). This diff therefore also
carries #4173's commit so it builds — please review T3 in its own PR. Once #4173 merges this
branch rebases cleanly onto it (same commit).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
- `go build ./...`, `go vet ./...`, and `gofmt -l` all pass clean.
- No new unit test: this block is exercised the same way its sibling `CnsClusterFlavorGuest` CRD-creation blocks are (e.g. `SupportsExposingStoragePolicyAttributes` above it has none either) — verified manually at syncer startup (`kubectl get crd vksregistervolumes.cns.vmware.com` present with FSS on, absent with FSS off).
- Full functional E2E is blocked on T4 (controller registration with the manager) and T6 (Supervisor watch) landing; tracked separately.
- Verified Build & deploy images to a VKS cluster. new CRD is installed

```
root@4213686c2571e8c14f495349a25538e2 [ ~ ]# kubectl --kubeconfig=/tmp/vks-kubeconfig -n vmware-system-csi rollout status deployment/vsphere-csi-controller
kubectl --kubeconfig=/tmp/vks-kubeconfig -n vmware-system-csi get pods -l app=vsphere-csi-controller
deployment "vsphere-csi-controller" successfully rolled out
NAME                                    READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-9b7688d4-njb8w   7/7     Running   0          14h
root@4213686c2571e8c14f495349a25538e2 [ ~ ]#
root@4213686c2571e8c14f495349a25538e2 [ ~ ]#
root@4213686c2571e8c14f495349a25538e2 [ ~ ]# kubectl --kubeconfig=/tmp/vks-kubeconfig get crd vksregistervolumes.cns.vmware.com
NAME                                CREATED AT
vksregistervolumes.cns.vmware.com   2026-07-24T18:31:19Z
root@4213686c2571e8c14f495349a25538e2 [ ~ ]# kubectl --kubeconfig=/tmp/vks-kubeconfig -n vmware-system-csi logs deploy/vsphere-csi-controller -c vsphere-syncer | \
  grep -E '"controller":"vksregistervolume-controller"' | grep -E "Starting Controller|Starting workers"
{"level":"info","time":"2026-07-26T05:35:55.682511607Z","caller":"controller/controller.go:302","msg":"Starting Controller","TraceId":"9067f927-1fc6-486c-88be-e6981cd20f36","controller":"vksregistervolume-controller","controllerGroup":"cns.vmware.com","controllerKind":"VKSRegisterVolume"}
{"level":"info","time":"2026-07-26T05:35:55.682668022Z","caller":"controller/controller.go:305","msg":"Starting workers","TraceId":"9067f927-1fc6-486c-88be-e6981cd20f36","controller":"vksregistervolume-controller","controllerGroup":"cns.vmware.com","controllerKind":"VKSRegisterVolume","worker count":10}
```

pre-checkin pipeline passed:

https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1409/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1853/

**Special notes for your reviewer**:
- This is purely CRD-creation wiring — the `VKSRegisterVolume` controller itself is not yet registered with the manager (T4) and cannot yet drive a CR to `Registered` (T6/T7 wiring), so this PR has no observable runtime effect beyond CRD presence until those land.

**Release note**:
```release-note
NONE