### PR TITLE
Add a cache warm delay for ns scoped SPI controller

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,7 +23,7 @@ set -o nounset
 set -o pipefail
 set -x
 
-DO_WINDOWS_BUILD=${DO_WINDOWS_BUILD_ENV:-true}
+DO_WINDOWS_BUILD=${DO_WINDOWS_BUILD_ENV:-false}
 
 # BASE_REPO is the root path of the image repository
 readonly BASE_IMAGE_REPO=us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -94,6 +94,10 @@ const (
 	// spiMarkerIndexField is the field index key used to list only marker-policy
 	// StoragePolicyInfo objects in mapFVSNamespaceToMarkerSPIs.
 	spiMarkerIndexField = "isMarkerPolicy"
+	// cacheWarmupDelay is how long the controller waits after starting before it
+	// begins reconciling. This gives enough time for the cache to get populated,
+	// which the SPI controller depends on.
+	cacheWarmupDelay = 5 * time.Minute
 )
 
 // zoneGVK identifies the namespace-scoped Zone custom resource
@@ -184,9 +188,13 @@ func newReconciler(mgr manager.Manager, configInfo *config.ConfigurationInfo,
 	}
 }
 
+// add registers field indexes immediately (required before the manager's
+// Kubernetes-object cache starts) and defers actually building/registering the
+// storagepolicyinfo controller — predicates, watches, and the periodic resync
+// runnable — until cacheWarmupDelay has elapsed. That delay gives
+// enough time for the shared cache to get populated.
 func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 	ctx, log := logger.GetNewContextWithLogger()
-	maxWorkerThreads := util.GetMaxWorkerThreads(ctx, workerThreadsEnvVar, defaultMaxWorkerThreads)
 
 	// Index StoragePolicyInfo by name so mapInfraSPItoSPI can list only matching
 	// objects rather than doing a full cross-namespace list.
@@ -214,6 +222,34 @@ func add(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
 			return err
 		}
 	}
+
+	// manager.Add can be called after the manager has already started, in which
+	// case the Runnable is started immediately instead of waiting for Start(); this
+	// lets us run the delay as a one-time runnable rather than blocking add() itself.
+	if err := mgr.Add(manager.RunnableFunc(func(runnableCtx context.Context) error {
+		timer := time.NewTimer(cacheWarmupDelay)
+		defer timer.Stop()
+		select {
+		case <-runnableCtx.Done():
+			return nil
+		case <-timer.C:
+		}
+		log.Infof("StoragePolicyInfo controller: cache warmup delay of %s elapsed; "+
+			"registering controller", cacheWarmupDelay)
+		return registerController(mgr, r)
+	})); err != nil {
+		log.Errorf("failed to add delayed storagepolicyinfo controller registration runnable. Err: %v", err)
+		return err
+	}
+	return nil
+}
+
+// registerController builds and registers the storagepolicyinfo controller
+// (predicates, watches, and the periodic resync runnable) with mgr. Split out
+// from add so it can be run immediately or deferred behind cacheWarmupDelay.
+func registerController(mgr manager.Manager, r *ReconcileStoragePolicyInfo) error {
+	ctx, log := logger.GetNewContextWithLogger()
+	maxWorkerThreads := util.GetMaxWorkerThreads(ctx, workerThreadsEnvVar, defaultMaxWorkerThreads)
 
 	// Reconcile only on SPQ CREATE (policy assigned -> create the SPI). DELETE is
 	// ignored: the SPI's owner reference to the SPQ makes GC delete it when the quota


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a delay in startup on NS scoped SPI controller so that there us enough time for cache to get updated.

**Testing done**:

After 5 mins of delay the SPI controller got restarted and al the CRs were reconciled.

```
k logs vsphere-csi-controller-d5c9646d6-jpzdz -n vmware-system-csi -c vsphere-syncer -f | grep -i "StoragePolicyInfo controller"
{"level":"info","time":"2026-07-28T10:24:54.082134621Z","caller":"storagepolicyinfo/controller.go:164","msg":"StoragePolicyInfo Controller: capability \"supports_vsan_fileservice\" is not activated; marker-policy topology support is disabled","TraceId":"d74caf6a-ec36-4468-9249-028cac17c7eb"}
{"level":"info","time":"2026-07-28T10:29:55.679031113Z","caller":"storagepolicyinfo/controller.go:235","msg":"StoragePolicyInfo controller: cache warmup delay of 5m0s elapsed; registering controller","TraceId":"15f906fc-4dbf-402a-8510-c9d58c6a89fb"}
```

Also ensured that Cluster SPI controller is not blocked by this delay.

WCP precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1850/
VKS precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1405/