### PR TITLE
Remove the duplicated ClusterStoragePolicyInfo/StoragePolicyInfo slow-sync scheduling code into one shared, jittered helper.

### DIFF
--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/slowsync.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/slowsync.go
@@ -18,9 +18,6 @@ package clusterstoragepolicyinfo
 
 import (
 	"context"
-	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -29,6 +26,7 @@ import (
 
 	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 const (
@@ -37,90 +35,58 @@ const (
 	// the vCenter. Expressed in minutes; defaults to 720 (12 hours).
 	slowSyncIntervalEnvVar     = "STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES"
 	defaultSlowSyncIntervalMin = 720
+	// slowSyncLogPrefix namespaces slow-sync log lines to this controller.
+	slowSyncLogPrefix = "ClusterStoragePolicyInfo"
 )
 
 // getSlowSyncInterval returns the periodic resync interval for
 // ClusterStoragePolicyInfo CRs.
 func getSlowSyncInterval(ctx context.Context) time.Duration {
-	log := logger.GetLogger(ctx)
-	v := strings.TrimSpace(os.Getenv(slowSyncIntervalEnvVar))
-	if v == "" {
-		return defaultSlowSyncIntervalMin * time.Minute
-	}
-	value, err := strconv.Atoi(v)
-	if err != nil {
-		log.Warnf("ClusterStoragePolicyInfo slow sync: %s=%q is invalid, "+
-			"using default %d minutes", slowSyncIntervalEnvVar, v, defaultSlowSyncIntervalMin)
-		return defaultSlowSyncIntervalMin * time.Minute
-	}
-	if value <= 0 {
-		log.Warnf("ClusterStoragePolicyInfo slow sync: %s=%q is non-positive, "+
-			"using default %d minutes", slowSyncIntervalEnvVar, v, defaultSlowSyncIntervalMin)
-		return defaultSlowSyncIntervalMin * time.Minute
-	}
-	log.Infof("ClusterStoragePolicyInfo slow sync: interval set to %d minutes", value)
-	return time.Duration(value) * time.Minute
+	return util.GetSlowSyncInterval(ctx, slowSyncLogPrefix, slowSyncIntervalEnvVar,
+		defaultSlowSyncIntervalMin)
 }
 
-// StartPeriodicResync runs a goroutine that, every interval, lists all
-// ClusterStoragePolicyInfo CRs and sends them to ch so the controller
-// re-reconciles each one against the vCenter (slow sync).
+// StartPeriodicResync lists all ClusterStoragePolicyInfo CRs every interval
+// (jittered) and sends each to ch for re-reconciliation (slow sync). Returns
+// immediately; the goroutine runs until ctx is cancelled.
 func StartPeriodicResync(ctx context.Context, c client.Client,
 	ch chan<- event.GenericEvent, interval time.Duration) {
-	log := logger.GetLogger(ctx)
-	go func() {
-		if interval <= 0 {
-			log.Warnf("ClusterStoragePolicyInfo slow sync: interval %s is non-positive, "+
-				"using default %d minutes", interval, defaultSlowSyncIntervalMin)
-			interval = defaultSlowSyncIntervalMin * time.Minute
+	go util.RunPeriodicResync(ctx, slowSyncLogPrefix, interval, defaultSlowSyncIntervalMin, func(ctx context.Context) {
+		log := logger.GetLogger(ctx)
+		var list clusterspiv1alpha1.ClusterStoragePolicyInfoList
+		if err := c.List(ctx, &list); err != nil {
+			log.Errorf("ClusterStoragePolicyInfo periodic resync: list failed: %v", err)
+			return
 		}
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
+		enqueued := 0
+		for i := range list.Items {
+			obj := &list.Items[i]
+			namespacedName := apitypes.NamespacedName{Name: obj.Name}
+
+			backOffDurationMapMutex.Lock()
+			backoff := backOffDuration[namespacedName]
+			backOffDurationMapMutex.Unlock()
+			if backoff > time.Second {
+				// A backoff above one second means the instance failed a recent
+				// reconcile and is already scheduled to retry via RequeueAfter, so
+				// skip it here to avoid defeating the backoff.
+				continue
+			}
+
 			select {
+			case ch <- event.GenericEvent{Object: obj}:
+				enqueued++
 			case <-ctx.Done():
-				log.Infof("ClusterStoragePolicyInfo periodic resync goroutine stopping")
 				return
-			case <-ticker.C:
-				var list clusterspiv1alpha1.ClusterStoragePolicyInfoList
-				if err := c.List(ctx, &list); err != nil {
-					log.Errorf("ClusterStoragePolicyInfo periodic resync: list failed: %v", err)
-					continue
-				}
-				enqueued := 0
-				for i := range list.Items {
-					obj := &list.Items[i]
-					namespacedName := apitypes.NamespacedName{Name: obj.Name}
-
-					backOffDurationMapMutex.Lock()
-					backoff := backOffDuration[namespacedName]
-					backOffDurationMapMutex.Unlock()
-					if backoff > time.Second {
-						// Backoff is only incremented above one second after a
-						// failed reconcile (it is reset to one second / deleted on
-						// success). A value greater than one second therefore means
-						// the instance is already scheduled to reconcile via
-						// RequeueAfter, so skip it here to avoid defeating the
-						// backoff.
-						continue
-					}
-
-					select {
-					case ch <- event.GenericEvent{Object: obj}:
-						enqueued++
-					case <-ctx.Done():
-						return
-					default:
-						// ch is full; do not block this goroutine waiting for a slot,
-						// since that would stall the rest of this sweep. Skip obj for
-						// this tick, it will be picked up on the next resync interval.
-						log.Warnf("ClusterStoragePolicyInfo periodic resync: resync channel full, "+
-							"skipping %q for this tick", obj.Name)
-					}
-				}
-				log.Infof("ClusterStoragePolicyInfo periodic resync: enqueued %d/%d CRs",
-					enqueued, len(list.Items))
+			default:
+				// ch is full; do not block this goroutine waiting for a slot,
+				// since that would stall the rest of this sweep. Skip obj for
+				// this tick, it will be picked up on the next resync interval.
+				log.Warnf("ClusterStoragePolicyInfo periodic resync: resync channel full, "+
+					"skipping %q for this tick", obj.Name)
 			}
 		}
-	}()
+		log.Infof("ClusterStoragePolicyInfo periodic resync: enqueued %d/%d CRs",
+			enqueued, len(list.Items))
+	})
 }

--- a/pkg/syncer/cnsoperator/controller/storagepolicyinfo/slowsync.go
+++ b/pkg/syncer/cnsoperator/controller/storagepolicyinfo/slowsync.go
@@ -18,9 +18,6 @@ package storagepolicyinfo
 
 import (
 	"context"
-	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -29,6 +26,7 @@ import (
 
 	spiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicyinfo/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util"
 )
 
 const (
@@ -37,93 +35,61 @@ const (
 	// minutes; defaults to 60 (1 hour).
 	slowSyncIntervalEnvVar     = "NS_STORAGE_POLICY_INFO_RESYNC_INTERVAL_MINUTES"
 	defaultSlowSyncIntervalMin = 60
+	// slowSyncLogPrefix namespaces slow-sync log lines to this controller.
+	slowSyncLogPrefix = "StoragePolicyInfo"
 )
 
 // getSlowSyncInterval returns the periodic resync interval for StoragePolicyInfo
 // CRs.
 func getSlowSyncInterval(ctx context.Context) time.Duration {
-	log := logger.GetLogger(ctx)
-	v := strings.TrimSpace(os.Getenv(slowSyncIntervalEnvVar))
-	if v == "" {
-		return defaultSlowSyncIntervalMin * time.Minute
-	}
-	value, err := strconv.Atoi(v)
-	if err != nil {
-		log.Warnf("StoragePolicyInfo slow sync: %s=%q is invalid, "+
-			"using default %d minutes", slowSyncIntervalEnvVar, v, defaultSlowSyncIntervalMin)
-		return defaultSlowSyncIntervalMin * time.Minute
-	}
-	if value <= 0 {
-		log.Warnf("StoragePolicyInfo slow sync: %s=%q is non-positive, "+
-			"using default %d minutes", slowSyncIntervalEnvVar, v, defaultSlowSyncIntervalMin)
-		return defaultSlowSyncIntervalMin * time.Minute
-	}
-	log.Infof("StoragePolicyInfo slow sync: interval set to %d minutes", value)
-	return time.Duration(value) * time.Minute
+	return util.GetSlowSyncInterval(ctx, slowSyncLogPrefix, slowSyncIntervalEnvVar,
+		defaultSlowSyncIntervalMin)
 }
 
-// StartPeriodicResync runs a goroutine that, every interval, lists all
-// StoragePolicyInfo CRs across all namespaces and sends them to ch so the
-// controller re-reconciles each one (slow sync).
+// StartPeriodicResync lists all StoragePolicyInfo CRs across all namespaces every
+// interval (jittered) and sends each to ch for re-reconciliation (slow sync).
+// Returns immediately; the goroutine runs until ctx is cancelled.
 func StartPeriodicResync(ctx context.Context, c client.Client,
 	ch chan<- event.GenericEvent, interval time.Duration, r *ReconcileStoragePolicyInfo) {
-	log := logger.GetLogger(ctx)
-	go func() {
-		if interval <= 0 {
-			log.Warnf("StoragePolicyInfo slow sync: interval %s is non-positive, "+
-				"using default %d minutes", interval, defaultSlowSyncIntervalMin)
-			interval = defaultSlowSyncIntervalMin * time.Minute
+	go util.RunPeriodicResync(ctx, slowSyncLogPrefix, interval, defaultSlowSyncIntervalMin, func(ctx context.Context) {
+		log := logger.GetLogger(ctx)
+		var list spiv1alpha1.StoragePolicyInfoList
+		if err := c.List(ctx, &list); err != nil {
+			log.Errorf("StoragePolicyInfo periodic resync: list failed: %v", err)
+			return
 		}
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
+		enqueued := 0
+		for i := range list.Items {
+			obj := &list.Items[i]
+			namespacedName := apitypes.NamespacedName{
+				Namespace: obj.Namespace,
+				Name:      obj.Name,
+			}
+
+			r.backOffDurationMapMutex.Lock()
+			backoff := r.backOffDuration[namespacedName]
+			r.backOffDurationMapMutex.Unlock()
+			if backoff > time.Second {
+				// A backoff above one second means the instance failed a recent
+				// reconcile and is already scheduled to retry via RequeueAfter, so
+				// skip it here to avoid defeating the backoff.
+				continue
+			}
+
 			select {
+			case ch <- event.GenericEvent{Object: obj}:
+				enqueued++
 			case <-ctx.Done():
-				log.Infof("StoragePolicyInfo periodic resync goroutine stopping")
 				return
-			case <-ticker.C:
-				var list spiv1alpha1.StoragePolicyInfoList
-				if err := c.List(ctx, &list); err != nil {
-					log.Errorf("StoragePolicyInfo periodic resync: list failed: %v", err)
-					continue
-				}
-				enqueued := 0
-				for i := range list.Items {
-					obj := &list.Items[i]
-					namespacedName := apitypes.NamespacedName{
-						Namespace: obj.Namespace,
-						Name:      obj.Name,
-					}
-
-					r.backOffDurationMapMutex.Lock()
-					backoff := r.backOffDuration[namespacedName]
-					r.backOffDurationMapMutex.Unlock()
-					if backoff > time.Second {
-						// Backoff is only incremented above one second after a
-						// failed reconcile (it is reset to one second / deleted on
-						// success). A value greater than one second therefore means
-						// the instance is already scheduled to reconcile via
-						// RequeueAfter, so skip it here to avoid defeating the
-						// backoff.
-						continue
-					}
-
-					select {
-					case ch <- event.GenericEvent{Object: obj}:
-						enqueued++
-					case <-ctx.Done():
-						return
-					default:
-						// ch is full; do not block this goroutine waiting for a slot,
-						// since that would stall the rest of this sweep. Skip obj for
-						// this tick, it will be picked up on the next resync interval.
-						log.Warnf("StoragePolicyInfo periodic resync: resync channel full, "+
-							"skipping %q for this tick", namespacedName)
-					}
-				}
-				log.Infof("StoragePolicyInfo periodic resync: enqueued %d/%d CRs",
-					enqueued, len(list.Items))
+			default:
+				// ch is full; do not block this goroutine waiting for a slot,
+				// since that would stall the rest of this sweep. Skip obj for
+				// this tick, it will be picked up on the next resync interval.
+				log.Warnf("StoragePolicyInfo periodic resync: resync channel full, "+
+					"skipping %q for this tick", namespacedName)
 			}
 		}
-	}()
+		log.Infof("StoragePolicyInfo periodic resync: enqueued %d/%d CRs",
+			enqueued, len(list.Items))
+	})
 }

--- a/pkg/syncer/cnsoperator/util/slowsync.go
+++ b/pkg/syncer/cnsoperator/util/slowsync.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// slowSyncJitterFactor spreads out the cnsoperator controllers' resync schedules so
+// they don't fire in lockstep against the API server.
+const slowSyncJitterFactor = 0.01
+
+// GetSlowSyncInterval reads envVar (whole minutes) and returns the resync interval,
+// falling back to defaultMin if unset/invalid/non-positive. logPrefix namespaces
+// the log lines to the calling controller.
+func GetSlowSyncInterval(ctx context.Context, logPrefix, envVar string,
+	defaultMin int) time.Duration {
+	log := logger.GetLogger(ctx)
+	v := strings.TrimSpace(os.Getenv(envVar))
+	if v == "" {
+		return time.Duration(defaultMin) * time.Minute
+	}
+	value, err := strconv.Atoi(v)
+	if err != nil {
+		log.Warnf("%s slow sync: %s=%q is invalid, using default %d minutes",
+			logPrefix, envVar, v, defaultMin)
+		return time.Duration(defaultMin) * time.Minute
+	}
+	if value <= 0 {
+		log.Warnf("%s slow sync: %s=%q is non-positive, using default %d minutes",
+			logPrefix, envVar, v, defaultMin)
+		return time.Duration(defaultMin) * time.Minute
+	}
+	log.Infof("%s slow sync: interval set to %d minutes", logPrefix, value)
+	return time.Duration(value) * time.Minute
+}
+
+// RunPeriodicResync waits one interval (jittered), invokes listAndEnqueue, and
+// repeats until ctx is cancelled, including the first run. Blocks, so
+// non-blocking callers (e.g. StartPeriodicResync) invoke it via `go`. Falls back
+// to defaultMin if interval is non-positive, matching GetSlowSyncInterval's own
+// fallback.
+//
+// The per-CR listing/backoff/send logic lives in the caller's closure since backoff
+// bookkeeping differs per controller (package-level map vs. per-reconciler field).
+func RunPeriodicResync(ctx context.Context, logPrefix string, interval time.Duration, defaultMin int,
+	listAndEnqueue func(ctx context.Context)) {
+	log := logger.GetLogger(ctx)
+	if interval <= 0 {
+		// Defensive: GetSlowSyncInterval never returns a non-positive value, but
+		// guard against a caller passing one so we never spin nor silently stop
+		// resyncing altogether.
+		log.Warnf("%s slow sync: interval %s is non-positive, using default %d minutes",
+			logPrefix, interval, defaultMin)
+		interval = time.Duration(defaultMin) * time.Minute
+	}
+	// JitterUntil's first call is immediate and unjittered; skip its work so the
+	// first real sweep waits out a jittered interval too.
+	first := true
+	wait.JitterUntil(func() {
+		if first {
+			first = false
+			return
+		}
+		listAndEnqueue(ctx)
+	}, interval, slowSyncJitterFactor, false, ctx.Done())
+	log.Infof("%s periodic resync stopping", logPrefix)
+}

--- a/pkg/syncer/cnsoperator/util/slowsync_test.go
+++ b/pkg/syncer/cnsoperator/util/slowsync_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+func TestGetSlowSyncInterval(t *testing.T) {
+	ctx, _ := logger.GetNewContextWithLogger()
+	const (
+		envVar     = "TEST_SLOW_SYNC_INTERVAL_MINUTES"
+		defaultMin = 60
+	)
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset uses default", "", defaultMin * time.Minute},
+		{"valid override", "30", 30 * time.Minute},
+		{"valid override with surrounding whitespace", "  30  ", 30 * time.Minute},
+		{"zero uses default", "0", defaultMin * time.Minute},
+		{"negative uses default", "-1", defaultMin * time.Minute},
+		{"invalid uses default", "abc", defaultMin * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envVar, tt.env)
+			assert.Equal(t, tt.want,
+				GetSlowSyncInterval(ctx, "Test", envVar, defaultMin))
+		})
+	}
+}
+
+// TestRunPeriodicResyncDoesNotFireImmediately verifies the first sweep waits out an
+// interval instead of running as soon as RunPeriodicResync is called, and that
+// cancelling during that initial wait still returns.
+func TestRunPeriodicResyncDoesNotFireImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fired := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		RunPeriodicResync(ctx, "Test", time.Hour, 60, func(context.Context) {
+			select {
+			case fired <- struct{}{}:
+			default:
+			}
+		})
+		close(done)
+	}()
+
+	select {
+	case <-fired:
+		t.Fatal("sweep fired immediately; the first sweep should wait out the interval")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Cancelling mid-wait must return rather than block for the full hour.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunPeriodicResync did not return after context cancel during the initial wait")
+	}
+}
+
+// TestRunPeriodicResyncFiresAndStops verifies the sweep runs once the interval has
+// elapsed, repeats, and that the call returns promptly after the context is
+// cancelled.
+func TestRunPeriodicResyncFiresAndStops(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fired := make(chan struct{}, 2)
+	done := make(chan struct{})
+	go func() {
+		RunPeriodicResync(ctx, "Test", 50*time.Millisecond, 60, func(context.Context) {
+			select {
+			case fired <- struct{}{}:
+			default:
+			}
+		})
+		close(done)
+	}()
+
+	// Two sweeps: the one the initial wait timed, plus a subsequent periodic one.
+	for i := range 2 {
+		select {
+		case <-fired:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for sweep %d", i+1)
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunPeriodicResync did not return after context cancel")
+	}
+}
+
+// TestRunPeriodicResyncNonPositiveInterval verifies a non-positive interval falls
+// back to defaultMin instead of spinning, checked by asserting no sweep happens in a
+// short window since the fallback is minute-scale.
+func TestRunPeriodicResyncNonPositiveInterval(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fired := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		RunPeriodicResync(ctx, "Test", 0, 1, func(context.Context) {
+			select {
+			case fired <- struct{}{}:
+			default:
+			}
+		})
+		close(done)
+	}()
+
+	select {
+	case <-fired:
+		t.Fatal("sweep fired inside the short window; a non-positive interval should " +
+			"fall back to the minute-scale default, not spin")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunPeriodicResync did not return after context cancel")
+	}
+}


### PR DESCRIPTION
Both controllers had their own separate copy of the code that periodically re-checks every CR against vCenter as slow sync. Since they run in the same process, if left unjittered their timers could eventually line up and fire at the same moment, causing both to hit the Kubernetes API server at once. This change pulls the duplicated scheduling logic into one shared helper, and adds a small randomized delay to each tick so the two schedules stay spread apart instead of syncing up. Nothing else changes i.e. what gets checked, how failures back off and retry, and how the background loop starts and stops are all exactly as before.

With the final jitter factor we landed on (`slowSyncJitterFactor = 0.01`), `wait.Jitter`'s formula is additive-only.
Actual interval = `[interval, interval × 1.01)`. 
For `ClusterStoragePolicyInfo`'s 720 min (12h) nominal interval, the actual interval falls in 720–727.2 min, a worst-case slip of ~7.2 min and an average slip of ~3.6 min.
For `StoragePolicyInfo`'s 60 min (1h) nominal interval, the actual interval falls in 60–60.6 min, a worst-case slip of ~36 sec and an average slip of ~18 sec.

Testing Done:

https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1866/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1418/ - Passed

On supervisor cluster testbed (Intervals were temporarily shortened for fast iteration):

1. Jitter behavior validated against the scheduling formula:
```
kubectl logs -n vmware-system-csi deploy/vsphere-csi-controller -c vsphere-syncer --timestamps \
  | grep "periodic resync: enqueued" > /tmp/resync.log
cat /tmp/resync.log

2026-07-30T05:29:44.391438789Z {"level":"info","time":"2026-07-30T05:29:44.391248076Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
2026-07-30T05:29:44.496661776Z {"level":"info","time":"2026-07-30T05:29:44.496407716Z","caller":"clusterstoragepolicyinfo/slowsync.go:90","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 22/22 CRs"}
2026-07-30T05:30:49.830441483Z {"level":"info","time":"2026-07-30T05:30:49.830121957Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
2026-07-30T05:31:53.415680680Z {"level":"info","time":"2026-07-30T05:31:53.415422271Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
2026-07-30T05:31:56.258174342Z {"level":"info","time":"2026-07-30T05:31:56.257820006Z","caller":"clusterstoragepolicyinfo/slowsync.go:90","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 22/22 CRs"}
2026-07-30T05:32:56.126335927Z {"level":"info","time":"2026-07-30T05:32:56.12524518Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
2026-07-30T05:33:58.238531417Z {"level":"info","time":"2026-07-30T05:33:58.238209077Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
2026-07-30T05:34:06.915761184Z {"level":"info","time":"2026-07-30T05:34:06.915335888Z","caller":"clusterstoragepolicyinfo/slowsync.go:90","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 22/22 CRs"}
2026-07-30T05:34:59.509336463Z {"level":"info","time":"2026-07-30T05:34:59.506558103Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
2026-07-30T05:36:00.325670445Z {"level":"info","time":"2026-07-30T05:36:00.324767404Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
2026-07-30T05:36:18.827606313Z {"level":"info","time":"2026-07-30T05:36:18.827217791Z","caller":"clusterstoragepolicyinfo/slowsync.go:90","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 22/22 CRs"}
2026-07-30T05:37:02.838691725Z {"level":"info","time":"2026-07-30T05:37:02.838391697Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
2026-07-30T05:38:02.943903913Z {"level":"info","time":"2026-07-30T05:38:02.943553558Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
2026-07-30T05:38:24.960630660Z {"level":"info","time":"2026-07-30T05:38:24.96045377Z","caller":"clusterstoragepolicyinfo/slowsync.go:90","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 22/22 CRs"}
```
Computed inter-tick gaps from the above:

StoragePolicyInfo (nominal 60s interval): 65.44s, 63.59s, 62.71s, 62.11s, 61.27s, 60.82s, 62.51s, 60.11s — all within [60s, 66s).
ClusterStoragePolicyInfo (nominal 120s interval): 131.76s, 130.66s, 131.91s, 126.13s — all within [120s, 132s).
Both match wait.Jitter's additive-only formula ([interval, interval × (1 + jitterFactor))) at the jitter factor in effect during this run (0.1). Also confirmed the desynchronizing effect directly: the two controllers' tick times started 0.105s apart (05:29:44.391 vs 05:29:44.496) and drifted to 22.017s apart by the end of the capture (05:38:02.943 vs 05:38:24.960), confirming the jitter breaks lockstep rather than letting the two schedules stay phase-aligned.

Note: the jitter factor was subsequently reduced from 0.1 → 0.01 after this test.

2. No functional regression from the refactor: Confirmed both controllers still resolve their interval via the shared util.GetSlowSyncInterval and log identically to the pre-refactor code:
```
kubectl logs -n vmware-system-csi vsphere-csi-controller-c77b88bf6-c8mtk -c vsphere-syncer | grep "slow sync: interval set to"

{"level":"info","time":"2026-07-30T04:48:35.281574107Z","caller":"util/slowsync.go:59","msg":"ClusterStoragePolicyInfo slow sync: interval set to 2 minutes","TraceId":"06abe47a-fdd4-4ff3-a0ad-2b0ee7ccd452"}
{"level":"info","time":"2026-07-30T04:48:35.758007088Z","caller":"util/slowsync.go:59","msg":"StoragePolicyInfo slow sync: interval set to 1 minutes","TraceId":"b712fea7-819f-4051-9063-eb17b228d28e"}
Confirmed both controllers' periodic sweeps continue to fire and enqueue every CR correctly over multiple consecutive ticks:

kubectl logs -n vmware-system-csi deploy/vsphere-csi-controller -c vsphere-syncer -f \
  | grep --line-buffered "periodic resync: enqueued"

{"level":"info","time":"2026-07-30T04:48:35.886105315Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
{"level":"info","time":"2026-07-30T04:48:35.990535334Z","caller":"clusterstoragepolicyinfo/slowsync.go:90","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 22/22 CRs"}
{"level":"info","time":"2026-07-30T04:49:41.023180406Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"}
{"level":"info","time":"2026-07-30T04:50:37.444317354Z","caller":"clusterstoragepolicyinfo/slowsync.go:90","msg":"ClusterStoragePolicyInfo periodic resync: enqueued 22/22 CRs"}
```

3. Backoff-skip logic preserved (moved into a closure; logic itself unchanged) Forced a reconcile error by deleting InfraStoragePolicyInfo for a policy shared by 3 namespaces:
```
kubectl delete infraspi vm-encryption-policy
kubectl logs -n vmware-system-csi deploy/vsphere-csi-controller -c vsphere-syncer -f \
  | grep -E "InfraStoragePolicyInfo .* not yet available|Failed to reconcile StoragePolicyInfo"
```  
Retry backoff doubled exactly as designed (1s → 2s → 4s → 8s → 16s), shown here for svc-cci-ns-tts1r/vm-encryption-policy:
```
{"level":"error","time":"2026-07-30T05:02:26.138101607Z","caller":"storagepolicyinfo/controller.go:1097","msg":"Failed to reconcile StoragePolicyInfo \"svc-cci-ns-tts1r/vm-encryption-policy\". Err: InfraStoragePolicyInfo.cns.vmware.com \"vm-encryption-policy\" not found"}   // +1.00s
{"level":"error","time":"2026-07-30T05:02:28.140238699Z","caller":"storagepolicyinfo/controller.go:1097","msg":"Failed to reconcile StoragePolicyInfo \"svc-cci-ns-tts1r/vm-encryption-policy\". Err: InfraStoragePolicyInfo.cns.vmware.com \"vm-encryption-policy\" not found"}   // +2.00s
{"level":"error","time":"2026-07-30T05:02:32.140724925Z","caller":"storagepolicyinfo/controller.go:1097","msg":"Failed to reconcile StoragePolicyInfo \"svc-cci-ns-tts1r/vm-encryption-policy\". Err: InfraStoragePolicyInfo.cns.vmware.com \"vm-encryption-policy\" not found"}   // +4.00s

kubectl logs -n vmware-system-csi deploy/vsphere-csi-controller -c vsphere-syncer -f \
  | grep "StoragePolicyInfo periodic resync: enqueued"

{"level":"info","time":"2026-07-30T05:20:39.090919508Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 23/23 CRs"} {"level":"info","time":"2026-07-30T05:21:41.462352943Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 20/23 CRs"} {"level":"info","time":"2026-07-30T05:22:46.005048305Z","caller":"storagepolicyinfo/slowsync.go:93","msg":"StoragePolicyInfo periodic resync: enqueued 20/23 CRs"}
```
20/23 confirms the 3 backed-off instances (all referencing vm-encryption-policy) were correctly excluded from the sweep.

4. Clean pod restart (restored non-blocking goroutine design)
New pod reached 7/7 Running within ~9s; old pod was fully terminated and garbage-collected with no stuck Terminating observed. Cross-checked via events on the old pod:
```
kubectl get events -n vmware-system-csi --field-selector involvedObject.name=vsphere-csi-controller-c77b88bf6-5c8c6 --sort-by='.lastTimestamp'

3m33s   Normal   Killing   pod/vsphere-csi-controller-c77b88bf6-5c8c6   Stopping container liveness-probe
3m33s   Normal   Killing   pod/vsphere-csi-controller-c77b88bf6-5c8c6   Stopping container csi-resizer
...
```