### PR TITLE
Add secret reconciler to watch cert data to be updated in SnapshotMetadataService CR on cert renewal in VKS cluster

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -421,8 +421,11 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 			}()
 		}
 
-		if clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
-			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API) {
+		csiBackupAPIEnabled := (clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API)) ||
+			(clusterFlavor == cnstypes.CnsClusterFlavorGuest &&
+				commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSI_Backup_API_FSS))
+		if csiBackupAPIEnabled {
 			go func() {
 				defer func() {
 					if r := recover(); r != nil {
@@ -430,18 +433,20 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 						cleanupSessions(ctx, r)
 					}
 				}()
-				// The CSI_Backup_API feature relies on the Data Protection Operator service for CbtConfig CRD definition.
-				installed, err := commonco.ContainerOrchestratorUtility.IsDPOServiceInstalled(ctx)
-				if err != nil {
-					log.Errorf("Error checking Data Protection Operator service installation. Error: %+v", err)
-					utils.LogoutAllvCenterSessions(ctx)
-					os.Exit(1)
+				if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+					// The CSI_Backup_API feature relies on the Data Protection Operator service for CbtConfig CRD definition.
+					installed, err := commonco.ContainerOrchestratorUtility.IsDPOServiceInstalled(ctx)
+					if err != nil {
+						log.Errorf("Error checking Data Protection Operator service installation. Error: %+v", err)
+						utils.LogoutAllvCenterSessions(ctx)
+						os.Exit(1)
+					}
+					if !installed {
+						commonco.ContainerOrchestratorUtility.HandleLateInstallationOfDPOService(ctx)
+						return
+					}
 				}
-				if !installed {
-					commonco.ContainerOrchestratorUtility.HandleLateInstallationOfDPOService(ctx)
-					return
-				}
-				if err := startDpOperator(ctx, configInfo); err != nil {
+				if err := startDpOperator(ctx, configInfo, clusterFlavor); err != nil {
 					log.Errorf("Error initializing Data Protection(DP) operator. Error: %+v", err)
 					utils.LogoutAllvCenterSessions(ctx)
 					os.Exit(1)
@@ -481,8 +486,9 @@ func startK8sOperator(ctx context.Context,
 	return mgr.Start(ctx)
 }
 
-func startDpOperator(ctx context.Context, configInfo *config.ConfigurationInfo) error {
-	mgr, err := dpoperator.NewManager(ctx, configInfo)
+func startDpOperator(ctx context.Context, configInfo *config.ConfigurationInfo,
+	clusterFlavor cnstypes.CnsClusterFlavor) error {
+	mgr, err := dpoperator.NewManager(ctx, configInfo, clusterFlavor)
 	if err != nil {
 		return err
 	}

--- a/pkg/syncer/dpoperator/controller/add_snapshotmetadataservice.go
+++ b/pkg/syncer/dpoperator/controller/add_snapshotmetadataservice.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/dpoperator/controller/snapshotmetadataservice"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, snapshotmetadataservice.Add)
+}

--- a/pkg/syncer/dpoperator/controller/add_snapshotmetadataservicegc.go
+++ b/pkg/syncer/dpoperator/controller/add_snapshotmetadataservicegc.go
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package k8scontroller
+package controller
 
 import (
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8soperator/k8scontroller/snapshotmetadataservice"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/dpoperator/controller/snapshotmetadataservicegc"
 )
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, snapshotmetadataservice.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, snapshotmetadataservicegc.Add)
 }

--- a/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller.go
+++ b/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller.go
@@ -18,8 +18,10 @@ package cbtconfig
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
@@ -36,7 +38,10 @@ import (
 
 	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer"
 )
 
@@ -59,14 +64,46 @@ func cbtStatusState(st *cbtconfigv1alpha1.CBTConfigStatus) (active, configured b
 	return *st.State == cbtconfigv1alpha1.CBTStateActive, true
 }
 
-// Add creates a new CBTConfig controller and adds it to the Manager.
-// pvLister, pvcLister and vaLister come from the singleton InformerManager shared with the
-// metadata syncer and k8sorchestrator, so no second copy of those informers is started here.
-// kubeClient is the shared clientset used by the CBT label-sync phase.
-func Add(mgr manager.Manager, kubeClient clientset.Interface, volumeManager volume.Manager,
-	pvLister corelisters.PersistentVolumeLister,
-	pvcLister corelisters.PersistentVolumeClaimLister,
-	vaLister storagelistersv1.VolumeAttachmentLister) error {
+// Add creates a new CBTConfig controller and adds it to the Manager. CBTConfig only exists on
+// the Supervisor (Workload) cluster; Add is a no-op for every other cluster flavor.
+func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
+	configInfo *cnsconfig.ConfigurationInfo) error {
+	ctx, log := logger.GetNewContextWithLogger()
+
+	if clusterFlavor != cnstypes.CnsClusterFlavorWorkload {
+		log.Debug("Not initializing the CBTConfig Controller as its a non-WCP CSI deployment")
+		return nil
+	}
+
+	vcClient, err := cnsvsphere.GetVirtualCenterInstance(ctx, configInfo, false)
+	if err != nil {
+		return err
+	}
+
+	volumeManager, err := volume.GetManager(ctx, vcClient, nil, false, false, false,
+		cnstypes.CnsClusterFlavorWorkload, configInfo.Cfg.Global.SupervisorID,
+		configInfo.Cfg.Global.ClusterDistribution)
+	if err != nil {
+		return fmt.Errorf("failed to create an instance of volume manager: %w", err)
+	}
+
+	// Reuse the singleton InformerManager so the CBTConfig controller's PV/PVC/VA reads share
+	// the same cluster-wide informer caches that the metadata syncer (and other syncer
+	// controllers) already run in this process. Listen() starts the factory and waits for the
+	// registered informers' caches to sync (idempotent across callers - the metadata syncer
+	// also calls Listen on the same singleton).
+	kubeClient, err := k8s.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client for cbtconfig controller: %w", err)
+	}
+	informerManager := k8s.NewInformer(ctx, kubeClient)
+	informerManager.InitVolumeAttachmentInformer()
+	informerManager.Listen()
+
+	pvLister := informerManager.GetPVLister()
+	pvcLister := informerManager.GetPVCLister()
+	vaLister := informerManager.GetVolumeAttachmentLister()
+
 	rec := newReconciler(mgr, kubeClient, volumeManager, pvLister, pvcLister, vaLister)
 	return add(mgr, rec)
 }

--- a/pkg/syncer/dpoperator/controller/controller.go
+++ b/pkg/syncer/dpoperator/controller/controller.go
@@ -17,38 +17,27 @@ limitations under the License.
 package controller
 
 import (
-	clientset "k8s.io/client-go/kubernetes"
-	corelisters "k8s.io/client-go/listers/core/v1"
-	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 )
 
-// AddToManagerFunc registers a single DP operator controller with mgr. The PV / PVC /
-// VolumeAttachment listers come from the singleton InformerManager (shared with the metadata
-// syncer and k8sorchestrator) so child controllers do not start their own copies of those
-// informers via the controller-runtime cache. kubeClient is shared across all controllers
-// registered under one manager so there is no second apiserver connection.
-type AddToManagerFunc func(mgr manager.Manager, kubeClient clientset.Interface,
-	volumeManager volume.Manager,
-	pvLister corelisters.PersistentVolumeLister,
-	pvcLister corelisters.PersistentVolumeClaimLister,
-	vaLister storagelistersv1.VolumeAttachmentLister) error
+// AddToManagerFunc registers a single DP operator controller with mgr. clusterFlavor and
+// configInfo are passed through as-is; each registration func is responsible for deciding
+// whether it applies to clusterFlavor and for building whatever dependencies (vCenter client,
+// volume manager, informers, etc.) it needs from configInfo.
+type AddToManagerFunc func(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
+	configInfo *cnsconfig.ConfigurationInfo) error
 
 // AddToManagerFuncs is the list of registration funcs invoked by AddToManager.
-// The DP operator only runs on the Supervisor (Workload) cluster, so cluster flavor
-// is implied and not threaded through these registration funcs.
 var AddToManagerFuncs []AddToManagerFunc
 
 // AddToManager adds all Controllers to the Manager.
-func AddToManager(mgr manager.Manager, kubeClient clientset.Interface,
-	volumeManager volume.Manager,
-	pvLister corelisters.PersistentVolumeLister,
-	pvcLister corelisters.PersistentVolumeClaimLister,
-	vaLister storagelistersv1.VolumeAttachmentLister) error {
+func AddToManager(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
+	configInfo *cnsconfig.ConfigurationInfo) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(mgr, kubeClient, volumeManager, pvLister, pvcLister, vaLister); err != nil {
+		if err := f(mgr, clusterFlavor, configInfo); err != nil {
 			return err
 		}
 	}

--- a/pkg/syncer/dpoperator/controller/snapshotmetadataservice/snapshotmetadataservice_controller.go
+++ b/pkg/syncer/dpoperator/controller/snapshotmetadataservice/snapshotmetadataservice_controller.go
@@ -47,9 +47,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
@@ -87,40 +86,21 @@ const (
 var (
 	backOffDuration         map[string]time.Duration
 	backOffDurationMapMutex = sync.Mutex{}
-
-	// getContainerOrchestratorInterface is a package-level indirection over
-	// commonco.GetContainerOrchestratorInterface so unit tests can inject a
-	// fake CO interface without requiring a real Kubernetes client.
-	getContainerOrchestratorInterface = commonco.GetContainerOrchestratorInterface
 )
 
 // Add creates a new SnapshotMetadataService Controller and adds it to the
 // Manager. The Manager will set fields on the Controller and Start it when the
 // Manager is Started.
-func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor) error {
+func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
+	_ *cnsconfig.ConfigurationInfo) error {
 	ctx, log := logger.GetNewContextWithLogger()
 
-	// TODO: remove this check once we add changes for Guest cluster
 	if clusterFlavor != cnstypes.CnsClusterFlavorWorkload {
 		log.Debug("Not initializing the SnapshotMetadataService Controller as its a non-WCP CSI deployment")
 		return nil
 	}
 
-	// Check if CSI_Backup_API FSS is enabled
-	coCommonInterface, err := getContainerOrchestratorInterface(ctx,
-		common.Kubernetes, clusterFlavor, nil)
-	if err != nil {
-		log.Errorf("Failed to get CO common interface. Err: %v", err)
-		return err
-	}
-
-	isCSIBackupAPIEnabled := coCommonInterface.IsFSSEnabled(ctx, common.CSI_Backup_API)
-	if !isCSIBackupAPIEnabled {
-		log.Infof("CSI_Backup_API FSS is not enabled. Skipping SnapshotMetadataService Controller initialization")
-		return nil
-	}
-
-	log.Infof("CSI_Backup_API FSS is enabled. Initializing SnapshotMetadataService Controller")
+	log.Infof("Initializing SnapshotMetadataService Controller")
 
 	// Initializes kubernetes client.
 	k8sclient, err := k8s.NewClient(ctx)
@@ -317,13 +297,6 @@ func (r *ReconcileSnapshotMetadataService) Reconcile(ctx context.Context,
 	ctx = logger.NewContextWithLogger(ctx)
 	reconcileLog := logger.GetLogger(ctx)
 	reconcileLog.Infof("Received Reconcile for request: %q", request.NamespacedName)
-
-	go func() {
-		<-ctx.Done()
-		reconcileLog.Infof("context canceled for reconcile for SnapshotMetadataService request: %q, error: %v",
-			request.NamespacedName, ctx.Err())
-	}()
-
 	reconcileLog.Infof("Started Reconcile for SnapshotMetadataService request: %q", request.NamespacedName)
 
 	// Fetch the owned SnapshotMetadataService CR (the primary object).

--- a/pkg/syncer/dpoperator/controller/snapshotmetadataservice/snapshotmetadataservice_controller_test.go
+++ b/pkg/syncer/dpoperator/controller/snapshotmetadataservice/snapshotmetadataservice_controller_test.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"math/big"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
@@ -45,12 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 )
 
 // ---------------------------------------------------------------------------
@@ -178,41 +172,6 @@ func generateSelfSignedCertPEM(t *testing.T, ips ...net.IP) []byte {
 	require.NoError(t, err)
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }
-
-// withInjectedCO swaps the package-level getContainerOrchestratorInterface
-// indirection with one that returns the supplied CO and error, and returns a
-// cleanup function to restore the original implementation.
-func withInjectedCO(co commonco.COCommonInterface, err error) func() {
-	original := getContainerOrchestratorInterface
-	getContainerOrchestratorInterface = func(ctx context.Context, _ int,
-		_ cnstypes.CnsClusterFlavor, _ interface{}) (commonco.COCommonInterface, error) {
-		return co, err
-	}
-	return func() {
-		getContainerOrchestratorInterface = original
-	}
-}
-
-// fssCallTracker wraps a COCommonInterface to record which feature names had
-// their state queried. It lets us assert that Add only consults the
-// CSI_Backup_API gate before bailing out.
-type fssCallTracker struct {
-	commonco.COCommonInterface
-	mu         sync.Mutex
-	fssQueries []string
-}
-
-func (f *fssCallTracker) IsFSSEnabled(ctx context.Context, featureName string) bool {
-	f.mu.Lock()
-	f.fssQueries = append(f.fssQueries, featureName)
-	f.mu.Unlock()
-	return f.COCommonInterface.IsFSSEnabled(ctx, featureName)
-}
-
-// Reference manager.Manager so the import is recognised as used. Add expects
-// a manager.Manager argument; the FSS-disabled tests pass nil because Add
-// short-circuits before touching it.
-var _ manager.Manager = (manager.Manager)(nil)
 
 // smsReconcileRequest is the reconcile.Request every watch in this package
 // maps onto: the single, cluster-scoped SnapshotMetadataService CR.
@@ -1248,16 +1207,14 @@ func TestReconcileBackoffInitialization(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Add() / FSS gating tests
+// Add() flavor gating tests
 // ---------------------------------------------------------------------------
 
 // TestAddSkipsInitForNonWorkloadFlavor verifies that Add returns immediately
-// without consulting the CO interface or initializing any resources when the
-// cluster flavor is not Workload (WCP).
+// without initializing any resources when the cluster flavor is not Workload
+// (WCP). The CSI_Backup_API gate that used to live inside Add is now enforced
+// once, by the caller, before Add is ever invoked.
 func TestAddSkipsInitForNonWorkloadFlavor(t *testing.T) {
-	restore := withInjectedCO(nil, errors.New("CO factory must not be called for non-WCP flavor"))
-	defer restore()
-
 	flavors := []cnstypes.CnsClusterFlavor{
 		cnstypes.CnsClusterFlavorVanilla,
 		cnstypes.CnsClusterFlavorGuest,
@@ -1265,45 +1222,8 @@ func TestAddSkipsInitForNonWorkloadFlavor(t *testing.T) {
 	for _, flavor := range flavors {
 		flavor := flavor
 		t.Run(string(flavor), func(t *testing.T) {
-			err := Add(nil, flavor)
+			err := Add(nil, flavor, nil)
 			assert.NoError(t, err, "Add should be a no-op for non-WCP flavors")
 		})
 	}
-}
-
-// TestAddSkipsInitWhenCSIBackupAPIFSSDisabled verifies the controller is not
-// initialized (i.e., Add returns nil and never reaches manager-related setup)
-// when the CSI_Backup_API capability/FSS is disabled on the WCP cluster.
-func TestAddSkipsInitWhenCSIBackupAPIFSSDisabled(t *testing.T) {
-	fakeCO, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
-	require.NoError(t, err)
-
-	require.NoError(t, fakeCO.DisableFSS(context.Background(), common.CSI_Backup_API))
-	require.False(t, fakeCO.IsFSSEnabled(context.Background(), common.CSI_Backup_API),
-		"precondition: CSI_Backup_API FSS must be disabled in the fake CO")
-
-	tracker := &fssCallTracker{COCommonInterface: fakeCO}
-	restore := withInjectedCO(tracker, nil)
-	defer restore()
-
-	// A nil manager is intentional: Add should bail out before any manager
-	// method is invoked. A panic here would be a strong regression signal.
-	err = Add(nil, cnstypes.CnsClusterFlavorWorkload)
-	assert.NoError(t, err, "Add should return nil when CSI_Backup_API FSS is disabled")
-
-	assert.Equal(t, []string{common.CSI_Backup_API}, tracker.fssQueries,
-		"Add should query IsFSSEnabled exactly once for CSI_Backup_API")
-}
-
-// TestAddPropagatesCOInterfaceError verifies that Add returns the error from
-// the CO interface factory (and does not initialize the controller) when CO
-// initialization fails on the WCP cluster.
-func TestAddPropagatesCOInterfaceError(t *testing.T) {
-	expectedErr := errors.New("co init failure")
-	restore := withInjectedCO(nil, expectedErr)
-	defer restore()
-
-	err := Add(nil, cnstypes.CnsClusterFlavorWorkload)
-	assert.ErrorIs(t, err, expectedErr,
-		"Add should propagate the CO factory error and not initialize the controller")
 }

--- a/pkg/syncer/dpoperator/controller/snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go
+++ b/pkg/syncer/dpoperator/controller/snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go
@@ -1,0 +1,357 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package snapshotmetadataservicegc runs in the guest (VKS) cluster. It keeps
+// the guest-local SnapshotMetadataService CR's spec.caCert in sync with the
+// targetsecretname TLS secret that backs the guest cluster's own csi-snapshot-metadata
+// sidecar (the one guest workloads dial directly for GetMetadataAllocated /
+// GetMetadataDelta). That secret is a copy of a supervisor-issued leaf
+// certificate (see docs/cbt-api-guest-cluster-deployment.md); its ca.crt field
+// holds the CA that signed the leaf, which is exactly what spec.caCert must
+// contain for the guest's csi-snapshot-metadata sidecar's serving cert to be
+// trusted.
+package snapshotmetadataservicegc
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	snapshotmetadatav1beta1 "github.com/kubernetes-csi/external-snapshot-metadata/client/apis/snapshotmetadataservice/v1beta1"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+)
+
+const (
+	maxWorkerThreads = 1
+
+	// targetSecretName is the guest-local copy of the supervisor-issued
+	// leaf certificate that secures the guest cluster's own csi-snapshot-metadata
+	// sidecar. Its ca.crt field is the CA that must be published in the guest
+	// SnapshotMetadataService CR's spec.caCert.
+	targetSecretName = "vmware-system-csi-snapshot-metadata-service-cert-gc"
+
+	// targetNamespace is the namespace of targetSecretName in the guest cluster.
+	targetNamespace = "vmware-system-csi"
+
+	// targetSMSName is the (cluster-scoped) guest-local SnapshotMetadataService
+	// CR that this controller owns.
+	targetSMSName = "csi.vsphere.vmware.com"
+)
+
+// backOffDuration is a map of SnapshotMetadataService CR name's to the time
+// after which a request for this instance will be requeued.
+// Initialized to 1 second for new instances and for instances whose latest
+// reconcile operation succeeded. If the reconcile fails, backoff is incremented
+// exponentially.
+var (
+	backOffDuration         map[string]time.Duration
+	backOffDurationMapMutex = sync.Mutex{}
+)
+
+// Add creates a new SnapshotMetadataServiceGC Controller and adds it to the
+// Manager. The Manager will set fields on the Controller and Start it when the
+// Manager is Started.
+//
+// This controller only runs in the guest (VKS) cluster's pvCSI syncer — it is
+// a no-op in the supervisor, which owns its own SnapshotMetadataService CR via
+// the sibling snapshotmetadataservice controller.
+func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
+	_ *cnsconfig.ConfigurationInfo) error {
+	ctx, log := logger.GetNewContextWithLogger()
+
+	if clusterFlavor != cnstypes.CnsClusterFlavorGuest {
+		log.Debug("Not initializing the SnapshotMetadataServiceGC Controller as its not a Guest cluster CSI deployment")
+		return nil
+	}
+
+	log.Infof("Initializing SnapshotMetadataServiceGC Controller")
+
+	// Initializes kubernetes client.
+	k8sclient, err := k8s.NewClient(ctx)
+	if err != nil {
+		log.Errorf("Creating Kubernetes client failed. Err: %v", err)
+		return err
+	}
+	// eventBroadcaster broadcasts events on SnapshotMetadataService instances to
+	// the event sink.
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(
+		&typedcorev1.EventSinkImpl{
+			Interface: k8sclient.CoreV1().Events(""),
+		},
+	)
+
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: cnsoperatorapis.GroupName})
+	return add(mgr, newReconciler(mgr, recorder))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, recorder record.EventRecorder) reconcile.Reconciler {
+	return &ReconcileSnapshotMetadataServiceGC{
+		client:   mgr.GetClient(),
+		scheme:   mgr.GetScheme(),
+		recorder: recorder,
+	}
+}
+
+// enqueueSMSRequest returns the single reconcile.Request for the owned,
+// cluster-scoped SnapshotMetadataService CR. The Secret watch maps its events
+// onto this request so the controller always reconciles its owned object
+// regardless of which input changed.
+func enqueueSMSRequest() []reconcile.Request {
+	return []reconcile.Request{{NamespacedName: k8stypes.NamespacedName{Name: targetSMSName}}}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler.
+//
+// The controller is keyed on the guest-local SnapshotMetadataService CR (the
+// resource whose desired state it maintains). The targetsecretname TLS Secret is watched
+// as the input; only changes to its ca.crt field are interesting, so the rest
+// are filtered out before they ever reach Reconcile.
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	_, log := logger.GetNewContextWithLogger()
+
+	// Create a new controller.
+	c, err := controller.New("snapshotmetadataservicegc-controller", mgr,
+		controller.Options{Reconciler: r, MaxConcurrentReconciles: maxWorkerThreads})
+	if err != nil {
+		log.Errorf("failed to create new SnapshotMetadataServiceGC controller with error: %+v", err)
+		return err
+	}
+
+	backOffDuration = make(map[string]time.Duration)
+
+	// Primary watch: the owned SnapshotMetadataService CR. Reconcile on create,
+	// and on updates only when spec.caCert actually changed (drift correction) —
+	// ignore status/metadata-only churn and our own no-op writes.
+	smsPred := predicate.TypedFuncs[*snapshotmetadatav1beta1.SnapshotMetadataService]{
+		CreateFunc: func(e event.TypedCreateEvent[*snapshotmetadatav1beta1.SnapshotMetadataService]) bool {
+			return e.Object.GetName() == targetSMSName
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*snapshotmetadatav1beta1.SnapshotMetadataService]) bool {
+			if e.ObjectNew.GetName() != targetSMSName {
+				return false
+			}
+			return !reflect.DeepEqual(e.ObjectOld.Spec.CACert, e.ObjectNew.Spec.CACert)
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*snapshotmetadatav1beta1.SnapshotMetadataService]) bool {
+			log.Debug("Ignoring SnapshotMetadataService reconciliation on delete event")
+			return false
+		},
+	}
+	err = c.Watch(source.Kind(
+		mgr.GetCache(),
+		&snapshotmetadatav1beta1.SnapshotMetadataService{},
+		&handler.TypedEnqueueRequestForObject[*snapshotmetadatav1beta1.SnapshotMetadataService]{},
+		smsPred))
+	if err != nil {
+		log.Errorf("failed to watch for changes to SnapshotMetadataService resource with error: %+v", err)
+		return err
+	}
+
+	// Secondary watch: the targetsecretname TLS Secret. Only the target Secret, and only
+	// changes to its ca.crt field, are interesting.
+	secretPred := predicate.TypedFuncs[*v1.Secret]{
+		CreateFunc: func(e event.TypedCreateEvent[*v1.Secret]) bool {
+			return shouldProcessSecret(e.Object)
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*v1.Secret]) bool {
+			if !shouldProcessSecret(e.ObjectNew) {
+				return false
+			}
+			return !reflect.DeepEqual(e.ObjectOld.Data["ca.crt"], e.ObjectNew.Data["ca.crt"])
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*v1.Secret]) bool {
+			return false
+		},
+		GenericFunc: func(e event.TypedGenericEvent[*v1.Secret]) bool {
+			return false
+		},
+	}
+	err = c.Watch(source.Kind(
+		mgr.GetCache(),
+		&v1.Secret{},
+		handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, _ *v1.Secret) []reconcile.Request {
+			return enqueueSMSRequest()
+		}),
+		secretPred,
+	))
+	if err != nil {
+		log.Errorf("failed to watch for changes to the %q Secret with error: %+v", targetSecretName, err)
+		return err
+	}
+	return nil
+}
+
+// shouldProcessSecret checks if the Secret should be processed
+func shouldProcessSecret(secret *v1.Secret) bool {
+	return secret.Name == targetSecretName && secret.Namespace == targetNamespace
+}
+
+// blank assignment to verify that ReconcileSnapshotMetadataServiceGC implements
+// reconcile.Reconciler.
+var _ reconcile.Reconciler = &ReconcileSnapshotMetadataServiceGC{}
+
+// ReconcileSnapshotMetadataServiceGC reconciles the guest-local
+// SnapshotMetadataService CR, keeping its spec.caCert in sync with the ca.crt
+// field of the targetsecretname TLS Secret.
+type ReconcileSnapshotMetadataServiceGC struct {
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder record.EventRecorder
+}
+
+// Reconcile brings the guest-local SnapshotMetadataService CR's spec.caCert in
+// sync with the current ca.crt of the targetsecretname Secret.
+//
+// Note:
+// The Controller will requeue the Request to be processed again if the returned
+// error is non-nil or Result.Requeue is true. Otherwise, upon completion it
+// will remove the work from the queue.
+func (r *ReconcileSnapshotMetadataServiceGC) Reconcile(ctx context.Context,
+	request reconcile.Request) (reconcile.Result, error) {
+	ctx = logger.NewContextWithLogger(ctx)
+	reconcileLog := logger.GetLogger(ctx)
+	reconcileLog.Infof("Received Reconcile for request: %q", request.NamespacedName)
+	reconcileLog.Infof("Started Reconcile for SnapshotMetadataServiceGC request: %q", request.NamespacedName)
+
+	// Fetch the owned SnapshotMetadataService CR (the primary object).
+	sms := &snapshotmetadatav1beta1.SnapshotMetadataService{}
+	if err := r.client.Get(ctx, k8stypes.NamespacedName{Name: targetSMSName}, sms); err != nil {
+		if apierrors.IsNotFound(err) {
+			reconcileLog.Infof("SnapshotMetadataService %s not found. Nothing to reconcile.", targetSMSName)
+			return reconcile.Result{}, nil
+		}
+		reconcileLog.Errorf("Error reading SnapshotMetadataService %s. Err: %+v", targetSMSName, err)
+		reconcileLog.Errorf("Operation failed, reporting failure status to Prometheus."+
+			" Fault Type: %q", csifault.CSIInternalFault)
+		return reconcile.Result{}, err
+	}
+
+	// Initialize backOffDuration for the instance, if required.
+	backOffDurationMapMutex.Lock()
+	var timeout time.Duration
+	if _, exists := backOffDuration[sms.Name]; !exists {
+		backOffDuration[sms.Name] = time.Second
+	}
+	timeout = backOffDuration[sms.Name]
+	backOffDurationMapMutex.Unlock()
+
+	// Fetch the targetsecretname Secret and read its ca.crt.
+	secret := &v1.Secret{}
+	if err := r.client.Get(ctx, k8stypes.NamespacedName{
+		Name:      targetSecretName,
+		Namespace: targetNamespace,
+	}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			msg := fmt.Sprintf("Secret %s/%s not found yet", targetNamespace, targetSecretName)
+			recordEvent(ctx, r, sms, v1.EventTypeWarning, msg)
+			reconcileLog.Errorf("Operation failed, reporting failure status to Prometheus."+
+				" Fault Type: %q", csifault.CSIApiServerOperationFault)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+		msg := fmt.Sprintf("Failed to get secret %s/%s. Err: %+v", targetNamespace, targetSecretName, err)
+		recordEvent(ctx, r, sms, v1.EventTypeWarning, msg)
+		reconcileLog.Errorf("Operation failed, reporting failure status to Prometheus."+
+			" Fault Type: %q", csifault.CSIApiServerOperationFault)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
+	caCertBytes, ok := secret.Data["ca.crt"]
+	if !ok || len(caCertBytes) == 0 {
+		msg := fmt.Sprintf("Secret %s/%s does not have ca.crt field or it is empty",
+			targetNamespace, targetSecretName)
+		recordEvent(ctx, r, sms, v1.EventTypeWarning, msg)
+		reconcileLog.Errorf("Operation failed, reporting failure status to Prometheus."+
+			" Fault Type: %q", csifault.CSIInternalFault)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
+	// Publish the CA cert to the SnapshotMetadataService CR if it changed.
+	if !reflect.DeepEqual(sms.Spec.CACert, caCertBytes) {
+		reconcileLog.Infof("Updating SnapshotMetadataService %s caCert from Secret %s/%s",
+			targetSMSName, targetNamespace, targetSecretName)
+		patch := client.MergeFrom(sms.DeepCopy())
+		sms.Spec.CACert = caCertBytes
+		if err := r.client.Patch(ctx, sms, patch); err != nil {
+			msg := fmt.Sprintf("Failed to patch SnapshotMetadataService %s. Err: %+v", targetSMSName, err)
+			recordEvent(ctx, r, sms, v1.EventTypeWarning, msg)
+			reconcileLog.Errorf("Operation failed, reporting failure status to Prometheus."+
+				" Fault Type: %q", csifault.CSIApiServerOperationFault)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+		msg := fmt.Sprintf("Successfully synced SnapshotMetadataService %s caCert from Secret %s/%s",
+			targetSMSName, targetNamespace, targetSecretName)
+		recordEvent(ctx, r, sms, v1.EventTypeNormal, msg)
+	} else {
+		reconcileLog.Infof("SnapshotMetadataService %s caCert already up-to-date, no action needed", targetSMSName)
+	}
+
+	// Cleanup instance entry from backOffDuration map.
+	backOffDurationMapMutex.Lock()
+	delete(backOffDuration, sms.Name)
+	backOffDurationMapMutex.Unlock()
+
+	reconcileLog.Infof("Finished Reconcile for SnapshotMetadataServiceGC request: %q", request.NamespacedName)
+	return reconcile.Result{}, nil
+}
+
+// recordEvent records the event on the SnapshotMetadataService instance, sets the
+// backOffDuration for the instance appropriately and logs the message.
+// backOffDuration is reset to 1 second on success and doubled on failure.
+func recordEvent(ctx context.Context, r *ReconcileSnapshotMetadataServiceGC,
+	instance *snapshotmetadatav1beta1.SnapshotMetadataService, eventtype string, msg string) {
+	log := logger.GetLogger(ctx)
+	switch eventtype {
+	case v1.EventTypeWarning:
+		// Double backOff duration.
+		backOffDurationMapMutex.Lock()
+		backOffDuration[instance.Name] = backOffDuration[instance.Name] * 2
+		backOffDurationMapMutex.Unlock()
+		r.recorder.Event(instance, v1.EventTypeWarning, "SnapshotMetadataServiceGCSyncFailed", msg)
+		log.Error(msg)
+	case v1.EventTypeNormal:
+		// Reset backOff duration to one second.
+		backOffDurationMapMutex.Lock()
+		backOffDuration[instance.Name] = time.Second
+		backOffDurationMapMutex.Unlock()
+		r.recorder.Event(instance, v1.EventTypeNormal, "SnapshotMetadataServiceGCSyncSucceeded", msg)
+		log.Info(msg)
+	}
+}

--- a/pkg/syncer/dpoperator/controller/snapshotmetadataservicegc/snapshotmetadataservicegc_controller_test.go
+++ b/pkg/syncer/dpoperator/controller/snapshotmetadataservicegc/snapshotmetadataservicegc_controller_test.go
@@ -1,0 +1,517 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshotmetadataservicegc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	snapshotmetadatav1beta1 "github.com/kubernetes-csi/external-snapshot-metadata/client/apis/snapshotmetadataservice/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ---------------------------------------------------------------------------
+// shared test fixtures / helpers
+// ---------------------------------------------------------------------------
+
+// newTestScheme creates a runtime scheme with all types required for the
+// SnapshotMetadataServiceGC controller tests.
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v1.AddToScheme(s))
+	require.NoError(t, snapshotmetadatav1beta1.AddToScheme(s))
+	return s
+}
+
+// resetBackOffDuration ensures each test starts with a clean backOffDuration map.
+func resetBackOffDuration() {
+	backOffDurationMapMutex.Lock()
+	defer backOffDurationMapMutex.Unlock()
+	backOffDuration = make(map[string]time.Duration)
+}
+
+// makeSMSCR returns a SnapshotMetadataService CR fixture with the given caCert.
+func makeSMSCR(caCert []byte) *snapshotmetadatav1beta1.SnapshotMetadataService {
+	return &snapshotmetadatav1beta1.SnapshotMetadataService{
+		ObjectMeta: metav1.ObjectMeta{Name: targetSMSName},
+		Spec: snapshotmetadatav1beta1.SnapshotMetadataServiceSpec{
+			CACert:   caCert,
+			Address:  "vmware-system-csi-snapshot-metadata-service.vmware-system-csi.svc.cluster.local:8100",
+			Audience: "csi.vsphere.vmware.com",
+		},
+	}
+}
+
+// makeGCSecret returns a "-gc" TLS Secret fixture with the given ca.crt data.
+// If data is nil, the Secret has no ca.crt field at all.
+func makeGCSecret(caCert []byte) *v1.Secret {
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: targetSecretName, Namespace: targetNamespace},
+		Type:       v1.SecretTypeTLS,
+		Data:       map[string][]byte{},
+	}
+	if caCert != nil {
+		secret.Data["ca.crt"] = caCert
+	}
+	return secret
+}
+
+func smsReconcileRequest() reconcile.Request {
+	return reconcile.Request{NamespacedName: k8stypes.NamespacedName{Name: targetSMSName}}
+}
+
+// ---------------------------------------------------------------------------
+// pure function tests
+// ---------------------------------------------------------------------------
+
+func TestShouldProcessSecret(t *testing.T) {
+	tests := []struct {
+		name     string
+		secret   *v1.Secret
+		expected bool
+	}{
+		{
+			name: "matching name and namespace returns true",
+			secret: &v1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: targetSecretName, Namespace: targetNamespace,
+			}},
+			expected: true,
+		},
+		{
+			name: "different name returns false",
+			secret: &v1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: "some-other-secret", Namespace: targetNamespace,
+			}},
+			expected: false,
+		},
+		{
+			name: "different namespace returns false",
+			secret: &v1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: targetSecretName, Namespace: "some-other-namespace",
+			}},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, shouldProcessSecret(tc.secret))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// recordEvent tests
+// ---------------------------------------------------------------------------
+
+func TestRecordEvent(t *testing.T) {
+	t.Run("warning event doubles backoff and emits warning", func(t *testing.T) {
+		resetBackOffDuration()
+		instance := makeSMSCR(nil)
+		backOffDuration[instance.Name] = 2 * time.Second
+
+		recorder := record.NewFakeRecorder(10)
+		r := &ReconcileSnapshotMetadataServiceGC{recorder: recorder}
+
+		recordEvent(context.Background(), r, instance, v1.EventTypeWarning, "something failed")
+
+		backOffDurationMapMutex.Lock()
+		got := backOffDuration[instance.Name]
+		backOffDurationMapMutex.Unlock()
+		assert.Equal(t, 4*time.Second, got)
+
+		select {
+		case ev := <-recorder.Events:
+			assert.Contains(t, ev, "Warning")
+			assert.Contains(t, ev, "SnapshotMetadataServiceGCSyncFailed")
+			assert.Contains(t, ev, "something failed")
+		case <-time.After(time.Second):
+			t.Fatal("expected a warning event to be recorded")
+		}
+	})
+
+	t.Run("normal event resets backoff and emits normal", func(t *testing.T) {
+		resetBackOffDuration()
+		instance := makeSMSCR(nil)
+		backOffDuration[instance.Name] = 16 * time.Second
+
+		recorder := record.NewFakeRecorder(10)
+		r := &ReconcileSnapshotMetadataServiceGC{recorder: recorder}
+
+		recordEvent(context.Background(), r, instance, v1.EventTypeNormal, "all good")
+
+		backOffDurationMapMutex.Lock()
+		got := backOffDuration[instance.Name]
+		backOffDurationMapMutex.Unlock()
+		assert.Equal(t, time.Second, got)
+
+		select {
+		case ev := <-recorder.Events:
+			assert.Contains(t, ev, "Normal")
+			assert.Contains(t, ev, "SnapshotMetadataServiceGCSyncSucceeded")
+			assert.Contains(t, ev, "all good")
+		case <-time.After(time.Second):
+			t.Fatal("expected a normal event to be recorded")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile end-to-end tests
+// ---------------------------------------------------------------------------
+
+func TestReconcileSMSNotFound(t *testing.T) {
+	resetBackOffDuration()
+	scheme := newTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := &ReconcileSnapshotMetadataServiceGC{
+		client:   fakeClient,
+		scheme:   scheme,
+		recorder: record.NewFakeRecorder(10),
+	}
+
+	res, err := r.Reconcile(context.Background(), smsReconcileRequest())
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+}
+
+func TestReconcileSMSGetError(t *testing.T) {
+	resetBackOffDuration()
+	scheme := newTestScheme(t)
+	expectedErr := errors.New("api server is down")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+				obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*snapshotmetadatav1beta1.SnapshotMetadataService); ok {
+					return expectedErr
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &ReconcileSnapshotMetadataServiceGC{
+		client:   fakeClient,
+		scheme:   scheme,
+		recorder: record.NewFakeRecorder(10),
+	}
+
+	res, err := r.Reconcile(context.Background(), smsReconcileRequest())
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, reconcile.Result{}, res)
+}
+
+func TestReconcileSecretNotFound(t *testing.T) {
+	resetBackOffDuration()
+	scheme := newTestScheme(t)
+	sms := makeSMSCR(nil)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sms).Build()
+	recorder := record.NewFakeRecorder(10)
+	r := &ReconcileSnapshotMetadataServiceGC{client: fakeClient, scheme: scheme, recorder: recorder}
+
+	res, err := r.Reconcile(context.Background(), smsReconcileRequest())
+	assert.NoError(t, err)
+	assert.True(t, res.RequeueAfter > 0)
+
+	select {
+	case ev := <-recorder.Events:
+		assert.Contains(t, ev, "Warning")
+		assert.Contains(t, ev, "Secret")
+	case <-time.After(time.Second):
+		t.Fatal("expected a warning event to be recorded")
+	}
+}
+
+func TestReconcileSecretGetError(t *testing.T) {
+	resetBackOffDuration()
+	scheme := newTestScheme(t)
+	sms := makeSMSCR(nil)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sms).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+				obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*v1.Secret); ok {
+					return errors.New("transient secret get failure")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	r := &ReconcileSnapshotMetadataServiceGC{client: fakeClient, scheme: scheme, recorder: recorder}
+
+	res, err := r.Reconcile(context.Background(), smsReconcileRequest())
+	assert.NoError(t, err)
+	assert.True(t, res.RequeueAfter > 0)
+
+	select {
+	case ev := <-recorder.Events:
+		assert.Contains(t, ev, "Warning")
+		assert.Contains(t, ev, "Failed to get secret")
+	case <-time.After(time.Second):
+		t.Fatal("expected a warning event to be recorded")
+	}
+}
+
+func TestReconcileSecretMissingCAField(t *testing.T) {
+	cases := []struct {
+		name   string
+		secret *v1.Secret
+	}{
+		{name: "missing ca.crt key", secret: makeGCSecret(nil)},
+		{name: "empty ca.crt", secret: makeGCSecret([]byte{})},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetBackOffDuration()
+			scheme := newTestScheme(t)
+			sms := makeSMSCR(nil)
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sms, tc.secret).Build()
+			recorder := record.NewFakeRecorder(10)
+			r := &ReconcileSnapshotMetadataServiceGC{client: fakeClient, scheme: scheme, recorder: recorder}
+
+			res, err := r.Reconcile(context.Background(), smsReconcileRequest())
+			assert.NoError(t, err)
+			assert.True(t, res.RequeueAfter > 0)
+
+			select {
+			case ev := <-recorder.Events:
+				assert.Contains(t, ev, "Warning")
+				assert.Contains(t, ev, "ca.crt")
+			case <-time.After(time.Second):
+				t.Fatal("expected a warning event to be recorded")
+			}
+		})
+	}
+}
+
+func TestReconcileCAPatchSuccess(t *testing.T) {
+	resetBackOffDuration()
+	scheme := newTestScheme(t)
+	newCA := []byte("new-ca-bytes")
+	oldCA := []byte("old-ca-bytes")
+
+	sms := makeSMSCR(oldCA)
+	secret := makeGCSecret(newCA)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sms, secret).Build()
+	recorder := record.NewFakeRecorder(10)
+	r := &ReconcileSnapshotMetadataServiceGC{client: fakeClient, scheme: scheme, recorder: recorder}
+
+	// Pre-seed a backoff entry to verify it is cleaned up.
+	backOffDurationMapMutex.Lock()
+	backOffDuration[targetSMSName] = 8 * time.Second
+	backOffDurationMapMutex.Unlock()
+
+	res, err := r.Reconcile(context.Background(), smsReconcileRequest())
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	updated := &snapshotmetadatav1beta1.SnapshotMetadataService{}
+	require.NoError(t, fakeClient.Get(context.Background(), k8stypes.NamespacedName{Name: targetSMSName}, updated))
+	assert.Equal(t, newCA, updated.Spec.CACert)
+
+	backOffDurationMapMutex.Lock()
+	_, exists := backOffDuration[targetSMSName]
+	backOffDurationMapMutex.Unlock()
+	assert.False(t, exists, "expected backoff entry to be deleted on success")
+
+	select {
+	case ev := <-recorder.Events:
+		assert.Contains(t, ev, "Normal")
+		assert.Contains(t, ev, "Successfully synced")
+	case <-time.After(time.Second):
+		t.Fatal("expected a normal event to be recorded")
+	}
+}
+
+func TestReconcileCAPatchFailure(t *testing.T) {
+	resetBackOffDuration()
+	scheme := newTestScheme(t)
+	newCA := []byte("new-ca-bytes")
+	oldCA := []byte("old-ca-bytes")
+
+	sms := makeSMSCR(oldCA)
+	secret := makeGCSecret(newCA)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sms, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object,
+				patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*snapshotmetadatav1beta1.SnapshotMetadataService); ok {
+					return errors.New("patch failed")
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	r := &ReconcileSnapshotMetadataServiceGC{client: fakeClient, scheme: scheme, recorder: recorder}
+
+	res, err := r.Reconcile(context.Background(), smsReconcileRequest())
+	assert.NoError(t, err)
+	assert.True(t, res.RequeueAfter > 0)
+
+	updated := &snapshotmetadatav1beta1.SnapshotMetadataService{}
+	require.NoError(t, fakeClient.Get(context.Background(), k8stypes.NamespacedName{Name: targetSMSName}, updated))
+	assert.Equal(t, oldCA, updated.Spec.CACert)
+
+	backOffDurationMapMutex.Lock()
+	got := backOffDuration[targetSMSName]
+	backOffDurationMapMutex.Unlock()
+	assert.Equal(t, 2*time.Second, got)
+
+	select {
+	case ev := <-recorder.Events:
+		assert.Contains(t, ev, "Warning")
+		assert.Contains(t, ev, "Failed to patch")
+	case <-time.After(time.Second):
+		t.Fatal("expected a warning event to be recorded")
+	}
+}
+
+// TestReconcileAlreadyUpToDate_NoOp verifies that no patch and no event occur
+// when the SMS CR's caCert already matches the Secret's ca.crt.
+func TestReconcileAlreadyUpToDate_NoOp(t *testing.T) {
+	resetBackOffDuration()
+	scheme := newTestScheme(t)
+	caBytes := []byte("current-ca")
+
+	sms := makeSMSCR(caBytes)
+	secret := makeGCSecret(caBytes)
+
+	patchCalled := false
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sms, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object,
+				patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*snapshotmetadatav1beta1.SnapshotMetadataService); ok {
+					patchCalled = true
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	r := &ReconcileSnapshotMetadataServiceGC{client: fakeClient, scheme: scheme, recorder: recorder}
+
+	backOffDurationMapMutex.Lock()
+	backOffDuration[targetSMSName] = 8 * time.Second
+	backOffDurationMapMutex.Unlock()
+
+	res, err := r.Reconcile(context.Background(), smsReconcileRequest())
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+	assert.False(t, patchCalled, "no patch should be issued when caCert is already correct")
+
+	backOffDurationMapMutex.Lock()
+	_, exists := backOffDuration[targetSMSName]
+	backOffDurationMapMutex.Unlock()
+	assert.False(t, exists)
+
+	select {
+	case ev := <-recorder.Events:
+		t.Fatalf("did not expect any event, got: %s", ev)
+	case <-time.After(100 * time.Millisecond):
+		// expected: no event recorded
+	}
+}
+
+func TestReconcileBackoffInitialization(t *testing.T) {
+	resetBackOffDuration()
+	scheme := newTestScheme(t)
+	sms := makeSMSCR(nil)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sms).Build()
+	r := &ReconcileSnapshotMetadataServiceGC{
+		client:   fakeClient,
+		scheme:   scheme,
+		recorder: record.NewFakeRecorder(10),
+	}
+
+	backOffDurationMapMutex.Lock()
+	_, existsBefore := backOffDuration[targetSMSName]
+	backOffDurationMapMutex.Unlock()
+	assert.False(t, existsBefore)
+
+	_, err := r.Reconcile(context.Background(), smsReconcileRequest())
+	assert.NoError(t, err)
+
+	// The map is lazily seeded to 1s, but since the Secret is missing, the
+	// same Reconcile call also hits the "Secret not found" Warning path, which
+	// doubles it to 2s before returning — there's no intermediate no-op branch
+	// in this controller to observe the seed value in isolation.
+	backOffDurationMapMutex.Lock()
+	got, existsAfter := backOffDuration[targetSMSName]
+	backOffDurationMapMutex.Unlock()
+	assert.True(t, existsAfter, "backoff entry should be created after reconcile")
+	assert.Equal(t, 2*time.Second, got)
+}
+
+// ---------------------------------------------------------------------------
+// Add() flavor gating tests
+// ---------------------------------------------------------------------------
+
+// TestAddSkipsInitForNonGuestFlavor verifies that Add returns immediately
+// without initializing any resources when the cluster flavor is not Guest
+// (VKS). The CSI_Backup_API_FSS gate that used to live inside Add is now
+// enforced once, by the caller, before Add is ever invoked.
+func TestAddSkipsInitForNonGuestFlavor(t *testing.T) {
+	flavors := []cnstypes.CnsClusterFlavor{
+		cnstypes.CnsClusterFlavorVanilla,
+		cnstypes.CnsClusterFlavorWorkload,
+	}
+	for _, flavor := range flavors {
+		flavor := flavor
+		t.Run(string(flavor), func(t *testing.T) {
+			err := Add(nil, flavor, nil)
+			assert.NoError(t, err, "Add should be a no-op for non-Guest flavors")
+		})
+	}
+}

