### PR TITLE
Allow only the hosts belonging to active clusters to be considered for linkedclone.

### DIFF
--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -866,8 +866,13 @@ func (r *ReconcileClusterStoragePolicyInfo) syncInfraSPIAttributes(ctx context.C
 		overallErr = errors.Join(overallErr, err)
 	}
 
+	if r.topologyMgr == nil {
+		return fmt.Errorf("topology manager is not available")
+	}
+	zoneClusters := r.topologyMgr.GetAZClustersMap(ctx)
+
 	// Populate volume capabilities.
-	if err := populateVolumeCapabilities(ctx, infraSPI, vc, profile.ID, zoneCompatibleDS); err != nil {
+	if err := populateVolumeCapabilities(ctx, infraSPI, vc, profile.ID, zoneCompatibleDS, zoneClusters); err != nil {
 		log.Errorf("Failed to populate volume capabilities for profile %s: %v", profile.ID, err)
 		overallErr = errors.Join(overallErr, err)
 	}

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -3902,8 +3902,8 @@ func TestPopulateVolumeCapabilities_MarkerPolicy(t *testing.T) {
 			infraSPI.Name = tt.k8sCompliantName
 
 			// Call populateVolumeCapabilities with minimal required parameters
-			// We pass nil for vc and zoneCompatibleDS since we only want to test the logic
-			err := populateVolumeCapabilities(ctx, infraSPI, nil, "test-profile-id", nil)
+			// We pass nil for vc, zoneCompatibleDS and zoneClusters since we only want to test the logic
+			err := populateVolumeCapabilities(ctx, infraSPI, nil, "test-profile-id", nil, nil)
 
 			// For marker policies, there should be no error since we skip the HPLC check
 			// For non-marker policies, there may be an error due to nil parameters, but capabilities should still be set
@@ -3968,7 +3968,7 @@ func TestCheckHighPerformanceLinkedClone_ZonesWithNoHosts(t *testing.T) {
 func TestCheckLinkedClone_NoZones(t *testing.T) {
 	ctx := context.Background()
 	stubVC := &cnsvsphere.VirtualCenter{Client: &govmomi.Client{}}
-	lc, perZone, err := checkLinkedClone(ctx, stubVC, "test-policy", map[string][]*cnsvsphere.DatastoreInfo{})
+	lc, perZone, err := checkLinkedClone(ctx, stubVC, "test-policy", map[string][]*cnsvsphere.DatastoreInfo{}, nil)
 	assert.NoError(t, err)
 	assert.False(t, lc, "LC must be false when there are no zones")
 	assert.Empty(t, perZone)
@@ -3978,7 +3978,7 @@ func TestCheckLinkedClone_NoZones(t *testing.T) {
 // without a vCenter client.
 func TestCheckLinkedClone_NilVC(t *testing.T) {
 	ctx := context.Background()
-	lc, perZone, err := checkLinkedClone(ctx, nil, "test-policy", nil)
+	lc, perZone, err := checkLinkedClone(ctx, nil, "test-policy", nil, nil)
 	assert.Error(t, err)
 	assert.False(t, lc)
 	assert.Nil(t, perZone)
@@ -4193,7 +4193,7 @@ func TestFetchESXi91HostsForDatastore_AllOldHosts(t *testing.T) {
 	ds := dsInfoFromSim(vc.Client, dsRef)
 	pc := property.DefaultCollector(vc.Client.Client)
 
-	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]bool))
+	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]*hostClusterRef))
 	require.NoError(t, err)
 	assert.Empty(t, hosts, "no ESXi 9.1+ hosts should be returned when all hosts run 7.0")
 }
@@ -4217,10 +4217,10 @@ func TestFetchESXi91HostsForDatastore_MixedVersions(t *testing.T) {
 	ds := dsInfoFromSim(vc.Client, dsRef)
 	pc := property.DefaultCollector(vc.Client.Client)
 
-	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]bool))
+	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]*hostClusterRef))
 	require.NoError(t, err)
 	require.Len(t, hosts, 1, "only the 9.1+ host should be returned")
-	assert.Equal(t, hostRefs[0].Value, hosts[0].Value)
+	assert.Equal(t, hostRefs[0].Value, hosts[0].Host.Value)
 }
 
 // TestFetchESXi91HostsForDatastore_AllESXi91 verifies that all mounting hosts are
@@ -4242,7 +4242,7 @@ func TestFetchESXi91HostsForDatastore_AllESXi91(t *testing.T) {
 	ds := dsInfoFromSim(vc.Client, dsRef)
 	pc := property.DefaultCollector(vc.Client.Client)
 
-	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]bool))
+	hosts, err := fetchESXi91HostsForDatastore(ctx, pc, ds, make(map[string]*hostClusterRef))
 	require.NoError(t, err)
 	assert.Len(t, hosts, len(hostRefs), "all ESXi 9.1+ hosts should be returned")
 }
