### PR TITLE
Add an AvailabilityZone CR watch to the ClusterStoragePolicyInfo controller so AZ changes reactively recompute topology and LinkedClone/HPLC for affected policies.

### DIFF
--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -29,7 +30,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -87,6 +90,50 @@ const (
 	dataserviceNs           = "com.vmware.storageprofile.dataservice"
 )
 
+// availabilityZoneGVK identifies the cluster-scoped AvailabilityZone CR
+// (topology.tanzu.vmware.com/v1alpha1). Watched as unstructured since no
+// typed client is registered for this CRD.
+var availabilityZoneGVK = schema.GroupVersionKind{
+	Group:   "topology.tanzu.vmware.com",
+	Version: "v1alpha1",
+	Kind:    "AvailabilityZone",
+}
+
+// newAZPredicate admits delete, or an update to spec.clusterComputeResourceMoIDs; other churn,
+// including create, is ignored. Create is skipped since a just-created AZ can't yet have any
+// policies mapped to it in mapAZToClusterSPIs.
+func newAZPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			oldObj, oldOK := e.ObjectOld.(*unstructured.Unstructured)
+			newObj, newOK := e.ObjectNew.(*unstructured.Unstructured)
+			if !oldOK || !newOK {
+				return false
+			}
+			oldClusters, _, oldErr := unstructured.NestedStringSlice(oldObj.Object,
+				"spec", "clusterComputeResourceMoIDs")
+			newClusters, _, newErr := unstructured.NestedStringSlice(newObj.Object,
+				"spec", "clusterComputeResourceMoIDs")
+			if oldErr != nil || newErr != nil {
+				logger.GetLoggerWithNoContext().Warnf(
+					"newAZPredicate: failed to read spec.clusterComputeResourceMoIDs on AvailabilityZone %q "+
+						"update, oldErr: %v, newErr: %v", e.ObjectNew.GetName(), oldErr, newErr)
+				return true
+			}
+			return !slices.Equal(oldClusters, newClusters)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object != nil
+		},
+	}
+}
+
 // Add registers the ClusterStoragePolicyInfo controller with the Manager (WCP / Workload only).
 func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	configInfo *config.ConfigurationInfo, _ volumes.Manager) error {
@@ -118,11 +165,13 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
-	// Initialize topology service.
+	// Initialize topology service. A nil error with a nil topologyMgr means the AvailabilityZone
+	// CRD isn't registered, so the watch below is skipped; any actual error is returned so Add()
+	// gets retried.
 	topologyMgr, err := commonco.ContainerOrchestratorUtility.InitTopologyServiceInController(ctx)
 	if err != nil {
-		log := logger.GetLogger(ctx)
-		log.Warnf("Failed to initialize topology service in ClusterStoragePolicyInfo controller: %v", err)
+		log.Errorf("Failed to initialize topology service in ClusterStoragePolicyInfo controller: %v", err)
+		return err
 	}
 
 	eventBroadcaster := record.NewBroadcaster()
@@ -214,6 +263,23 @@ func add(mgr manager.Manager, r *ReconcileClusterStoragePolicyInfo) error {
 			handler.EnqueueRequestsFromMapFunc(r.mapFVSNamespaceToClusterMarkerSPI),
 			builder.WithPredicates(nsFVSPredicate),
 		)
+
+	// Watch AvailabilityZone CRs so an AZ->cluster change reactively recomputes
+	// topology + LinkedClone/HPLC, instead of waiting for slow-sync. Gated on
+	// r.topologyMgr being non-nil, which happens only when the AZ CRD is
+	// registered, to avoid the manager cache failing to list/watch a missing CRD.
+	if r.topologyMgr != nil {
+		azObj := &unstructured.Unstructured{}
+		azObj.SetGroupVersionKind(availabilityZoneGVK)
+		blder = blder.Watches(
+			azObj,
+			handler.EnqueueRequestsFromMapFunc(r.mapAZToClusterSPIs),
+			builder.WithPredicates(newAZPredicate()),
+		)
+	} else {
+		log.Infof("AvailabilityZone CR not registered; skipping AvailabilityZone watch " +
+			"for ClusterStoragePolicyInfo controller")
+	}
 
 	// VolumeAttributesClass API is supported from K8s version 1.34 onwards.
 	// Add watch for VolumeAttributesClass only if API is available.
@@ -369,6 +435,29 @@ func (r *ReconcileClusterStoragePolicyInfo) mapFVSNamespaceToClusterMarkerSPI(ct
 	return []reconcile.Request{{
 		NamespacedName: apitypes.NamespacedName{Name: common.StorageClassVsanFileServicePolicy},
 	}}
+}
+
+// mapAZToClusterSPIs maps an AvailabilityZone event to reconcile requests for
+// policies compatible with that zone, via vsphereinfra.PoliciesForZone. This
+// catches a cluster removed from the zone or the zone deleted, since
+// PoliciesForZone reflects each policy's last-reconciled zone compatibility,
+// independent of the event object's contents.
+func (r *ReconcileClusterStoragePolicyInfo) mapAZToClusterSPIs(ctx context.Context,
+	obj client.Object) []reconcile.Request {
+	log := logger.GetLogger(ctx)
+	if obj == nil {
+		return nil
+	}
+	azName := obj.GetName()
+
+	policies := vsphereinfra.GetCache().PoliciesForZone(azName)
+	reqs := make([]reconcile.Request, 0, len(policies))
+	for _, name := range policies {
+		reqs = append(reqs, reconcile.Request{NamespacedName: apitypes.NamespacedName{Name: name}})
+	}
+	log.Infof("AvailabilityZone %q change enqueued %d ClusterStoragePolicyInfo reconcile request(s)",
+		azName, len(reqs))
+	return reqs
 }
 
 var _ reconcile.Reconciler = &ReconcileClusterStoragePolicyInfo{}

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -40,6 +40,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -48,6 +49,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
@@ -60,6 +62,7 @@ import (
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 	cnsoperatorutil "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/vsphereinfra"
 )
 
 func testScheme(t *testing.T) *runtime.Scheme {
@@ -4428,4 +4431,97 @@ func TestMapFVSNamespaceToClusterMarkerSPI_NilObject(t *testing.T) {
 	reqs := r.mapFVSNamespaceToClusterMarkerSPI(ctx, nil)
 	require.Len(t, reqs, 1)
 	assert.Equal(t, common.StorageClassVsanFileServicePolicy, reqs[0].Name)
+}
+
+// newAZ builds an unstructured AvailabilityZone CR with the given cluster
+// morefs, matching the object the AvailabilityZone watch delivers to
+// mapAZToClusterSPIs / newAZPredicate.
+func newAZ(name string, clusters []string) *unstructured.Unstructured {
+	az := &unstructured.Unstructured{}
+	az.SetGroupVersionKind(availabilityZoneGVK)
+	az.SetName(name)
+	if clusters != nil {
+		// unstructured stores slices as []interface{}.
+		asAny := make([]interface{}, len(clusters))
+		for i, c := range clusters {
+			asAny[i] = c
+		}
+		_ = unstructured.SetNestedSlice(az.Object, asAny, "spec", "clusterComputeResourceMoIDs")
+	}
+	return az
+}
+
+// TestMapAZToClusterSPIs verifies that an AvailabilityZone change resolves to the policies
+// vsphereinfra.PoliciesForZone reports as compatible with that zone, not a fan-out to every
+// ClusterStoragePolicyInfo.
+func TestMapAZToClusterSPIs(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+
+	t.Run("nil object returns nil", func(t *testing.T) {
+		r := &ReconcileClusterStoragePolicyInfo{}
+		assert.Nil(t, r.mapAZToClusterSPIs(ctx, nil))
+	})
+
+	t.Run("enqueues policies PoliciesForZone reports for this zone", func(t *testing.T) {
+		cache := vsphereinfra.GetCache()
+		cache.SetDatastoresForPolicyZones("gold", map[string][]string{"az-map": {"ds-1"}})
+		cache.SetDatastoresForPolicyZones("silver", map[string][]string{"az-map": {"ds-2"}})
+		cache.SetDatastoresForPolicyZones("bronze", map[string][]string{"az-other": {"ds-3"}})
+		t.Cleanup(func() {
+			cache.SetDatastoresForPolicyZones("gold", nil)
+			cache.SetDatastoresForPolicyZones("silver", nil)
+			cache.SetDatastoresForPolicyZones("bronze", nil)
+		})
+		r := &ReconcileClusterStoragePolicyInfo{}
+
+		reqs := r.mapAZToClusterSPIs(ctx, newAZ("az-map", []string{"domain-c-map"}))
+		got := make([]string, len(reqs))
+		for i, req := range reqs {
+			got[i] = req.Name
+			assert.Empty(t, req.Namespace, "cluster-scoped: requests carry no namespace")
+		}
+		sort.Strings(got)
+		assert.Equal(t, []string{"gold", "silver"}, got)
+	})
+
+	t.Run("no policies compatible with the zone returns empty", func(t *testing.T) {
+		r := &ReconcileClusterStoragePolicyInfo{}
+		reqs := r.mapAZToClusterSPIs(ctx, newAZ("az-none", []string{"domain-c-none"}))
+		assert.Empty(t, reqs)
+	})
+}
+
+// TestNewAZPredicate verifies the AvailabilityZone watch predicate ignores create (a no-op for
+// mapAZToClusterSPIs), admits delete unconditionally, and admits updates only when the cluster
+// membership (spec.clusterComputeResourceMoIDs) changed.
+func TestNewAZPredicate(t *testing.T) {
+	p := newAZPredicate()
+
+	t.Run("create ignored", func(t *testing.T) {
+		assert.False(t, p.Create(event.CreateEvent{Object: newAZ("az1", []string{"domain-c1"})}))
+	})
+
+	t.Run("delete fires", func(t *testing.T) {
+		assert.True(t, p.Delete(event.DeleteEvent{Object: newAZ("az1", []string{"domain-c1"})}))
+	})
+
+	t.Run("update fires when clusters change", func(t *testing.T) {
+		old := newAZ("az1", []string{"domain-c1"})
+		updated := newAZ("az1", []string{"domain-c1", "domain-c2"})
+		assert.True(t, p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}))
+	})
+
+	t.Run("update ignored when clusters unchanged", func(t *testing.T) {
+		old := newAZ("az1", []string{"domain-c1", "domain-c2"})
+		updated := newAZ("az1", []string{"domain-c1", "domain-c2"})
+		// Simulate unrelated churn (e.g. an annotation) that leaves clusters intact.
+		updated.SetAnnotations(map[string]string{"unrelated": "change"})
+		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}))
+	})
+
+	t.Run("update fires when a cluster is removed", func(t *testing.T) {
+		old := newAZ("az1", []string{"domain-c1", "domain-c2"})
+		updated := newAZ("az1", []string{"domain-c1"})
+		assert.True(t, p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}))
+	})
 }

