### PR TITLE
Fix orphaned volume attachments caused by pvCSI reporting attach timeouts as final failures

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -78,6 +78,16 @@ var (
 	// Declared as a var so it can be adjusted in tests.
 	modifyVolumeTimeoutInMin = defaultModifyVolumeTimeoutInMin
 
+	// attachStillRequestedCheckInterval is how often ControllerPublishVolume
+	// re-checks that the attach is still requested while waiting for the volume
+	// to be attached. Declared as a var so it can be shortened in tests.
+	attachStillRequestedCheckInterval = 15 * time.Second
+
+	// removeStaleVolumeTimeout bounds how long we retry removing a volume entry
+	// from VirtualMachine.Spec.Volumes once the attach is known to be stale.
+	// Declared as a var so it can be shortened in tests.
+	removeStaleVolumeTimeout = 30 * time.Second
+
 	// controllerCaps represents the capability of controller service
 	controllerCaps = []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
@@ -995,6 +1005,56 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	return resp, err
 }
 
+// removeVolumeFromVMSpec removes volumeID from the VirtualMachine's
+// Spec.Volumes if it is present, retrying until deadline on patch conflicts.
+// It is a no-op (returns nil) when the VirtualMachine is gone or the volume is
+// not in the spec, so it is safe to call speculatively.
+//
+// This is only called once the attach is known to be unwanted - the
+// VolumeAttachment that requested it no longer exists. Removing the entry then
+// mirrors what ControllerUnpublishVolume would have done, and is the only way
+// to stop vm-operator from continuing to reconcile an attach that nothing in
+// Kubernetes is left to detach.
+func removeVolumeFromVMSpec(ctx context.Context, c *controller, vmKey types.NamespacedName,
+	volumeID string, deadline time.Time) error {
+	log := logger.GetLogger(ctx)
+	for {
+		virtualMachine, _, err := utils.GetVirtualMachine(ctx, vmKey, c.vmOperatorClient)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				log.Infof("VirtualMachine %q not found, nothing to remove for volume %q", vmKey.Name, volumeID)
+				return nil
+			}
+			return err
+		}
+		oldVirtualMachine := virtualMachine.DeepCopy()
+		found := false
+		for index, volume := range virtualMachine.Spec.Volumes {
+			if volume.Name == volumeID {
+				virtualMachine.Spec.Volumes = append(virtualMachine.Spec.Volumes[:index],
+					virtualMachine.Spec.Volumes[index+1:]...)
+				found = true
+				break
+			}
+		}
+		if !found {
+			log.Infof("Volume %q is not present in virtualmachine %q spec, nothing to remove",
+				volumeID, vmKey.Name)
+			return nil
+		}
+		if err := utils.PatchVirtualMachine(ctx, c.vmOperatorClient, virtualMachine, oldVirtualMachine); err == nil {
+			log.Infof("Removed volume %q from virtualmachine %q spec", volumeID, vmKey.Name)
+			return nil
+		} else {
+			log.Errorf("failed to remove volume %q from virtualmachine %q spec. Err: %v",
+				volumeID, vmKey.Name, err)
+			if time.Now().After(deadline) {
+				return err
+			}
+		}
+	}
+}
+
 // controllerPublishForBlockVolume is a helper mthod for handling ControllerPublishVolume request for Block volumes
 func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest, c *controller) (
 	*csi.ControllerPublishVolumeResponse, string, error) {
@@ -1045,6 +1105,18 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 			},
 		}
 		virtualMachine.Spec.Volumes = append(virtualMachine.Spec.Volumes, vmvolumes)
+		// Adding the volume to VirtualMachine.Spec.Volumes records the attach as
+		// desired state, which vm-operator keeps reconciling until it succeeds -
+		// including after this RPC has given up and reported failure. Confirm the
+		// attach is still requested before writing it, so that a request which
+		// became stale while we were retrying cannot leave the volume attached
+		// with no VolumeAttachment left to drive its detach.
+		if !c.isAttachStillRequested(ctx, req.VolumeId, req.NodeId) {
+			msg := fmt.Sprintf("attach of volume %q to node %q is no longer requested, "+
+				"not adding it to virtualmachine %q spec", req.VolumeId, req.NodeId, virtualMachine.Name)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.FailedPrecondition, msg)
+		}
 		// Issue a patch with the modified VM against the patch created above.
 		if err := utils.PatchVirtualMachine(ctx, c.vmOperatorClient, virtualMachine, oldVirtualMachine); err == nil {
 			break
@@ -1052,9 +1124,10 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 			log.Errorf("failed to update virtualmachine. Err: %v", err)
 		}
 		if time.Now().After(timeout) {
-			msg := fmt.Sprintf("timedout to update VirtualMachines %q", virtualMachine.Name)
+			msg := fmt.Sprintf("timed out after %d minute(s) trying to add volume %q to virtualmachine %q spec",
+				getAttacherTimeoutInMin(ctx), req.VolumeId, virtualMachine.Name)
 			log.Error(msg)
-			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.DeadlineExceeded, msg)
 		}
 		virtualMachine = &vmoperatortypes.VirtualMachine{}
 	}
@@ -1081,16 +1154,44 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 		}
 		defer watchVirtualMachine.Stop()
 
+		// The volume is already recorded in VirtualMachine.Spec.Volumes at this
+		// point, so the pre-patch guard can no longer help: if the VolumeAttachment
+		// disappears while we wait, nothing is left to issue ControllerUnpublishVolume
+		// and vm-operator would keep reconciling the attach forever. Re-check
+		// periodically and undo our own spec entry if the attach became stale.
+		staleCheck := time.NewTicker(attachStillRequestedCheckInterval)
+		defer staleCheck.Stop()
+
 		// Watch all update events made on VirtualMachine instance until volume.DiskUuid is set
 		for diskUUID == "" {
 			// blocking wait for update event
 			log.Debugf("waiting for update on virtualmachine: %q", virtualMachine.Name)
-			event := <-watchVirtualMachine.ResultChan()
+			var event watch.Event
+			select {
+			case <-staleCheck.C:
+				if c.isAttachStillRequested(ctx, req.VolumeId, req.NodeId) {
+					continue
+				}
+				msg := fmt.Sprintf("attach of volume %q to node %q is no longer requested while waiting for it "+
+					"to be attached, removing it from virtualmachine %q spec",
+					req.VolumeId, req.NodeId, virtualMachine.Name)
+				log.Error(msg)
+				if rmErr := removeVolumeFromVMSpec(ctx, c, vmKey, req.VolumeId,
+					time.Now().Add(removeStaleVolumeTimeout)); rmErr != nil {
+					return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal,
+						"%s. Failed to remove it, volume may stay attached: %v", msg, rmErr)
+				}
+				return nil, csifault.CSIInternalFault, status.Error(codes.FailedPrecondition, msg)
+			case event = <-watchVirtualMachine.ResultChan():
+			}
+			if event.Type == watch.Error {
+				faultType, err := vmWatchErrorEventError(ctx, "attach", virtualMachine.Name, event.Object)
+				return nil, faultType, err
+			}
 			vm, ok := event.Object.(*vmoperatortypes.VirtualMachine)
 			if !ok {
-				msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
-				log.Error(msg)
-				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+				faultType, err := vmWatchClosedError(ctx, "attach", virtualMachine.Name)
+				return nil, faultType, err
 			}
 			if vm.Name != virtualMachine.Name {
 				log.Debugf("Observed vm name: %q, expecting vm name: %q, volumeID: %q",
@@ -1417,9 +1518,10 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 			log.Errorf("failed to update virtualmachine. Err: %v", err)
 		}
 		if time.Now().After(timeout) {
-			msg := fmt.Sprintf("timedout to update VirtualMachines %q", virtualMachine.Name)
+			msg := fmt.Sprintf("timed out after %d minute(s) trying to remove volume %q from virtualmachine %q spec",
+				getAttacherTimeoutInMin(ctx), req.VolumeId, virtualMachine.Name)
 			log.Error(msg)
-			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.DeadlineExceeded, msg)
 		}
 		virtualMachine = &vmoperatortypes.VirtualMachine{}
 	}
@@ -1458,11 +1560,14 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 			log.Debugf("Waiting for update on VirtualMachine: %q", virtualMachine.Name)
 			// Block on update events
 			event := <-watchVirtualMachine.ResultChan()
