### PR TITLE
VKSRegisterVolume: add Supervisor watch for volume registration

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -701,16 +701,22 @@ const (
 	// on the supervisor.
 	HostLocalStorageSupportFSS = "host-local-storage-support"
 
-	// DataProtectionSnapshotService is the WCP capability that gates VKS volume restore
-	// (VKSRegisterVolume). It is activated when VC >= 9.1.2, Supervisor >= 9.1.2,
-	// TKG >= 3.8.0, and the dp-operator snapservice has been registered and activated.
-	// The capability string matches the entry in supervisor-capabilities.yaml owned by
-	// the snapservice team.
-	DataProtectionSnapshotService = "supports_data_protection_snapshot_service"
+	// VSphereDPLPModernApp is the WCP capability that gates the Supervisor
+	// CnsRegisterVolume controller accepting a spec with both VolumeID and DiskURLPath
+	// set (the VKS volume-restore path). It is activated when VC >= 9.1.2,
+	// Supervisor >= 9.1.2, TKG >= 3.8.0, and the dp-operator snapservice has been
+	// registered and activated. The capability string matches the entry in
+	// supervisor-capabilities.yaml owned by the snapservice team.
+	//
+	// This capability is NOT associated with the VKSRegisterVolume guest-cluster FSS
+	// below: whether the VKSRegisterVolume controller starts does not depend on any
+	// Supervisor capability, only on the two-ConfigMap FSS check (see VKSRegisterVolume).
+	VSphereDPLPModernApp = "supports_vsphere_dp_lp_modern_app"
 
 	// VKSRegisterVolume is the guest-cluster FSS that gates the VKSRegisterVolume
-	// operator. Requires both this flag in the guest PVCSI ConfigMap and the
-	// DataProtectionSnapshotService WCP capability on the Supervisor.
+	// operator. Requires the flag to be true in both the guest PVCSI ConfigMap and the
+	// Supervisor csi-feature-states ConfigMap (two-ConfigMap gating, not associated with
+	// any WCP capability — deliberately absent from WCPFeatureStateAssociatedWithPVCSI).
 	VKSRegisterVolume = "vks-register-volume"
 )
 
@@ -734,7 +740,7 @@ var WCPFeatureStates = map[string]struct{}{
 	SupportsPerNamespaceNetworkProviders:    {},
 	VMPVCStoragePolicyMutability:            {},
 	HostLocalStorageSupport:                 {},
-	DataProtectionSnapshotService:           {},
+	VSphereDPLPModernApp:                    {},
 }
 
 // WCPFeatureStatesSupportsLateEnablement contains capabilities that can be enabled later
@@ -755,7 +761,7 @@ var WCPFeatureStatesSupportsLateEnablement = map[string]struct{}{
 	SupportsPerNamespaceNetworkProviders:    {},
 	VMPVCStoragePolicyMutability:            {},
 	HostLocalStorageSupport:                 {},
-	DataProtectionSnapshotService:           {},
+	VSphereDPLPModernApp:                    {},
 }
 
 // WCPFeatureAssociatedWithPVCSI contains FSS name used in PVCSI and associated WCP Capability name on a
@@ -769,6 +775,5 @@ var WCPFeatureStateAssociatedWithPVCSI = map[string]string{
 	CSI_Backup_API_FSS:                      CSI_Backup_API,
 	VMPVCStoragePolicyMutabilityFSS:         VMPVCStoragePolicyMutability,
 	HostLocalStorageSupportFSS:              HostLocalStorageSupport,
-	VKSRegisterVolume:                       DataProtectionSnapshotService,
 	SupportsExposingStoragePolicyAttributes: SupportsExposingStoragePolicyAttributes,
 }

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -92,10 +92,10 @@ var (
 	isTKGSHAEnabled                         bool
 	isMultipleClustersPerVsphereZoneEnabled bool
 	isSharedDiskEnabled                     bool
-	// isDataProtectionSnapshotServiceEnabled caches the DataProtectionSnapshotService
+	// isVSphereDPLPModernAppEnabled caches the VSphereDPLPModernApp
 	// WCP capability at controller startup. Set once in Add(); late enablement triggers
 	// a pod restart which re-evaluates this value.
-	isDataProtectionSnapshotServiceEnabled bool
+	isVSphereDPLPModernAppEnabled bool
 )
 
 // Add creates a new CnsRegisterVolume Controller and adds it to the Manager,
