### PR TITLE
Revert DO_WINDOWS_BUILD_ENV to true

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,7 +23,7 @@ set -o nounset
 set -o pipefail
 set -x
 
-DO_WINDOWS_BUILD=${DO_WINDOWS_BUILD_ENV:-false}
+DO_WINDOWS_BUILD=${DO_WINDOWS_BUILD_ENV:-true}
 
 # BASE_REPO is the root path of the image repository
 readonly BASE_IMAGE_REPO=us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/4186 accidentally changed DO_WINDOWS_BUILD_ENV to false.
This fix changes it back to true.

**Testing done**:
WCP precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1868/
VKS precheckin: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1420/