+			if event.Type == watch.Error {
+				faultType, err := vmWatchErrorEventError(ctx, "detach", virtualMachine.Name, event.Object)
+				return nil, faultType, err
+			}
 			vm, ok := event.Object.(*vmoperatortypes.VirtualMachine)
 			if !ok {
-				msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
-				log.Error(msg)
-				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+				faultType, err := vmWatchClosedError(ctx, "detach", virtualMachine.Name)
+				return nil, faultType, err
 			}
 			if vm.Name != virtualMachine.Name {
 				log.Debugf("Observed vm name: %q, expecting vm name: %q, volumeID: %q",

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1024,6 +1024,18 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 			},
 		}
 		virtualMachine.Spec.Volumes = append(virtualMachine.Spec.Volumes, vmvolumes)
+		// Adding the volume to VirtualMachine.Spec.Volumes records the attach as
+		// desired state, which vm-operator keeps reconciling until it succeeds -
+		// including after this RPC has given up and reported failure. Confirm the
+		// attach is still requested before writing it, so that a request which
+		// became stale while we were retrying cannot leave the volume attached
+		// with no VolumeAttachment left to drive its detach.
+		if !c.isAttachStillRequested(ctx, req.VolumeId, req.NodeId) {
+			msg := fmt.Sprintf("attach of volume %q to node %q is no longer requested, "+
+				"not adding it to virtualmachine %q spec", req.VolumeId, req.NodeId, virtualMachine.Name)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.FailedPrecondition, msg)
+		}
 		// Issue a patch with the modified VM against the patch created above.
 		if err := utils.PatchVirtualMachine(ctx, c.vmOperatorClient, virtualMachine, oldVirtualMachine); err == nil {
 			break
@@ -1031,9 +1043,10 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 			log.Errorf("failed to update virtualmachine. Err: %v", err)
 		}
 		if time.Now().After(timeout) {
-			msg := fmt.Sprintf("timedout to update VirtualMachines %q", virtualMachine.Name)
+			msg := fmt.Sprintf("timed out after %d minute(s) trying to add volume %q to virtualmachine %q spec",
+				getAttacherTimeoutInMin(ctx), req.VolumeId, virtualMachine.Name)
 			log.Error(msg)
-			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.DeadlineExceeded, msg)
 		}
 		virtualMachine = &vmoperatortypes.VirtualMachine{}
 	}
@@ -1065,11 +1078,14 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 			// blocking wait for update event
 			log.Debugf("waiting for update on virtualmachine: %q", virtualMachine.Name)
 			event := <-watchVirtualMachine.ResultChan()
+			if event.Type == watch.Error {
+				faultType, err := vmWatchErrorEventError(ctx, "attach", virtualMachine.Name, event.Object)
+				return nil, faultType, err
+			}
 			vm, ok := event.Object.(*vmoperatortypes.VirtualMachine)
 			if !ok {
-				msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
-				log.Error(msg)
-				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+				faultType, err := vmWatchClosedError(ctx, "attach", virtualMachine.Name)
+				return nil, faultType, err
 			}
 			if vm.Name != virtualMachine.Name {
 				log.Debugf("Observed vm name: %q, expecting vm name: %q, volumeID: %q",
@@ -1396,9 +1412,10 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 			log.Errorf("failed to update virtualmachine. Err: %v", err)
 		}
 		if time.Now().After(timeout) {
-			msg := fmt.Sprintf("timedout to update VirtualMachines %q", virtualMachine.Name)
+			msg := fmt.Sprintf("timed out after %d minute(s) trying to remove volume %q from virtualmachine %q spec",
+				getAttacherTimeoutInMin(ctx), req.VolumeId, virtualMachine.Name)
 			log.Error(msg)
-			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+			return nil, csifault.CSIInternalFault, status.Error(codes.DeadlineExceeded, msg)
 		}
 		virtualMachine = &vmoperatortypes.VirtualMachine{}
 	}
@@ -1437,11 +1454,14 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 			log.Debugf("Waiting for update on VirtualMachine: %q", virtualMachine.Name)
 			// Block on update events
 			event := <-watchVirtualMachine.ResultChan()
+			if event.Type == watch.Error {
+				faultType, err := vmWatchErrorEventError(ctx, "detach", virtualMachine.Name, event.Object)
+				return nil, faultType, err
+			}
 			vm, ok := event.Object.(*vmoperatortypes.VirtualMachine)
 			if !ok {
-				msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
-				log.Error(msg)
-				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+				faultType, err := vmWatchClosedError(ctx, "detach", virtualMachine.Name)
+				return nil, faultType, err
 			}
 			if vm.Name != virtualMachine.Name {
 				log.Debugf("Observed vm name: %q, expecting vm name: %q, volumeID: %q",

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -18,6 +18,7 @@ package wcpguest
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -30,15 +31,20 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	snap "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
+	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 )
 
 const (
@@ -585,6 +591,79 @@ func getModifyVolumeTimeoutInMin(ctx context.Context) int {
 		}
 	}
 	return modifyVolumeTimeoutInMin
+}
+
+// vmWatchErrorEventError reports a watch.Error event, which carries a
+// *metav1.Status explaining why the watch itself failed (e.g. an expired
+// resourceVersion). Uses codes.Unavailable, not Internal: the attach/detach
+// may still be in progress via VirtualMachine.Spec.Volumes, so sidecars must
+// keep retrying rather than treat this as final.
+func vmWatchErrorEventError(ctx context.Context, operation string, vmName string, obj runtime.Object) (string, error) {
+	log := logger.GetLogger(ctx)
+	msg := fmt.Sprintf("watch on virtualmachine %q failed while waiting for volume %s to complete", vmName, operation)
+	if watchStatus, ok := obj.(*metav1.Status); ok {
+		msg = fmt.Sprintf("%s: %s", msg, watchStatus.Message)
+	}
+	msg += ". The operation may still be in progress."
+	log.Error(msg)
+	return csifault.CSIInternalFault, status.Error(codes.Unavailable, msg)
+}
+
+// vmWatchClosedError reports the VirtualMachine watch closing (context done or
+// watch timeout) without observing the expected state. Uses codes.Canceled or
+// codes.DeadlineExceeded, not Internal: the volume may still be reconciling via
+// VirtualMachine.Spec.Volumes, so sidecars must keep retrying rather than treat
+// this as final.
+func vmWatchClosedError(ctx context.Context, operation string, vmName string) (string, error) {
+	log := logger.GetLogger(ctx)
+	code := codes.DeadlineExceeded
+	var msg string
+	switch ctx.Err() {
+	case context.Canceled:
+		code = codes.Canceled
+		msg = fmt.Sprintf("watch on virtualmachine %q was cancelled while waiting for volume %s to complete. "+
+			"The operation may still be in progress.", vmName, operation)
+	case context.DeadlineExceeded:
+		msg = fmt.Sprintf("context deadline exceeded while watching virtualmachine %q for volume %s to complete. "+
+			"The operation may still be in progress.", vmName, operation)
+	default:
+		msg = fmt.Sprintf("watch on virtualmachine %q timed out after %d minute(s) waiting for volume %s to "+
+			"complete. The operation may still be in progress.", vmName, getAttacherTimeoutInMin(ctx), operation)
+	}
+	log.Error(msg)
+	return csifault.CSIInternalFault, status.Error(code, msg)
+}
+
+// volumeAttachmentName returns the name of the VolumeAttachment object that the
+// Kubernetes attach/detach controller creates for the given volume handle, CSI
+// driver and node. The name is a deterministic hash of those three values,
+// mirroring getAttachmentName() in k8s.io/kubernetes/pkg/volume/csi, which lets
+// callers look the object up directly instead of listing every VolumeAttachment
+// in the cluster.
+func volumeAttachmentName(volumeHandle, driverName, nodeName string) string {
+	return fmt.Sprintf("csi-%x", sha256.Sum256([]byte(volumeHandle+driverName+nodeName)))
+}
+
+// isAttachStillRequested checks the VolumeAttachment still exists before we add
+// the volume to VirtualMachine.Spec.Volumes. That's desired state vm-operator
+// keeps reconciling regardless of this RPC's outcome, so writing it after the
+// VolumeAttachment is gone would strand the volume attached with nothing left
+// to detach it. Fails open: only a definitive NotFound blocks the attach, so a
+// transient API error or missing RBAC rule doesn't fail a legitimate request.
+func (c *controller) isAttachStillRequested(ctx context.Context, volumeHandle, nodeName string) bool {
+	log := logger.GetLogger(ctx)
+	vaName := volumeAttachmentName(volumeHandle, csitypes.Name, nodeName)
+	if _, err := c.guestClient.StorageV1().VolumeAttachments().Get(
+		ctx, vaName, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Infof("VolumeAttachment %q for volume %q on node %q no longer exists, "+
+				"attach is no longer requested", vaName, volumeHandle, nodeName)
+			return false
+		}
+		log.Warnf("failed to get VolumeAttachment %q for volume %q on node %q, proceeding with attach. Error: %v",
+			vaName, volumeHandle, nodeName, err)
+	}
+	return true
 }
 
 func constructListSnapshotEntry(vs snap.VolumeSnapshot) *csi.ListSnapshotsResponse_Entry {

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -18,6 +18,7 @@ package wcpguest
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -30,15 +31,20 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	snap "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
+	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 )
 
 const (
@@ -663,6 +669,79 @@ func getModifyVolumeTimeoutInMin(ctx context.Context) int {
 		}
 	}
 	return modifyVolumeTimeoutInMin