--- a/pkg/syncer/dpoperator/manager.go
+++ b/pkg/syncer/dpoperator/manager.go
@@ -20,26 +20,27 @@ import (
 	"context"
 	"fmt"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	snapshotmetadatav1beta1 "github.com/kubernetes-csi/external-snapshot-metadata/client/apis/snapshotmetadataservice/v1beta1"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
-	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/dpoperator/controller"
 )
 
-// NewManager creates and initializes a new controller manager for the DP operator.
-// The DP operator only runs on the Supervisor (Workload) cluster, so the cluster flavor
-// is implied and hard-coded internally rather than being passed in by the caller.
+// NewManager creates and initializes a new controller manager for the DP operator. clusterFlavor
+// and configInfo are handed to each registered controller as-is via controller.AddToManager; each
+// controller decides for itself whether it applies to clusterFlavor and builds whatever
+// dependencies (vCenter client, volume manager, informers, etc.) it needs from configInfo.
 func NewManager(
 	ctx context.Context,
 	configInfo *cnsconfig.ConfigurationInfo,
+	clusterFlavor cnstypes.CnsClusterFlavor,
 ) (ctrlmgr.Manager, error) {
 	log := logger.GetLogger(ctx)
 	log.Infof("Initializing DP Operator")
@@ -64,38 +65,19 @@ func NewManager(
 			cbtconfigv1alpha1.GroupVersion.String(), err)
 	}
 