--- a/pkg/syncer/cnsoperator/vsphereinfra/cache.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/cache.go
@@ -69,7 +69,10 @@ type StoragePolicyInfoCache struct {
 
 	// PolicyZoneDatastores tracks, per storage policy, the datastores compatible with that
 	// policy within each zone. key: policy K8s-compliant name; inner key: zone name;
-	// innermost key: datastore moref.
+	// innermost key: datastore moref. Also read in the reverse direction by PoliciesForZone
+	// (zone -> compatible policies), for the clusterstoragepolicyinfo controller's
+	// AvailabilityZone watch to resolve a zone change to the policies that could lose
+	// accessibility there, without a separate maintained index that could drift out of sync.
 	PolicyZoneDatastores map[string]map[string]map[string]struct{}
 
 	// ClusterToESAEnabled records whether a cluster has vSAN-ESA enabled, keyed by cluster
@@ -243,6 +246,22 @@ func (c *StoragePolicyInfoCache) SetDatastoresForPolicyZones(policyName string, 
 		zones[zone] = set
 	}
 	c.PolicyZoneDatastores[policyName] = zones
+}
+
+// PoliciesForZone returns policy names compatible with at least one datastore
+// in the given zone, as of each policy's last reconcile. Derived by scanning
+// PolicyZoneDatastores rather than maintaining a separate index, since the
+// scan is cheap on a rare AvailabilityZone event and can't drift out of sync.
+func (c *StoragePolicyInfoCache) PoliciesForZone(zone string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	var policies []string
+	for policyName, zones := range c.PolicyZoneDatastores {
+		if len(zones[zone]) > 0 {
+			policies = append(policies, policyName)
+		}
+	}
+	return policies
 }
 
 // GetDatastoresForPolicyZone returns a copy of the cached datastore set compatible with