+}
+
+// vmWatchErrorEventError reports a watch.Error event, which carries a
+// *metav1.Status explaining why the watch itself failed (e.g. an expired
+// resourceVersion). Uses codes.Unavailable, not Internal: the attach/detach
+// may still be in progress via VirtualMachine.Spec.Volumes, so sidecars must
+// keep retrying rather than treat this as final.
+func vmWatchErrorEventError(ctx context.Context, operation string, vmName string, obj runtime.Object) (string, error) {
+	log := logger.GetLogger(ctx)
+	msg := fmt.Sprintf("watch on virtualmachine %q failed while waiting for volume %s to complete", vmName, operation)
+	if watchStatus, ok := obj.(*metav1.Status); ok {
+		msg = fmt.Sprintf("%s: %s", msg, watchStatus.Message)
+	}
+	msg += ". The operation may still be in progress."
+	log.Error(msg)
+	return csifault.CSIInternalFault, status.Error(codes.Unavailable, msg)
+}
+
+// vmWatchClosedError reports the VirtualMachine watch closing (context done or
+// watch timeout) without observing the expected state. Uses codes.Canceled or
+// codes.DeadlineExceeded, not Internal: the volume may still be reconciling via
+// VirtualMachine.Spec.Volumes, so sidecars must keep retrying rather than treat
+// this as final.
+func vmWatchClosedError(ctx context.Context, operation string, vmName string) (string, error) {
+	log := logger.GetLogger(ctx)
+	code := codes.DeadlineExceeded
+	var msg string
+	switch ctx.Err() {
+	case context.Canceled:
+		code = codes.Canceled
+		msg = fmt.Sprintf("watch on virtualmachine %q was cancelled while waiting for volume %s to complete. "+
+			"The operation may still be in progress.", vmName, operation)
+	case context.DeadlineExceeded:
+		msg = fmt.Sprintf("context deadline exceeded while watching virtualmachine %q for volume %s to complete. "+
+			"The operation may still be in progress.", vmName, operation)
+	default:
+		msg = fmt.Sprintf("watch on virtualmachine %q timed out after %d minute(s) waiting for volume %s to "+
+			"complete. The operation may still be in progress.", vmName, getAttacherTimeoutInMin(ctx), operation)
+	}
+	log.Error(msg)
+	return csifault.CSIInternalFault, status.Error(code, msg)
+}
+
+// volumeAttachmentName returns the name of the VolumeAttachment object that the
+// Kubernetes attach/detach controller creates for the given volume handle, CSI
+// driver and node. The name is a deterministic hash of those three values,
+// mirroring getAttachmentName() in k8s.io/kubernetes/pkg/volume/csi, which lets
+// callers look the object up directly instead of listing every VolumeAttachment
+// in the cluster.
+func volumeAttachmentName(volumeHandle, driverName, nodeName string) string {
+	return fmt.Sprintf("csi-%x", sha256.Sum256([]byte(volumeHandle+driverName+nodeName)))
+}
+
+// isAttachStillRequested checks the VolumeAttachment still exists before we add
+// the volume to VirtualMachine.Spec.Volumes. That's desired state vm-operator
+// keeps reconciling regardless of this RPC's outcome, so writing it after the
+// VolumeAttachment is gone would strand the volume attached with nothing left
+// to detach it. Fails open: only a definitive NotFound blocks the attach, so a
+// transient API error or missing RBAC rule doesn't fail a legitimate request.
+func (c *controller) isAttachStillRequested(ctx context.Context, volumeHandle, nodeName string) bool {
+	log := logger.GetLogger(ctx)
+	vaName := volumeAttachmentName(volumeHandle, csitypes.Name, nodeName)
+	if _, err := c.guestClient.StorageV1().VolumeAttachments().Get(
+		ctx, vaName, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Infof("VolumeAttachment %q for volume %q on node %q no longer exists, "+
+				"attach is no longer requested", vaName, volumeHandle, nodeName)
+			return false
+		}
+		log.Warnf("failed to get VolumeAttachment %q for volume %q on node %q, proceeding with attach. Error: %v",
+			vaName, volumeHandle, nodeName, err)
+	}
+	return true
 }
 
 func constructListSnapshotEntry(vs snap.VolumeSnapshot) *csi.ListSnapshotsResponse_Entry {

--- a/pkg/csi/service/wcpguest/controller_timeout_test.go
+++ b/pkg/csi/service/wcpguest/controller_timeout_test.go
@@ -18,19 +18,34 @@ package wcpguest
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	snapshotclientset "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fakesnapshot"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 )
 
 // TestTimeoutErrorCodes verifies that timeout operations return the correct gRPC error code
