### PR TITLE
Fail csinodetopology reconciliation when boot disk PVC is in Pending state

### DIFF
--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -476,9 +476,8 @@ func getNodeTopologyInfoForGuest(ctx context.Context, instance *csinodetopologyv
 		hostname, err = getHostnameFromNonRemovableVolume(ctx, supervisorClientset, virtualMachine,
 			supervisorNamespace)
 		if err != nil {
-			log.Warnf("failed to resolve ESXi hostname for node %q. Skipping host topology label. Error: %+v",
-				instance.Name, err)
-			hostname = ""
+			return nil, logger.LogNewErrorf(log,
+				"failed to resolve ESXi hostname for node %q. Error: %+v", instance.Name, err)
 		}
 	} else {
 		log.Info("fetching virtual machines with all versions")
@@ -536,6 +535,16 @@ func getHostnameFromNonRemovableVolume(ctx context.Context, supervisorClientset 
 		ctx, pvcName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get PVC %q: %w", pvcName, err)
+	}
+
+	// Get() succeeds and returns the PVC object as soon as it is created,
+	// regardless of binding state. The volume-accessible-topology annotation
+	// is only stamped once the underlying volume is provisioned and bound,
+	// so a still-Pending PVC must be treated as a hard error (and retried),
+	// not silently skipped.
+	if pvc.Status.Phase == corev1.ClaimPending {
+		return "", fmt.Errorf("boot disk PVC %q is still in %q phase; cannot resolve ESXi hostname yet",
+			pvcName, corev1.ClaimPending)
 	}
 
 	rawTopology, ok := pvc.Annotations[common.AnnVolumeAccessibleTopology]

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
@@ -160,6 +160,15 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 				Namespace: testSupervisorNamespace,
 			},
 		}
+		testPVCPending = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testPVCName,
+				Namespace: testSupervisorNamespace,
+			},
+			Status: corev1.PersistentVolumeClaimStatus{
+				Phase: corev1.ClaimPending,
+			},
+		}
 		testBufferSize = 1024
 	)
 
@@ -215,30 +224,31 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 			vm:                            testVMwithNonRemovableVolume.DeepCopy(),
 			enableHostLocalSupportInGuest: true,
 			existingPVC:                   testPVCWithoutTopologyAnnotation.DeepCopy(),
-			expectedTopologyLabels: []csinodetopologyv1alpha1.TopologyLabel{
-				{
-					Key:   expectedZoneKey,
-					Value: expectedZoneValue,
-				},
-			},
-			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologySuccess,
-			expectedReconcileResult: reconcile.Result{},
-			expectedReconcileError:  nil,
+			expectedTopologyLabels:        nil,
+			expectedCRDStatus:             csinodetopologyv1alpha1.CSINodeTopologyError,
+			expectedReconcileResult:       reconcile.Result{RequeueAfter: time.Second},
+			expectedReconcileError:        nil,
+		},
+		{
+			name:                          "TestWithHostLocalSupportEnabled_PVCPending",
+			csiNodeTopology:               testCSINodeTopology.DeepCopy(),
+			vm:                            testVMwithNonRemovableVolume.DeepCopy(),
+			enableHostLocalSupportInGuest: true,
+			existingPVC:                   testPVCPending.DeepCopy(),
+			expectedTopologyLabels:        nil,
+			expectedCRDStatus:             csinodetopologyv1alpha1.CSINodeTopologyError,
+			expectedReconcileResult:       reconcile.Result{RequeueAfter: time.Second},
+			expectedReconcileError:        nil,
 		},
 		{
 			name:                          "TestWithHostLocalSupportEnabled_NoNonRemovableVolume",
 			csiNodeTopology:               testCSINodeTopology.DeepCopy(),
 			vm:                            testVMwithRemovableVolumeOnly.DeepCopy(),
 			enableHostLocalSupportInGuest: true,
-			expectedTopologyLabels: []csinodetopologyv1alpha1.TopologyLabel{
-				{
-					Key:   expectedZoneKey,
-					Value: expectedZoneValue,
-				},
-			},
-			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologySuccess,
-			expectedReconcileResult: reconcile.Result{},
-			expectedReconcileError:  nil,
+			expectedTopologyLabels:        nil,
+			expectedCRDStatus:             csinodetopologyv1alpha1.CSINodeTopologyError,
+			expectedReconcileResult:       reconcile.Result{RequeueAfter: time.Second},
+			expectedReconcileError:        nil,
 		},
 		{
 			name:                          "TestWithHostLocalSupportDisabled",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fail CSINodeTopology reconciliation when the boot disk PVC isn't bound yet, instead of silently skipping the host label

For host-local storage support, the CSINodeTopology controller resolves a node's ESXi hostname by reading the csi.vsphere.volume-accessible-topology annotation off the PVC backing the VM's boot disk. That annotation is only written once the volume is actually provisioned and bound — it doesn't exist while the PVC is still Pending.

Previously, if the PVC was still pending (or the annotation was otherwise missing), the controller just logged a warning ("failed to resolve ESXi hostname... skipping host topology label") and moved on, marking the reconcile as successful with the host topology label silently left out. This meant a node could get published without its host-local topology label and nothing would flag it or retry.

This PR changes that behavior so it fails loudly instead:

The controller now explicitly checks if the boot disk PVC is still in Pending phase, and if so, returns a clear error.
Any failure to resolve the hostname (pending PVC, missing annotation, no boot volume found, etc.) now fails the reconcile outright, which triggers the controller's standard retry/backoff instead of quietly succeeding without the label.
Also added/updated unit tests to cover the pending-PVC case and to verify these failure paths now correctly result in a reconcile error and requeue rather than a false "success."

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running e2e pipelines, results TBA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fail csinodetopology reconciliation when boot disk PVC is in Pending state
```
