### PR TITLE
Check VAC version

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -421,6 +421,11 @@ const (
 	// mutable_parameters take precedence over parameters.
 	AttributeSupervisorVolumeAttributesClass = "svvolumeattributesclass"
 
+	// VolumeAttributesClassResourceName is the plural resource name of the VolumeAttributesClass
+	// API (storage.k8s.io), as reported by discovery in APIResource.Name. Used to check whether
+	// the API is served by a given cluster.
+	VolumeAttributesClassResourceName = "volumeattributesclasses"
+
 	// VolumeSnapshotApiGroup represents the VolumeSnapshot API Group name
 	VolumeSnapshotApiGroup = "snapshot.storage.k8s.io"
 

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -63,6 +63,7 @@ var (
 	featureFileVolumesWithVmServiceEnabled bool
 	featureIsSharedDiskEnabled             bool
 	featureIsLinkedCloneSupportEnabled     bool
+	featureIsVACPolicyMutabilityEnabled    bool
 )
 
 // watchConfigChange watches on the webhook configuration directory for changes
@@ -172,6 +173,15 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 		}
 		featureIsLinkedCloneSupportEnabled = linkedClonePVCSIFSS && linkedCloneCapability
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
+		vacPolicyMutabilityCapability := false
+		vacPolicyMutabilityPVCSIFSS := containerOrchestratorUtility.IsPVCSIFSSEnabled(ctx,
+			common.VMPVCStoragePolicyMutabilityFSS)
+		if vacPolicyMutabilityPVCSIFSS {
+			// Check the VAC policy mutability capability only if the internal fss is enabled.
+			vacPolicyMutabilityCapability = containerOrchestratorUtility.IsFSSEnabled(ctx,
+				common.VMPVCStoragePolicyMutabilityFSS)
+		}
+		featureIsVACPolicyMutabilityEnabled = vacPolicyMutabilityPVCSIFSS && vacPolicyMutabilityCapability
 		// Start the late enablement watcher only if the PVCSI internal FSS is enabled, but the current supervisor
 		// capability is disabled.
 		if linkedClonePVCSIFSS && !linkedCloneCapability {

--- a/pkg/syncer/admissionhandler/pvcsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/pvcsi_admissionhandler.go
@@ -126,7 +126,7 @@ func (h *CSIGuestWebhook) Handle(ctx context.Context, req admission.Request) (re
 
 	resp = admission.Allowed("")
 	if req.Kind.Kind == "PersistentVolumeClaim" {
-		if featureGateBlockVolumeSnapshotEnabled {
+		if featureGateBlockVolumeSnapshotEnabled || featureIsVACPolicyMutabilityEnabled {
 			admissionResp := validatePVC(ctx, &req.AdmissionRequest)
 			resp.AdmissionResponse = *admissionResp.DeepCopy()
 		}

--- a/pkg/syncer/admissionhandler/validatepvc.go
+++ b/pkg/syncer/admissionhandler/validatepvc.go
@@ -16,6 +16,7 @@ import (
 	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
@@ -36,13 +37,60 @@ const (
 	ExpandLinkedCloneVolumeErrorMessage    = "Expanding linked clone volume is not allowed"
 	UpdateLinkedCloneVolumeAnnErrorMessage = "Cannot update linked clone volume annotations after creation"
 	DeleteVolumeWithSnapshotErrorMessage   = "Deleting volume with snapshots is not allowed"
+	VACChangeFeatureDisabledErrorMessage   = "VolumeAttributesClass modification is not allowed: " +
+		"VM_PVC_STORAGE_POLICY_MUTABILITY feature is disabled"
+	VACChangeAPINotServedErrorMessage = "VolumeAttributesClass modification is not allowed: " +
+		"the VolumeAttributesClass API is not served by this cluster"
 )
+
+// vacAPIGroupVersion is the GA VolumeAttributesClass API version required for VAC-based
+// modification to be supported. VAC-based modification is only supported on Kubernetes 1.34+
+// guest clusters serving the GA API; pre-1.34 guests serving only the beta storage.k8s.io/v1beta1
+// API are not supported.
+const vacAPIGroupVersion = "storage.k8s.io/v1"
+
+// isVolumeAttributesClassServed reports whether the guest cluster serves the GA
+// VolumeAttributesClass API (vacAPIGroupVersion). It is a package variable so tests can
+// substitute a fake.
+var isVolumeAttributesClassServed = func(ctx context.Context) (bool, error) {
+	kubeClient, err := newK8sClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	resourceList, err := kubeClient.Discovery().ServerResourcesForGroupVersion(vacAPIGroupVersion)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, resource := range resourceList.APIResources {
+		if resource.Name == common.VolumeAttributesClassResourceName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// detectVACChange compares VolumeAttributesClassName between old and new PVC and returns whether
+// a change was detected, along with the old and new VAC names.
+func detectVACChange(oldPVC, newPVC corev1.PersistentVolumeClaim) (bool, string, string) {
+	oldVAC := ""
+	if oldPVC.Spec.VolumeAttributesClassName != nil {
+		oldVAC = *oldPVC.Spec.VolumeAttributesClassName
+	}
+	newVAC := ""
+	if newPVC.Spec.VolumeAttributesClassName != nil {
+		newVAC = *newPVC.Spec.VolumeAttributesClassName
+	}
+	return oldVAC != newVAC, oldVAC, newVAC
+}
 
 // validatePVC helps validate AdmissionReview requests for PersistentVolumeClaim.
 func validatePVC(ctx context.Context, req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
-	if !featureGateBlockVolumeSnapshotEnabled {
-		// If CSI block volume snapshot is disabled and webhook is running,
-		// skip validation for PersistentVolumeClaim.
+	if !featureGateBlockVolumeSnapshotEnabled && !featureIsVACPolicyMutabilityEnabled {
+		// If none of the features backed by this function are enabled, skip
+		// validation for PersistentVolumeClaim.
 		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
@@ -198,6 +246,34 @@ func validatePVC(ctx context.Context, req *admissionv1.AdmissionRequest) *admiss
 							Reason: ExpandLinkedCloneVolumeErrorMessage,
 						}
 					}
+				}
+			}
+		}
+		// VolumeAttributesClass change gate: a VAC change on the guest PVC is proxied to the
+		// supervisor PVC (see pvCSI ControllerModifyVolume), where it is only honored if the
+		// cluster serves the VolumeAttributesClass API. Deny it here so the failure surfaces
+		// immediately instead of later, asynchronously, on the supervisor side.
+		if req.Operation == admissionv1.Update && allowed {
+			if vacChanged, oldVAC, newVAC := detectVACChange(oldPVC, newPVC); vacChanged {
+				if !featureIsVACPolicyMutabilityEnabled {
+					allowed = false
+					result = &metav1.Status{
+						Reason: VACChangeFeatureDisabledErrorMessage,
+					}
+				} else if served, err := isVolumeAttributesClassServed(ctx); err != nil {
+					allowed = false
+					result = &metav1.Status{
+						Reason: metav1.StatusReason(fmt.Sprintf(
+							"failed to determine whether the VolumeAttributesClass API is served: %v", err)),
+					}
+				} else if !served {
+					allowed = false
+					result = &metav1.Status{
+						Reason: VACChangeAPINotServedErrorMessage,
+					}
+				} else {
+					log.Infof("VAC change detected for PVC %s/%s: %q -> %q",
+						oldPVC.Namespace, oldPVC.Name, oldVAC, newVAC)
 				}
 			}
 		}

--- a/pkg/syncer/admissionhandler/validatepvc_test.go
+++ b/pkg/syncer/admissionhandler/validatepvc_test.go
@@ -3,6 +3,7 @@ package admissionhandler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 
@@ -1141,6 +1142,243 @@ func TestValidateGuestPVCOperation_LinkedClone_StorageClass(t *testing.T) {
 					"Expected error message to contain '%s' but got: %s",
 					test.expectedMessageContain, response.Result.Message)
 			}
+		})
+	}
+}
+
+func TestValidatePVC_VACChange(t *testing.T) {
+	oldVACName := "old-vac"
+	newVACName := "new-vac"
+
+	makeVACUpdateReq := func(oldVAC, newVAC *string) *admissionv1.AdmissionRequest {
+		oldPVC := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testFirstPVCName},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName:          &testStorageClassName,
+				VolumeAttributesClassName: oldVAC,
+				AccessModes:               []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				VolumeMode:                &volumeMode,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("5Gi")},
+				},
+			},
+		}
+		newPVC := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testFirstPVCName},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName:          &testStorageClassName,
+				VolumeAttributesClassName: newVAC,
+				AccessModes:               []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				VolumeMode:                &volumeMode,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("5Gi")},
+				},
+			},
+		}
+		oldRaw, err := json.Marshal(oldPVC)
+		assert.NoError(t, err)
+		newRaw, err := json.Marshal(newPVC)
+		assert.NoError(t, err)
+		return &admissionv1.AdmissionRequest{
+			Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+			Operation: admissionv1.Update,
+			OldObject: runtime.RawExtension{Raw: oldRaw},
+			Object:    runtime.RawExtension{Raw: newRaw},
+		}
+	}
+
+	tests := []struct {
+		name string
+		// blockVolumeSnapshotEnabled is set explicitly per case (rather than left to whatever
+		// other tests in this package leave the global at) so validatePVC's top-level gate -
+		// "featureGateBlockVolumeSnapshotEnabled || featureIsVACPolicyMutabilityEnabled" - is
+		// satisfied deterministically even for cases where vacPolicyMutabilityEnabled is false.
+		blockVolumeSnapshotEnabled    bool
+		vacPolicyMutabilityEnabled    bool
+		isVolumeAttributesClassServed func(ctx context.Context) (bool, error)
+		req                           *admissionv1.AdmissionRequest
+		expectedAllowed               bool
+		expectedReason                metav1.StatusReason
+	}{
+		{
+			name:                       "no VAC change is unaffected regardless of feature state",
+			blockVolumeSnapshotEnabled: true,
+			vacPolicyMutabilityEnabled: false,
+			req:                        makeVACUpdateReq(&oldVACName, &oldVACName),
+			expectedAllowed:            true,
+		},
+		{
+			name:                       "VAC change denied when VACPolicyMutability feature is disabled",
+			blockVolumeSnapshotEnabled: true,
+			vacPolicyMutabilityEnabled: false,
+			req:                        makeVACUpdateReq(&oldVACName, &newVACName),
+			expectedAllowed:            false,
+			expectedReason:             VACChangeFeatureDisabledErrorMessage,
+		},
+		{
+			name:                       "VAC change denied when VolumeAttributesClass API is not served",
+			vacPolicyMutabilityEnabled: true,
+			isVolumeAttributesClassServed: func(ctx context.Context) (bool, error) {
+				return false, nil
+			},
+			req:             makeVACUpdateReq(&oldVACName, &newVACName),
+			expectedAllowed: false,
+			expectedReason:  VACChangeAPINotServedErrorMessage,
+		},
+		{
+			name:                       "VAC change denied when API availability check errors",
+			vacPolicyMutabilityEnabled: true,
+			isVolumeAttributesClassServed: func(ctx context.Context) (bool, error) {
+				return false, errors.New("discovery unavailable")
+			},
+			req:             makeVACUpdateReq(&oldVACName, &newVACName),
+			expectedAllowed: false,
+		},
+		{
+			name:                       "VAC change allowed when feature enabled and API served",
+			vacPolicyMutabilityEnabled: true,
+			isVolumeAttributesClassServed: func(ctx context.Context) (bool, error) {
+				return true, nil
+			},
+			req:             makeVACUpdateReq(&oldVACName, &newVACName),
+			expectedAllowed: true,
+		},
+	}
+
+	origBlockVolumeSnapshotEnabled := featureGateBlockVolumeSnapshotEnabled
+	origVACPolicyMutabilityEnabled := featureIsVACPolicyMutabilityEnabled
+	origIsVolumeAttributesClassServed := isVolumeAttributesClassServed
+	defer func() {
+		featureGateBlockVolumeSnapshotEnabled = origBlockVolumeSnapshotEnabled
+		featureIsVACPolicyMutabilityEnabled = origVACPolicyMutabilityEnabled
+		isVolumeAttributesClassServed = origIsVolumeAttributesClassServed
+	}()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			featureGateBlockVolumeSnapshotEnabled = test.blockVolumeSnapshotEnabled
+			featureIsVACPolicyMutabilityEnabled = test.vacPolicyMutabilityEnabled
+			if test.isVolumeAttributesClassServed != nil {
+				isVolumeAttributesClassServed = test.isVolumeAttributesClassServed
+			} else {
+				isVolumeAttributesClassServed = origIsVolumeAttributesClassServed
+			}
+
+			resp := validatePVC(context.Background(), test.req)
+			assert.Equal(t, test.expectedAllowed, resp.Allowed)
+			if test.expectedReason != "" {
+				assert.Equal(t, test.expectedReason, resp.Result.Reason)
+			}
+		})
+	}
+}
+
+func TestDetectVACChange(t *testing.T) {
+	vacA := "vac-a"
+	vacB := "vac-b"
+
+	tests := []struct {
+		name            string
+		oldVAC          *string
+		newVAC          *string
+		expectedChanged bool
+		expectedOldVAC  string
+		expectedNewVAC  string
+	}{
+		{name: "both nil", oldVAC: nil, newVAC: nil, expectedChanged: false},
+		{name: "unset to set", oldVAC: nil, newVAC: &vacA, expectedChanged: true, expectedNewVAC: vacA},
+		{name: "set to unset", oldVAC: &vacA, newVAC: nil, expectedChanged: true, expectedOldVAC: vacA},
+		{name: "same value", oldVAC: &vacA, newVAC: &vacA, expectedChanged: false,
+			expectedOldVAC: vacA, expectedNewVAC: vacA},
+		{name: "different values", oldVAC: &vacA, newVAC: &vacB, expectedChanged: true,
+			expectedOldVAC: vacA, expectedNewVAC: vacB},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oldPVC := corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: test.oldVAC},
+			}
+			newPVC := corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: test.newVAC},
+			}
+			changed, oldVAC, newVAC := detectVACChange(oldPVC, newPVC)
+			assert.Equal(t, test.expectedChanged, changed)
+			assert.Equal(t, test.expectedOldVAC, oldVAC)
+			assert.Equal(t, test.expectedNewVAC, newVAC)
+		})
+	}
+}
+
+func TestIsVolumeAttributesClassServed(t *testing.T) {
+	tests := []struct {
+		name           string
+		resources      []*metav1.APIResourceList
+		clientErr      error
+		expectedServed bool
+		expectErr      bool
+	}{
+		{
+			name: "GA v1 serves VolumeAttributesClass",
+			resources: []*metav1.APIResourceList{
+				{GroupVersion: "storage.k8s.io/v1", APIResources: []metav1.APIResource{
+					{Name: common.VolumeAttributesClassResourceName},
+				}},
+			},
+			expectedServed: true,
+		},
+		{
+			name: "beta v1beta1 only is not sufficient (GA required)",
+			resources: []*metav1.APIResourceList{
+				{GroupVersion: "storage.k8s.io/v1beta1", APIResources: []metav1.APIResource{
+					{Name: common.VolumeAttributesClassResourceName},
+				}},
+			},
+			expectedServed: false,
+		},
+		{
+			name: "GA served without the volumeattributesclasses resource",
+			resources: []*metav1.APIResourceList{
+				{GroupVersion: "storage.k8s.io/v1", APIResources: []metav1.APIResource{{Name: "storageclasses"}}},
+			},
+			expectedServed: false,
+		},
+		{
+			name:           "GA not served",
+			resources:      []*metav1.APIResourceList{},
+			expectedServed: false,
+		},
+		{
+			name:      "client construction error propagates",
+			clientErr: errors.New("failed to build client"),
+			expectErr: true,
+		},
+	}
+
+	origK8sClient := newK8sClient
+	defer func() { newK8sClient = origK8sClient }()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.clientErr != nil {
+				newK8sClient = func(ctx context.Context) (clientset.Interface, error) {
+					return nil, test.clientErr
+				}
+			} else {
+				kubeClient := fake.NewClientset()
+				kubeClient.Fake.Resources = test.resources
+				newK8sClient = func(ctx context.Context) (clientset.Interface, error) {
+					return kubeClient, nil
+				}
+			}
+
+			served, err := isVolumeAttributesClassServed(context.Background())
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedServed, served)
 		})
 	}
 }