--- a/pkg/syncer/cnsoperator/vsphereinfra/cache_test.go
+++ b/pkg/syncer/cnsoperator/vsphereinfra/cache_test.go
@@ -389,6 +389,10 @@ func TestSetDatastoresForPolicyZones(t *testing.T) {
 		ds, ok = c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-b")
 		require.True(t, ok)
 		assert.Equal(t, map[string]struct{}{"ds-3": {}}, ds)
+
+		// PoliciesForZone should reflect the policies recorded in PolicyZoneDatastores.
+		assert.ElementsMatch(t, []string{"policy-1"}, c.PoliciesForZone("zone-a"))
+		assert.ElementsMatch(t, []string{"policy-1"}, c.PoliciesForZone("zone-b"))
 	})
 
 	t.Run("unpopulated policy or zone is not found", func(t *testing.T) {
@@ -413,6 +417,8 @@ func TestSetDatastoresForPolicyZones(t *testing.T) {
 
 		_, ok := c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-b")
 		assert.False(t, ok, "zone-b is no longer compatible, its entry must be removed")
+		assert.Empty(t, c.PoliciesForZone("zone-b"), "PoliciesForZone must drop the stale zone-b entry too")
+		assert.ElementsMatch(t, []string{"policy-1"}, c.PoliciesForZone("zone-a"))
 	})
 
 	t.Run("nil zone map clears the policy's entry entirely", func(t *testing.T) {
@@ -423,6 +429,7 @@ func TestSetDatastoresForPolicyZones(t *testing.T) {
 
 		_, ok := c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-a")
 		assert.False(t, ok)
+		assert.Empty(t, c.PoliciesForZone("zone-a"), "PoliciesForZone must drop the policy from every prior zone")
 	})
 
 	t.Run("does not disturb other policies", func(t *testing.T) {
@@ -435,6 +442,8 @@ func TestSetDatastoresForPolicyZones(t *testing.T) {
 		ds, ok := c.GetDatastoresForPolicyZone(context.Background(), "policy-2", "zone-a")
 		require.True(t, ok)
 		assert.Equal(t, map[string]struct{}{"ds-2": {}}, ds)
+		assert.ElementsMatch(t, []string{"policy-2"}, c.PoliciesForZone("zone-a"),
+			"policy-1 must be removed from zone-a's results without disturbing policy-2")
 	})
 
 	t.Run("returned map is a copy", func(t *testing.T) {
@@ -448,6 +457,36 @@ func TestSetDatastoresForPolicyZones(t *testing.T) {
 		internal, _ := c.GetDatastoresForPolicyZone(context.Background(), "policy-1", "zone-a")
 		assert.Equal(t, map[string]struct{}{"ds-1": {}}, internal,
 			"mutating the returned map must not leak into the cache")
+	})
+}
+
+func TestPoliciesForZone(t *testing.T) {
+	t.Run("multiple policies compatible with the same zone are all returned", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{"zone-a": {"ds-1"}})
+		c.SetDatastoresForPolicyZones("policy-2", map[string][]string{"zone-a": {"ds-2"}})
+
+		assert.ElementsMatch(t, []string{"policy-1", "policy-2"}, c.PoliciesForZone("zone-a"))
+	})
+
+	t.Run("a policy compatible with a different zone is excluded", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{"zone-a": {"ds-1"}})
+		c.SetDatastoresForPolicyZones("policy-2", map[string][]string{"zone-b": {"ds-2"}})
+
+		assert.Equal(t, []string{"policy-1"}, c.PoliciesForZone("zone-a"))
+	})
+
+	t.Run("unknown zone returns empty", func(t *testing.T) {
+		c := newTestCache()
+		c.SetDatastoresForPolicyZones("policy-1", map[string][]string{"zone-a": {"ds-1"}})
+
+		assert.Empty(t, c.PoliciesForZone("zone-never-seen"))
+	})
+
+	t.Run("empty cache returns empty", func(t *testing.T) {
+		c := newTestCache()
+		assert.Empty(t, c.PoliciesForZone("zone-a"))
 	})
 }
 


