### PR TITLE
Update deployment yaml files for v3.7.3

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -149,7 +149,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.7.3-rc.1
+          image: registry.k8s.io/csi-vsphere/syncer:v3.7.3
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -279,7 +279,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.7.3-rc.1
+          image: registry.k8s.io/csi-vsphere/driver:v3.7.3
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -340,7 +340,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.7.3-rc.1
+          image: registry.k8s.io/csi-vsphere/syncer:v3.7.3
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -475,7 +475,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.7.3-rc.1
+          image: registry.k8s.io/csi-vsphere/driver:v3.7.3
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -622,7 +622,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: vsphere-csi-node
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.7.3-rc.1
+          image: registry.k8s.io/csi-vsphere/driver:v3.7.3
           command:
             - "csi.exe"
           args:


### PR DESCRIPTION
## Summary
- Update the vanilla deployment manifests (`vsphere-csi-driver.yaml`, `validatingwebhook.yaml`) to reference the final `v3.7.3` release images at `registry.k8s.io/csi-vsphere/{driver,syncer}`, replacing the `v3.7.3-rc.1` staging images — following the same pattern as #4159 / commit 42baad5a79bc28c7987a2b4e1546615af6e4e385 for the v3.7.2 release.

## Test plan
- [ ] Verify `registry.k8s.io/csi-vsphere/driver:v3.7.3` and `registry.k8s.io/csi-vsphere/syncer:v3.7.3` images exist and are pullable
- [ ] Apply the updated manifests to a test cluster and confirm the CSI driver deploys successfully
