### PR TITLE
Don't make duplicate create CNS volume call if the previous call already succeeded

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -767,7 +767,42 @@ func (m *defaultManager) createVolumeWithTransaction(ctx context.Context, spec *
 	}
 
 	volumeOperationDetails, finalErr = m.operationStore.GetRequestDetails(ctx, volNameFromInputSpec)
-	if finalErr != nil && !apierrors.IsNotFound(finalErr) {
+	switch {
+	case finalErr == nil:
+		if volumeOperationDetails.OperationDetails != nil {
+			// Validate if a previous attempt already completed successfully. This guards
+			// against duplicate/retried CreateVolume calls for the same volume name (e.g. a
+			// provisioner retry that races an in-flight or just-completed call): without this
+			// check, a concurrent caller would re-invoke CNS CreateVolume with the same
+			// pre-assigned VolumeId, get CnsVolumeAlreadyExistsFault, and the fault handler in
+			// CreateVolume() would delete and recreate a volume that another caller may have
+			// already returned to the CO as a bound PV.
+			if volumeOperationDetails.OperationDetails.TaskStatus == taskInvocationStatusSuccess &&
+				volumeOperationDetails.VolumeID != "" {
+				log.Infof("Volume with name %q and id %q is already created on CNS with opId: %q.",
+					volNameFromInputSpec, volumeOperationDetails.VolumeID,
+					volumeOperationDetails.OperationDetails.OpID)
+				return &CnsVolumeInfo{
+					DatastoreURL: "",
+					VolumeID: cnstypes.CnsVolumeId{
+						Id: volumeOperationDetails.VolumeID,
+					},
+				}, "", nil
+			}
+			// Validate if a previous operation is still pending. If so, reuse that task instead
+			// of invoking CNS CreateVolume a second time for the same volume name.
+			if IsTaskPending(volumeOperationDetails) {
+				log.Infof("Volume with name %s has CreateVolume task %s pending on CNS.",
+					volNameFromInputSpec,
+					volumeOperationDetails.OperationDetails.TaskID)
+				taskMoRef := vim25types.ManagedObjectReference{
+					Type:  "Task",
+					Value: volumeOperationDetails.OperationDetails.TaskID,
+				}
+				task = object.NewTask(m.virtualCenter.Client.Client, taskMoRef)
+			}
+		}
+	case !apierrors.IsNotFound(finalErr):
 		return nil, csifault.CSIInternalFault, finalErr
 	}
 
@@ -815,32 +850,39 @@ func (m *defaultManager) createVolumeWithTransaction(ctx context.Context, spec *
 			}
 		}
 	}()
-	volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
-		quotaInfo, metav1.Now(), "", vCenterServerForVolumeOperationCR, "",
-		taskInvocationStatusInProgress, "", "")
-	err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
-	if err != nil {
-		// Don't return if CreateVolume details can't be stored.
-		log.Warnf("failed to store CreateVolume details with error: %v", err)
-	}
-	task, finalErr = invokeCNSCreateVolume(ctx, m.virtualCenter, spec)
-	if finalErr != nil {
-		log.Errorf("failed to create volume with error: %v", finalErr)
+	if task == nil {
+		// The task object is nil in two cases:
+		// - No previous CreateVolume task for this volume was retrieved from the
+		//   persistent store.
+		// - The previous CreateVolume task failed.
+		// In both cases, invoke CNS CreateVolume again.
 		volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
-			quotaInfo, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, "",
-			vCenterServerForVolumeOperationCR, "", taskInvocationStatusError, finalErr.Error(), "")
-		faultType = ExtractFaultTypeFromErr(ctx, finalErr)
-		return nil, faultType, finalErr
-	}
-	if !isStaticallyProvisioned(spec) {
-		// Persist task details only for dynamically provisioned volumes.
-		volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
-			quotaInfo, metav1.Now(), task.Reference().Value, vCenterServerForVolumeOperationCR, "",
+			quotaInfo, metav1.Now(), "", vCenterServerForVolumeOperationCR, "",
 			taskInvocationStatusInProgress, "", "")
 		err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
 		if err != nil {
 			// Don't return if CreateVolume details can't be stored.
 			log.Warnf("failed to store CreateVolume details with error: %v", err)
+		}
+		task, finalErr = invokeCNSCreateVolume(ctx, m.virtualCenter, spec)
+		if finalErr != nil {
+			log.Errorf("failed to create volume with error: %v", finalErr)
+			volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
+				quotaInfo, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, "",
+				vCenterServerForVolumeOperationCR, "", taskInvocationStatusError, finalErr.Error(), "")
+			faultType = ExtractFaultTypeFromErr(ctx, finalErr)
+			return nil, faultType, finalErr
+		}
+		if !isStaticallyProvisioned(spec) {
+			// Persist task details only for dynamically provisioned volumes.
+			volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
+				quotaInfo, metav1.Now(), task.Reference().Value, vCenterServerForVolumeOperationCR, "",
+				taskInvocationStatusInProgress, "", "")
+			err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
+			if err != nil {
+				// Don't return if CreateVolume details can't be stored.
+				log.Warnf("failed to store CreateVolume details with error: %v", err)
+			}
 		}
 	}
 