### PR DESCRIPTION
The AZ->cluster mapping determines each policy's accessible zones and LinkedClone/HPLC capabilities, but previously only the periodic slow-sync picked up AZ changes. This adds a controller-runtime watch on AvailabilityZone CRs that resolves each event to the affected ClusterStoragePolicyInfo policies via vsphereinfra.PoliciesForZone, that is derived on the fly from the existing PolicyZoneDatastores cache rather than a new maintained index, so there's nothing extra to keep in sync. This reactively covers removals (a cluster dropped from a zone, or the zone deleted); a cluster newly added to a zone is intentionally left to slow-sync, since no policy has reconciled against that zone yet to populate the cache.

Testing done:

Pipelines:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1402/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1843/ - Passed


(1) Removal: cluster removed from a zone:
```
kubectl get availabilityzones
kubectl get availabilityzone az1 -o jsonpath='{.spec.clusterComputeResourceMoIDs}'
kubectl get infrastoragepolicyinfo test-storage-policy -o jsonpath='{.status.topology.accessibleZones}'
NAME   AGE
az1    11d
["domain-c9"]
["az1"]
```

Confirms test-storage-policy is accessible via az1, backed by domain-c9. Removing az1's only cluster:
```
kubectl patch availabilityzone az1 --type=merge -p='{"spec":{"clusterComputeResourceMoIDs":[]}}'

{"level":"info","caller":"clusterstoragepolicyinfo/controller.go:468","msg":"AvailabilityZone \"az1\" change enqueued 8 ClusterStoragePolicyInfo reconcile request(s)"}
```