@@ -926,4 +941,486 @@ func TestSnapshotTimeoutScenario(t *testing.T) {
 // Helper function
 func stringPtr(s string) *string {
 	return &s
+}
+
+// TestVolumeAttachmentName verifies that the VolumeAttachment name derived here
+// matches the name the Kubernetes attach/detach controller actually assigns. The
+// expected values below are real VolumeAttachment names captured from a live
+// cluster, alongside the volume handle and node they were created for. If
+// getAttachmentName() in k8s.io/kubernetes/pkg/volume/csi ever changes its
+// hashing scheme, this test fails and isAttachStillRequested must be revisited -
+// it would otherwise silently start reporting every attach as "no longer
+// requested".
+func TestVolumeAttachmentName(t *testing.T) {
+	const node = "lin-vks5-small-0-node-pool-1-m6gq2-qv98v-cvfxv"
+	tests := []struct {
+		name         string
+		volumeHandle string
+		expected     string
+	}{
+		{
+			name:         "volume 0",
+			volumeHandle: "c48f1df3-76e3-4495-b111-b87715287128-0dd0bfc4-9996-4070-9716-ddb3d11738ad",
+			expected:     "csi-524e5016960dd561947c30fbf6bfa195d83a52044d88a0efa2c1cfc9ca6dddf2",
+		},
+		{
+			name:         "volume 1",
+			volumeHandle: "c48f1df3-76e3-4495-b111-b87715287128-d81c9aca-1e05-438b-8e03-5e234501a6da",
+			expected:     "csi-68eee207f9c4e23024f703ba0268513789cfb8af82a6ed7639a7624ec1e27627",
+		},
+		{
+			name:         "volume 2",
+			volumeHandle: "c48f1df3-76e3-4495-b111-b87715287128-b1831b35-7e03-40b2-8213-ec6cfeb8e339",
+			expected:     "csi-5a514b08aa0b5ea23feda388299cbe6ffa819e9abd86fcfa2eb4daeba77270ab",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := volumeAttachmentName(tt.volumeHandle, csitypes.Name, node)
+			if got != tt.expected {
+				t.Errorf("volumeAttachmentName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsAttachStillRequested verifies the staleness guard consulted before the
+// attach is written into VirtualMachine.Spec.Volumes.
+func TestIsAttachStillRequested(t *testing.T) {
+	ctx := context.Background()
+	const (
+		volumeHandle = "c48f1df3-76e3-4495-b111-b87715287128-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+		nodeName     = "lin-vks5-small-0-node-pool-1-m6gq2-qv98v-cvfxv"
+	)
+
+	t.Run("VolumeAttachment present means attach is still requested", func(t *testing.T) {
+		pvName := "pvc-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+		va := &storagev1.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeAttachmentName(volumeHandle, csitypes.Name, nodeName),
+			},
+			Spec: storagev1.VolumeAttachmentSpec{
+				Attacher: csitypes.Name,
+				NodeName: nodeName,
+				Source: storagev1.VolumeAttachmentSource{
+					PersistentVolumeName: &pvName,
+				},
+			},
+		}
+		c := &controller{guestClient: testclient.NewClientset(va)}
+		if !c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected attach to be reported as still requested when the VolumeAttachment exists")
+		}
+	})
+
+	t.Run("VolumeAttachment absent means attach is no longer requested", func(t *testing.T) {
+		c := &controller{guestClient: testclient.NewClientset()}
+		if c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected attach to be reported as no longer requested when the VolumeAttachment is gone")
+		}
+	})
+
+	t.Run("VolumeAttachment for a different node does not satisfy the guard", func(t *testing.T) {
+		otherNode := "lin-vks5-small-0-node-pool-1-m6gq2-qv98v-other"
+		va := &storagev1.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeAttachmentName(volumeHandle, csitypes.Name, otherNode),
+			},
+		}
+		c := &controller{guestClient: testclient.NewClientset(va)}
+		if c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected the guard to ignore a VolumeAttachment belonging to another node")
+		}
+	})
+
+	// The guard must fail open. Blocking attaches because the API server is
+	// briefly unreachable - or because the driver's RBAC lacks access to
+	// volumeattachments - would be far worse than the orphaned attachment it is
+	// trying to prevent.
+	t.Run("transient API error fails open", func(t *testing.T) {
+		guestClient := testclient.NewClientset()
+		guestClient.PrependReactor("get", "volumeattachments",
+			func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewServiceUnavailable("apiserver is unavailable")
+			})
+		c := &controller{guestClient: guestClient}
+		if !c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected the guard to fail open and allow the attach when the lookup errors")
+		}
+	})
+
+	t.Run("forbidden error fails open", func(t *testing.T) {
+		guestClient := testclient.NewClientset()
+		guestClient.PrependReactor("get", "volumeattachments",
+			func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewForbidden(
+					storagev1.Resource("volumeattachments"), "", nil)
+			})
+		c := &controller{guestClient: guestClient}
+		if !c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected the guard to fail open when RBAC denies the lookup")
+		}
+	})
+}
+
+// TestVMWatchClosedError verifies that a VirtualMachine watch closing without the
+// expected state is never reported as codes.Internal. CSI sidecars treat Internal
+// as a final error meaning "the operation is for sure not in progress", which is
+// untrue here: the volume remains in VirtualMachine.Spec.Volumes and vm-operator
+// keeps reconciling it, so the attach or detach may still complete.
+func TestVMWatchClosedError(t *testing.T) {
+	const vmName = "lin-vks1-medium-0-node-pool-1-g4xm6-zkp89-dgdql"
+
+	t.Run("watch timeout reports DeadlineExceeded", func(t *testing.T) {
+		_, err := vmWatchClosedError(context.Background(), "attach", vmName)
+		assertGRPCCode(t, err, codes.DeadlineExceeded)
+	})
+
+	t.Run("cancelled context reports Canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := vmWatchClosedError(ctx, "attach", vmName)
+		assertGRPCCode(t, err, codes.Canceled)
+	})
+
+	t.Run("expired context deadline reports DeadlineExceeded", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+		<-ctx.Done()
+		_, err := vmWatchClosedError(ctx, "detach", vmName)
+		assertGRPCCode(t, err, codes.DeadlineExceeded)
+	})
+
+	// Both codes must be non-final so that the CSI sidecars keep the
+	// VolumeAttachment around and retry, rather than concluding the operation
+	// definitively failed.
+	t.Run("reported codes are never Internal", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		for _, c := range []context.Context{context.Background(), ctx} {
+			_, err := vmWatchClosedError(c, "attach", vmName)
+			if st, ok := status.FromError(err); ok && st.Code() == codes.Internal {
+				t.Errorf("watch closure reported codes.Internal, which sidecars treat as a final error")
+			}
+		}
+	})
+}
+
+// TestVMWatchErrorEventError verifies that a watch.Error event - which carries a
+// *metav1.Status describing why the watch itself failed, e.g. an expired
+// resourceVersion - is reported with that detail rather than being collapsed
+// into the generic "watch closed" timeout/cancel message. The two cases are
+// distinguishable at the call site by event.Type, and must be handled by
+// different helpers: conflating them would silently discard the actual
+// apiserver-reported reason for the watch failing.
+func TestVMWatchErrorEventError(t *testing.T) {
+	const vmName = "lin-vks1-medium-0-node-pool-1-g4xm6-zkp89-dgdql"
+
+	t.Run("status message from the watch.Error event is included", func(t *testing.T) {
+		watchStatus := &metav1.Status{
+			Message: "too old resource version: 12345 (67890)",
+		}
+		_, err := vmWatchErrorEventError(context.Background(), "attach", vmName, watchStatus)
+		assertGRPCCode(t, err, codes.Unavailable)
+		if st, _ := status.FromError(err); !strings.Contains(st.Message(), watchStatus.Message) {
+			t.Errorf("expected error message to include the watch status message %q, got %q",
+				watchStatus.Message, st.Message())
+		}
+	})
+
+	t.Run("reports Unavailable even without a status payload", func(t *testing.T) {
+		_, err := vmWatchErrorEventError(context.Background(), "detach", vmName, nil)
+		assertGRPCCode(t, err, codes.Unavailable)
+	})
+
+	// codes.Unavailable must be non-final for the same reason as
+	// vmWatchClosedError's codes: a failed watch says nothing about whether the
+	// underlying attach/detach itself completed.
+	t.Run("reported code is never Internal", func(t *testing.T) {
+		_, err := vmWatchErrorEventError(context.Background(), "attach", vmName, nil)
+		if st, ok := status.FromError(err); ok && st.Code() == codes.Internal {
+			t.Errorf("watch error event reported codes.Internal, which sidecars treat as a final error")
+		}
+	})
+}
+
+// TestControllerPublishForBlockVolumeStaleAttach drives controllerPublishForBlockVolume
+// itself, to verify the guard actually prevents the write to
+// VirtualMachine.Spec.Volumes. This is the regression that matters: it is the
+// persisted spec entry, not the returned error, that strands a volume attached to
+// a node with no VolumeAttachment left to detach it.
+func TestControllerPublishForBlockVolumeStaleAttach(t *testing.T) {
+	ctx := context.Background()
+	const (
+		namespace    = "test-ns"
+		nodeName     = "test-node"
+		volumeHandle = "test-cluster-uid-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+	)
+
+	newVM := func() *vmoperatortypes.VirtualMachine {
+		return &vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: namespace},
+		}
+	}
+
+	scheme := runtime.NewScheme()
+	if err := vmoperatortypes.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register vmoperator scheme: %v", err)
+	}
+
+	t.Run("stale attach is rejected without modifying the VM spec", func(t *testing.T) {
+		vmClient := ctrlclientfake.NewClientBuilder().
+			WithScheme(scheme).WithObjects(newVM()).Build()
+		c := &controller{
+			vmOperatorClient:    vmClient,
+			guestClient:         testclient.NewClientset(), // no VolumeAttachment: attach is stale
+			supervisorNamespace: namespace,
+		}
+
+		_, _, err := controllerPublishForBlockVolume(ctx, &csi.ControllerPublishVolumeRequest{
+			VolumeId: volumeHandle,
+			NodeId:   nodeName,
+		}, c)
+
+		assertGRPCCode(t, err, codes.FailedPrecondition)
+
+		// The critical assertion: nothing was persisted into the VM spec.
+		vm := &vmoperatortypes.VirtualMachine{}
+		if getErr := vmClient.Get(ctx,
+			types.NamespacedName{Namespace: namespace, Name: nodeName}, vm); getErr != nil {
+			t.Fatalf("failed to read back VirtualMachine: %v", getErr)
+		}
+		if len(vm.Spec.Volumes) != 0 {
+			t.Errorf("expected VirtualMachine.Spec.Volumes to be left untouched, got %+v", vm.Spec.Volumes)
+		}
+	})
+
+	t.Run("live attach is written into the VM spec", func(t *testing.T) {
+		// status.Volumes reports the disk as already attached so that the call
+		// returns without needing the VirtualMachine watch.
+		vm := newVM()
+		vm.Status.Volumes = []vmoperatortypes.VirtualMachineVolumeStatus{
+			{Name: volumeHandle, Attached: true, DiskUUID: "6000c29-fake-disk-uuid"},
+		}
+		va := &storagev1.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeAttachmentName(volumeHandle, csitypes.Name, nodeName),
+			},
+		}
+		vmClient := ctrlclientfake.NewClientBuilder().
+			WithScheme(scheme).WithObjects(vm).Build()
+		c := &controller{
+			vmOperatorClient:    vmClient,
+			guestClient:         testclient.NewClientset(va),
+			supervisorNamespace: namespace,
+		}
+
+		resp, _, err := controllerPublishForBlockVolume(ctx, &csi.ControllerPublishVolumeRequest{
+			VolumeId: volumeHandle,
+			NodeId:   nodeName,
+		}, c)
+		if err != nil {
+			t.Fatalf("expected the attach to succeed, got %v", err)
+		}
+		if resp == nil {
+			t.Fatal("expected a ControllerPublishVolumeResponse")
+		}
+
+		updated := &vmoperatortypes.VirtualMachine{}
+		if getErr := vmClient.Get(ctx,
+			types.NamespacedName{Namespace: namespace, Name: nodeName}, updated); getErr != nil {
+			t.Fatalf("failed to read back VirtualMachine: %v", getErr)
+		}
+		if len(updated.Spec.Volumes) != 1 || updated.Spec.Volumes[0].Name != volumeHandle {
+			t.Errorf("expected volume %q to be added to the VM spec, got %+v", volumeHandle, updated.Spec.Volumes)
+		}
+	})
+}
+
+// TestControllerPublishForBlockVolumeStaleAttachOnRetry verifies that
+// isAttachStillRequested is re-evaluated on every iteration of the attach
+// retry loop, not just once when the RPC starts. It simulates a VolumeAttachment
+// disappearing between a failed patch attempt and the next retry: the first
+// patch attempt is forced to fail with a conflict, and while handling that
+// failure, the VolumeAttachment is deleted out from under the request. If the
+// guard only ran once at the top of the function, the second iteration would
+// go on to patch VirtualMachine.Spec.Volumes despite nothing left in Kubernetes
+// to ever detach it.
+func TestControllerPublishForBlockVolumeStaleAttachOnRetry(t *testing.T) {
+	ctx := context.Background()
+	const (
+		namespace    = "test-ns"
+		nodeName     = "test-node"
+		volumeHandle = "test-cluster-uid-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+	)
+
+	scheme := runtime.NewScheme()
+	if err := vmoperatortypes.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register vmoperator scheme: %v", err)
+	}
+
+	va := &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: volumeAttachmentName(volumeHandle, csitypes.Name, nodeName),
+		},
+	}
+	guestClient := testclient.NewClientset(va)
+
+	patchAttempts := 0
+	vmClient := ctrlclientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: namespace},
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cli ctrlclient.WithWatch, obj ctrlclient.Object,
+				patch ctrlclient.Patch, opts ...ctrlclient.PatchOption) error {
+				patchAttempts++
+				if patchAttempts == 1 {
+					if err := guestClient.StorageV1().VolumeAttachments().Delete(
+						ctx, va.Name, metav1.DeleteOptions{}); err != nil {
+						t.Fatalf("failed to delete VolumeAttachment: %v", err)
+					}
+					return apierrors.NewConflict(storagev1.Resource("virtualmachines"), obj.GetName(), errors.New("conflict"))
+				}
+				return cli.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	c := &controller{
+		vmOperatorClient:    vmClient,
+		guestClient:         guestClient,
+		supervisorNamespace: namespace,
+	}
+
+	_, _, err := controllerPublishForBlockVolume(ctx, &csi.ControllerPublishVolumeRequest{
+		VolumeId: volumeHandle,
+		NodeId:   nodeName,
+	}, c)
+
+	assertGRPCCode(t, err, codes.FailedPrecondition)
+	if patchAttempts != 1 {
+		t.Errorf("expected the guard to reject the second iteration before it could retry the patch, "+
+			"but the patch was attempted %d time(s)", patchAttempts)
+	}
+
+	vm := &vmoperatortypes.VirtualMachine{}
+	if getErr := vmClient.Get(ctx,
+		types.NamespacedName{Namespace: namespace, Name: nodeName}, vm); getErr != nil {
+		t.Fatalf("failed to read back VirtualMachine: %v", getErr)
+	}
+	if len(vm.Spec.Volumes) != 0 {
+		t.Errorf("expected VirtualMachine.Spec.Volumes to be left untouched, got %+v", vm.Spec.Volumes)
+	}
+}
+
+// TestControllerUnpublishForBlockVolumeWatchTermination drives
+// controllerUnpublishForBlockVolume through its VirtualMachine watch loop to
+// verify the two ways that watch can end without observing the volume detached
+// are reported with the expected non-final codes: a watch.Error event maps to
+// vmWatchErrorEventError (codes.Unavailable, with the underlying status
+// message), and a closed result channel maps to vmWatchClosedError
+// (codes.DeadlineExceeded). Both must never be codes.Internal, or CSI sidecars
+// will treat the detach as finished when VirtualMachine.Spec.Volumes may still
+// be mid-reconcile.
+func TestControllerUnpublishForBlockVolumeWatchTermination(t *testing.T) {
+	ctx := context.Background()
+	const (
+		namespace    = "test-ns"
+		nodeName     = "test-node"
+		volumeHandle = "test-cluster-uid-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+	)
+
+	scheme := runtime.NewScheme()
+	if err := vmoperatortypes.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register vmoperator scheme: %v", err)
+	}
+
+	// The volume is already absent from Spec.Volumes, so the removal loop exits
+	// immediately, but still reported as attached in Status.Volumes, so the
+	// function proceeds to the watch loop under test.
+	newAttachedVM := func() *vmoperatortypes.VirtualMachine {
+		return &vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: namespace},
+			Status: vmoperatortypes.VirtualMachineStatus{
+				Volumes: []vmoperatortypes.VirtualMachineVolumeStatus{
+					{Name: volumeHandle, Attached: true},
+				},
+			},
+		}
+	}
+
+	// runUnpublish starts controllerUnpublishForBlockVolume in the background,
+	// since it blocks reading watchVirtualMachine.ResultChan(), then calls
+	// injectEvent to deliver (or close) the watch and waits for the RPC to
+	// return.
+	runUnpublish := func(t *testing.T, fakeWatch *watch.FakeWatcher, injectEvent func()) error {
+		t.Helper()
+		vmClient := ctrlclientfake.NewClientBuilder().
+			WithScheme(scheme).WithObjects(newAttachedVM()).Build()
+		c := &controller{
+			vmOperatorClient:    vmClient,
+			guestClient:         testclient.NewClientset(),
+			supervisorNamespace: namespace,
+			vmWatcher: &cache.ListWatch{
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					return fakeWatch, nil
+				},
+			},
+		}
+
+		done := make(chan error, 1)
+		go func() {
+			_, _, err := controllerUnpublishForBlockVolume(ctx, &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: volumeHandle,
+				NodeId:   nodeName,
+			}, c)
+			done <- err
+		}()
+
+		injectEvent()
+
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(5 * time.Second):
+			t.Fatal("controllerUnpublishForBlockVolume did not return after the watch terminated")
+			return nil
+		}
+	}
+
+	t.Run("watch.Error event reports Unavailable with the status message", func(t *testing.T) {
+		fakeWatch := watch.NewFake()
+		const wantMessage = "too old resource version: 12345 (67890)"
+		err := runUnpublish(t, fakeWatch, func() {
+			fakeWatch.Error(&metav1.Status{Message: wantMessage})
+		})
+		assertGRPCCode(t, err, codes.Unavailable)
+		if st, _ := status.FromError(err); !strings.Contains(st.Message(), wantMessage) {
+			t.Errorf("expected error to include the watch status message %q, got %q", wantMessage, st.Message())
+		}
+	})
+
+	t.Run("closed watch reports DeadlineExceeded", func(t *testing.T) {
+		fakeWatch := watch.NewFake()
+		err := runUnpublish(t, fakeWatch, func() {
+			fakeWatch.Stop()
+		})
+		assertGRPCCode(t, err, codes.DeadlineExceeded)
+	})
+}
+
+func assertGRPCCode(t *testing.T, err error, want codes.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error with code %v, got nil", want)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected a gRPC status error, got %v", err)
+	}
+	if st.Code() != want {
+		t.Errorf("expected code %v, got %v (message: %q)", want, st.Code(), st.Message())
+	}
 }

