### PR TITLE
Add aggregate-to-view RBAC ClusterRole to grant devops users read-only access to namespaced StoragePolicyInfo CRs.

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -235,6 +235,17 @@ rules:
   resources: ["cnsfileaccessconfigs"]
   verbs: ["get", "list", "watch", "create", "delete"]
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: storagepolicyinfos-view-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["cns.vmware.com"]
+  resources: ["storagepolicyinfos"]
+  verbs: ["get", "list", "watch"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -253,6 +253,17 @@ rules:
   resources: ["cnsfileaccessconfigs"]
   verbs: ["get", "list", "watch", "create", "delete"]
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: storagepolicyinfos-view-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["cns.vmware.com"]
+  resources: ["storagepolicyinfos"]
+  verbs: ["get", "list", "watch"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -253,6 +253,17 @@ rules:
   resources: ["cnsfileaccessconfigs"]
   verbs: ["get", "list", "watch", "create", "delete"]
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: storagepolicyinfos-view-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["cns.vmware.com"]
+  resources: ["storagepolicyinfos"]
+  verbs: ["get", "list", "watch"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -253,6 +253,17 @@ rules:
   resources: ["cnsfileaccessconfigs"]
   verbs: ["get", "list", "watch", "create", "delete"]
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: storagepolicyinfos-view-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["cns.vmware.com"]
+  resources: ["storagepolicyinfos"]
+  verbs: ["get", "list", "watch"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
Devops users in a Supervisor namespace currently have no way to view StoragePolicyInfo (SPI) CRs — RBAC for this resource is scoped only to the vsphere-csi-controller ServiceAccount.

This change adds a storagepolicyinfos-view-role ClusterRole labeled rbac.authorization.k8s.io/aggregate-to-view: "true", granting get/list/watch on storagepolicyinfos. Kubernetes automatically aggregates this into the built-in view ClusterRole, so any user already granted "Can view" on a Supervisor Namespace gets read access to SPI CRs there. View-only role added. Only the namespaced StoragePolicyInfo CRD is affected; ClusterStoragePolicyInfo and InfraStoragePolicyInfo are untouched.

Testing done:

Pipelines:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1858/ - passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1416/ - passed

Verified end-to-end on a live Supervisor cluster that the new storagepolicyinfos-view-role ClusterRole aggregates correctly into the built-in view role and grants read-only access to namespaced StoragePolicyInfo CRs.

1. Applied the new ClusterRole and confirmed the label triggered aggregation into the built-in view ClusterRole
```
kubectl get clusterrole view -o jsonpath='{.rules[?(@.resources[0]=="storagepolicyinfos")]}'
```
```
{"apiGroups":["cns.vmware.com"],"resources":["storagepolicyinfos"],"verbs":["get","list","watch"]}
```

2. Bound a test identity to view only, then confirmed read access is granted

```
NS=test-gc-e2e-demo-ns
kubectl create rolebinding test-spi-view --clusterrole=view --user=test-devops-user -n $NS

kubectl auth can-i get   storagepolicyinfos -n $NS --as=test-devops-user   # yes
kubectl auth can-i list  storagepolicyinfos -n $NS --as=test-devops-user   # yes
kubectl auth can-i watch storagepolicyinfos -n $NS --as=test-devops-user   # yes
```

4. Confirmed write access is still denied (this role is view-only)
```
kubectl auth can-i create storagepolicyinfos -n $NS --as=test-devops-user  # no
kubectl auth can-i delete storagepolicyinfos -n $NS --as=test-devops-user  # no
kubectl auth can-i update storagepolicyinfos -n $NS --as=test-devops-user  # no
```
5. Confirmed the cluster-scoped ClusterStoragePolicyInfo was not affected (out of scope for this change)
```
kubectl auth can-i get clusterstoragepolicyinfos --as=test-devops-user     # no
```
Result: devops users bound to the standard view ClusterRole can get/list/watch namespaced StoragePolicyInfo CRs in their own namespace, cannot perform any write operation on them, and gain no additional access to the cluster-scoped ClusterStoragePolicyInfo/InfraStoragePolicyInfo CRDs.

6.  Without the ClusterRole, access is denied
```
kubectl delete clusterrole storagepolicyinfos-view-role

kubectl get clusterrole view -o jsonpath='{.rules[?(@.resources[0]=="storagepolicyinfos")]}'
# (empty output — rule no longer aggregated into `view`)

NS=test-gc-e2e-demo-ns
kubectl create rolebinding test-spi-view --clusterrole=view --user=test-devops-user -n $NS

kubectl auth can-i get storagepolicyinfos -n $NS --as=test-devops-user
# no
```