--- a/pkg/common/cns-lib/volume/manager_test.go
+++ b/pkg/common/cns-lib/volume/manager_test.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -16,9 +17,13 @@ import (
 	"github.com/vmware/govmomi/vslm"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
+	cnsvolumeoprequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
 )
 
 const createVolumeTaskTimeout = 3 * time.Second
@@ -972,4 +977,148 @@ func TestDefaultVslmHooksDisconnectedVC(t *testing.T) {
 	assert.Error(t, err)
 	_, err = defaultRetrieveSnapshotDetailsHook(ctx, &cnsvsphere.VirtualCenter{}, vim25types.ID{}, vim25types.ID{})
 	assert.Error(t, err)
+}
+
+// fakeOperationStore is a minimal in-memory stand-in for
+// cnsvolumeoperationrequest.VolumeOperationRequest, used to unit test
+// createVolumeWithTransaction's idempotency behavior without a real API server.
+type fakeOperationStore struct {
+	getRequestDetails func(ctx context.Context, name string) (
+		*cnsvolumeoperationrequest.VolumeOperationRequestDetails, error)
+	storeCallCount int
+}
+
+func (f *fakeOperationStore) GetRequestDetails(ctx context.Context, name string) (
+	*cnsvolumeoperationrequest.VolumeOperationRequestDetails, error) {
+	return f.getRequestDetails(ctx, name)
+}
+
+func (f *fakeOperationStore) StoreRequestDetails(ctx context.Context,
+	instance *cnsvolumeoperationrequest.VolumeOperationRequestDetails) error {
+	f.storeCallCount++
+	return nil
+}
+
+func (f *fakeOperationStore) DeleteRequestDetails(ctx context.Context, name string) error {
+	return nil
+}
+
+func (f *fakeOperationStore) HasPriorSuccessfulCreate(ctx context.Context, name string) bool {
+	return false
+}
+
+// notFoundErr builds a k8s NotFound error the same way a real API server would
+// for a CnsVolumeOperationRequest CR that does not exist yet.
+func notFoundErr(name string) error {
+	return apierrors.NewNotFound(
+		cnsvolumeoprequestv1alpha1.Resource(cnsvolumeoperationrequest.CRDPlural), name)
+}
+
+// TestCreateVolumeWithTransactionPriorSuccessSkipsCNSInvocation is a regression test for the
+// PR-3762313-Perf incident: a duplicate/retried CreateVolume call for a volume name that the
+// CnsVolumeOperationRequest store already reports as successfully created must return the
+// cached volume ID directly, without invoking CNS CreateVolume again. Before this fix,
+// createVolumeWithTransaction unconditionally re-invoked CNS, which raced a concurrent
+// successful caller, hit CnsVolumeAlreadyExistsFault, and triggered a delete+recreate of a
+// volume that had already been returned to the CO as a bound PV.
+//
+// virtualCenter is left as a zero value (nil CnsClient) on purpose: if the idempotency
+// short-circuit regresses and the code falls through to invokeCNSCreateVolume, that call
+// panics on the nil CnsClient, so assert.NotPanics below fails loudly instead of the test
+// silently passing for the wrong reason.
+func TestCreateVolumeWithTransactionPriorSuccessSkipsCNSInvocation(t *testing.T) {
+	ctx := context.TODO()
+	const volName = "pvc-5954ecf3-215f-4396-8b8d-87d6ae007247"
+	const cachedVolumeID = "5954ecf3-215f-4396-8b8d-87d6ae007247"
+
+	store := &fakeOperationStore{
+		getRequestDetails: func(ctx context.Context, name string) (
+			*cnsvolumeoperationrequest.VolumeOperationRequestDetails, error) {
+			assert.Equal(t, volName, name)
+			return &cnsvolumeoperationrequest.VolumeOperationRequestDetails{
+				Name:     volName,
+				VolumeID: cachedVolumeID,
+				OperationDetails: &cnsvolumeoperationrequest.OperationDetails{
+					TaskStatus: cnsvolumeoperationrequest.TaskInvocationStatusSuccess,
+					OpID:       "opid-1",
+				},
+			}, nil
+		},
+	}
+	m := &defaultManager{
+		operationStore: store,
+		virtualCenter:  &cnsvsphere.VirtualCenter{},
+	}
+	spec := &cnstypes.CnsVolumeCreateSpec{Name: volName}
+
+	var resp *CnsVolumeInfo
+	var faultType string
+	var err error
+	assert.NotPanics(t, func() {
+		resp, faultType, err = m.createVolumeWithTransaction(ctx, spec, nil)
+	})
+
+	assert.NoError(t, err)
+	assert.Empty(t, faultType)
+	if assert.NotNil(t, resp) {
+		assert.Equal(t, cachedVolumeID, resp.VolumeID.Id)
+	}
+	assert.Zero(t, store.storeCallCount,
+		"a duplicate call for an already-successfully-created volume must not persist a new InProgress record")
+}
+
+// TestCreateVolumeWithTransactionNoPriorRecordInvokesCNS is the counterpart to the test above:
+// when the operation store has no record at all for this volume name (a genuinely new
+// CreateVolume call), createVolumeWithTransaction must still fall through and attempt to invoke
+// CNS CreateVolume, i.e. the idempotency short-circuit must not swallow first-time creates too.
+// It asserts this indirectly: with a nil CnsClient, reaching invokeCNSCreateVolume panics, so a
+// panic here is the expected, correct outcome and proves the fall-through path is intact.
+func TestCreateVolumeWithTransactionNoPriorRecordInvokesCNS(t *testing.T) {
+	ctx := context.TODO()
+	const volName = "pvc-brand-new-volume"
+
+	store := &fakeOperationStore{
+		getRequestDetails: func(ctx context.Context, name string) (
+			*cnsvolumeoperationrequest.VolumeOperationRequestDetails, error) {
+			return nil, notFoundErr(name)
+		},
+	}
+	m := &defaultManager{
+		operationStore: store,
+		virtualCenter:  &cnsvsphere.VirtualCenter{},
+	}
+	spec := &cnstypes.CnsVolumeCreateSpec{Name: volName}
+
+	assert.Panics(t, func() {
+		_, _, _ = m.createVolumeWithTransaction(ctx, spec, nil)
+	})
+	assert.Equal(t, 1, store.storeCallCount,
+		"a first-time create must persist an InProgress record before invoking CNS")
+}
+
+// TestCreateVolumeWithTransactionOperationStorePropagatesUnexpectedError verifies that an
+// unexpected (non-NotFound) error reading the operation store is still surfaced as a
+// CSIInternalFault, preserving the pre-existing error-handling behavior after restructuring the
+// GetRequestDetails handling into the idempotency-checking switch statement.
+func TestCreateVolumeWithTransactionOperationStorePropagatesUnexpectedError(t *testing.T) {
+	ctx := context.TODO()
+	wantErr := errors.New("etcd is unavailable")
+
+	store := &fakeOperationStore{
+		getRequestDetails: func(ctx context.Context, name string) (
+			*cnsvolumeoperationrequest.VolumeOperationRequestDetails, error) {
+			return nil, wantErr
+		},
+	}
+	m := &defaultManager{
+		operationStore: store,
+		virtualCenter:  &cnsvsphere.VirtualCenter{},
+	}
+	spec := &cnstypes.CnsVolumeCreateSpec{Name: "pvc-test"}
+
+	resp, faultType, err := m.createVolumeWithTransaction(ctx, spec, nil)
+	assert.Nil(t, resp)
+	assert.Equal(t, csifault.CSIInternalFault, faultType)
+	assert.Equal(t, wantErr, err)
+	assert.Zero(t, store.storeCallCount)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Stop making duplicate create CNS volume call if the previous call already succeeded.

Fix: In pkg/common/cns-lib/volume/manager.go, createVolumeWithTransaction now checks the CnsVolumeOperationRequest record before calling CNS. If a prior CreateVolume attempt for the same volume already succeeded, it returns the cached volume ID immediately instead of calling CNS again.

Why: A duplicate/retried CreateVolume call for the same PVC was racing a call that had already succeeded and been turned into a bound PV. The duplicate call re-invoked CNS with the same volume ID, hit CnsVolumeAlreadyExistsFault, and the driver's fault handler deleted and recreated that live volume — causing CreateSnapshot to later fail with "volume not found" even though the PV was bound. The fix stops the duplicate call from ever reaching CNS a second time, closing the race at its source.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: 
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1855/ (passed)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1410/ (passed)

Manual testing pending.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Stop making duplicate create CNS volume call if the previous call already succeeded.
```