--- a/pkg/csi/service/wcpguest/controller_timeout_test.go
+++ b/pkg/csi/service/wcpguest/controller_timeout_test.go
@@ -18,19 +18,34 @@ package wcpguest
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	snapshotclientset "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fakesnapshot"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 )
 
 // TestTimeoutErrorCodes verifies that timeout operations return the correct gRPC error code
@@ -926,4 +941,593 @@ func TestSnapshotTimeoutScenario(t *testing.T) {
 // Helper function
 func stringPtr(s string) *string {
 	return &s
+}
+
+// TestVolumeAttachmentName verifies that the VolumeAttachment name derived here
+// matches the name the Kubernetes attach/detach controller actually assigns. The
+// expected values below are real VolumeAttachment names captured from a live
+// cluster, alongside the volume handle and node they were created for. If
+// getAttachmentName() in k8s.io/kubernetes/pkg/volume/csi ever changes its
+// hashing scheme, this test fails and isAttachStillRequested must be revisited -
+// it would otherwise silently start reporting every attach as "no longer
+// requested".
+func TestVolumeAttachmentName(t *testing.T) {
+	const node = "lin-vks5-small-0-node-pool-1-m6gq2-qv98v-cvfxv"
+	tests := []struct {
+		name         string
+		volumeHandle string
+		expected     string
+	}{
+		{
+			name:         "volume 0",
+			volumeHandle: "c48f1df3-76e3-4495-b111-b87715287128-0dd0bfc4-9996-4070-9716-ddb3d11738ad",
+			expected:     "csi-524e5016960dd561947c30fbf6bfa195d83a52044d88a0efa2c1cfc9ca6dddf2",
+		},
+		{
+			name:         "volume 1",
+			volumeHandle: "c48f1df3-76e3-4495-b111-b87715287128-d81c9aca-1e05-438b-8e03-5e234501a6da",
+			expected:     "csi-68eee207f9c4e23024f703ba0268513789cfb8af82a6ed7639a7624ec1e27627",
+		},
+		{
+			name:         "volume 2",
+			volumeHandle: "c48f1df3-76e3-4495-b111-b87715287128-b1831b35-7e03-40b2-8213-ec6cfeb8e339",
+			expected:     "csi-5a514b08aa0b5ea23feda388299cbe6ffa819e9abd86fcfa2eb4daeba77270ab",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := volumeAttachmentName(tt.volumeHandle, csitypes.Name, node)
+			if got != tt.expected {
+				t.Errorf("volumeAttachmentName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsAttachStillRequested verifies the staleness guard consulted before the
+// attach is written into VirtualMachine.Spec.Volumes.
+func TestIsAttachStillRequested(t *testing.T) {
+	ctx := context.Background()
+	const (
+		volumeHandle = "c48f1df3-76e3-4495-b111-b87715287128-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+		nodeName     = "lin-vks5-small-0-node-pool-1-m6gq2-qv98v-cvfxv"
+	)
+
+	t.Run("VolumeAttachment present means attach is still requested", func(t *testing.T) {
+		pvName := "pvc-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+		va := &storagev1.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeAttachmentName(volumeHandle, csitypes.Name, nodeName),
+			},
+			Spec: storagev1.VolumeAttachmentSpec{
+				Attacher: csitypes.Name,
+				NodeName: nodeName,
+				Source: storagev1.VolumeAttachmentSource{
+					PersistentVolumeName: &pvName,
+				},
+			},
+		}
+		c := &controller{guestClient: testclient.NewClientset(va)}
+		if !c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected attach to be reported as still requested when the VolumeAttachment exists")
+		}
+	})
+
+	t.Run("VolumeAttachment absent means attach is no longer requested", func(t *testing.T) {
+		c := &controller{guestClient: testclient.NewClientset()}
+		if c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected attach to be reported as no longer requested when the VolumeAttachment is gone")
+		}
+	})
+
+	t.Run("VolumeAttachment for a different node does not satisfy the guard", func(t *testing.T) {
+		otherNode := "lin-vks5-small-0-node-pool-1-m6gq2-qv98v-other"
+		va := &storagev1.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeAttachmentName(volumeHandle, csitypes.Name, otherNode),
+			},
+		}
+		c := &controller{guestClient: testclient.NewClientset(va)}
+		if c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected the guard to ignore a VolumeAttachment belonging to another node")
+		}
+	})
+
+	// The guard must fail open. Blocking attaches because the API server is
+	// briefly unreachable - or because the driver's RBAC lacks access to
+	// volumeattachments - would be far worse than the orphaned attachment it is
+	// trying to prevent.
+	t.Run("transient API error fails open", func(t *testing.T) {
+		guestClient := testclient.NewClientset()
+		guestClient.PrependReactor("get", "volumeattachments",
+			func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewServiceUnavailable("apiserver is unavailable")
+			})
+		c := &controller{guestClient: guestClient}
+		if !c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected the guard to fail open and allow the attach when the lookup errors")
+		}
+	})
+
+	t.Run("forbidden error fails open", func(t *testing.T) {
+		guestClient := testclient.NewClientset()
+		guestClient.PrependReactor("get", "volumeattachments",
+			func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewForbidden(
+					storagev1.Resource("volumeattachments"), "", nil)
+			})
+		c := &controller{guestClient: guestClient}
+		if !c.isAttachStillRequested(ctx, volumeHandle, nodeName) {
+			t.Error("expected the guard to fail open when RBAC denies the lookup")
+		}
+	})
+}
+
+// TestVMWatchClosedError verifies that a VirtualMachine watch closing without the
+// expected state is never reported as codes.Internal. CSI sidecars treat Internal
+// as a final error meaning "the operation is for sure not in progress", which is
+// untrue here: the volume remains in VirtualMachine.Spec.Volumes and vm-operator
+// keeps reconciling it, so the attach or detach may still complete.
+func TestVMWatchClosedError(t *testing.T) {
+	const vmName = "lin-vks1-medium-0-node-pool-1-g4xm6-zkp89-dgdql"
+
+	t.Run("watch timeout reports DeadlineExceeded", func(t *testing.T) {
+		_, err := vmWatchClosedError(context.Background(), "attach", vmName)
+		assertGRPCCode(t, err, codes.DeadlineExceeded)
+	})
+
+	t.Run("cancelled context reports Canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := vmWatchClosedError(ctx, "attach", vmName)
+		assertGRPCCode(t, err, codes.Canceled)
+	})
+
+	t.Run("expired context deadline reports DeadlineExceeded", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+		<-ctx.Done()
+		_, err := vmWatchClosedError(ctx, "detach", vmName)
+		assertGRPCCode(t, err, codes.DeadlineExceeded)
+	})
+
+	// Both codes must be non-final so that the CSI sidecars keep the
+	// VolumeAttachment around and retry, rather than concluding the operation
+	// definitively failed.
+	t.Run("reported codes are never Internal", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		for _, c := range []context.Context{context.Background(), ctx} {
+			_, err := vmWatchClosedError(c, "attach", vmName)
+			if st, ok := status.FromError(err); ok && st.Code() == codes.Internal {
+				t.Errorf("watch closure reported codes.Internal, which sidecars treat as a final error")
+			}
+		}
+	})
+}
+
+// TestVMWatchErrorEventError verifies that a watch.Error event - which carries a
+// *metav1.Status describing why the watch itself failed, e.g. an expired
+// resourceVersion - is reported with that detail rather than being collapsed
+// into the generic "watch closed" timeout/cancel message. The two cases are
+// distinguishable at the call site by event.Type, and must be handled by
+// different helpers: conflating them would silently discard the actual
+// apiserver-reported reason for the watch failing.
+func TestVMWatchErrorEventError(t *testing.T) {
+	const vmName = "lin-vks1-medium-0-node-pool-1-g4xm6-zkp89-dgdql"
+
+	t.Run("status message from the watch.Error event is included", func(t *testing.T) {
+		watchStatus := &metav1.Status{
+			Message: "too old resource version: 12345 (67890)",
+		}
+		_, err := vmWatchErrorEventError(context.Background(), "attach", vmName, watchStatus)
+		assertGRPCCode(t, err, codes.Unavailable)
+		if st, _ := status.FromError(err); !strings.Contains(st.Message(), watchStatus.Message) {
+			t.Errorf("expected error message to include the watch status message %q, got %q",
+				watchStatus.Message, st.Message())
+		}
+	})
+
+	t.Run("reports Unavailable even without a status payload", func(t *testing.T) {
+		_, err := vmWatchErrorEventError(context.Background(), "detach", vmName, nil)
+		assertGRPCCode(t, err, codes.Unavailable)
+	})
+
+	// codes.Unavailable must be non-final for the same reason as
+	// vmWatchClosedError's codes: a failed watch says nothing about whether the
+	// underlying attach/detach itself completed.
+	t.Run("reported code is never Internal", func(t *testing.T) {
+		_, err := vmWatchErrorEventError(context.Background(), "attach", vmName, nil)
+		if st, ok := status.FromError(err); ok && st.Code() == codes.Internal {
+			t.Errorf("watch error event reported codes.Internal, which sidecars treat as a final error")
+		}
+	})
+}
+
+// TestControllerPublishForBlockVolumeStaleAttach drives controllerPublishForBlockVolume
+// itself, to verify the guard actually prevents the write to
+// VirtualMachine.Spec.Volumes. This is the regression that matters: it is the
+// persisted spec entry, not the returned error, that strands a volume attached to
+// a node with no VolumeAttachment left to detach it.
+func TestControllerPublishForBlockVolumeStaleAttach(t *testing.T) {
+	ctx := context.Background()
+	const (
+		namespace    = "test-ns"
+		nodeName     = "test-node"
+		volumeHandle = "test-cluster-uid-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+	)
+
+	newVM := func() *vmoperatortypes.VirtualMachine {
+		return &vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: namespace},
+		}
+	}
+
+	scheme := runtime.NewScheme()
+	if err := vmoperatortypes.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register vmoperator scheme: %v", err)
+	}
+
+	t.Run("stale attach is rejected without modifying the VM spec", func(t *testing.T) {
+		vmClient := ctrlclientfake.NewClientBuilder().
+			WithScheme(scheme).WithObjects(newVM()).Build()
+		c := &controller{
+			vmOperatorClient:    vmClient,
+			guestClient:         testclient.NewClientset(), // no VolumeAttachment: attach is stale
+			supervisorNamespace: namespace,
+		}
+
+		_, _, err := controllerPublishForBlockVolume(ctx, &csi.ControllerPublishVolumeRequest{
+			VolumeId: volumeHandle,
+			NodeId:   nodeName,
+		}, c)
+
+		assertGRPCCode(t, err, codes.FailedPrecondition)
+
+		// The critical assertion: nothing was persisted into the VM spec.
+		vm := &vmoperatortypes.VirtualMachine{}
+		if getErr := vmClient.Get(ctx,
+			types.NamespacedName{Namespace: namespace, Name: nodeName}, vm); getErr != nil {
+			t.Fatalf("failed to read back VirtualMachine: %v", getErr)
+		}
+		if len(vm.Spec.Volumes) != 0 {
+			t.Errorf("expected VirtualMachine.Spec.Volumes to be left untouched, got %+v", vm.Spec.Volumes)
+		}
+	})
+
+	t.Run("live attach is written into the VM spec", func(t *testing.T) {
+		// status.Volumes reports the disk as already attached so that the call
+		// returns without needing the VirtualMachine watch.
+		vm := newVM()
+		vm.Status.Volumes = []vmoperatortypes.VirtualMachineVolumeStatus{
+			{Name: volumeHandle, Attached: true, DiskUUID: "6000c29-fake-disk-uuid"},
+		}
+		va := &storagev1.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeAttachmentName(volumeHandle, csitypes.Name, nodeName),
+			},
+		}
+		vmClient := ctrlclientfake.NewClientBuilder().
+			WithScheme(scheme).WithObjects(vm).Build()
+		c := &controller{
+			vmOperatorClient:    vmClient,
+			guestClient:         testclient.NewClientset(va),
+			supervisorNamespace: namespace,
+		}
+
+		resp, _, err := controllerPublishForBlockVolume(ctx, &csi.ControllerPublishVolumeRequest{
+			VolumeId: volumeHandle,
+			NodeId:   nodeName,
+		}, c)
+		if err != nil {
+			t.Fatalf("expected the attach to succeed, got %v", err)
+		}
+		if resp == nil {
+			t.Fatal("expected a ControllerPublishVolumeResponse")
+		}
+
+		updated := &vmoperatortypes.VirtualMachine{}
+		if getErr := vmClient.Get(ctx,
+			types.NamespacedName{Namespace: namespace, Name: nodeName}, updated); getErr != nil {
+			t.Fatalf("failed to read back VirtualMachine: %v", getErr)
+		}
+		if len(updated.Spec.Volumes) != 1 || updated.Spec.Volumes[0].Name != volumeHandle {
+			t.Errorf("expected volume %q to be added to the VM spec, got %+v", volumeHandle, updated.Spec.Volumes)
+		}
+	})
+}
+
+// TestControllerPublishForBlockVolumeStaleAttachOnRetry verifies that
+// isAttachStillRequested is re-evaluated on every iteration of the attach
+// retry loop, not just once when the RPC starts. It simulates a VolumeAttachment
+// disappearing between a failed patch attempt and the next retry: the first
+// patch attempt is forced to fail with a conflict, and while handling that
+// failure, the VolumeAttachment is deleted out from under the request. If the
+// guard only ran once at the top of the function, the second iteration would
+// go on to patch VirtualMachine.Spec.Volumes despite nothing left in Kubernetes
+// to ever detach it.
+func TestControllerPublishForBlockVolumeStaleAttachOnRetry(t *testing.T) {
+	ctx := context.Background()
+	const (
+		namespace    = "test-ns"
+		nodeName     = "test-node"
+		volumeHandle = "test-cluster-uid-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+	)
+
+	scheme := runtime.NewScheme()
+	if err := vmoperatortypes.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register vmoperator scheme: %v", err)
+	}
+
+	va := &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: volumeAttachmentName(volumeHandle, csitypes.Name, nodeName),
+		},
+	}
+	guestClient := testclient.NewClientset(va)
+
+	patchAttempts := 0
+	vmClient := ctrlclientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: namespace},
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cli ctrlclient.WithWatch, obj ctrlclient.Object,
+				patch ctrlclient.Patch, opts ...ctrlclient.PatchOption) error {
+				patchAttempts++
+				if patchAttempts == 1 {
+					if err := guestClient.StorageV1().VolumeAttachments().Delete(
+						ctx, va.Name, metav1.DeleteOptions{}); err != nil {
+						t.Fatalf("failed to delete VolumeAttachment: %v", err)
+					}
+					return apierrors.NewConflict(storagev1.Resource("virtualmachines"), obj.GetName(), errors.New("conflict"))
+				}
+				return cli.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	c := &controller{
+		vmOperatorClient:    vmClient,
+		guestClient:         guestClient,
+		supervisorNamespace: namespace,
+	}
+
+	_, _, err := controllerPublishForBlockVolume(ctx, &csi.ControllerPublishVolumeRequest{
+		VolumeId: volumeHandle,
+		NodeId:   nodeName,
+	}, c)
+
+	assertGRPCCode(t, err, codes.FailedPrecondition)
+	if patchAttempts != 1 {
+		t.Errorf("expected the guard to reject the second iteration before it could retry the patch, "+
+			"but the patch was attempted %d time(s)", patchAttempts)
+	}
+
+	vm := &vmoperatortypes.VirtualMachine{}
+	if getErr := vmClient.Get(ctx,
+		types.NamespacedName{Namespace: namespace, Name: nodeName}, vm); getErr != nil {
+		t.Fatalf("failed to read back VirtualMachine: %v", getErr)
+	}
+	if len(vm.Spec.Volumes) != 0 {
+		t.Errorf("expected VirtualMachine.Spec.Volumes to be left untouched, got %+v", vm.Spec.Volumes)
+	}
+}
+
+// TestControllerUnpublishForBlockVolumeWatchTermination drives
+// controllerUnpublishForBlockVolume through its VirtualMachine watch loop to
+// verify the two ways that watch can end without observing the volume detached
+// are reported with the expected non-final codes: a watch.Error event maps to
+// vmWatchErrorEventError (codes.Unavailable, with the underlying status
+// message), and a closed result channel maps to vmWatchClosedError
+// (codes.DeadlineExceeded). Both must never be codes.Internal, or CSI sidecars
+// will treat the detach as finished when VirtualMachine.Spec.Volumes may still
+// be mid-reconcile.
+func TestControllerUnpublishForBlockVolumeWatchTermination(t *testing.T) {
+	ctx := context.Background()
+	const (
+		namespace    = "test-ns"
+		nodeName     = "test-node"
+		volumeHandle = "test-cluster-uid-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+	)
+
+	scheme := runtime.NewScheme()
+	if err := vmoperatortypes.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register vmoperator scheme: %v", err)
+	}
+
+	// The volume is already absent from Spec.Volumes, so the removal loop exits
+	// immediately, but still reported as attached in Status.Volumes, so the
+	// function proceeds to the watch loop under test.
+	newAttachedVM := func() *vmoperatortypes.VirtualMachine {
+		return &vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: namespace},
+			Status: vmoperatortypes.VirtualMachineStatus{
+				Volumes: []vmoperatortypes.VirtualMachineVolumeStatus{
+					{Name: volumeHandle, Attached: true},
+				},
+			},
+		}
+	}
+
+	// runUnpublish starts controllerUnpublishForBlockVolume in the background,
+	// since it blocks reading watchVirtualMachine.ResultChan(), then calls
+	// injectEvent to deliver (or close) the watch and waits for the RPC to
+	// return.
+	runUnpublish := func(t *testing.T, fakeWatch *watch.FakeWatcher, injectEvent func()) error {
+		t.Helper()
+		vmClient := ctrlclientfake.NewClientBuilder().
+			WithScheme(scheme).WithObjects(newAttachedVM()).Build()
+		c := &controller{
+			vmOperatorClient:    vmClient,
+			guestClient:         testclient.NewClientset(),
+			supervisorNamespace: namespace,
+			vmWatcher: &cache.ListWatch{
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					return fakeWatch, nil
+				},
+			},
+		}
+
+		done := make(chan error, 1)
+		go func() {
+			_, _, err := controllerUnpublishForBlockVolume(ctx, &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: volumeHandle,
+				NodeId:   nodeName,
+			}, c)
+			done <- err
+		}()
+
+		injectEvent()
+
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(5 * time.Second):
+			t.Fatal("controllerUnpublishForBlockVolume did not return after the watch terminated")
+			return nil
+		}
+	}
+
+	t.Run("watch.Error event reports Unavailable with the status message", func(t *testing.T) {
+		fakeWatch := watch.NewFake()
+		const wantMessage = "too old resource version: 12345 (67890)"
+		err := runUnpublish(t, fakeWatch, func() {
+			fakeWatch.Error(&metav1.Status{Message: wantMessage})
+		})
+		assertGRPCCode(t, err, codes.Unavailable)
+		if st, _ := status.FromError(err); !strings.Contains(st.Message(), wantMessage) {
+			t.Errorf("expected error to include the watch status message %q, got %q", wantMessage, st.Message())
+		}
+	})
+
+	t.Run("closed watch reports DeadlineExceeded", func(t *testing.T) {
+		fakeWatch := watch.NewFake()
+		err := runUnpublish(t, fakeWatch, func() {
+			fakeWatch.Stop()
+		})
+		assertGRPCCode(t, err, codes.DeadlineExceeded)
+	})
+}
+
+// TestControllerPublishStaleAfterPatch covers the window the pre-patch guard
+// cannot: the volume is already written into VirtualMachine.Spec.Volumes and we
+// are waiting for it to be attached when the VolumeAttachment disappears. At
+// that point nothing else will ever issue ControllerUnpublishVolume for it, so
+// the driver must undo its own spec entry rather than leave vm-operator
+// reconciling an attach no one wants.
+func TestControllerPublishStaleAfterPatch(t *testing.T) {
+	ctx := context.Background()
+	const (
+		namespace    = "test-ns"
+		nodeName     = "test-node"
+		volumeHandle = "test-cluster-uid-0dd0bfc4-9996-4070-9716-ddb3d11738ad"
+	)
+
+	scheme := runtime.NewScheme()
+	if err := vmoperatortypes.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register vmoperator scheme: %v", err)
+	}
+
+	// Shorten the poll interval so the test does not wait 15s.
+	origInterval := attachStillRequestedCheckInterval
+	attachStillRequestedCheckInterval = 50 * time.Millisecond
+	defer func() { attachStillRequestedCheckInterval = origInterval }()
+
+	va := &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: volumeAttachmentName(volumeHandle, csitypes.Name, nodeName),
+		},
+	}
+	guestClient := testclient.NewClientset(va)
+
+	// VM starts with no volumes; the publish path will patch ours in, then block
+	// waiting for DiskUUID on a watch that never delivers a successful attach.
+	vmClient := ctrlclientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: namespace},
+		}).
+		Build()
+
+	fakeWatch := watch.NewFake()
+	defer fakeWatch.Stop()
+
+	c := &controller{
+		vmOperatorClient:    vmClient,
+		guestClient:         guestClient,
+		supervisorNamespace: namespace,
+		vmWatcher: &cache.ListWatch{
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return fakeWatch, nil
+			},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := controllerPublishForBlockVolume(ctx, &csi.ControllerPublishVolumeRequest{
+			VolumeId: volumeHandle,
+			NodeId:   nodeName,
+		}, c)
+		done <- err
+	}()
+
+	// Wait until the publish path has actually persisted the volume into the VM
+	// spec, otherwise we would be re-testing the pre-patch guard instead.
+	patched := false
+	for i := 0; i < 100; i++ {
+		vm := &vmoperatortypes.VirtualMachine{}
+		if err := vmClient.Get(ctx,
+			types.NamespacedName{Namespace: namespace, Name: nodeName}, vm); err == nil {
+			if len(vm.Spec.Volumes) == 1 && vm.Spec.Volumes[0].Name == volumeHandle {
+				patched = true
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !patched {
+		t.Fatal("expected the volume to be written into VirtualMachine.Spec.Volumes before the VA is deleted")
+	}
+
+	// Now the VolumeAttachment vanishes mid-attach.
+	if err := guestClient.StorageV1().VolumeAttachments().Delete(
+		ctx, va.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("failed to delete VolumeAttachment: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		assertGRPCCode(t, err, codes.FailedPrecondition)
+	case <-time.After(15 * time.Second):
+		t.Fatal("controllerPublishForBlockVolume did not return after the VolumeAttachment was deleted")
+	}
+
+	// The critical assertion: our own spec entry was rolled back, so vm-operator
+	// is no longer being told to keep the volume attached.
+	vm := &vmoperatortypes.VirtualMachine{}
+	if err := vmClient.Get(ctx,
+		types.NamespacedName{Namespace: namespace, Name: nodeName}, vm); err != nil {
+		t.Fatalf("failed to read back VirtualMachine: %v", err)
+	}
+	if len(vm.Spec.Volumes) != 0 {
+		t.Errorf("expected the stale volume to be removed from VirtualMachine.Spec.Volumes, got %+v",
+			vm.Spec.Volumes)
+	}
+}
+
+func assertGRPCCode(t *testing.T, err error, want codes.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error with code %v, got nil", want)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected a gRPC status error, got %v", err)
+	}
+	if st.Code() != want {
+		t.Errorf("expected code %v, got %v (message: %q)", want, st.Code(), st.Message())
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes orphaned volume attachments in pvCSI (guest cluster CSI driver) caused by attach/detach timeouts being reported as final gRPC errors.

Root cause: 

pvCSI requests an attach by appending the volume to VirtualMachine.Spec.Volumes, then watches for status.DiskUUID to be set, timing out after ~4 minutes. On timeout it returned codes.Internal, which CSI sidecars treat as a final error ("operation is for sure not in progress"). That's false here — the volume stays in Spec.Volumes as desired state, so vm-operator keeps reconciling and can complete the attach long after CSI reported failure. If the pod is rescheduled elsewhere in that window, the VolumeAttachment gets deleted with no record that the original node ever received the disk — leaving it permanently attached there with nothing left to trigger a detach.

Changes:

- Return codes.DeadlineExceeded/codes.Canceled instead of codes.Internal for attach/detach timeouts (4 sites), so sidecars correctly treat them as retryable/non-final.
- Add a staleness guard (isAttachStillRequested) before writing to Spec.Volumes: confirms the corresponding VolumeAttachment still exists, checked on every retry iteration. Fails open on lookup errors so a transient API issue or RBAC gap can't block legitimate attaches.
- Explicitly handle watch.Error events on the VirtualMachine watch (previously collapsed into the generic timeout path, discarding the actual apiserver-reported reason); report via codes.Unavailable with the real status message.
- Add a second, periodic staleness re-check inside the post-patch wait loop: once the volume is already written into Spec.Volumes, we can no longer refuse the write, so instead re-check every ~15s whether the VolumeAttachment still exists. If it's gone (the attach became stale while we were waiting for DiskUUID), remove the entry we added and return codes.FailedPrecondition instead of leaving it to be reconciled by vm-operator forever.

Known limitation: both staleness checks in this PR only run inside an active ControllerPublishVolume call. If that call's process is killed outright (e.g. the CSI controller pod is restarted or rolls over) rather than returning normally, the check protecting that specific attach dies with it. The Spec.Volumes entry it already wrote persists, and if the VolumeAttachment is later removed through any path that doesn't trigger a fresh attach attempt against that same node, nothing ever re-examines that entry. Closing that gap needs a periodic drift-detection reconciler, out of scope for this PR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1424/ (passed)
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1448/ (passed)
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1873/ (passed)

Unit tests: New/expanded coverage in controller_timeout_test.go, including validation that the derived VolumeAttachment name matches real names from a live cluster, and an end-to-end check that a stale attach leaves Spec.Volumes untouched.

[Manual testing](https://gist.github.com/xing-yang/4c1aec7070aadf8345666c4c71881874#file-orphaned-volume-attachments-fix-md)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