@@ -115,8 +115,8 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	isTKGSHAEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 	isMultipleClustersPerVsphereZoneEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.MultipleClustersPerVsphereZone)
-	isDataProtectionSnapshotServiceEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
-		common.DataProtectionSnapshotService)
+	isVSphereDPLPModernAppEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.VSphereDPLPModernApp)
 
 	var volumeInfoService cnsvolumeinfo.VolumeInfoService
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
@@ -1214,10 +1214,10 @@ func validateCnsRegisterVolumeSpec(ctx context.Context, instance *cnsregistervol
 	var msg string
 	// Both VolumeID and DiskURLPath may be set by ss-metadata-manager for the VKSRegisterVolume
 	// restore path: CNS locates the VMDK by URL and stamps the provided FCD UUID onto it.
-	// This combination is only permitted when the DataProtectionSnapshotService WCP capability
+	// This combination is only permitted when the VSphereDPLPModernApp WCP capability
 	// is active on the Supervisor; on older Supervisors the original rejection is preserved.
 	if instance.Spec.VolumeID != "" && instance.Spec.DiskURLPath != "" {
-		if !isDataProtectionSnapshotServiceEnabled {
+		if !isVSphereDPLPModernAppEnabled {
 			return errors.New("VolumeID and DiskURLPath cannot be specified together")
 		}
 		// Capability is active: both fields are valid. The single-field checks below

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -1818,7 +1818,7 @@ func TestValidateCnsRegisterVolumeSpecWithVolumeIdAndAccessMode(t *testing.T) {
 }
 
 // TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityEnabled verifies that
-// both VolumeID and DiskURLPath are accepted when the DataProtectionSnapshotService WCP capability
+// both VolumeID and DiskURLPath are accepted when the VSphereDPLPModernApp WCP capability
 // is active (VKSRegisterVolume restore path via ss-metadata-manager).
 func TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityEnabled(t *testing.T) {
 	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
@@ -1835,13 +1835,13 @@ func TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityEn
 	}
 
 	isSharedDiskEnabled = false
-	isDataProtectionSnapshotServiceEnabled = true
+	isVSphereDPLPModernAppEnabled = true
 	err := validateCnsRegisterVolumeSpec(context.TODO(), instance)
 	assert.NoError(t, err)
 }
 
 // TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityDisabled verifies that
-// both VolumeID and DiskURLPath are rejected when the DataProtectionSnapshotService WCP capability
+// both VolumeID and DiskURLPath are rejected when the VSphereDPLPModernApp WCP capability
 // is absent, preserving the original behaviour on older Supervisors.
 func TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityDisabled(t *testing.T) {
 	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
@@ -1858,13 +1858,13 @@ func TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityDi
 	}
 
 	isSharedDiskEnabled = false
-	isDataProtectionSnapshotServiceEnabled = false
+	isVSphereDPLPModernAppEnabled = false
 	err := validateCnsRegisterVolumeSpec(context.TODO(), instance)
 	assert.EqualError(t, err, "VolumeID and DiskURLPath cannot be specified together")
 }
 
 // TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityEnabled verifies that
-// when both VolumeID and DiskURLPath are set and the DataProtectionSnapshotService WCP capability
+// when both VolumeID and DiskURLPath are set and the VSphereDPLPModernApp WCP capability
 // is active, BackingObjectDetails carries both fields.
 func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityEnabled(t *testing.T) {
 	volumeID := "fcd-uuid-123456"
@@ -1892,7 +1892,7 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityE
 		configInfo: &config.ConfigurationInfo{Cfg: cfg},
 	}
 
-	isDataProtectionSnapshotServiceEnabled = true
+	isVSphereDPLPModernAppEnabled = true
 	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
@@ -1901,7 +1901,7 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityE
 }
 
 // TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityDisabled verifies that
-// when both VolumeID and DiskURLPath are set but the DataProtectionSnapshotService WCP capability
+// when both VolumeID and DiskURLPath are set but the VSphereDPLPModernApp WCP capability
 // is absent (older vCenter), the spec falls back to VolumeID-only to avoid sending an unsupported
 // API call to the vCenter.
 func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityDisabled(t *testing.T) {
@@ -1930,7 +1930,7 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityD
 		configInfo: &config.ConfigurationInfo{Cfg: cfg},
 	}
 