@@ -4264,8 +4264,9 @@ func TestCheckLinkedClone_SingleZoneAllHostsESXi91(t *testing.T) {
 	require.NotEmpty(t, clusterDS)
 
 	zoneCompatibleDS := map[string][]*cnsvsphere.DatastoreInfo{"zone-a": clusterDS}
+	zoneClusters := map[string][]string{"zone-a": {clusterRef.Value}}
 
-	lc, perZone, err := checkLinkedClone(ctx, vc, "test-policy", zoneCompatibleDS)
+	lc, perZone, err := checkLinkedClone(ctx, vc, "test-policy", zoneCompatibleDS, zoneClusters)
 	require.NoError(t, err)
 	assert.True(t, lc, "LC should be true when the zone's datastore is mounted only by ESXi 9.1+ hosts")
 	assert.NotEmpty(t, perZone["zone-a"])
@@ -4289,10 +4290,50 @@ func TestCheckLinkedClone_OneZoneMissingESXi91Host(t *testing.T) {
 		"zone-a": {datastores[0]},
 		"zone-b": {datastores[1]},
 	}
+	zoneClusters := map[string][]string{
+		"zone-a": {clusters[0].Value},
+		"zone-b": {clusters[1].Value},
+	}
 
-	lc, _, err := checkLinkedClone(ctx, vc, "test-policy", zoneCompatibleDS)
+	lc, _, err := checkLinkedClone(ctx, vc, "test-policy", zoneCompatibleDS, zoneClusters)
 	require.NoError(t, err)
 	assert.False(t, lc, "LC must be false when not every zone has a qualifying ESXi 9.1+ host")
+}
+
+// TestCheckLinkedClone_HostFromInactiveClusterExcluded verifies that a host is only
+// attributed to a zone if its parent cluster is one of that zone's active clusters, even
+// when the host is ESXi 9.1+ and mounts a datastore attributed to the zone. setupLCSim's
+// single datastore is shared by every host in the datacenter (across both clusters), so
+// without the active-cluster filter clusterB's host would incorrectly count toward zone-a.
+func TestCheckLinkedClone_HostFromInactiveClusterExcluded(t *testing.T) {
+	ctx, vc, model, stop := setupLCSim(t, 2, 1)
+	defer stop()
+
+	clusters := model.Map().All("ClusterComputeResource")
+	require.Len(t, clusters, 2)
+	clusterARef := clusters[0].Reference()
+	clusterBRef := clusters[1].Reference()
+
+	hostsA := hostRefsInCluster(model, clusterARef)
+	hostsB := hostRefsInCluster(model, clusterBRef)
+	require.Len(t, hostsA, 1)
+	require.Len(t, hostsB, 1)
+	setHostESXiVersion(model, hostsA[0], "9.1.0")
+	setHostESXiVersion(model, hostsB[0], "9.1.0")
+
+	dsRef := model.Map().All("Datastore")[0].Reference()
+	ds := dsInfoFromSim(vc.Client, dsRef)
+	zoneCompatibleDS := map[string][]*cnsvsphere.DatastoreInfo{"zone-a": {ds}}
+	// Only clusterA is an active member of zone-a; clusterB shares the datastore but is not
+	// part of the zone (e.g. it belongs to a different zone, or was recently removed from it).
+	zoneClusters := map[string][]string{"zone-a": {clusterARef.Value}}
+
+	lc, perZone, err := checkLinkedClone(ctx, vc, "test-policy", zoneCompatibleDS, zoneClusters)
+	require.NoError(t, err)
+	assert.True(t, lc, "LC should be true: zone-a has an ESXi 9.1+ host in its active cluster")
+	assert.Contains(t, perZone["zone-a"], hostsA[0].Value, "clusterA's host is an active member of zone-a")
+	assert.NotContains(t, perZone["zone-a"], hostsB[0].Value,
+		"clusterB's host must be excluded: clusterB is not an active member of zone-a")
 }
 
 // --- checkHighPerformanceLinkedClone simulator tests ----------------------------------

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
@@ -521,7 +521,8 @@ func findStoragePolicyProfile(ctx context.Context,
 func populateVolumeCapabilities(ctx context.Context,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
 	vc *cnsvsphere.VirtualCenter, profileID string,
-	zoneCompatibleDS map[string][]*cnsvsphere.DatastoreInfo) error {
+	zoneCompatibleDS map[string][]*cnsvsphere.DatastoreInfo,
+	zoneClusters map[string][]string) error {
 	log := logger.GetLogger(ctx)
 
 	caps := map[infraspiv1alpha1.VolumeCapability]bool{
@@ -549,7 +550,7 @@ func populateVolumeCapabilities(ctx context.Context,
 		return nil
 	}
 
-	lc, esxi91HostsPerZone, err := checkLinkedClone(ctx, vc, profileID, zoneCompatibleDS)
+	lc, esxi91HostsPerZone, err := checkLinkedClone(ctx, vc, profileID, zoneCompatibleDS, zoneClusters)
 	if err != nil {
 		log.Errorf("Failed to check SupportsLinkedClone for policy %s: %v", profileID, err)
 		caps[infraspiv1alpha1.SupportsHighPerformanceLinkedClone] = false
@@ -587,10 +588,12 @@ func populateVolumeCapabilities(ctx context.Context,
 
 // checkLinkedClone returns whether LinkedClone is supported across ALL zones and the per-zone
 // ESXi 9.1+ hosts. LC is true only when every zone that has compatible datastores also has at
-// least one ESXi 9.1+ host mounting those datastores.
+// least one ESXi 9.1+ host, belonging to a cluster that is currently an active member of that
+// zone, mounting those datastores.
 func checkLinkedClone(ctx context.Context,
 	vc *cnsvsphere.VirtualCenter, profileID string,
 	zoneCompatibleDS map[string][]*cnsvsphere.DatastoreInfo,
+	zoneClusters map[string][]string,
 ) (bool, map[string]map[string]vimtypes.ManagedObjectReference, error) {
 	log := logger.GetLogger(ctx)
 
@@ -605,13 +608,22 @@ func checkLinkedClone(ctx context.Context,
 	pc := property.DefaultCollector(vc.Client.Client)
 	// esxi91HostsPerZone holds, per zone, the ESXi 9.1+ host refs found via that zone's datastores.
 	esxi91HostsPerZone := make(map[string]map[string]vimtypes.ManagedObjectReference)
-	// checkedHosts records whether each evaluated host is ESXi 9.1+ (true) or not (false).
+	// checkedHosts caches each evaluated host's ESXi 9.1+ eligibility and parent cluster; a nil
+	// entry means the host was checked and found ineligible (not ESXi 9.1+, or no cluster parent with a
+	// zone associated to it).
 	// All evaluated hosts are stored so that a host mounting multiple datastores is only
 	// queried from vCenter once.
-	checkedHosts := make(map[string]bool)
+	checkedHosts := make(map[string]*hostClusterRef)
 	// datastoreESXi91HostsCache caches the ESXi 9.1+ hosts for a given datastore so that when
 	// the same datastore appears in multiple zones we reuse the result.
-	datastoreESXi91HostsCache := make(map[string][]vimtypes.ManagedObjectReference)
+	datastoreESXi91HostsCache := make(map[string][]hostClusterRef)
+
+	// zoneClusterSets is zoneClusters converted to per-zone sets, built once upfront for O(1)
+	// membership checks against each host's parent cluster.
+	zoneClusterSets := make(map[string]map[string]bool, len(zoneClusters))
+	for zone, clusters := range zoneClusters {
+		zoneClusterSets[zone] = toClusterSet(clusters)
+	}
 
 	// relevantZones counts zones that have at least one compatible datastore for the policy.
 	// Zones with no compatible datastores are excluded: the policy cannot be provisioned there,
@@ -626,16 +638,22 @@ func checkLinkedClone(ctx context.Context,
 		relevantZones++
 
 		esxi91HostsPerZone[zone] = make(map[string]vimtypes.ManagedObjectReference)
+		activeClusters := zoneClusterSets[zone]
 
 		for _, ds := range compatibleDatastores {
 			dsHosts, err := getOrFetchESXi91HostsForDS(ctx, pc, ds, checkedHosts, datastoreESXi91HostsCache)
 			if err != nil {
 				return false, nil, err
 			}
-			for _, hostRef := range dsHosts {
-				esxi91HostsPerZone[zone][hostRef.Value] = hostRef
+			for _, hc := range dsHosts {
+				if !activeClusters[hc.Cluster] {
+					log.Infof("Skipping host %s for zone %s: parent cluster %s is not an active member of the zone",
+						hc.Host.Value, zone, hc.Cluster)
+					continue
+				}
+				esxi91HostsPerZone[zone][hc.Host.Value] = hc.Host
 				log.Debugf("Attributed ESXi 9.1+ host %s to zone %s via datastore %s",
-					hostRef.Value, zone, ds.Reference().Value)
+					hc.Host.Value, zone, ds.Reference().Value)
 			}
 		}
 	}
@@ -663,13 +681,28 @@ func checkLinkedClone(ctx context.Context,
 	return linkedCloneSupported, esxi91HostsPerZone, nil
 }
 
-// getOrFetchESXi91HostsForDS returns the ESXi 9.1+ hosts for a datastore, using cache when
-// available. On a cache miss the hosts are fetched and stored. On error the result is not cached
-// so the next zone can retry.
+// hostClusterRef pairs an ESXi 9.1+ host with the moref of its parent ClusterComputeResource.
+type hostClusterRef struct {
+	Host    vimtypes.ManagedObjectReference
+	Cluster string
+}
+
+// toClusterSet converts a slice of cluster morefs into a set for O(1) membership checks.
+func toClusterSet(clusters []string) map[string]bool {
+	set := make(map[string]bool, len(clusters))
+	for _, c := range clusters {
+		set[c] = true
+	}
+	return set
+}
+
+// getOrFetchESXi91HostsForDS returns the ESXi 9.1+ hosts (with their parent cluster) for a
+// datastore, using cache when available. On a cache miss the hosts are fetched and stored. On
+// error the result is not cached so the next zone can retry.
 func getOrFetchESXi91HostsForDS(ctx context.Context, pc *property.Collector,
-	ds *cnsvsphere.DatastoreInfo, checkedHosts map[string]bool,
-	dsHostsCache map[string][]vimtypes.ManagedObjectReference,
-) ([]vimtypes.ManagedObjectReference, error) {
+	ds *cnsvsphere.DatastoreInfo, checkedHosts map[string]*hostClusterRef,
+	dsHostsCache map[string][]hostClusterRef,
+) ([]hostClusterRef, error) {
 	datastoreValue := ds.Reference().Value
 	if _, fetched := dsHostsCache[datastoreValue]; fetched {
 		return dsHostsCache[datastoreValue], nil
@@ -683,12 +716,12 @@ func getOrFetchESXi91HostsForDS(ctx context.Context, pc *property.Collector,
 }
 
 // fetchESXi91HostsForDatastore returns all ESXi 9.1+ hosts that mount the given datastore and
-// belong to a ClusterComputeResource. checkedHosts is a shared cache (hostValue → bool) storing
-// all evaluated hosts — true if ESXi 9.1+, false otherwise — to avoid redundant vCenter calls
-// for hosts shared across datastores.
+// belong to a ClusterComputeResource, along with each host's parent cluster moref. checkedHosts
+// is a shared cache (hostValue → *hostClusterRef, nil if ineligible) storing all evaluated hosts
+// to avoid redundant vCenter calls for hosts shared across datastores.
 func fetchESXi91HostsForDatastore(ctx context.Context, pc *property.Collector,
-	ds *cnsvsphere.DatastoreInfo, checkedHosts map[string]bool,
-) ([]vimtypes.ManagedObjectReference, error) {
+	ds *cnsvsphere.DatastoreInfo, checkedHosts map[string]*hostClusterRef,
+) ([]hostClusterRef, error) {
 	datastoreValue := ds.Reference().Value
 
 	var dsMO mo.Datastore
@@ -704,11 +737,11 @@ func fetchESXi91HostsForDatastore(ctx context.Context, pc *property.Collector,
 		return nil, nil
 	}
 
-	var esxi91Hosts []vimtypes.ManagedObjectReference
+	var esxi91Hosts []hostClusterRef
 	for _, ref := range hostRefs {
-		if isESXi91, checked := checkedHosts[ref.Value]; checked {
-			if isESXi91 {
-				esxi91Hosts = append(esxi91Hosts, ref)
+		if hc, checked := checkedHosts[ref.Value]; checked {
+			if hc != nil {
+				esxi91Hosts = append(esxi91Hosts, *hc)
 			}
 			continue
 		}
@@ -717,17 +750,20 @@ func fetchESXi91HostsForDatastore(ctx context.Context, pc *property.Collector,
 			return nil, fmt.Errorf("retrieve properties for host %s: %w", ref.Value, err)
 		}
 		if hostMO.Parent == nil || hostMO.Parent.Type != "ClusterComputeResource" || hostMO.Config == nil {
-			checkedHosts[ref.Value] = false
+			checkedHosts[ref.Value] = nil
 			continue
 		}
 		is91, err := cnsvsphere.IsvSphereVersion91orAbove(ctx, hostMO.Config.Product)
 		if err != nil {
 			return nil, fmt.Errorf("parse ESXi version for host %s: %w", ref.Value, err)
 		}
-		checkedHosts[ref.Value] = is91
-		if is91 {
-			esxi91Hosts = append(esxi91Hosts, ref)
+		if !is91 {
+			checkedHosts[ref.Value] = nil
+			continue
 		}
+		hc := &hostClusterRef{Host: ref, Cluster: hostMO.Parent.Value}
+		checkedHosts[ref.Value] = hc
+		esxi91Hosts = append(esxi91Hosts, *hc)
 	}
 	return esxi91Hosts, nil
 }

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -565,7 +565,10 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 	origStatus := instance.Status.DeepCopy()
 
 	// Populate TopologyInfo from InfraStoragePolicyInfo.
-	if err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI); err != nil {
+	// activeClustersByZone contains the active-cluster set namespaceFilteredZones already
+	// resolved per zone.
+	activeClustersByZone, err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
+	if err != nil {
 		log.Errorf("Failed to sync topology for StoragePolicyInfo %q: %v",
 			request.NamespacedName, err)
 		if setErr := r.setSPIError(ctx, instance, origStatus,
@@ -577,7 +580,7 @@ func (r *ReconcileStoragePolicyInfo) Reconcile(ctx context.Context,
 	}
 
 	// Populate VolumeCapabilities from InfraStoragePolicyInfo.
-	if err := syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI); err != nil {
+	if err := r.syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI, activeClustersByZone); err != nil {
 		log.Errorf("Failed to sync volume capabilities for StoragePolicyInfo %q: %v",
 			request.NamespacedName, err)
 		if setErr := r.setSPIError(ctx, instance, origStatus,
@@ -699,12 +702,15 @@ func (r *ReconcileStoragePolicyInfo) ensureInfraSPIOwnerReference(ctx context.Co
 
 // syncTopologyFromInfraSPI copies topology information from the cluster-scoped
 // InfraStoragePolicyInfo into the namespace-scoped StoragePolicyInfo status,
-// filtering accessible zones down to only those assigned to the namespace.
-// For marker policies the zone set is derived from FVS instance namespaces that
-// share the consumer namespace's VPC path, bypassing the standard namespace filter.
+// filtering accessible zones down to only those assigned to the namespace. It returns the
+// active-cluster set namespaceFilteredZones resolved per zone along the way, so
+// syncVolumeCapabilitiesFromInfraSPI can reuse it instead of re-resolving it; this is nil for
+// marker policies (whose zone set is derived from FVS instance namespaces that share the
+// consumer namespace's VPC path, bypassing the standard namespace filter) and for policies
+// with no topology.
 func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Context,
 	instance *spiv1alpha1.StoragePolicyInfo,
-	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) error {
+	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) (map[string]map[string]bool, error) {
 	log := logger.GetLogger(ctx)
 
 	// Marker policies derive namespace-level zones from VPC/FVS instance namespace
@@ -712,17 +718,17 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 	// path is only taken when marker-policy support is enabled; otherwise a marker
 	// policy falls through to the regular namespace-filtered topology path.
 	if r.IsVsanFileVolumeService && common.IsvSANFileServiceMarkerPolicyName(instance.Name) {
-		return r.syncMarkerPolicyTopology(ctx, instance, infraSPI)
+		return nil, r.syncMarkerPolicyTopology(ctx, instance, infraSPI)
 	}
 
 	if infraSPI.Status.Topology == nil {
 		log.Debugf("InfraStoragePolicyInfo %q has no topology; clearing StoragePolicyInfo topology",
 			infraSPI.Name)
 		instance.Status.TopologyInfo = nil
-		return nil
+		return nil, nil
 	}
 
-	accessibleZones := r.namespaceFilteredZones(ctx, instance.Namespace,
+	accessibleZones, activeClustersByZone := r.namespaceFilteredZones(ctx, instance.Namespace,
 		infraSPI.Status.Topology.AccessibleZones)
 
 	instance.Status.TopologyInfo = &spiv1alpha1.Topology{
@@ -733,7 +739,7 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 		instance.Namespace, instance.Name,
 		instance.Status.TopologyInfo.TopologyType,
 		instance.Status.TopologyInfo.AccessibleZones)
-	return nil
+	return activeClustersByZone, nil
 }
 
 // syncVolumeCapabilitiesFromInfraSPI populates the namespace-scoped
@@ -743,11 +749,12 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 // SupportsVolumeModeBlock is copied as-is from InfraSPI.
 // SupportsLinkedClone and SupportsHighPerformanceLinkedClone are recomputed for just the zones accessible
 // to this namespace.
-func syncVolumeCapabilitiesFromInfraSPI(ctx context.Context, instance *spiv1alpha1.StoragePolicyInfo,
-	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) error {
+func (r *ReconcileStoragePolicyInfo) syncVolumeCapabilitiesFromInfraSPI(ctx context.Context,
+	instance *spiv1alpha1.StoragePolicyInfo, infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
+	activeClustersByZone map[string]map[string]bool) error {
 	infraCaps := infraSPI.Status.VolumeCapabilities
 
-	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, instance, infraSPI)
+	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, r.zonesProvider, activeClustersByZone, instance, infraSPI)
 	if err != nil {
 		return err
 	}
@@ -773,7 +780,8 @@ func syncVolumeCapabilitiesFromInfraSPI(ctx context.Context, instance *spiv1alph
 // Topology with an empty TopologyType. That's an upstream failure, not an absence of
 // applicable zones, so it's surfaced as an error here rather than silently falling back to
 // infraCaps (which was computed from that same failed reconcile and can't be trusted either).
-func linkedCloneCapabilitiesForNamespace(ctx context.Context, instance *spiv1alpha1.StoragePolicyInfo,
+func linkedCloneCapabilitiesForNamespace(ctx context.Context, zp zonesProvider,
+	activeClustersByZone map[string]map[string]bool, instance *spiv1alpha1.StoragePolicyInfo,
 	infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo) (lc bool, hplc bool, err error) {
 	if instance.Status.TopologyInfo == nil {
 		return false, false, fmt.Errorf(
@@ -782,25 +790,55 @@ func linkedCloneCapabilitiesForNamespace(ctx context.Context, instance *spiv1alp
 	}
 
 	nsZones := instance.Status.TopologyInfo.AccessibleZones
-	lc, err = computeLinkedCloneForNamespace(ctx, infraSPI.Name, nsZones)
+
+	if activeClustersByZone == nil {
+		activeClustersByZone = activeClusterSetsForZones(ctx, zp, instance.Namespace, nsZones)
+	}
+
+	lc, err = computeLinkedCloneForNamespace(ctx, activeClustersByZone, infraSPI.Name, nsZones)
 	if err != nil {
 		return false, false, err
 	}
-	hplc, err = computeHPLCForNamespace(ctx, infraSPI.Name, nsZones, lc)
+	hplc, err = computeHPLCForNamespace(ctx, activeClustersByZone, infraSPI.Name, nsZones, lc)
 	if err != nil {
 		return false, false, err
 	}
 	return lc, hplc, nil
 }
 
+// activeClusterSetsForZones resolves, once per zone, the set of cluster morefs the namespace is
+// actively on within that zone. A zone with no active cluster for the namespace (error, or
+// an empty result) is omitted from the returned map.
+func activeClusterSetsForZones(ctx context.Context, zp zonesProvider, namespace string,
+	zones []string) map[string]map[string]bool {
+	log := logger.GetLogger(ctx)
+	activeClustersByZone := make(map[string]map[string]bool, len(zones))
+	for _, zone := range zones {
+		activeClusters, err := zp.GetActiveClustersForNamespaceInRequestedZones(ctx, namespace, []string{zone})
+		if err != nil || len(activeClusters) == 0 {
+			log.Debugf("activeClusterSetsForZones: namespace %q has no active cluster in zone %q; skipping: %v",
+				namespace, zone, err)
+			continue
+		}
+		activeClusterSet := make(map[string]bool, len(activeClusters))
+		for _, cluster := range activeClusters {
+			activeClusterSet[cluster] = true
+		}
+		activeClustersByZone[zone] = activeClusterSet
+	}
+	return activeClustersByZone
+}
+
 // computeLinkedCloneForNamespace determines whether the storage policy identified by
 // policyName (its K8s-compliant name) supports LinkedClone within nsZones, using
 // data already cached by vsphereinfra.StoragePolicyInfoCache.
 // LinkedClone is supported for the namespace if any host mounting a
-// datastore compatible with policyName within one of nsZones is running ESXi 9.1 or
-// above.
-func computeLinkedCloneForNamespace(ctx context.Context, policyName string, nsZones []string) (bool, error) {
-	return anyQualifyingHostForNamespace(ctx, "LinkedClone", policyName, nsZones, hostSupportsLinkedClone)
+// datastore compatible with policyName within one of nsZones, and belonging to a cluster
+// the namespace is actually active on within that zone, is running ESXi 9.1 or above.
+func computeLinkedCloneForNamespace(ctx context.Context, activeClustersByZone map[string]map[string]bool,
+	policyName string, nsZones []string) (bool, error) {
+	return anyQualifyingHostForNamespace(ctx, activeClustersByZone, "LinkedClone", policyName, nsZones,
+		hostSupportsLinkedClone)
 }
 
 // computeHPLCForNamespace determines whether SupportsHighPerformanceLinkedClone is true
@@ -808,23 +846,41 @@ func computeLinkedCloneForNamespace(ctx context.Context, policyName string, nsZo
 // false without evaluating the vSAN-ESA condition. Otherwise it looks for a qualifying
 // host (ESXi 9.1+) whose cluster has vSAN-ESA enabled
 // (hostSupportsHighPerformanceLinkedClone).
-func computeHPLCForNamespace(ctx context.Context, policyName string, nsZones []string,
-	lcSupported bool) (bool, error) {
+func computeHPLCForNamespace(ctx context.Context, activeClustersByZone map[string]map[string]bool, policyName string,
+	nsZones []string, lcSupported bool) (bool, error) {
 	if !lcSupported {
 		return false, nil
 	}
-	return anyQualifyingHostForNamespace(ctx, "HighPerformanceLinkedClone", policyName, nsZones,
+	return anyQualifyingHostForNamespace(ctx, activeClustersByZone, "HighPerformanceLinkedClone", policyName, nsZones,
 		hostSupportsHighPerformanceLinkedClone)
 }
 
 // anyQualifyingHostForNamespace walks every host mounting a datastore compatible with
-// policyName within one of nsZones to find out if LC or HPLC are supported or not.
+// policyName within one of nsZones to find out if LC or HPLC are supported or not. A host is
+// only considered if its parent cluster is in that zone's precomputed active-cluster set
+// (activeClusterSetsForZones) — a zone can span multiple clusters, and the namespace may only
+// be active on a subset of them.
 // checkName ("LinkedClone" or "HPLC") identifies which check is running in the logs, since
 // both checks walk the same hosts/datastores/zones and would otherwise be indistinguishable.
-func anyQualifyingHostForNamespace(ctx context.Context, operation string, policyName string, nsZones []string,
+func anyQualifyingHostForNamespace(ctx context.Context, activeClustersByZone map[string]map[string]bool,
+	operation string, policyName string, nsZones []string,
 	qualifies func(ctx context.Context, hostID string) (bool, error)) (bool, error) {
 	log := logger.GetLogger(ctx)
+
+	// hostClusterCache memoizes ClusterForHost lookups across the whole call, so a host
+	// mounting multiple compatible datastores — whether within one zone or across zones sharing
+	// a stretched datastore — is only resolved once. An empty string means "checked, no cluster
+	// found" (ClusterForHost's not-found return is also "").
+	hostClusterCache := make(map[string]string)
+
 	for _, zone := range nsZones {
+		activeClusterSet, ok := activeClustersByZone[zone]
+		if !ok {
+			log.Debugf("anyQualifyingHostForNamespace[%s]: no active cluster for zone %q; skipping",
+				operation, zone)
+			continue
+		}
+
 		zoneDS, ok := vsphereinfra.GetCache().GetDatastoresForPolicyZone(ctx, policyName, zone)
 		if !ok {
 			continue
@@ -841,6 +897,16 @@ func anyQualifyingHostForNamespace(ctx context.Context, operation string, policy
 			}
 			log.Infof("anyQualifyingHostForNamespace[%s]: found hosts %+v for datastore %s", operation, hosts, dsID)
 			for hostID := range hosts {
+				clusterID, cached := hostClusterCache[hostID]
+				if !cached {
+					clusterID, _ = vsphereinfra.GetCache().ClusterForHost(hostID)
+					hostClusterCache[hostID] = clusterID
+				}
+				if clusterID == "" || !activeClusterSet[clusterID] {
+					log.Debugf("anyQualifyingHostForNamespace[%s]: host %s cluster %q is not active in "+
+						"zone %q; skipping", operation, hostID, clusterID, zone)
+					continue
+				}
 				qualified, err := qualifies(ctx, hostID)
 				if err != nil {
 					return false, fmt.Errorf("failed to check host %s (datastore %s, zone %q): %w",
@@ -959,10 +1025,14 @@ func (r *ReconcileStoragePolicyInfo) syncMarkerPolicyTopology(ctx context.Contex
 	return nil
 }
 
-// namespaceFilteredZones returns the subset of clusterZones that are also
-// assigned to the given namespace, by consulting the namespace-scoped Zone CRs.
+// namespaceFilteredZones returns the subset of clusterZones that are also assigned to the given
+// namespace, by consulting the namespace-scoped Zone CRs, along with the active-cluster set it
+// resolved per filtered zone (activeClusterSetsForZones) — returned so callers (see
+// syncTopologyFromInfraSPI) can pass it on to the LinkedClone/HPLC computation instead of
+// re-resolving the same per-zone data via another GetActiveClustersForNamespaceInRequestedZones
+// scan.
 func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
-	namespace string, clusterZones []string) []string {
+	namespace string, clusterZones []string) ([]string, map[string]map[string]bool) {
 	log := logger.GetLogger(ctx)
 
 	nsZones := r.zonesProvider.GetZonesForNamespace(namespace)
@@ -973,7 +1043,7 @@ func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 		// WDI/zonal deployment.
 		log.Debugf("Namespace %q has no zone assignments; accessibleZones will be empty",
 			namespace)
-		return []string{}
+		return []string{}, map[string]map[string]bool{}
 	}
 
 	// Intersect cluster-accessible zones with namespace-assigned zones.
@@ -990,21 +1060,19 @@ func (r *ReconcileStoragePolicyInfo) namespaceFilteredZones(ctx context.Context,
 	// attributed to that zone (via PolicyZoneDatastores, computed over every cluster in the
 	// zone) could be reported as accessible even though this namespace's volumes could never
 	// actually land there.
-	// GetActiveClustersForNamespaceInRequestedZones does a full informer-store scan internally,
-	// calling it once per zone is fine for typical zone counts.
+	activeClustersByZone := activeClusterSetsForZones(ctx, r.zonesProvider, namespace, assignedZones)
 	filtered := make([]string, 0, len(assignedZones))
 	for _, zone := range assignedZones {
-		activeClusters, err := r.zonesProvider.GetActiveClustersForNamespaceInRequestedZones(ctx, namespace, []string{zone})
-		if err != nil || len(activeClusters) == 0 {
-			log.Debugf("Namespace %q is assigned zone %q but has no active cluster within it; excluding: %v",
-				namespace, zone, err)
-			continue
+		if _, active := activeClustersByZone[zone]; active {
+			filtered = append(filtered, zone)
+		} else {
+			log.Debugf("Namespace %q is assigned zone %q but has no active cluster within it; excluding",
+				namespace, zone)
 		}
-		filtered = append(filtered, zone)
 	}
 	log.Infof("Namespace %q has zone assignments %v; filtered %d cluster zones → %d namespace-accessible zones",
 		namespace, nsZones, len(clusterZones), len(filtered))
-	return filtered
+	return filtered, activeClustersByZone
 }
 
 // setSPIError sets the error status and records a Warning event on the instance.

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller_test.go
@@ -532,7 +532,7 @@ func TestSyncTopologyFromInfraSPI_CopiesTopology(t *testing.T) {
 		},
 	}
 
-	err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
+	_, err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
 	require.NoError(t, err)
 	require.NotNil(t, inst.Status.TopologyInfo)
 	assert.Equal(t, "zonal", inst.Status.TopologyInfo.TopologyType)
@@ -560,7 +560,7 @@ func TestSyncTopologyFromInfraSPI_ClearsWhenNilTopology(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "gold"},
 	}
 
-	err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
+	_, err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
 	require.NoError(t, err)
 	assert.Nil(t, inst.Status.TopologyInfo)
 }
@@ -592,7 +592,7 @@ func TestSyncTopologyFromInfraSPI_NoAccessibleZonesKeepsTopologyType(t *testing.
 		},
 	}
 
-	err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
+	_, err := r.syncTopologyFromInfraSPI(ctx, inst, infraSPI)
 	require.NoError(t, err)
 	require.NotNil(t, inst.Status.TopologyInfo)
 	assert.Equal(t, "zonal", inst.Status.TopologyInfo.TopologyType)
@@ -671,7 +671,7 @@ func TestNamespaceFilteredZones(t *testing.T) {
 				},
 			}
 
-			got := r.namespaceFilteredZones(ctx, "ns1", tt.clusterZones)
+			got, _ := r.namespaceFilteredZones(ctx, "ns1", tt.clusterZones)
 			if len(tt.expectedZones) == 0 {
 				assert.Empty(t, got)
 			} else {
@@ -1333,7 +1333,7 @@ func TestSyncTopologyFromInfraSPI_MarkerPolicy(t *testing.T) {
 		IsVsanFileVolumeService: true,
 	}
 
-	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
+	_, err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
 	require.NoError(t, err)
 	require.NotNil(t, instance.Status.TopologyInfo)
 	assert.Equal(t, "zonal", instance.Status.TopologyInfo.TopologyType)
@@ -1379,7 +1379,7 @@ func TestSyncTopologyFromInfraSPI_MarkerPolicy_NoFVSNamespaces(t *testing.T) {
 		IsVsanFileVolumeService: true,
 	}
 
-	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
+	_, err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
 	require.NoError(t, err)
 	assert.Nil(t, instance.Status.TopologyInfo,
 		"TopologyInfo should be nil when InfraStoragePolicyInfo has no topology type")
@@ -1408,7 +1408,7 @@ func TestSyncTopologyFromInfraSPI_MarkerPolicy_NilTopology(t *testing.T) {
 		IsVsanFileVolumeService: true,
 	}
 
-	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
+	_, err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
 	require.NoError(t, err)
 	assert.Nil(t, instance.Status.TopologyInfo,
 		"TopologyInfo should be nil when InfraStoragePolicyInfo has no topology")
@@ -1454,7 +1454,7 @@ func TestSyncTopologyFromInfraSPI_MarkerPolicy_FSSDisabled(t *testing.T) {
 		IsVsanFileVolumeService: false,
 	}
 
-	err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
+	_, err := r.syncTopologyFromInfraSPI(ctx, instance, infraSPI)
 	require.NoError(t, err)
 	require.NotNil(t, instance.Status.TopologyInfo)
 	assert.Equal(t, "zonal", instance.Status.TopologyInfo.TopologyType)

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/volume_capabilities_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/volume_capabilities_test.go
@@ -39,9 +39,37 @@ func clearPolicyZoneCache(t *testing.T, policyName string) {
 	t.Cleanup(func() { vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, nil) })
 }
 
+// zoneAActiveClusters returns an activeClustersByZone map where zone-a's active cluster is
+// "cluster-for-zone-a" (mirroring mockZonesProvider's naming convention).
+func zoneAActiveClusters() map[string]map[string]bool {
+	return map[string]map[string]bool{"zone-a": {"cluster-for-zone-a": true}}
+}
+
+// zoneAZonesProvider is a mockZonesProvider where the given namespace is assigned and active
+// on zone-a, with active cluster moref "cluster-for-zone-a" (mockZonesProvider's convention).
+func zoneAZonesProvider(namespace string) *mockZonesProvider {
+	return &mockZonesProvider{zonesForNamespace: map[string]map[string]struct{}{
+		namespace: {"zone-a": {}},
+	}}
+}
+
 func TestAnyQualifyingHostForNamespace_NoZones(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
-	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", "policy-1", nil,
+	ok, err := anyQualifyingHostForNamespace(ctx, nil, "test-op", "policy-1", nil,
+		func(context.Context, string) (bool, error) { return true, nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAnyQualifyingHostForNamespace_NoActiveClusterInZone(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const policyName = "policy-anqhfn-noactivecluster"
+	clearPolicyZoneCache(t, policyName)
+
+	// No entry for zone-a in activeClustersByZone means the namespace has no active cluster
+	// there, so the zone is skipped before datastores are even consulted.
+	ok, err := anyQualifyingHostForNamespace(ctx, map[string]map[string]bool{}, "test-op",
+		policyName, []string{"zone-a"},
 		func(context.Context, string) (bool, error) { return true, nil })
 	require.NoError(t, err)
 	assert.False(t, ok)
@@ -49,7 +77,8 @@ func TestAnyQualifyingHostForNamespace_NoZones(t *testing.T) {
 
 func TestAnyQualifyingHostForNamespace_ZoneNotCached(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
-	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", "policy-never-cached", []string{"zone-a"},
+	ok, err := anyQualifyingHostForNamespace(ctx, zoneAActiveClusters(), "test-op",
+		"policy-never-cached", []string{"zone-a"},
 		func(context.Context, string) (bool, error) { return true, nil })
 	require.NoError(t, err)
 	assert.False(t, ok)
@@ -63,7 +92,8 @@ func TestAnyQualifyingHostForNamespace_DatastoreNotInDsToHosts(t *testing.T) {
 	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-1"}})
 	// Deliberately not populating DsToHosts for ds-1.
 
-	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", policyName, []string{"zone-a"},
+	ok, err := anyQualifyingHostForNamespace(ctx, zoneAActiveClusters(), "test-op",
+		policyName, []string{"zone-a"},
 		func(context.Context, string) (bool, error) { return true, nil })
 	require.NoError(t, err)
 	assert.False(t, ok)
@@ -72,28 +102,59 @@ func TestAnyQualifyingHostForNamespace_DatastoreNotInDsToHosts(t *testing.T) {
 func TestAnyQualifyingHostForNamespace_QualifyingHostFound(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	const policyName = "policy-anqhfn-2"
+	const clusterID = "cluster-for-zone-a"
 	clearPolicyZoneCache(t, policyName)
 	t.Cleanup(func() { vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-2", map[string]struct{}{}) })
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateCluster(clusterID) })
 
 	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-anqhfn-2"}})
 	vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-2", map[string]struct{}{"host-1": {}, "host-2": {}})
+	vsphereinfra.GetCache().UpdateClusterHosts(clusterID, map[string]struct{}{"host-1": {}, "host-2": {}})
 
-	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", policyName, []string{"zone-a"},
+	ok, err := anyQualifyingHostForNamespace(ctx, zoneAActiveClusters(), "test-op",
+		policyName, []string{"zone-a"},
 		func(_ context.Context, hostID string) (bool, error) { return hostID == "host-2", nil })
 	require.NoError(t, err)
 	assert.True(t, ok)
 }
 
+func TestAnyQualifyingHostForNamespace_HostClusterNotActiveForNamespace(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const policyName = "policy-anqhfn-inactivecluster"
+	const clusterID = "cluster-not-active"
+	clearPolicyZoneCache(t, policyName)
+	t.Cleanup(func() { vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-inactivecluster", map[string]struct{}{}) })
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateCluster(clusterID) })
+
+	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName,
+		map[string][]string{"zone-a": {"ds-anqhfn-inactivecluster"}})
+	vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-inactivecluster", map[string]struct{}{"host-1": {}})
+	// host-1 belongs to a cluster that is not the namespace's active cluster for zone-a
+	// ("cluster-for-zone-a"), so it must be skipped even though qualifies would otherwise
+	// return true.
+	vsphereinfra.GetCache().UpdateClusterHosts(clusterID, map[string]struct{}{"host-1": {}})
+
+	ok, err := anyQualifyingHostForNamespace(ctx, zoneAActiveClusters(), "test-op",
+		policyName, []string{"zone-a"},
+		func(context.Context, string) (bool, error) { return true, nil })
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
 func TestAnyQualifyingHostForNamespace_NoQualifyingHost(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	const policyName = "policy-anqhfn-3"
+	const clusterID = "cluster-for-zone-a"
 	clearPolicyZoneCache(t, policyName)
 	t.Cleanup(func() { vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-3", map[string]struct{}{}) })
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateCluster(clusterID) })
 
 	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-anqhfn-3"}})
 	vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-3", map[string]struct{}{"host-1": {}})
+	vsphereinfra.GetCache().UpdateClusterHosts(clusterID, map[string]struct{}{"host-1": {}})
 
-	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", policyName, []string{"zone-a"},
+	ok, err := anyQualifyingHostForNamespace(ctx, zoneAActiveClusters(), "test-op",
+		policyName, []string{"zone-a"},
 		func(context.Context, string) (bool, error) { return false, nil })
 	require.NoError(t, err)
 	assert.False(t, ok)
@@ -102,14 +163,18 @@ func TestAnyQualifyingHostForNamespace_NoQualifyingHost(t *testing.T) {
 func TestAnyQualifyingHostForNamespace_QualifiesErrorPropagates(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	const policyName = "policy-anqhfn-4"
+	const clusterID = "cluster-for-zone-a"
 	clearPolicyZoneCache(t, policyName)
 	t.Cleanup(func() { vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-4", map[string]struct{}{}) })
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateCluster(clusterID) })
 
 	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-anqhfn-4"}})
 	vsphereinfra.GetCache().UpdateDsHosts("ds-anqhfn-4", map[string]struct{}{"host-1": {}})
+	vsphereinfra.GetCache().UpdateClusterHosts(clusterID, map[string]struct{}{"host-1": {}})
 
 	wantErr := errors.New("boom")
-	ok, err := anyQualifyingHostForNamespace(ctx, "test-op", policyName, []string{"zone-a"},
+	ok, err := anyQualifyingHostForNamespace(ctx, zoneAActiveClusters(), "test-op",
+		policyName, []string{"zone-a"},
 		func(context.Context, string) (bool, error) { return false, wantErr })
 	assert.ErrorIs(t, err, wantErr)
 	assert.False(t, ok)
@@ -209,7 +274,7 @@ func TestLinkedCloneCapabilitiesForNamespace_NilTopologyInfoReturnsError(t *test
 	}
 	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: "policy-lccfn-notopology"}}
 
-	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, instance, infraSPI)
+	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, &mockZonesProvider{}, nil, instance, infraSPI)
 	assert.Error(t, err)
 	assert.False(t, lc)
 	assert.False(t, hplc)
@@ -218,25 +283,31 @@ func TestLinkedCloneCapabilitiesForNamespace_NilTopologyInfoReturnsError(t *test
 func TestLinkedCloneCapabilitiesForNamespace_ZonalRecomputesFromCache(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
 	const policyName = "policy-lccfn-zonal"
+	const namespace = "ns-lccfn-zonal"
+	const clusterID = "cluster-for-zone-a"
 	clearPolicyZoneCache(t, policyName)
 	t.Cleanup(func() { vsphereinfra.GetCache().UpdateDsHosts("ds-lccfn-zonal", map[string]struct{}{}) })
 	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateHostVersion("host-lccfn-zonal") })
+	t.Cleanup(func() { vsphereinfra.GetCache().InvalidateCluster(clusterID) })
 
 	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {"ds-lccfn-zonal"}})
 	vsphereinfra.GetCache().UpdateDsHosts("ds-lccfn-zonal", map[string]struct{}{"host-lccfn-zonal": {}})
 	vsphereinfra.GetCache().UpdateHostVersion("host-lccfn-zonal", "9.1.0")
+	vsphereinfra.GetCache().UpdateClusterHosts(clusterID, map[string]struct{}{"host-lccfn-zonal": {}})
 
 	instance := &spiv1alpha1.StoragePolicyInfo{
-		ObjectMeta: metav1.ObjectMeta{Name: policyName},
+		ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: namespace},
 		Status: spiv1alpha1.StoragePolicyInfoStatus{
 			TopologyInfo: &spiv1alpha1.Topology{TopologyType: "zonal", AccessibleZones: []string{"zone-a"}},
 		},
 	}
 	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: policyName}}
 
-	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, instance, infraSPI)
+	// activeClustersByZone is nil here to exercise the fresh-lookup fallback path (as marker
+	// policies use), rather than a precomputed map from namespaceFilteredZones.
+	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, zoneAZonesProvider(namespace), nil, instance, infraSPI)
 	require.NoError(t, err)
-	assert.True(t, lc, "zone-a has a compatible datastore mounted by an ESXi 9.1+ host")
+	assert.True(t, lc, "zone-a has a compatible datastore mounted by an ESXi 9.1+ host in the namespace's active cluster")
 	assert.False(t, hplc, "no vSAN-ESA cluster was configured for this host")
 }
 
@@ -259,7 +330,8 @@ func TestSyncVolumeCapabilitiesFromInfraSPI_CopiesBlockAndFilesystemCapabilities
 		},
 	}
 
-	err := syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI)
+	r := &ReconcileStoragePolicyInfo{zonesProvider: &mockZonesProvider{}}
+	err := r.syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI, nil)
 	require.NoError(t, err)
 	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsVolumeModeFilesystem],
 		"SupportsVolumeModeFilesystem is always true, independent of InfraSPI")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Allow only the hosts belonging to active clusters to be considered for linkedclone validation in infraSPI as well as SPI CRs.
Currently, all hosts from the VC are considered which is misleading.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
InfraSPI CR:

```
 k logs vsphere-csi-controller-54d6dc8ccf-jxplg -n vmware-system-csi -c vsphere-syncer | grep -i "093a1271-85ae-454c-af5e-178f09e71126"
{"level":"info","time":"2026-07-24T07:52:28.26312588Z","caller":"clusterstoragepolicyinfo/controller.go:394","msg":"Reconciling ClusterStoragePolicyInfo","TraceId":"093a1271-85ae-454c-af5e-178f09e71126","name":"/vsan-default-storage-policy"}
{"level":"info","time":"2026-07-24T07:52:28.362052762Z","caller":"clusterstoragepolicyinfo/controller.go:752","msg":"Updated InfraStoragePolicyInfo \"vsan-default-storage-policy\" owner references/spec","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.362112135Z","caller":"clusterstoragepolicyinfo/helper.go:480","msg":"Looking up storage policy for K8s compliant name \"vsan-default-storage-policy\"","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.437330916Z","caller":"vsphere/pbm.go:360","msg":"Found storage policy with K8s compliant name vsan-default-storage-policy: ID=aa6d5a82-1c88-45da-85d3-3d74b91a5bad, Name=vSAN Default Storage Policy","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.437428125Z","caller":"clusterstoragepolicyinfo/helper.go:498","msg":"Storage policy found with K8s compliant name \"vsan-default-storage-policy\": ID=aa6d5a82-1c88-45da-85d3-3d74b91a5bad, Name=vSAN Default Storage Policy","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.463121371Z","caller":"clusterstoragepolicyinfo/controller.go:824","msg":"Syncing storage policy attributes for ClusterStoragePolicyInfo \"vsan-default-storage-policy\" (policy ID: aa6d5a82-1c88-45da-85d3-3d74b91a5bad, name: vSAN Default Storage Policy)","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.463168075Z","caller":"clusterstoragepolicyinfo/helper.go:309","msg":"Storage policy aa6d5a82-1c88-45da-85d3-3d74b91a5bad does not support vSAN encryption","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.463181316Z","caller":"clusterstoragepolicyinfo/helper.go:325","msg":"Storage policy aa6d5a82-1c88-45da-85d3-3d74b91a5bad does not support any encryption","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.463188363Z","caller":"clusterstoragepolicyinfo/helper.go:277","msg":"Storage policy aa6d5a82-1c88-45da-85d3-3d74b91a5bad has no IOPS limit","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.463260398Z","caller":"clusterstoragepolicyinfo/controller.go:857","msg":"Syncing InfraSPI attributes for \"vsan-default-storage-policy\" (policy ID: aa6d5a82-1c88-45da-85d3-3d74b91a5bad, name: vSAN Default Storage Policy)","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.463401716Z","caller":"clusterstoragepolicyinfo/helper.go:376","msg":"Found StorageClass \"vsan-default-storage-policy\" referencing storage policy ID \"aa6d5a82-1c88-45da-85d3-3d74b91a5bad\"","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.463418369Z","caller":"clusterstoragepolicyinfo/controller.go:932","msg":"Storage policy aa6d5a82-1c88-45da-85d3-3d74b91a5bad has topology type \"\" from StorageClass \"vsan-default-storage-policy\"","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.463429062Z","caller":"clusterstoragepolicyinfo/controller.go:947","msg":"Storage policy aa6d5a82-1c88-45da-85d3-3d74b91a5bad: populating accessible zones","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.794236876Z","caller":"vsphere/pbm.go:208","msg":"Found 3 placement results for profile aa6d5a82-1c88-45da-85d3-3d74b91a5bad across 1 clusters","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.794406431Z","caller":"util/util.go:648","msg":"Storage policy aa6d5a82-1c88-45da-85d3-3d74b91a5bad is accessible from zones: [az1]","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.794446075Z","caller":"clusterstoragepolicyinfo/helper.go:539","msg":"Storage policy aa6d5a82-1c88-45da-85d3-3d74b91a5bad SupportsVolumeModeBlock=true (isMarkerPolicy=false)","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:28.946738811Z","caller":"clusterstoragepolicyinfo/helper.go:675","msg":"Storage policy aa6d5a82-1c88-45da-85d3-3d74b91a5bad supports LinkedClone: all 1 zones have ESXi 9.1+ hosts","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:29.038719925Z","caller":"clusterstoragepolicyinfo/helper.go:809","msg":"Zone az1: no ESXi 9.1+ host found in a vSAN-ESA enabled cluster; SupportsHighPerformanceLinkedClone=false","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:29.038928731Z","caller":"clusterstoragepolicyinfo/helper.go:582","msg":"Storage policy aa6d5a82-1c88-45da-85d3-3d74b91a5bad SupportsLinkedClone=true, SupportsHighPerformanceLinkedClone=false","TraceId":"093a1271-85ae-454c-af5e-178f09e71126"}
{"level":"info","time":"2026-07-24T07:52:29.039455642Z","caller":"clusterstoragepolicyinfo/controller.go:530","msg":"Successfully synced storage policy attributes for \"vsan-default-storage-policy\"","TraceId":"093a1271-85ae-454c-af5e-178f09e71126","name":"/vsan-default-storage-policy"}
{"level":"info","time":"2026-07-24T07:52:29.039595454Z","caller":"clusterstoragepolicyinfo/controller.go:796","msg":"Successfully reconciled ClusterStoragePolicyInfo","TraceId":"093a1271-85ae-454c-af5e-178f09e71126","name":"/vsan-default-storage-policy"}
```

```
k get infraspi -oyaml vsan-default-storage-policy
apiVersion: cns.vmware.com/v1alpha1
kind: InfraStoragePolicyInfo
metadata:
  creationTimestamp: "2026-07-23T08:07:45Z"
  generation: 5
  name: vsan-default-storage-policy
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: ClusterStoragePolicyInfo
    name: vsan-default-storage-policy
    uid: 333235a6-5e63-4bae-ab90-aff24a357f4e
  resourceVersion: "1192486"
  uid: ae22899e-eb99-4857-b8d4-925e3da08e4e
spec:
  clusterStoragePolicyInfoRef:
    apiGroup: cns.vmware.com/v1alpha1
    kind: ClusterStoragePolicyInfo
    name: vsan-default-storage-policy
status:
  topology:
    accessibleZones:
    - az1
    topologyType: ""
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsLinkedClone: true
    SupportsPersistentVolumeBlock: true
    SupportsPersistentVolumeFilesystem: true
```

Namespace scoped:

```
k get spi -n test -oyaml vsan-default-storage-policy
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyInfo
metadata:
  creationTimestamp: "2026-07-23T08:25:06Z"
  generation: 6
  name: vsan-default-storage-policy
  namespace: test
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha1
    blockOwnerDeletion: false
    controller: false
    kind: InfraStoragePolicyInfo
    name: vsan-default-storage-policy
    uid: ae22899e-eb99-4857-b8d4-925e3da08e4e
  resourceVersion: "1216230"
  uid: 42f16538-5a39-4522-b48a-9e22bbc9cc93
status:
  topologyInfo:
    accessibleZones:
    - az1
    topologyType: ""
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsLinkedClone: true
    SupportsPersistentVolumeBlock: true
    SupportsPersistentVolumeFilesystem: true
```

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1842/
VKS precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1401/