### PR TITLE
Fix typo "DataProtectionSnapshotService" WCP capability string.

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -695,7 +695,7 @@ const (
 	// TKG >= 3.8.0, and the dp-operator snapservice has been registered and activated.
 	// The capability string matches the entry in supervisor-capabilities.yaml owned by
 	// the snapservice team.
-	DataProtectionSnapshotService = "supports_data_protection_snaphot_service"
+	DataProtectionSnapshotService = "supports_data_protection_snapshot_service"
 
 	// VKSRegisterVolume is the guest-cluster FSS that gates the VKSRegisterVolume
 	// operator. Requires both this flag in the guest PVCSI ConfigMap and the


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The `DataProtectionSnapshotService` WCP capability string was introduced with a typo —
`supports_data_protection_snaphot_service` — that does not match the actual capability name
defined in the tera `supervisor-capabilities.yaml` (`supports_data_protection_snapshot_service`).

Because the guest cluster reads this capability by exact string match against the
`supervisor-capabilities` CR, the mismatch would cause `IsFSSEnabled(ctx,
common.DataProtectionSnapshotService)` to always return `false`, silently disabling the
VKSRegisterVolume both-`VolumeID`-and-`DiskURLPath` restore path even once the Supervisor
capability is activated.

This PR fixes the string value to match tera exactly. The Go identifier
`DataProtectionSnapshotService` itself was already correctly spelled and is unchanged — only the
underlying capability string literal is corrected.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

- Verified no other references to the misspelled string exist in the codebase.
- `go build ./...` passes.
- All existing unit tests in `cnsregistervolume_controller_test.go` continue to pass, including:
  - `TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityEnabled`
  - `TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityDisabled`
  - `TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityEnabled`
  - `TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityDisabled`

These tests exercise the capability check via the cached package-level boolean and are unaffected
by the string value itself, so this fix does not change any test's expected behavior — it only
corrects what the code will match against a real Supervisor cluster.

Precheck pipeline passed:

https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1383/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1832/


**Release note**:
```release-note
Fix a typo in the DataProtectionSnapshotService WCP capability string so it matches the Supervisor-defined capability name
```