-	isDataProtectionSnapshotServiceEnabled = false
+	isVSphereDPLPModernAppEnabled = false
 	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -365,8 +365,8 @@ func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegister
 		},
 	}
 	if instance.Spec.VolumeID != "" && instance.Spec.DiskURLPath != "" &&
-		isDataProtectionSnapshotServiceEnabled {
-		// Both fields supplied and DataProtectionSnapshotService WCP capability is active:
+		isVSphereDPLPModernAppEnabled {
+		// Both fields supplied and VSphereDPLPModernApp WCP capability is active:
 		// CNS locates the VMDK by URL and stamps the provided FCD UUID onto it
 		// (VKSRegisterVolume restore path — ss-metadata-manager supplies both fields).
 		// Guard is required: older vCenters do not support both fields and would return an error.

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/supervisor_watch_test.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/supervisor_watch_test.go
@@ -323,6 +323,3 @@ func TestParseVolumeAccessibleTopologyAnnotation(t *testing.T) {
 		})
 	}
 }
-
-// toCSITopology itself is tested in pvspec_test.go (TestToCSITopology) — it's defined in pvspec.go,
-// shared by both the T6 (supervisor watch) and T7 (guest PV builder) call sites.

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/validation.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/validation.go
@@ -19,6 +19,7 @@ package vksregistervolume
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -63,12 +64,14 @@ func validateSpec(ctx context.Context, spec *vksregistervolumev1alpha1.VKSRegist
 //
 // The PVC must satisfy all of the following:
 //   - exists in the same namespace as the CR
-//   - not yet Bound (Phase == Pending; the PVC must already exist in Pending)
-//   - spec.volumeName is set (the pre-chosen guest PV name)
+//   - spec.volumeName is set (the pre-chosen guest PV name); Phase may be Pending or already
+//     Bound (to spec.volumeName, per Kubernetes' own binding contract) — both are valid, since
+//     Bound covers a re-reconcile of an already-completed or partially-completed prior pass
 //   - spec.accessModes is non-empty
 //   - spec.resources.requests[storage] > 0
 //   - spec.storageClassName is set and that StorageClass exists
-//   - the StorageClass carries the svstorageclass (common.AttributeSupervisorStorageClass) parameter
+//   - the StorageClass carries the svstorageclass (common.AttributeSupervisorStorageClass)
+//     parameter (case-insensitive)
 //
 // If the PVC is not found and the CR was created within pvcMissingTimeout, the error is transient
 // (the PVC may not have been created yet). After the timeout it becomes terminal.
@@ -102,15 +105,15 @@ func resolveGuestPVC(
 			instance.Namespace, instance.Spec.PVCName, age.Truncate(time.Second), pvcMissingTimeout)
 	}
 