Confirms the predicate detects the clusterComputeResourceMoIDs change and the mapper correctly resolves, via PoliciesForZone, to the 8 policies known-compatible with az1 — trigger fires immediately, scoped to the affected policies.

(2) Removal: AZ deleted entirely
```
kubectl delete availabilityzone az2

{"level":"info","caller":"clusterstoragepolicyinfo/controller.go:468","msg":"AvailabilityZone \"az2\" change enqueued 8 ClusterStoragePolicyInfo reconcile request(s)"}
```
The enqueued count (8) matches exactly the number of policies that had az2 in status.topology.accessibleZones. Verified with a before/after snapshot:
```
kubectl get infrastoragepolicyinfo -o json | jq -r '.items[] | "\(.metadata.name)=\(.status.topology.accessibleZones // [])"'
```
Before deletion (8 policies):
```
management-storage-policy-encryption=["az1","az2"]
management-storage-policy-regular=["az1","az2"]
management-storage-policy-single-node=["az1","az2"]
management-storage-policy-stretched-lite=["az1","az2"]
management-storage-policy-thin=["az1","az2"]
new-test-policy=["az1","az2"]
vm-encryption-policy=["az1","az2"]
vsan-default-storage-policy=["az1","az2"]
```
After deletion — all 8 dropped az2; the other 14 policies were unaffected:
```
management-storage-policy-encryption=["az1"]
management-storage-policy-regular=["az1"]
management-storage-policy-single-node=["az1"]
management-storage-policy-stretched-lite=["az1"]
management-storage-policy-thin=["az1"]
new-test-policy=["az1"]
vm-encryption-policy=["az1"]
vsan-default-storage-policy=["az1"]
```

(3) Addition: new cluster added to a zone

Creating az2 fires the watch, but enqueues nothing — no policy has ever reconciled against a zone that didn't exist until now:
```
{"level":"info","caller":"k8sorchestrator/topology.go:452","msg":"Added clusters [domain-c13] to \"az2\" zone in azClustersMap"}
{"level":"info","caller":"clusterstoragepolicyinfo/controller.go:468","msg":"AvailabilityZone \"az2\" change enqueued 0 ClusterStoragePolicyInfo reconcile request(s)"}
```
Shortly after, slow-sync picks it up, recomputing topology and LC/HPLC together:
```
{"level":"info","caller":"util/util.go:648","msg":"Storage policy 4d5f673c-536f-11e6-beb8-9e71128cae77 is accessible from zones: [az1 az2]"}
{"level":"info","caller":"clusterstoragepolicyinfo/helper.go:773","msg":"Zone az2: no ESXi 9.1+ host found in a vSAN-ESA enabled cluster; SupportsHighPerformanceLinkedClone=false"}
```