### PR TITLE
Mark LC and HPLC as false by default for ns-scoped StoragePolicyInfo CRs of the vSAN File Service marker policy

### DIFF
--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/controller.go
@@ -780,11 +780,24 @@ func (r *ReconcileStoragePolicyInfo) syncTopologyFromInfraSPI(ctx context.Contex
 // SupportsVolumeModeFilesystem is always true, independent of InfraSPI.
 // SupportsVolumeModeBlock is copied as-is from InfraSPI.
 // SupportsLinkedClone and SupportsHighPerformanceLinkedClone are recomputed for just the zones accessible
-// to this namespace.
+// to this namespace, except for the marker policy, which is file-only and forces
+// SupportsVolumeModeBlock, SupportsLinkedClone and SupportsHighPerformanceLinkedClone all false.
 func (r *ReconcileStoragePolicyInfo) syncVolumeCapabilitiesFromInfraSPI(ctx context.Context,
 	instance *spiv1alpha1.StoragePolicyInfo, infraSPI *infraspiv1alpha1.InfraStoragePolicyInfo,
 	activeClustersByZone map[string]map[string]bool) error {
 	infraCaps := infraSPI.Status.VolumeCapabilities
+
+	// The marker policy is file-only: Block volume mode, LinkedClone and
+	// HighPerformanceLinkedClone never apply to it, regardless of what InfraSPI reports.
+	if r.IsVsanFileVolumeService && common.IsvSANFileServiceMarkerPolicyName(instance.Name) {
+		instance.Status.VolumeCapabilities = map[spiv1alpha1.VolumeCapability]bool{
+			spiv1alpha1.SupportsVolumeModeFilesystem:       true,
+			spiv1alpha1.SupportsVolumeModeBlock:            false,
+			spiv1alpha1.SupportsLinkedClone:                false,
+			spiv1alpha1.SupportsHighPerformanceLinkedClone: false,
+		}
+		return nil
+	}
 
 	lc, hplc, err := linkedCloneCapabilitiesForNamespace(ctx, r.zonesProvider, activeClustersByZone, instance, infraSPI)
 	if err != nil {

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/volume_capabilities_test.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/volume_capabilities_test.go
@@ -27,6 +27,7 @@ import (
 
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
 	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/vsphereinfra"
 )
@@ -338,4 +339,105 @@ func TestSyncVolumeCapabilitiesFromInfraSPI_CopiesBlockAndFilesystemCapabilities
 	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsVolumeModeBlock])
 	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsLinkedClone])
 	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsHighPerformanceLinkedClone])
+}
+
+// setupPolicyZoneWithHPLCHost primes the cache so LC/HPLC over zone-a would compute true.
+func setupPolicyZoneWithHPLCHost(t *testing.T, policyName, dsID, hostID, clusterID string) {
+	t.Helper()
+	clearPolicyZoneCache(t, policyName)
+	t.Cleanup(func() {
+		vsphereinfra.GetCache().UpdateDsHosts(dsID, map[string]struct{}{})
+		vsphereinfra.GetCache().InvalidateHostVersion(hostID)
+		vsphereinfra.GetCache().InvalidateCluster(clusterID)
+	})
+	vsphereinfra.GetCache().SetDatastoresForPolicyZones(policyName, map[string][]string{"zone-a": {dsID}})
+	vsphereinfra.GetCache().UpdateDsHosts(dsID, map[string]struct{}{hostID: {}})
+	vsphereinfra.GetCache().UpdateHostVersion(hostID, "9.1.0")
+	vsphereinfra.GetCache().UpdateClusterHosts(clusterID, map[string]struct{}{hostID: {}})
+	vsphereinfra.GetCache().SetClusterESAEnabled(clusterID, true)
+}
+
+// TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyForcesLCHPLCFalse verifies Block mode,
+// LC and HPLC are all forced false for the marker policy, even when InfraSPI reports Block
+// mode support and the cache would otherwise compute LC/HPLC true.
+func TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyForcesLCHPLCFalse(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	markerPolicy := common.StorageClassVsanFileServicePolicy
+	setupPolicyZoneWithHPLCHost(t, markerPolicy, "ds-marker-force", "host-marker-force", "cluster-marker-force")
+
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: markerPolicy, Namespace: "consumer-ns"},
+		Status: spiv1alpha1.StoragePolicyInfoStatus{
+			TopologyInfo: &spiv1alpha1.Topology{TopologyType: "zonal", AccessibleZones: []string{"zone-a"}},
+		},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: markerPolicy},
+		Status: infraspiv1alpha1.InfraStoragePolicyInfoStatus{
+			VolumeCapabilities: map[infraspiv1alpha1.VolumeCapability]bool{
+				infraspiv1alpha1.SupportsVolumeModeBlock: true,
+			},
+		},
+	}
+
+	r := &ReconcileStoragePolicyInfo{IsVsanFileVolumeService: true}
+	err := r.syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI, nil)
+	require.NoError(t, err)
+	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsVolumeModeFilesystem])
+	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsVolumeModeBlock],
+		"marker policy must have Block mode forced false even when InfraSPI reports it true")
+	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsLinkedClone],
+		"marker policy must have LinkedClone forced false even when the cache would compute true")
+	assert.False(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsHighPerformanceLinkedClone],
+		"marker policy must have HighPerformanceLinkedClone forced false even when the cache would compute true")
+}
+
+// TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyFSSDisabledComputes verifies LC/HPLC are
+// computed normally for the marker policy when the marker FSS is disabled.
+func TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyFSSDisabledComputes(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	markerPolicy := common.StorageClassVsanFileServicePolicy
+	setupPolicyZoneWithHPLCHost(t, markerPolicy, "ds-marker-fssoff", "host-marker-fssoff", "cluster-marker-fssoff")
+
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: markerPolicy, Namespace: "consumer-ns"},
+		Status: spiv1alpha1.StoragePolicyInfoStatus{
+			TopologyInfo: &spiv1alpha1.Topology{TopologyType: "zonal", AccessibleZones: []string{"zone-a"}},
+		},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: markerPolicy}}
+
+	r := &ReconcileStoragePolicyInfo{IsVsanFileVolumeService: false}
+	activeClustersByZone := map[string]map[string]bool{"zone-a": {"cluster-marker-fssoff": true}}
+	err := r.syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI, activeClustersByZone)
+	require.NoError(t, err)
+	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsLinkedClone],
+		"with the marker FSS off, LinkedClone is computed normally (true here)")
+	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsHighPerformanceLinkedClone],
+		"with the marker FSS off, HighPerformanceLinkedClone is computed normally (true here)")
+}
+
+// TestSyncVolumeCapabilitiesFromInfraSPI_NonMarkerPolicyComputes verifies the marker
+// short-circuit doesn't affect ordinary policies.
+func TestSyncVolumeCapabilitiesFromInfraSPI_NonMarkerPolicyComputes(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const policyName = "policy-svcfi-nonmarker"
+	setupPolicyZoneWithHPLCHost(t, policyName, "ds-nonmarker", "host-nonmarker", "cluster-nonmarker")
+
+	instance := &spiv1alpha1.StoragePolicyInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: "consumer-ns"},
+		Status: spiv1alpha1.StoragePolicyInfoStatus{
+			TopologyInfo: &spiv1alpha1.Topology{TopologyType: "zonal", AccessibleZones: []string{"zone-a"}},
+		},
+	}
+	infraSPI := &infraspiv1alpha1.InfraStoragePolicyInfo{ObjectMeta: metav1.ObjectMeta{Name: policyName}}
+
+	r := &ReconcileStoragePolicyInfo{IsVsanFileVolumeService: true}
+	activeClustersByZone := map[string]map[string]bool{"zone-a": {"cluster-nonmarker": true}}
+	err := r.syncVolumeCapabilitiesFromInfraSPI(ctx, instance, infraSPI, activeClustersByZone)
+	require.NoError(t, err)
+	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsLinkedClone],
+		"non-marker policy is unaffected by the marker short-circuit")
+	assert.True(t, instance.Status.VolumeCapabilities[spiv1alpha1.SupportsHighPerformanceLinkedClone],
+		"non-marker policy is unaffected by the marker short-circuit")
 }