-	// PVC must not be Bound yet — it must already exist in Pending.
-	// A Bound PVC means another PV already claimed it; fail terminally.
-	if pvc.Status.Phase == corev1.ClaimBound {
-		return nil, true, fmt.Errorf("guest PVC %s/%s is already Bound (to PV %q); "+
-			"cannot import volume into an already-bound PVC",
-			instance.Namespace, instance.Spec.PVCName, pvc.Spec.VolumeName)
-	}
-
-	// spec.volumeName must be set — this is the pre-chosen guest PV name.
+	// spec.volumeName must be set — this is the pre-chosen guest PV name. A PVC's spec.volumeName
+	// is always exactly the PV it is or will be bound to (Kubernetes' own binding contract), so
+	// this is also the only "expected PV" this controller needs: whether the PVC is currently
+	// Pending or already Bound, spec.volumeName tells us which PV it is/will be bound to, and
+	// Steps 6-8 create/validate/wait-for exactly that PV idempotently. There is deliberately no
+	// separate "reject if already Bound" check here — a Bound PVC whose spec.volumeName matches
+	// is success (e.g. a re-reconcile of an already-completed or partially-completed prior pass,
+	// such as one interrupted between Step 7 succeeding and the Registered status patch landing),
+	// not a conflict.
 	if pvc.Spec.VolumeName == "" {
 		return nil, true, fmt.Errorf("guest PVC %s/%s has empty spec.volumeName; "+
 			"spec.volumeName must be set to the future PV name",
@@ -148,7 +151,17 @@ func resolveGuestPVC(
 		// API error: treat as transient.
 		return nil, false, fmt.Errorf("failed to GET StorageClass %q: %w", scName, err)
 	}
-	if _, hasSVSC := sc.Parameters[common.AttributeSupervisorStorageClass]; !hasSVSC {
+	// Case-insensitive lookup, matching the convention used elsewhere in this codebase
+	// (e.g. admissionhandler/validatepvc.go, wcpguest/controller.go) — StorageClass authors
+	// are not guaranteed to use the exact lowercase casing of the parameter key.
+	hasSVSC := false
+	for param := range sc.Parameters {
+		if strings.ToLower(param) == common.AttributeSupervisorStorageClass {
+			hasSVSC = true
+			break
+		}
+	}
+	if !hasSVSC {
 		return nil, true, fmt.Errorf("StorageClass %q referenced by PVC %s/%s does not have %q parameter; "+
 			"only guest StorageClasses backed by a Supervisor StorageClass are supported",
 			scName, instance.Namespace, instance.Spec.PVCName, common.AttributeSupervisorStorageClass)

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/validation_test.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/validation_test.go
@@ -66,6 +66,19 @@ func storageClassWithoutSVSC(name string) *storagev1.StorageClass {
 	}
 }
 
+// storageClassWithMixedCaseSVSC builds a StorageClass whose svstorageclass parameter key uses
+// the mixed casing ("SVStorageClass") this repo's own e2e test suite uses in practice — the
+// lookup must be case-insensitive to accept it.
+func storageClassWithMixedCaseSVSC(name string) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: name},
+		Provisioner: "csi.vsphere.vmware.com",
+		Parameters: map[string]string{
+			"SVStorageClass": "silver",
+		},
+	}
+}
+
 // pendingPVC returns a well-formed Pending PVC accepted by resolveGuestPVC.
 func pendingPVC(namespace, name, scName string) *corev1.PersistentVolumeClaim {
 	sc := scName
@@ -208,18 +221,22 @@ func TestResolveGuestPVC(t *testing.T) {
 
 		// ── PVC state validation ──────────────────────────────────────────────────────────────
 		{
-			name:     "PVC already Bound → terminal",
+			// A PVC's spec.volumeName is always the PV it is/will be bound to (Kubernetes'
+			// own binding contract), so a Bound PVC with spec.volumeName set is success, not a
+			// conflict — e.g. a re-reconcile of an already-completed (or interrupted between
+			// Step 7 succeeding and the Registered status patch landing) prior pass. Regression
+			// test for the bug where this was previously rejected unconditionally.
+			name:     "PVC already Bound to its own spec.volumeName → success, not terminal",
 			instance: freshInstance,
 			pvcInStore: func() *corev1.PersistentVolumeClaim {
 				pvc := pendingPVC(ns, pvcName, scName)
 				pvc.Status.Phase = corev1.ClaimBound
-				pvc.Spec.VolumeName = "existing-pv"
 				return pvc
 			}(),
 			scInStore:    storageClassWithSVSC(scName),
-			wantPVC:      false,
-			wantTerminal: true,
-			wantErr:      true,
+			wantPVC:      true,
+			wantTerminal: false,
+			wantErr:      false,
 		},
 		{
 			name:     "PVC spec.volumeName empty → terminal",
@@ -327,6 +344,17 @@ func TestResolveGuestPVC(t *testing.T) {
 			instance:     freshInstance,
 			pvcInStore:   pendingPVC(ns, pvcName, scName),
 			scInStore:    storageClassWithSVSC(scName),
+			wantPVC:      true,
+			wantTerminal: false,
+			wantErr:      false,
+		},
+		{
+			// Regression test: the svstorageclass parameter lookup must be case-insensitive,
+			// matching the convention used elsewhere in this codebase (e.g. validatepvc.go).
+			name:         "valid PVC with mixed-case SVStorageClass parameter → success",
+			instance:     freshInstance,
+			pvcInStore:   pendingPVC(ns, pvcName, scName),
+			scInStore:    storageClassWithMixedCaseSVSC(scName),
 			wantPVC:      true,
 			wantTerminal: false,
 			wantErr:      false,

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/vksregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/vksregistervolume_controller.go
@@ -70,7 +70,30 @@ var (
 	// Initialized to 1s on first reconcile; doubled on each failure up to MaxBackOffDurationForReconciler.
 	backOffDuration         map[apitypes.NamespacedName]time.Duration
 	backOffDurationMapMutex = sync.Mutex{}
+
+	// phaseOrder gives each non-terminal phase its position in the linear state machine, so
+	// Reconcile can tell whether the CR has already passed a given step and skip re-running it.
+	// Terminal phases (Registered, Failed) are intentionally absent: Reconcile already returns
+	// early for Registered, and Failed CRs are not requeued.
+	phaseOrder = map[vksregistervolumev1alpha1.VKSRegisterVolumePhase]int{
+		vksregistervolumev1alpha1.VKSRegisterVolumePhasePending:                          0,
+		vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration: 1,
+		vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorBinding:      2,
+		vksregistervolumev1alpha1.VKSRegisterVolumePhaseCreatingGuestPV:                  3,
+		vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForGuestPVCBound:          4,
+	}
 )
+
+// hasPassedPhase reports whether the CR's current phase is strictly beyond target in the linear
+// state machine (phaseOrder). An empty/unset current phase is treated as Pending (position 0), so
+// a CR that has never been reconciled before is never considered to have passed anything.
+func hasPassedPhase(current, target vksregistervolumev1alpha1.VKSRegisterVolumePhase) bool {
+	currentPos, ok := phaseOrder[current]
+	if !ok {
+		currentPos = phaseOrder[vksregistervolumev1alpha1.VKSRegisterVolumePhasePending]
+	}
+	return currentPos > phaseOrder[target]
+}
 
 // ReconcileVKSRegisterVolume reconciles VKSRegisterVolume objects in the guest cluster.
 type ReconcileVKSRegisterVolume struct {
@@ -492,11 +515,16 @@ func (r *ReconcileVKSRegisterVolume) setStatusError(ctx context.Context,
 }
 
 // setStatusPhase advances Phase, clears Error, and patches status.
+// setStatusPhase is a no-op both when the CR is already at phase (idempotent) and when it has
+// already progressed beyond phase (e.g. a later reconcile of a CR already in CreatingGuestPV
+// re-running an earlier step's phase-advance) — Reconcile always walks steps 1-N in order on
+// every invocation, so without this guard a CR's phase would regress on each reconcile after
+// its first successful pass. See phaseOrder/hasPassedPhase.
 func (r *ReconcileVKSRegisterVolume) setStatusPhase(ctx context.Context,
 	instance *vksregistervolumev1alpha1.VKSRegisterVolume,
 	phase vksregistervolumev1alpha1.VKSRegisterVolumePhase) error {
-	if instance.Status.Phase == phase {
-		return nil // already at this phase — idempotent
+	if instance.Status.Phase == phase || hasPassedPhase(instance.Status.Phase, phase) {
+		return nil
 	}
 	orig := instance.DeepCopy()
 	instance.Status.Phase = phase

--- a/pkg/syncer/cnsoperator/controller/vksregistervolume/vksregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/vksregistervolume/vksregistervolume_controller_test.go
@@ -27,6 +27,8 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	vksregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/vksregistervolume/v1alpha1"
@@ -101,5 +103,130 @@ func TestSetStatusRegistered(t *testing.T) {
 		}
 	default:
 		t.Error("expected a Normal event to be recorded, got none")
+
+	}
+}
+
+// ── TestHasPassedPhase ────────────────────────────────────────────────────────────────────────────
+
+func TestHasPassedPhase(t *testing.T) {
+	cases := []struct {
+		name    string
+		current vksregistervolumev1alpha1.VKSRegisterVolumePhase
+		target  vksregistervolumev1alpha1.VKSRegisterVolumePhase
+		want    bool
+	}{
+		{
+			name:    "unset current is treated as Pending — never past anything",
+			current: "",
+			target:  vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration,
+			want:    false,
+		},
+		{
+			name:    "current equals target is not past",
+			current: vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration,
+			target:  vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration,
+			want:    false,
+		},
+		{
+			name:    "current earlier than target is not past",
+			current: vksregistervolumev1alpha1.VKSRegisterVolumePhasePending,
+			target:  vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorBinding,
+			want:    false,
+		},
+		{
+			name:    "current later than target is past — the regression case",
+			current: vksregistervolumev1alpha1.VKSRegisterVolumePhaseCreatingGuestPV,
+			target:  vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration,
+			want:    true,
+		},
+		{
+			name:    "current one step later than target is past",
+			current: vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorBinding,
+			target:  vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration,
+			want:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasPassedPhase(tc.current, tc.target)
+			if got != tc.want {
+				t.Errorf("hasPassedPhase(%q, %q): got %v, want %v", tc.current, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── TestSetStatusPhaseDoesNotRegress ─────────────────────────────────────────────────────────────
+
+// TestSetStatusPhaseDoesNotRegress guards against the phase-regression bug Copilot flagged on
+// vksregistervolume PR #4180: Reconcile always walks its steps in order and, before this fix,
+// unconditionally called setStatusPhase for each step's target phase — so a CR already at a later
+// phase (e.g. CreatingGuestPV, once T7 exists) got patched backward to an earlier one
+// (WaitingForSupervisorRegistration) on every subsequent reconcile.
+func TestSetStatusPhaseDoesNotRegress(t *testing.T) {
+	cases := []struct {
+		name          string
+		startingPhase vksregistervolumev1alpha1.VKSRegisterVolumePhase
+		setPhase      vksregistervolumev1alpha1.VKSRegisterVolumePhase
+		wantPhase     vksregistervolumev1alpha1.VKSRegisterVolumePhase
+	}{
+		{
+			name:          "advancing forward patches normally",
+			startingPhase: vksregistervolumev1alpha1.VKSRegisterVolumePhasePending,
+			setPhase:      vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration,
+			wantPhase:     vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration,
+		},
+		{
+			name:          "re-setting the same phase is a no-op",
+			startingPhase: vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorBinding,
+			setPhase:      vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorBinding,
+			wantPhase:     vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorBinding,
+		},
+		{
+			name:          "setting an earlier phase than current does not regress",
+			startingPhase: vksregistervolumev1alpha1.VKSRegisterVolumePhaseCreatingGuestPV,
+			setPhase:      vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration,
+			wantPhase:     vksregistervolumev1alpha1.VKSRegisterVolumePhaseCreatingGuestPV,
+		},
+		{
+			name:          "setting an earlier phase one step back does not regress",
+			startingPhase: vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorBinding,
+			setPhase:      vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorRegistration,
+			wantPhase:     vksregistervolumev1alpha1.VKSRegisterVolumePhaseWaitingForSupervisorBinding,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := makeSupervisorScheme(t)
+			instance := &vksregistervolumev1alpha1.VKSRegisterVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "restore-db-vol", Namespace: "my-app"},
+				Status:     vksregistervolumev1alpha1.VKSRegisterVolumeStatus{Phase: tc.startingPhase},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(s).
+				WithRuntimeObjects(instance).WithStatusSubresource(instance).Build()
+
+			r := &ReconcileVKSRegisterVolume{client: fakeClient}
+
+			if err := r.setStatusPhase(context.Background(), instance, tc.setPhase); err != nil {
+				t.Fatalf("setStatusPhase returned unexpected error: %v", err)
+			}
+			if instance.Status.Phase != tc.wantPhase {
+				t.Errorf("in-memory instance phase: got %q, want %q", instance.Status.Phase, tc.wantPhase)
+			}
+
+			persisted := &vksregistervolumev1alpha1.VKSRegisterVolume{}
+			if err := fakeClient.Get(context.Background(),
+				client.ObjectKeyFromObject(instance), persisted); err != nil {
+				t.Fatalf("failed to GET persisted instance: %v", err)
+			}
+			if persisted.Status.Phase != tc.wantPhase {
+				t.Errorf("persisted phase: got %q, want %q", persisted.Status.Phase, tc.wantPhase)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
VKSRegisterVolume: add Supervisor watch for volume registration

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml 
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]# cat <<'EOF' | kubectl --kubeconfig=gc-cluster.yaml apply -f -
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: db-data-pvc
  namespace: my-app
spec:
  accessModes: [ReadWriteOnce]
  storageClassName: wcpglobal-storage-profile
  volumeName: pv-restore-db-vol
  resources:
    requests:
      storage: 1Gi
EOF
persistentvolumeclaim/db-data-pvc created
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]#
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]#
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]# kubectl --kubeconfig=gc-cluster.yaml -n my-app get pvc db-data-pvc
NAME          STATUS   VOLUME              CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
db-data-pvc   Bound    pv-restore-db-vol   1Gi        RWO            wcpglobal-storage-profile   <unset>                 6h40m
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]#
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]#
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]# cat <<EOF | kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f -
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: pv-restore-db-vol
  namespace: test-ns
spec:
  pvcName: pv-restore-db-vol
  volumeID: "62fc8af9-8b0e-4644-913d-e7ca9225715e"
  accessMode: ReadWriteOnce
EOF
cnsregistervolume.cns.vmware.com/pv-restore-db-vol created
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]# kubectl --kubeconfig=/etc/kubernetes/admin.conf -n test-ns get cnsregistervolume pv-restore-db-vol -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"cns.vmware.com/v1alpha1","kind":"CnsRegisterVolume","metadata":{"annotations":{},"name":"pv-restore-db-vol","namespace":"test-ns"},"spec":{"accessMode":"ReadWriteOnce","pvcName":"pv-restore-db-vol","volumeID":"62fc8af9-8b0e-4644-913d-e7ca9225715e"}}
  creationTimestamp: "2026-07-31T20:22:15Z"
  finalizers:
  - cns.vmware.com/register-volume
  generation: 1
  name: pv-restore-db-vol
  namespace: test-ns
  ownerReferences:
  - apiVersion: v1
    blockOwnerDeletion: true
    controller: true
    kind: PersistentVolumeClaim
    name: pv-restore-db-vol
    uid: 1cf2d94e-173b-49dd-8d5a-fd8689260058
  resourceVersion: "6277696"
  uid: 40fe2629-6b1e-4377-bdb3-dd584298724a
spec:
  accessMode: ReadWriteOnce
  pvcName: pv-restore-db-vol
  volumeID: 62fc8af9-8b0e-4644-913d-e7ca9225715e
status:
  registered: true
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]# kubectl --kubeconfig=/etc/kubernetes/admin.conf -n test-ns get pvc pv-restore-db-vol
NAME                STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
pv-restore-db-vol   Bound    static-pv-62fc8af9-8b0e-4644-913d-e7ca9225715e   1Gi        RWO            wcpglobal-storage-profile   <unset>                 37s
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]#

root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]# export KUBECONFIG=/root/gc-cluster.yaml 
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]# cat <<EOF | kubectl --kubeconfig=gc-cluster.yaml apply -f -
apiVersion: cns.vmware.com/v1alpha1
kind: VKSRegisterVolume
metadata:
  name: restore-db-vol
  namespace: my-app
spec:
  pvcName: db-data-pvc
  cnsRegisterVolumeName: pv-restore-db-vol
EOF
vksregistervolume.cns.vmware.com/restore-db-vol created

root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]# kubectl --kubeconfig=gc-cluster.yaml -n my-app get vksregistervolume restore-db-vol -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: VKSRegisterVolume
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"cns.vmware.com/v1alpha1","kind":"VKSRegisterVolume","metadata":{"annotations":{},"name":"restore-db-vol","namespace":"my-app"},"spec":{"cnsRegisterVolumeName":"pv-restore-db-vol","pvcName":"db-data-pvc"}}
  creationTimestamp: "2026-07-31T20:23:59Z"
  finalizers:
  - cns.vmware.com/vks-register-volume
  generation: 1
  name: restore-db-vol
  namespace: my-app
  resourceVersion: "2188340"
  uid: fae7df55-0491-45f9-9ba1-4d4d57651139
spec:
  cnsRegisterVolumeName: pv-restore-db-vol
  pvcName: db-data-pvc
status:
  error: ""
  phase: Registered
  registered: true
root@421a59ee8bf6275b1f4a36be96065627 [ ~ ]#
```

CSI Logs supervisor cluster:
[vksregistervolume_supervios_syncer.log](https://github.com/user-attachments/files/30604288/vksregistervolume_supervios_syncer.log)
[vksregistervolume_supervisor_csi-controller.log](https://github.com/user-attachments/files/30604294/vksregistervolume_supervisor_csi-controller.log)


CSI Logs guest cluster:
[vksregistervolume_controller.log](https://github.com/user-attachments/files/30604296/vksregistervolume_controller.log)
[syncer_vksresitervolume.log](https://github.com/user-attachments/files/30604299/syncer_vksresitervolume.log)



CSI Logs guest cluster:


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
VKSRegisterVolume: add Supervisor watch for volume registration
```