--- a/pkg/syncer/byokoperator/controller/controller.go
+++ b/pkg/syncer/byokoperator/controller/controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/persistentvolumeclaim"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/byokoperator/controller/storageclass"
@@ -72,7 +73,7 @@ func volumeAttributesClassAPIAvailable(cfg *rest.Config) (bool, error) {
 		return false, err
 	}
 	for i := range resources.APIResources {
-		if resources.APIResources[i].Name == "volumeattributesclasses" {
+		if resources.APIResources[i].Name == csicommon.VolumeAttributesClassResourceName {
 			return true, nil
 		}
 	}

--- a/pkg/syncer/byokoperator/controller/controller_test.go
+++ b/pkg/syncer/byokoperator/controller/controller_test.go
@@ -27,6 +27,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	csicommon "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 )
 
 // newDiscoveryTestServer stubs just the storage.k8s.io/v1 discovery endpoint that
@@ -45,7 +46,8 @@ func newDiscoveryTestServer(t *testing.T, includeVAC bool) *httptest.Server {
 		}
 		if includeVAC {
 			list.APIResources = append(list.APIResources, metav1.APIResource{
-				Name: "volumeattributesclasses", Namespaced: false, Kind: "VolumeAttributesClass", Verbs: verbs,
+				Name: csicommon.VolumeAttributesClassResourceName, Namespaced: false, Kind: "VolumeAttributesClass",
+				Verbs: verbs,
 			})
 		}
 		payload, err := json.Marshal(list)

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -133,7 +133,8 @@ func newDiscoveryTestServer(t *testing.T, includeVAC bool) *httptest.Server {
 		}
 		if includeVAC {
 			list.APIResources = append(list.APIResources, metav1.APIResource{
-				Name: "volumeattributesclasses", Namespaced: false, Kind: "VolumeAttributesClass", Verbs: verbs,
+				Name: common.VolumeAttributesClassResourceName, Namespaced: false, Kind: "VolumeAttributesClass",
+				Verbs: verbs,
 			})
 		}
 		payload, err := json.Marshal(list)

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
@@ -94,7 +94,7 @@ func volumeAttributesClassAPIAvailableFromRESTConfig(cfg *rest.Config) (bool, er
 			continue
 		}
 		for i := range list.APIResources {
-			if list.APIResources[i].Name == "volumeattributesclasses" {
+			if list.APIResources[i].Name == common.VolumeAttributesClassResourceName {
 				return true, nil
 			}
 		}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -4573,7 +4573,7 @@ func volumeAttributesClassAPIAvailableFromConfig(cfg *restclient.Config) (bool, 
 			continue
 		}
 		for i := range list.APIResources {
-			if list.APIResources[i].Name == "volumeattributesclasses" {
+			if list.APIResources[i].Name == common.VolumeAttributesClassResourceName {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds a VolumeAttributesClass (VAC) API-availability check to the guest-cluster (pvCSI) PVC validating admission webhook. This feature is only supported on Kubernetes 1.34+ guest clusters, where VAC reaches GA.

Today, a guest PVC's spec.volumeAttributesClassName change is picked up by the guest's own csi-resizer, which needs the guest cluster's VolumeAttributesClass API to resolve the VAC object before it can issue ControllerModifyVolume. If the guest cluster doesn't actually serve the GA API — e.g. a pre-1.34 guest — the modify request stalls inside the guest with no clear error: the PVC's status.modifyVolumeStatus never updates, no Event or Condition appears, and the only trace is buried in the csi-resizer sidecar's own logs. 

This PR fails fast at admission time instead: the webhook now denies a PVC update that changes volumeAttributesClassName unless (a) the VM_PVC_STORAGE_POLICY_MUTABILITY feature is enabled, and (b) the guest cluster genuinely serves the GA VolumeAttributesClass API (storage.k8s.io/v1).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1439/ (passed)
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1883/ (passed)

[Manual Testing](https://gist.github.com/xing-yang/bff827e7119fc1fcc2b0975118872c0a#file-pvcsi-vac-api-version-check-md)

**Special notes for your reviewer**:

**Release note**:
```release-note
Adds a VolumeAttributesClass (VAC) V1 API-availability check to the guest-cluster (pvCSI) PVC validating admission webhook.
```