### PR DESCRIPTION
Namespace-scoped StoragePolicyInfo (SPI) CRs compute LinkedClone (LC) and HighPerformanceLinkedClone (HPLC) support the same way for every storage policy, including the vSAN File Service marker policy. But LC/HPLC don't apply to that marker policy, so this computed value was misleading.

This change special-cases the marker policy: LC and HPLC are now always set to false for it, skipping the normal per-namespace computation. All other policies are unaffected.

Testing done:
Pipelines:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1851/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1407/ - Passed

Unit tests
```
go test ./pkg/syncer/cnsoperator/controller/storagepolicyinfo/... \
  -run 'TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyForcesLCHPLCFalse|TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyFSSDisabledComputes|TestSyncVolumeCapabilitiesFromInfraSPI_NonMarkerPolicyComputes' -v

=== RUN   TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyForcesLCHPLCFalse
--- PASS: TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyForcesLCHPLCFalse (0.00s)
=== RUN   TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyFSSDisabledComputes
--- PASS: TestSyncVolumeCapabilitiesFromInfraSPI_MarkerPolicyFSSDisabledComputes (0.00s)
=== RUN   TestSyncVolumeCapabilitiesFromInfraSPI_NonMarkerPolicyComputes
--- PASS: TestSyncVolumeCapabilitiesFromInfraSPI_NonMarkerPolicyComputes (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/storagepolicyinfo	0.931s
```

On supervisor cluster:
```
root@42242c1863955292705121d7e359f58d [ ~ ]# kubectl -n svc-velero-wp145 get storagepolicyinfos.cns.vmware.com vsan-file-service-policy -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyInfo
metadata:
  creationTimestamp: "2026-07-28T11:43:10Z"
  generation: 1
  name: vsan-file-service-policy
  namespace: svc-velero-wp145
  ownerReferences:
  - apiVersion: cns.vmware.com/v1alpha2
    blockOwnerDeletion: false
    controller: false
    kind: StoragePolicyQuota
    name: vsan-file-service-policy-storagepolicyquota
    uid: 34b28435-be8e-4940-a09f-f0b89e415686
  resourceVersion: "1731463"
  uid: 7f09dbbd-3cc3-4366-a9c8-4e8e82b3d1d9
spec:
  clusterStoragePolicyInfoRef:
    apiGroup: cns.vmware.com/v1alpha1
    kind: ClusterStoragePolicyInfo
    name: vsan-file-service-policy
status:
  volumeCapabilities:
    SupportsHighPerformanceLinkedClone: false
    SupportsLinkedClone: false
    SupportsPersistentVolumeBlock: true
    SupportsPersistentVolumeFilesystem: true
```