-	vcClient, err := cnsvsphere.GetVirtualCenterInstance(ctx, configInfo, false)
-	if err != nil {
-		return nil, err
+	if err := certmanagerv1.AddToScheme(mgr.GetScheme()); err != nil {
+		return nil, fmt.Errorf(
+			"failed to set scheme for Data Protection(DP) operator for type %s. Err: %+v",
+			certmanagerv1.SchemeGroupVersion.Group, err)
 	}
 
-	volumeManager, err := volume.GetManager(ctx, vcClient, nil, false, false, false,
-		cnstypes.CnsClusterFlavorWorkload, configInfo.Cfg.Global.SupervisorID,
-		configInfo.Cfg.Global.ClusterDistribution)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create an instance of volume manager: %w", err)
+	if err := snapshotmetadatav1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+		return nil, fmt.Errorf(
+			"failed to set scheme for Data Protection(DP) operator for type %s. Err: %+v",
+			snapshotmetadatav1beta1.SchemeGroupVersion.Group, err)
 	}
 
-	// Reuse the singleton InformerManager so the DP operator's PV/PVC/VA reads share the
-	// same cluster-wide informer caches that the metadata syncer (and other syncer
-	// controllers) already run in this process. Listen() starts the factory and waits for
-	// the registered informers' caches to sync (idempotent across callers - the metadata
-	// syncer also calls Listen on the same singleton).
-	k8sClient, err := k8s.NewClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client for dp operator: %w", err)
-	}
-	informerManager := k8s.NewInformer(ctx, k8sClient)
-	informerManager.InitVolumeAttachmentInformer()
-	informerManager.Listen()
-
-	// Get listers after Listen() so caches are populated by the time the controllers start
-	// reconciling.
-	pvLister := informerManager.GetPVLister()
-	pvcLister := informerManager.GetPVCLister()
-	vaLister := informerManager.GetVolumeAttachmentLister()
-
-	if err := controller.AddToManager(mgr, k8sClient, volumeManager, pvLister, pvcLister, vaLister); err != nil {
+	if err := controller.AddToManager(mgr, clusterFlavor, configInfo); err != nil {
 		return nil, err
 	}
 

--- a/pkg/syncer/k8soperator/manager.go
+++ b/pkg/syncer/k8soperator/manager.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	snapshotmetadatav1beta1 "github.com/kubernetes-csi/external-snapshot-metadata/client/apis/snapshotmetadataservice/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -58,18 +56,6 @@ func NewManager(
 	// Setup Scheme for all resources
 	if err := snapv1.AddToScheme(mgr.GetScheme()); err != nil {
 		return nil, fmt.Errorf("failed to set scheme for K8s operator for type %s. Err: %+v", snapv1.GroupName, err)
-	}
-
-	if err := certmanagerv1.AddToScheme(mgr.GetScheme()); err != nil {
-		return nil, fmt.Errorf(
-			"failed to set scheme for K8s operator for type %s. Err: %+v",
-			certmanagerv1.SchemeGroupVersion.Group, err)
-	}
-
-	if err := snapshotmetadatav1beta1.AddToScheme(mgr.GetScheme()); err != nil {
-		return nil, fmt.Errorf(
-			"failed to set scheme for K8s operator for type %s. Err: %+v",
-			snapshotmetadatav1beta1.SchemeGroupVersion.Group, err)
 	}
 
 	if err := k8scontroller.AddToManager(mgr, clusterFlavor); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
As a part of CSI CBT support, we deploy a new CSI snapshot metadata service in VKS cluster, that gets exposed by new CR called SnapshotMetadataService(SMS) CR for vsphere CSI driver.
This service has a cert-manager based self-signed certificate associated called vmware-system-csi-snapshot-metadata-service-gc-cert , that represents the server cert to its clients.
Since guest cluster does not have cert-manager installed by default, the cert is created on supervisor cluster and its data is exported to guest cluster via a secret.
SMS CR in spec field has CA bundle of the backing service (implemented by vSphere CSI driver) for its clients to connect securely over TLS. It is required to maintain this CA bundle up-to-date through its lifetime to make clients connect successful, even after cert renewals happening periodically.
To ensure this, current PR adds new secret reconciler in syncer that watches for secret carrying the certificate data added for CSI snapshot metadata service in VKS cluster, and updates the CA bundle in SnapshotMetadataService CR on change/renewal.
This PR is a variant of https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3956 for guest cluster CBT service

NOTE: This PR needs RBAC change in guest cluster CSI controller role, which will be handled with other VKS deployment changes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* WCP precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1838/
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 1 Pending | 1079 Skipped | 0 Flaked
```
* VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1399/
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```
* Verified change manually on VKS cluster
```
root@423d9a9457f7601b4f7e53b8507c26c8 [ ~ ]# export KUBECONFIG=gc_kubeconfig.yaml
root@423d9a9457f7601b4f7e53b8507c26c8 [ ~ ]# k get snapshotmetadataservices.cbt.storage.k8s.io -o yaml
apiVersion: v1
items:
- apiVersion: cbt.storage.k8s.io/v1beta1
  kind: SnapshotMetadataService
  metadata:
    creationTimestamp: "2026-07-21T07:56:10Z"
    generation: 6
    name: csi.vsphere.vmware.com
    resourceVersion: "28559"
    uid: 74af3b2a-7124-4c1f-9404-0fdd737ce594
  spec:
    address: vmware-system-csi-snapshot-metadata-service-gc.vmware-system-csi.svc.cluster.local:6443
    audience: csi.vsphere.vmware.com
    caCert: bm8tY2VydC1kYXRhCg==               <<< original temp cert in VKS SMS CR
kind: List
metadata:
  resourceVersion: ""
root@423d9a9457f7601b4f7e53b8507c26c8 [ ~ ]#
root@423d9a9457f7601b4f7e53b8507c26c8 [ ~ ]# k edit deploy -n vmware-system-csi vsphere-csi-controller
deployment.apps/vsphere-csi-controller edited
root@423d9a9457f7601b4f7e53b8507c26c8 [ ~ ]# k get snapshotmetadataservices.cbt.storage.k8s.io -o yaml
apiVersion: v1
items:
- apiVersion: cbt.storage.k8s.io/v1beta1
  kind: SnapshotMetadataService
  metadata:
    creationTimestamp: "2026-07-21T07:56:10Z"
    generation: 7
    name: csi.vsphere.vmware.com
    resourceVersion: "234692"
    uid: 74af3b2a-7124-4c1f-9404-0fdd737ce594
  spec:
    address: vmware-system-csi-snapshot-metadata-service-gc.vmware-system-csi.svc.cluster.local:6443
    audience: csi.vsphere.vmware.com
    caCert: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURGRENDQWZ5Z0F3SUJBZ0lVUGxIRTVBZnBwOFpjMHZFWm5PUVRCYU14VU8wd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0lqRWdNQjRHQTFVRUF4TVhWbE53YUdWeVpTMURVMGt0VTAxVExWSnZiM1F0UTBFd0hoY05Nall3TnpJeApNRFl5TmpNeldoY05Nell3TnpFNE1EWXlOak16V2pBaU1TQXdIZ1lEVlFRREV4ZFdVM0JvWlhKbExVTlRTUzFUClRWTXRVbTl2ZEMxRFFUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU9XWXkvRnQKZnlBdTFKdHhRQWRFVzQ0c255R1crWExTTGJvUWpWTU9RNk9EZDJlWlZxNUFldFZnZUxQaDV6T1FwSUkvWm9nMQpNaGd6eUxNRFE3RnFmQmRKV04rdDdjU3JNZkFjN21KbXkvUjBrK3A1MTNmNXhsaVBhdkVRbzJjdnhTZmM4M3BDClNzNGhZSGExcDBaVHEwZ2l2dUlzWG1CdVBkUFJqNzMxckFNRXF1emFYSkFtSlBoQVptQ1JYZnQwYnh6cEpEZkYKTlFMV01xVmpHTzRYVzFBNFZGbldVd0RSdGRoalVjT2hMcWN0NkE3blJnaU93dktPYW9tUnlFSXhyQk54RURqSQpacndRL1FJWlN6MEZrMjU5TzF5aXY2M2c0TnJreEs5OTV2YWR4VXgxcnlYUTBiYVMxaHZDM0lKakc4WXhjZWQ4CmI2THdmbVpGV3J6R3RRMENBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUYKTUFNQkFmOHdIUVlEVlIwT0JCWUVGR2Z1ZlNzcStsblNIcU1WdjZJYnhNMnNOZFFqTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQlZPc0x5U1c1aW9VbXB6dFRQeFpPa0FsYjVEcENGUUhmYU1YTFpmOU5yRGY5ank3VWJDblhWCm9qWUllRVBGKzIyNmZTV0RsMjVRSWk5akFtcVlGU084ZmZxbEZGSk5zRFBZa3BJVnd2cURGWnVkNURqV3p2QXoKMTNpd2tVYWg0S2gxeEYxSm8yd3JSdXZSMW9obVh4akNiWDd4dWVVSWRKMXQwQUxmODYrK3ZnWGd0WlkwVDBvZAovelFFdG1iaG5nVmdqeitVNXFoek8vOERXdDF1bEZ1aXR1RnRncTBldm9hY2FHQnhDQlREenQxbGVXdHpKSWx0CjNDTkVLazRST1hVdThYK0NLdUxFdVpJbGRoMGxiRm5NNmJLOG1DTkNRZjBLWWF2VSt1b3JGNGk1eFV3WVlwbGEKcTRYYkMrb2NYUWtoSmZLa21IS1U3MnJ2ZXlmUDhXa2kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
kind: List
metadata:
  resourceVersion: ""
root@423d9a9457f7601b4f7e53b8507c26c8 [ ~ ]#
```
CSI syncer logs:
```
2026-07-22T06:47:46.827Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:103   Initializing SnapshotMetadataServiceGC Controller       {"TraceId": "93ba08bf-40ad-453a-afc0-99e19bd8bd37"}
...
2026-07-22T06:47:47.078Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:251   Received Reconcile for request: "/csi.vsphere.vmware.com"       {"TraceId": "c4059ec8-0ae6-4c59-ab6a-1ef8bec37550"}
2026-07-22T06:47:47.078Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:259   Started Reconcile for SnapshotMetadataServiceGC request: "/csi.vsphere.vmware.com"      {"TraceId": "c4059ec8-0ae6-4c59-ab6a-1ef8bec37550"}
2026-07-22T06:47:47.079Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:315   Updating SnapshotMetadataService csi.vsphere.vmware.com caCert from Secret vmware-system-csi/vmware-system-csi-snapshot-metadata-service-cert-gc  {"TraceId": "c4059ec8-0ae6-4c59-ab6a-1ef8bec37550"}
2026-07-22T06:47:47.098Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:362   Successfully synced SnapshotMetadataService csi.vsphere.vmware.com caCert from Secret vmware-system-csi/vmware-system-csi-snapshot-metadata-service-cert-gc       {"TraceId": "c4059ec8-0ae6-4c59-ab6a-1ef8bec37550"}
...
2026-07-22T06:47:47.098Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:338   Finished Reconcile for SnapshotMetadataServiceGC request: "/csi.vsphere.vmware.com"     {"TraceId": "c4059ec8-0ae6-4c59-ab6a-1ef8bec37550"}
2026-07-22T06:47:47.098Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:251   Received Reconcile for request: "/csi.vsphere.vmware.com"       {"TraceId": "25c8654a-3361-4023-a63f-5b133fff7acb"}
2026-07-22T06:47:47.099Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:259   Started Reconcile for SnapshotMetadataServiceGC request: "/csi.vsphere.vmware.com"      {"TraceId": "25c8654a-3361-4023-a63f-5b133fff7acb"}
2026-07-22T06:47:47.099Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:330   SnapshotMetadataService csi.vsphere.vmware.com caCert already up-to-date, no action needed      {"TraceId": "25c8654a-3361-4023-a63f-5b133fff7acb"}
2026-07-22T06:47:47.099Z        INFO    snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go:338   Finished Reconcile for SnapshotMetadataServiceGC request: "/csi.vsphere.vmware.com"     {"TraceId": "25c8654a-3361-4023-a63f-5b133fff7acb"}

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add secret reconciler to watch cert data to be updated in SnapshotMetadataService CR on cert renewal in VKS cluster
```
