### PR TITLE
Set the right accessible topology for creating a pvc with volumesnapshot

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -2312,12 +2312,12 @@ func (c *K8sOrchestrator) GetLinkedCloneVolumeSnapshotSourceUUID(ctx context.Con
 	volumeSnapshot, err := c.snapshotterClient.SnapshotV1().VolumeSnapshots(dataSource.Namespace).Get(ctx,
 		dataSource.Name, metav1.GetOptions{})
 	if err != nil {
-		log.Errorf("failed to get source volumesnaphot %s/%s for linked clone PVC %s in "+
+		log.Errorf("failed to get source volumesnapshot %s/%s for linked clone PVC %s in "+
 			"namespace %s. err: %v", dataSource.Namespace, dataSource.Name, pvcName, pvcNamespace, err)
 		return "", err
 	}
 	vsUID := string(volumeSnapshot.UID)
-	log.Debugf("volumesnaphot %s/%s  has UID: %s for linked clone PVC %s/%s ",
+	log.Debugf("volumesnapshot %s/%s has UID: %s for linked clone PVC %s/%s",
 		dataSource.Namespace, dataSource.Name, vsUID, pvcName, pvcNamespace)
 	return vsUID, nil
 }
@@ -2342,7 +2342,7 @@ func (c *K8sOrchestrator) PreLinkedCloneCreateAction(ctx context.Context, pvcNam
 			linkedClonePVC.Labels = make(map[string]string)
 		}
 		// Add label
-		if _, ok := linkedClonePVC.Labels[common.AnnKeyLinkedClone]; !ok {
+		if _, ok := linkedClonePVC.Labels[common.LinkedClonePVCLabel]; !ok {
 			linkedClonePVC.Labels[common.LinkedClonePVCLabel] = linkedClonePVC.Annotations[common.AttributeIsLinkedClone]
 		}
 
@@ -2373,6 +2373,13 @@ func (c *K8sOrchestrator) GetVolumeSnapshotPVCSource(ctx context.Context, volume
 			volumeSnapshotNamespace, volumeSnapshotName, err)
 	}
 	sourcePVCName := volumeSnapshot.Spec.Source.PersistentVolumeClaimName
+	if sourcePVCName == nil || *sourcePVCName == "" {
+		// The snapshot is pre-provisioned from a VolumeSnapshotContent, so there is no
+		// source PVC in this cluster to derive information from.
+		return nil, logger.LogNewErrorf(log, "volumesnapshot %s/%s has no source PVC "+
+			"(pre-provisioned from a VolumeSnapshotContent)",
+			volumeSnapshotNamespace, volumeSnapshotName)
+	}
 	// Retrieve the source volume
 	sourcePVC, err := c.k8sClient.CoreV1().PersistentVolumeClaims(volumeSnapshotNamespace).Get(ctx, *sourcePVCName,
 		metav1.GetOptions{})

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_snapshot_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_snapshot_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sorchestrator
+
+import (
+	"testing"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fakesnapshot"
+)
+
+// TestGetVolumeSnapshotPVCSource covers how GetVolumeSnapshotPVCSource resolves (or
+// declines to resolve) the source PVC behind a VolumeSnapshot.
+//
+// VolumeSnapshotSource is a union: exactly one of PersistentVolumeClaimName (dynamic
+// snapshot) or VolumeSnapshotContentName (pre-provisioned snapshot) is set. The
+// pre-provisioned case must return an error rather than dereferencing the nil
+// PersistentVolumeClaimName pointer, since the CNS-CSI mutating webhook calls this for
+// every VolumeSnapshot-backed PVC and a panic there fails the admission request.
+func TestGetVolumeSnapshotPVCSource(t *testing.T) {
+	const namespace = "test-ns"
+
+	sourcePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "src-pvc",
+			Namespace: namespace,
+		},
+	}
+
+	// A dynamic snapshot: taken from a PVC that lives in this cluster.
+	dynamicSnapshot := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "dynamic-snap", Namespace: namespace},
+		Spec: snapshotv1.VolumeSnapshotSpec{
+			Source: snapshotv1.VolumeSnapshotSource{
+				PersistentVolumeClaimName: &[]string{"src-pvc"}[0],
+			},
+		},
+	}
+	// A pre-provisioned snapshot: bound to a VolumeSnapshotContent, so there is no
+	// source PVC and PersistentVolumeClaimName is nil.
+	preProvisionedSnapshot := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "preprovisioned-snap", Namespace: namespace},
+		Spec: snapshotv1.VolumeSnapshotSpec{
+			Source: snapshotv1.VolumeSnapshotSource{
+				VolumeSnapshotContentName: &[]string{"snapcontent-1"}[0],
+			},
+		},
+	}
+	// Defensive: an explicitly empty source PVC name is as unusable as a nil one.
+	emptyNameSnapshot := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-name-snap", Namespace: namespace},
+		Spec: snapshotv1.VolumeSnapshotSpec{
+			Source: snapshotv1.VolumeSnapshotSource{
+				PersistentVolumeClaimName: &[]string{""}[0],
+			},
+		},
+	}
+
+	orchestrator := &K8sOrchestrator{
+		k8sClient: k8sfake.NewSimpleClientset(sourcePVC),
+		snapshotterClient: fakesnapshot.NewClientset(
+			dynamicSnapshot, preProvisionedSnapshot, emptyNameSnapshot),
+	}
+
+	tests := []struct {
+		name              string
+		snapshotNamespace string
+		snapshotName      string
+		expectErr         bool
+		expectPVCName     string
+	}{
+		{
+			name:              "dynamic snapshot resolves its source PVC",
+			snapshotNamespace: namespace,
+			snapshotName:      "dynamic-snap",
+			expectPVCName:     "src-pvc",
+		},
+		{
+			name:              "pre-provisioned snapshot errors instead of panicking",
+			snapshotNamespace: namespace,
+			snapshotName:      "preprovisioned-snap",
+			expectErr:         true,
+		},
+		{
+			name:              "empty source PVC name errors instead of a bogus lookup",
+			snapshotNamespace: namespace,
+			snapshotName:      "empty-name-snap",
+			expectErr:         true,
+		},
+		{
+			name:              "missing snapshot errors",
+			snapshotNamespace: namespace,
+			snapshotName:      "does-not-exist",
+			expectErr:         true,
+		},
+		{
+			name:              "empty snapshot name errors",
+			snapshotNamespace: namespace,
+			snapshotName:      "",
+			expectErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The call must never panic, whatever shape the snapshot source has.
+			assert.NotPanics(t, func() {
+				pvc, err := orchestrator.GetVolumeSnapshotPVCSource(ctx, tt.snapshotNamespace, tt.snapshotName)
+				if tt.expectErr {
+					assert.Error(t, err)
+					assert.Nil(t, pvc)
+					return
+				}
+				assert.NoError(t, err)
+				assert.NotNil(t, pvc)
+				assert.Equal(t, tt.expectPVCName, pvc.Name)
+			})
+		})
+	}
+}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1182,6 +1182,26 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 	}
 
+	// Every placement mechanism CNS accepts is empty: no candidate hosts, no candidate
+	// datastores and no active clusters. CNS will reject this with an opaque
+	// "A specified parameter was not correct: createSpecs.datastores", which gives no hint
+	// about which precondition actually failed, so record the request shape here to make the
+	// subsequent failure attributable.
+	//
+	// This is deliberately a log and not an early return. Each mechanism is legitimately
+	// empty on its own in several supported combinations - a host-local request supplies
+	// hosts and intentionally no clusters (CNS rejects a spec carrying both), and a restore
+	// pinned to the snapshot's source host supplies datastores and no clusters - so only the
+	// total absence of all three is suspect. Even that is judged from the combinations that
+	// exist today; failing the request here would turn any future placement mechanism into a
+	// spurious rejection, so CNS stays the authority on whether the spec is valid.
+	if len(hostMoRefs) == 0 && len(candidateDatastores) == 0 && len(vSphereClusterMorefs) == 0 {
+		log.Errorf("no candidate host, datastore or vSphere cluster resolved to place volume %q "+
+			"in namespace %q (snapshot: %q, accessibility requirement: %+v); the create is "+
+			"expected to fail in CNS",
+			req.Name, pvcNamespace, contentSourceSnapshotID, req.AccessibilityRequirements)
+	}
+
 	// Create CreateVolumeSpec and populate values.
 	var createVolumeSpec = common.CreateVolumeSpec{
 		CapacityMB:              volSizeMB,

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -901,6 +901,11 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 						}
 						log.Infof("vSphere clusters: %v for the namespace %q accessible to snapshot: %q", vSphereClusterMorefs,
 							pvcNamespace, req.GetVolumeContentSource().GetSnapshot().GetSnapshotId())
+						if len(vSphereClusterMorefs) == 0 {
+							return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+								"no vSphere cluster in zone(s) %v for namespace %q can access the datastore "+
+									"backing snapshot %q", zones, pvcNamespace, snapshotID)
+						}
 					}
 				} else {
 					vSphereClusterMorefs, err = commonco.ContainerOrchestratorUtility.
@@ -910,6 +915,10 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 							"failed to find active clusters for the namespace: %q, err :%v", pvcNamespace, err)
 					}
 					log.Infof("Active vSphere clusters: %v for the namespace: %q", vSphereClusterMorefs, pvcNamespace)
+					if len(vSphereClusterMorefs) == 0 {
+						return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+							"no active vSphere cluster found in zone(s) %v for namespace %q", zones, pvcNamespace)
+					}
 				}
 			}
 		} else if hostnameLabelPresent {

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -2138,6 +2138,13 @@ func TestRestoreFromHostLocalSnapshotPinsPlacementToSourceHost(t *testing.T) {
 		if clusterPathTaken {
 			t.Fatalf("a host-exclusive source must not fall through to the activeClusters path (err: %v)", err)
 		}
+		// This path supplies datastores accessible to the source host and intentionally leaves
+		// vSphereClusterMorefs empty, so a placement pre-check keyed on empty clusters would
+		// reject a request that is actually valid. Provisioning may still fail further down
+		// against the simulator, so only that class of failure is asserted here.
+		if status.Code(err) == codes.FailedPrecondition {
+			t.Fatalf("a host-pinned restore must not be rejected by a placement precondition: %v", err)
+		}
 	})
 
 	hostLocalRestoreReq := func() *csi.CreateVolumeRequest {

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator"
@@ -429,7 +428,39 @@ func (h *CSISupervisorMutationWebhook) mutateNewCnsFileAccessConfig(ctx context.
 	return admission.PatchResponseFromRaw(req.Object.Raw, newRawCnsFileAccessConfig)
 }
 
+// pvcTopologyZones parses a csi.vsphere.volume-*-topology annotation value into the
+// set of "topology.kubernetes.io/zone" segments it contains. The annotation value is a
+// JSON array of topology segments, e.g. [{"topology.kubernetes.io/zone":"az1"}].
+func pvcTopologyZones(topologyAnnotation string) (map[string]bool, error) {
+	var segments []map[string]string
+	if err := json.Unmarshal([]byte(topologyAnnotation), &segments); err != nil {
+		return nil, err
+	}
+	zones := make(map[string]bool)
+	for _, seg := range segments {
+		if zone := seg[corev1.LabelTopologyZone]; zone != "" {
+			zones[zone] = true
+		}
+	}
+	return zones, nil
+}
+
+// isZoneSubset returns true if every zone in requested is also present in accessible,
+// i.e. the PVC can only be scheduled somewhere the source volume can actually be reached
+// from. Callers must only use this when both sets are non-empty; a topology carrying no
+// zone segments at all (e.g. a purely host-scoped one) has no zone constraint to compare.
+func isZoneSubset(requested, accessible map[string]bool) bool {
+	for zone := range requested {
+		if !accessible[zone] {
+			return false
+		}
+	}
+	return true
+}
+
 func (h *CSISupervisorMutationWebhook) mutateNewPVC(ctx context.Context, req admission.Request) admission.Response {
+	log := logger.GetLogger(ctx)
+
 	newPVC := &corev1.PersistentVolumeClaim{}
 	if err := json.Unmarshal(req.Object.Raw, newPVC); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
@@ -445,60 +476,104 @@ func (h *CSISupervisorMutationWebhook) mutateNewPVC(ctx context.Context, req adm
 		}
 	}
 
-	if featureIsLinkedCloneSupportEnabled &&
+	isLinkedCloneReq := featureIsLinkedCloneSupportEnabled &&
 		v1.HasAnnotation(newPVC.ObjectMeta, common.AnnKeyLinkedClone) &&
-		newPVC.Annotations[common.AnnKeyLinkedClone] == "true" {
+		newPVC.Annotations[common.AnnKeyLinkedClone] == "true"
+
+	// Retrieve the datasource. This is a pure in-memory computation on the PVC spec
+	// (no API calls), so it is safe/cheap to do for every PVC, not just linked clones.
+	dataSource, err := k8sorchestrator.GetPVCDataSource(ctx, newPVC)
+	if err != nil {
+		return admission.Denied("failed to retrieve the PVC data source. err:" + err.Error())
+	}
+
+	if isLinkedCloneReq {
 		// Set the same label
 		if newPVC.Labels == nil {
 			newPVC.Labels = make(map[string]string)
 		}
-		if _, ok := newPVC.Labels[common.AnnKeyLinkedClone]; !ok {
+		if _, ok := newPVC.Labels[common.LinkedClonePVCLabel]; !ok {
 			newPVC.Labels[common.LinkedClonePVCLabel] = newPVC.Annotations[common.AnnKeyLinkedClone]
 			wasMutated = true
 		}
-		// Retrieve the datasource
-		dataSource, err := k8sorchestrator.GetPVCDataSource(ctx, newPVC)
-		if err != nil {
-			return admission.Denied("failed to retrieve the linked clone source " +
-				"volumesnapshot. err:" + err.Error())
-		}
+	}
+
+	// Propagate the source snapshot's accessible topology onto this PVC's requested
+	// topology whenever restoring from a VolumeSnapshot, not just for linked clones. This
+	// lets vm-operator (via csi.vsphere.volume-requested-topology) constrain the consuming
+	// VM's placement to a zone where the snapshot's data is actually reachable, instead of
+	// only discovering the mismatch when CreateVolume later fails against CNS.
+	if dataSource != nil && dataSource.Kind == "VolumeSnapshot" {
 		volumeSnapshotNamespace, volumeSnapshotName := dataSource.Namespace, dataSource.Name
 		// Retrieve the source PVC
 		sourcePVC, err := h.coCommonInterface.GetVolumeSnapshotPVCSource(ctx, volumeSnapshotNamespace,
 			volumeSnapshotName)
 		if err != nil {
-			return admission.Denied("failed to retrieve the linked clone source PVC. err:" + err.Error())
-		}
-		sourcePVCAccessibility, ok := sourcePVC.Annotations[common.AnnVolumeAccessibleTopology]
-		if !ok {
-			errMsg := fmt.Sprintf("source PVC %s/%s does not have volume accessiblity annotation %s"+
-				" set, cannot determine accessibility requrirement for linked clone PVC %s/%s",
-				sourcePVC.Namespace, sourcePVC.Name, common.AnnVolumeAccessibleTopology,
-				newPVC.Namespace, newPVC.Name)
-			return admission.Denied(errMsg)
-		}
-		// Case-1: If the linked clone PVC has "csi.vsphere.volume-requested-topology" annotation:
-		// - Determine the source PVC accessibility from "csi.vsphere.volume-accessible-topology" annotation
-		// - Validate that it is same the linked clone PVC requested topology, fail the request if not.
-		// Case-2: If the linked clone PVC does NOT have "csi.vsphere.volume-requested-topology" annotation:
-		// - Determine the source PVC accessibility from "csi.vsphere.volume-accessible-topology" annotation
-		// - Add it as the "csi.vsphere.volume-requested-topology" annotation on the linked clone PVC
-		hasTopologyRequirement := v1.HasAnnotation(newPVC.ObjectMeta, common.AnnGuestClusterRequestedTopology)
-		if hasTopologyRequirement {
-			// determined the source accessibility requirement
-			newPVCAccessibility := newPVC.Annotations[common.AnnGuestClusterRequestedTopology]
-			if strings.Compare(newPVCAccessibility, sourcePVCAccessibility) != 0 {
-				// accessibility requirement mismatch, deny the request and suggest the correct annotation
-				errMsg := fmt.Sprintf("expected accessibility requirement: %s but got %s, "+
-					"linked clone volumes must have the same accessibility as the source volume, if unset, it "+
-					"will be automatically chosen", sourcePVCAccessibility, newPVCAccessibility)
+			if isLinkedCloneReq {
+				return admission.Denied("failed to retrieve the linked clone source PVC. err:" + err.Error())
+			}
+			// Best-effort for a plain restore: if the source PVC can't be resolved, skip
+			// propagating the topology hint rather than blocking the request.
+			log.Warnf("failed to retrieve source PVC for volumesnapshot %s/%s, skipping requested-topology "+
+				"propagation for PVC %s/%s. err: %v", volumeSnapshotNamespace, volumeSnapshotName,
+				newPVC.Namespace, newPVC.Name, err)
+		} else if sourcePVCAccessibility, ok := sourcePVC.Annotations[common.AnnVolumeAccessibleTopology]; !ok {
+			if isLinkedCloneReq {
+				errMsg := fmt.Sprintf("source PVC %s/%s does not have volume accessibility annotation %s"+
+					" set, cannot determine accessibility requirement for linked clone PVC %s/%s",
+					sourcePVC.Namespace, sourcePVC.Name, common.AnnVolumeAccessibleTopology,
+					newPVC.Namespace, newPVC.Name)
 				return admission.Denied(errMsg)
 			}
+			// Best-effort for a plain restore: no accessibility info available to propagate.
 		} else {
-			// If not present, set it as the same as the source PVC
-			newPVC.Annotations[common.AnnGuestClusterRequestedTopology] = sourcePVCAccessibility
-			wasMutated = true
+			// Case-1: If the PVC has "csi.vsphere.volume-requested-topology" annotation:
+			// - Validate that its zones are a subset of the source PVC's accessible zones,
+			//   fail the request if not.
+			// Case-2: If the PVC does NOT have "csi.vsphere.volume-requested-topology" annotation:
+			// - Add the source PVC's accessible topology as-is, so the consuming VM can only
+			//   be placed where the snapshot's data is reachable.
+			hasTopologyRequirement := v1.HasAnnotation(newPVC.ObjectMeta, common.AnnGuestClusterRequestedTopology)
+			if hasTopologyRequirement {
+				newPVCAccessibility := newPVC.Annotations[common.AnnGuestClusterRequestedTopology]
+				requestedZones, err := pvcTopologyZones(newPVCAccessibility)
+				if err != nil {
+					return admission.Denied("failed to parse " + common.AnnGuestClusterRequestedTopology +
+						". err:" + err.Error())
+				}
+				accessibleZones, err := pvcTopologyZones(sourcePVCAccessibility)
+				if err != nil {
+					return admission.Denied("failed to parse " + common.AnnVolumeAccessibleTopology +
+						". err:" + err.Error())
+				}
+				if len(requestedZones) == 0 || len(accessibleZones) == 0 {
+					// Topology annotations may legitimately carry only non-zone segments, e.g. a
+					// host-scoped topology for host-local storage. There is no zone constraint to
+					// compare in that case, so leave the request alone rather than denying it.
+					log.Infof("no zone segments to compare for PVC %s/%s (requested: %s, accessible: %s), "+
+						"skipping zone validation", newPVC.Namespace, newPVC.Name,
+						newPVCAccessibility, sourcePVCAccessibility)
+				} else if !isZoneSubset(requestedZones, accessibleZones) {
+					// accessibility requirement mismatch, deny the request and suggest the correct annotation
+					errMsg := fmt.Sprintf("expected accessibility requirement to be a subset of: %s but got %s, "+
+						"volumes restored from a snapshot must request a zone where the source snapshot is "+
+						"accessible, if unset, it will be automatically chosen", sourcePVCAccessibility,
+						newPVCAccessibility)
+					return admission.Denied(errMsg)
+				}
+			} else {
+				// If not present, set it as the same as the source PVC
+				if newPVC.Annotations == nil {
+					newPVC.Annotations = make(map[string]string)
+				}
+				newPVC.Annotations[common.AnnGuestClusterRequestedTopology] = sourcePVCAccessibility
+				wasMutated = true
+			}
 		}
+	} else if isLinkedCloneReq {
+		return admission.Denied(fmt.Sprintf(
+			"linked clone PVC %s/%s does not have a volumesnapshot data source",
+			newPVC.Namespace, newPVC.Name))
 	}
 
 	if !wasMutated {

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator"
@@ -429,7 +428,50 @@ func (h *CSISupervisorMutationWebhook) mutateNewCnsFileAccessConfig(ctx context.
 	return admission.PatchResponseFromRaw(req.Object.Raw, newRawCnsFileAccessConfig)
 }
 
+// pvcTopologyZones parses a csi.vsphere.volume-*-topology annotation value into the
+// set of "topology.kubernetes.io/zone" segments it contains. The annotation value is a
+// JSON array of topology segments, e.g. [{"topology.kubernetes.io/zone":"az1"}].
+func pvcTopologyZones(topologyAnnotation string) (map[string]bool, error) {
+	var segments []map[string]string
+	if err := json.Unmarshal([]byte(topologyAnnotation), &segments); err != nil {
+		return nil, err
+	}
+	zones := make(map[string]bool)
+	for _, seg := range segments {
+		if zone := seg[corev1.LabelTopologyZone]; zone != "" {
+			zones[zone] = true
+		}
+	}
+	return zones, nil
+}
+
+// isTopologyZoneSubset returns true if every zone in requestedTopology is also present
+// in accessibleTopology, i.e. the PVC can only be scheduled somewhere the accessible
+// PVC's volume can actually be reached from. Returns false if requestedTopology has no
+// zones at all, since a request with no zones cannot be a meaningful subset.
+func isTopologyZoneSubset(requestedTopology, accessibleTopology string) (bool, error) {
+	requestedZones, err := pvcTopologyZones(requestedTopology)
+	if err != nil {
+		return false, err
+	}
+	accessibleZones, err := pvcTopologyZones(accessibleTopology)
+	if err != nil {
+		return false, err
+	}
+	if len(requestedZones) == 0 {
+		return false, nil
+	}
+	for zone := range requestedZones {
+		if !accessibleZones[zone] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 func (h *CSISupervisorMutationWebhook) mutateNewPVC(ctx context.Context, req admission.Request) admission.Response {
+	log := logger.GetLogger(ctx)
+
 	newPVC := &corev1.PersistentVolumeClaim{}
 	if err := json.Unmarshal(req.Object.Raw, newPVC); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
@@ -445,9 +487,18 @@ func (h *CSISupervisorMutationWebhook) mutateNewPVC(ctx context.Context, req adm
 		}
 	}
 
-	if featureIsLinkedCloneSupportEnabled &&
+	isLinkedCloneReq := featureIsLinkedCloneSupportEnabled &&
 		v1.HasAnnotation(newPVC.ObjectMeta, common.AnnKeyLinkedClone) &&
-		newPVC.Annotations[common.AnnKeyLinkedClone] == "true" {
+		newPVC.Annotations[common.AnnKeyLinkedClone] == "true"
+
+	// Retrieve the datasource. This is a pure in-memory computation on the PVC spec
+	// (no API calls), so it is safe/cheap to do for every PVC, not just linked clones.
+	dataSource, err := k8sorchestrator.GetPVCDataSource(ctx, newPVC)
+	if err != nil {
+		return admission.Denied("failed to retrieve the PVC data source. err:" + err.Error())
+	}
+
+	if isLinkedCloneReq {
 		// Set the same label
 		if newPVC.Labels == nil {
 			newPVC.Labels = make(map[string]string)
@@ -456,49 +507,71 @@ func (h *CSISupervisorMutationWebhook) mutateNewPVC(ctx context.Context, req adm
 			newPVC.Labels[common.LinkedClonePVCLabel] = newPVC.Annotations[common.AnnKeyLinkedClone]
 			wasMutated = true
 		}
-		// Retrieve the datasource
-		dataSource, err := k8sorchestrator.GetPVCDataSource(ctx, newPVC)
-		if err != nil {
-			return admission.Denied("failed to retrieve the linked clone source " +
-				"volumesnapshot. err:" + err.Error())
-		}
+	}
+
+	// Propagate the source snapshot's accessible topology onto this PVC's requested
+	// topology whenever restoring from a VolumeSnapshot, not just for linked clones. This
+	// lets vm-operator (via csi.vsphere.volume-requested-topology) constrain the consuming
+	// VM's placement to a zone where the snapshot's data is actually reachable, instead of
+	// only discovering the mismatch when CreateVolume later fails against CNS.
+	if dataSource != nil && dataSource.Kind == "VolumeSnapshot" {
 		volumeSnapshotNamespace, volumeSnapshotName := dataSource.Namespace, dataSource.Name
 		// Retrieve the source PVC
 		sourcePVC, err := h.coCommonInterface.GetVolumeSnapshotPVCSource(ctx, volumeSnapshotNamespace,
 			volumeSnapshotName)
 		if err != nil {
-			return admission.Denied("failed to retrieve the linked clone source PVC. err:" + err.Error())
-		}
-		sourcePVCAccessibility, ok := sourcePVC.Annotations[common.AnnVolumeAccessibleTopology]
-		if !ok {
-			errMsg := fmt.Sprintf("source PVC %s/%s does not have volume accessiblity annotation %s"+
-				" set, cannot determine accessibility requrirement for linked clone PVC %s/%s",
-				sourcePVC.Namespace, sourcePVC.Name, common.AnnVolumeAccessibleTopology,
-				newPVC.Namespace, newPVC.Name)
-			return admission.Denied(errMsg)
-		}
-		// Case-1: If the linked clone PVC has "csi.vsphere.volume-requested-topology" annotation:
-		// - Determine the source PVC accessibility from "csi.vsphere.volume-accessible-topology" annotation
-		// - Validate that it is same the linked clone PVC requested topology, fail the request if not.
-		// Case-2: If the linked clone PVC does NOT have "csi.vsphere.volume-requested-topology" annotation:
-		// - Determine the source PVC accessibility from "csi.vsphere.volume-accessible-topology" annotation
-		// - Add it as the "csi.vsphere.volume-requested-topology" annotation on the linked clone PVC
-		hasTopologyRequirement := v1.HasAnnotation(newPVC.ObjectMeta, common.AnnGuestClusterRequestedTopology)
-		if hasTopologyRequirement {
-			// determined the source accessibility requirement
-			newPVCAccessibility := newPVC.Annotations[common.AnnGuestClusterRequestedTopology]
-			if strings.Compare(newPVCAccessibility, sourcePVCAccessibility) != 0 {
-				// accessibility requirement mismatch, deny the request and suggest the correct annotation
-				errMsg := fmt.Sprintf("expected accessibility requirement: %s but got %s, "+
-					"linked clone volumes must have the same accessibility as the source volume, if unset, it "+
-					"will be automatically chosen", sourcePVCAccessibility, newPVCAccessibility)
+			if isLinkedCloneReq {
+				return admission.Denied("failed to retrieve the linked clone source PVC. err:" + err.Error())
+			}
+			// Best-effort for a plain restore: if the source PVC can't be resolved, skip
+			// propagating the topology hint rather than blocking the request.
+			log.Warnf("failed to retrieve source PVC for volumesnapshot %s/%s, skipping requested-topology "+
+				"propagation for PVC %s/%s. err: %v", volumeSnapshotNamespace, volumeSnapshotName,
+				newPVC.Namespace, newPVC.Name, err)
+		} else if sourcePVCAccessibility, ok := sourcePVC.Annotations[common.AnnVolumeAccessibleTopology]; !ok {
+			if isLinkedCloneReq {
+				errMsg := fmt.Sprintf("source PVC %s/%s does not have volume accessiblity annotation %s"+
+					" set, cannot determine accessibility requrirement for linked clone PVC %s/%s",
+					sourcePVC.Namespace, sourcePVC.Name, common.AnnVolumeAccessibleTopology,
+					newPVC.Namespace, newPVC.Name)
 				return admission.Denied(errMsg)
 			}
+			// Best-effort for a plain restore: no accessibility info available to propagate.
 		} else {
-			// If not present, set it as the same as the source PVC
-			newPVC.Annotations[common.AnnGuestClusterRequestedTopology] = sourcePVCAccessibility
-			wasMutated = true
+			// Case-1: If the PVC has "csi.vsphere.volume-requested-topology" annotation:
+			// - Validate that its zones are a subset of the source PVC's accessible zones,
+			//   fail the request if not.
+			// Case-2: If the PVC does NOT have "csi.vsphere.volume-requested-topology" annotation:
+			// - Add the source PVC's accessible topology as-is, so the consuming VM can only
+			//   be placed where the snapshot's data is reachable.
+			hasTopologyRequirement := v1.HasAnnotation(newPVC.ObjectMeta, common.AnnGuestClusterRequestedTopology)
+			if hasTopologyRequirement {
+				newPVCAccessibility := newPVC.Annotations[common.AnnGuestClusterRequestedTopology]
+				isSubset, err := isTopologyZoneSubset(newPVCAccessibility, sourcePVCAccessibility)
+				if err != nil {
+					return admission.Denied("failed to parse topology annotations. err:" + err.Error())
+				}
+				if !isSubset {
+					// accessibility requirement mismatch, deny the request and suggest the correct annotation
+					errMsg := fmt.Sprintf("expected accessibility requirement to be a subset of: %s but got %s, "+
+						"volumes restored from a snapshot must request a zone where the source snapshot is "+
+						"accessible, if unset, it will be automatically chosen", sourcePVCAccessibility,
+						newPVCAccessibility)
+					return admission.Denied(errMsg)
+				}
+			} else {
+				// If not present, set it as the same as the source PVC
+				if newPVC.Annotations == nil {
+					newPVC.Annotations = make(map[string]string)
+				}
+				newPVC.Annotations[common.AnnGuestClusterRequestedTopology] = sourcePVCAccessibility
+				wasMutated = true
+			}
 		}
+	} else if isLinkedCloneReq {
+		return admission.Denied(fmt.Sprintf(
+			"linked clone PVC %s/%s does not have a volumesnapshot data source",
+			newPVC.Namespace, newPVC.Name))
 	}
 
 	if !wasMutated {

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -19,6 +19,7 @@ package admissionhandler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -382,7 +383,7 @@ func TestMutateNewPVC_LinkedClone_Success_SetTopologyAnnotation(t *testing.T) {
 			Name:      "src-pvc",
 			Namespace: "default",
 			Annotations: map[string]string{
-				common.AnnVolumeAccessibleTopology: "zone-1",
+				common.AnnVolumeAccessibleTopology: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -478,7 +479,7 @@ func TestMutateNewPVC_LinkedClone_Success_ValidateTopologyAnnotation(t *testing.
 			Namespace: "default",
 			Annotations: map[string]string{
 				common.AnnKeyLinkedClone:                "true",
-				common.AnnGuestClusterRequestedTopology: "zone-1",
+				common.AnnGuestClusterRequestedTopology: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -503,7 +504,7 @@ func TestMutateNewPVC_LinkedClone_Success_ValidateTopologyAnnotation(t *testing.
 			Name:      "src-pvc",
 			Namespace: "default",
 			Annotations: map[string]string{
-				common.AnnVolumeAccessibleTopology: "zone-1",
+				common.AnnVolumeAccessibleTopology: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -571,6 +572,108 @@ func TestMutateNewPVC_LinkedClone_Success_ValidateTopologyAnnotation(t *testing.
 	mockCOInterface.AssertExpectations(t)
 }
 
+// TestMutateNewPVC_LinkedClone_Success_HostScopedTopologySkipsZoneValidation verifies that a
+// topology annotation carrying only non-zone segments (here a host-scoped one, as used for
+// host-local storage) is left alone instead of being denied. There is no zone in either
+// annotation to compare, so the mismatched hostnames must not trigger a denial.
+func TestMutateNewPVC_LinkedClone_Success_HostScopedTopologySkipsZoneValidation(t *testing.T) {
+	ctx := context.Background()
+
+	// Enable linked clone support
+	originalFeatureGate := featureIsLinkedCloneSupportEnabled
+	featureIsLinkedCloneSupportEnabled = true
+	defer func() {
+		featureIsLinkedCloneSupportEnabled = originalFeatureGate
+	}()
+
+	testPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vs1-lc-1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				common.AnnKeyLinkedClone:                "true",
+				common.AnnGuestClusterRequestedTopology: `[{"kubernetes.io/hostname":"esx-1"}]`,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			DataSource: &corev1.TypedLocalObjectReference{
+				Name:     "vs-1",
+				Kind:     "VolumeSnapshot",
+				APIGroup: func() *string { s := common.VolumeSnapshotApiGroup; return &s }(),
+			},
+			StorageClassName: &[]string{"wcpglobal-storage-profile"}[0],
+		},
+	}
+
+	// Source PVC is accessible from a different host, and neither side carries a zone.
+	sourcePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "src-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				common.AnnVolumeAccessibleTopology: `[{"kubernetes.io/hostname":"esx-2"}]`,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			StorageClassName: &[]string{"wcpglobal-storage-profile"}[0],
+		},
+	}
+
+	dataSourceRef := &corev1.ObjectReference{
+		Name:       "vs-1",
+		Namespace:  "default",
+		Kind:       "VolumeSnapshot",
+		APIVersion: common.VolumeSnapshotApiGroup,
+	}
+
+	pvcBytes, _ := json.Marshal(testPVC)
+	req := admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+			Operation: v1.Create,
+			Object:    runtime.RawExtension{Raw: pvcBytes},
+		},
+	}
+
+	mockCOInterface := &MockCOCommonInterface{}
+	mockCryptoClient := &MockCryptoClient{}
+	mockCOInterface.On("GetVolumeSnapshotPVCSource", ctx, "default", "vs-1").Return(sourcePVC, nil)
+
+	patches := gomonkey.ApplyFunc(
+		k8sorchestrator.GetPVCDataSource, func(ctx context.Context,
+			pvc *corev1.PersistentVolumeClaim) (*corev1.ObjectReference, error) {
+			return dataSourceRef, nil
+		})
+	defer patches.Reset()
+
+	webhook := &CSISupervisorMutationWebhook{
+		coCommonInterface: mockCOInterface,
+		CryptoClient:      mockCryptoClient,
+	}
+
+	response := webhook.mutateNewPVC(ctx, req)
+
+	// The request must be allowed, with only the linked-clone label patch applied. The
+	// existing requested-topology annotation is preserved untouched.
+	assert.True(t, response.Allowed)
+	assert.Equal(t, 1, len(response.Patches))
+	assert.Equal(t, "/metadata/labels", response.Patches[0].Path)
+
+	mockCOInterface.AssertExpectations(t)
+}
+
 func TestMutateNewPVC_LinkedClone_Error_TopologyMismatch(t *testing.T) {
 	ctx := context.Background()
 
@@ -588,7 +691,7 @@ func TestMutateNewPVC_LinkedClone_Error_TopologyMismatch(t *testing.T) {
 			Namespace: "default",
 			Annotations: map[string]string{
 				common.AnnKeyLinkedClone:                "true",
-				common.AnnGuestClusterRequestedTopology: "zone-2", // Different from source
+				common.AnnGuestClusterRequestedTopology: `[{"topology.kubernetes.io/zone":"zone-2"}]`, // Different from source
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -613,7 +716,8 @@ func TestMutateNewPVC_LinkedClone_Error_TopologyMismatch(t *testing.T) {
 			Name:      "src-pvc",
 			Namespace: "default",
 			Annotations: map[string]string{
-				common.AnnVolumeAccessibleTopology: "zone-1", // Different from linked clone request
+				// Different from linked clone request
+				common.AnnVolumeAccessibleTopology: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -671,7 +775,7 @@ func TestMutateNewPVC_LinkedClone_Error_TopologyMismatch(t *testing.T) {
 
 	// Verify response - should be denied due to topology mismatch
 	assert.False(t, response.Allowed)
-	assert.Contains(t, response.Result.Message, "expected accessibility requirement: zone-1 but got zone-2")
+	assert.Contains(t, response.Result.Message, "expected accessibility requirement to be a subset of")
 
 	mockCOInterface.AssertExpectations(t)
 }
@@ -744,7 +848,7 @@ func TestMutateNewPVC_LinkedClone_Error_GetDataSourceFails(t *testing.T) {
 
 	// Verify response - should be denied due to error getting data source
 	assert.False(t, response.Allowed)
-	assert.Contains(t, response.Result.Message, "failed to retrieve the linked clone source volumesnapshot")
+	assert.Contains(t, response.Result.Message, "failed to retrieve the PVC data source")
 
 	mockCOInterface.AssertExpectations(t)
 }
@@ -932,7 +1036,8 @@ func TestMutateNewPVC_LinkedClone_Error_SourcePVCMissingTopologyAnnotation(t *te
 
 	// Verify response - should be denied due to missing topology annotation on source PVC
 	assert.False(t, response.Allowed)
-	assert.Contains(t, response.Result.Message, "source PVC default/src-pvc does not have volume accessiblity annotation")
+	assert.Contains(t, response.Result.Message,
+		"source PVC default/src-pvc does not have volume accessibility annotation")
 
 	mockCOInterface.AssertExpectations(t)
 }
@@ -1028,6 +1133,27 @@ func TestMutateNewPVC_LinkedCloneDisabled_Success(t *testing.T) {
 		},
 	}
 
+	// Create source PVC without topology annotation. The generalized snapshot-restore
+	// topology propagation is independent of the linked-clone feature gate, so it still
+	// runs here (best-effort); since the source lacks the annotation, it skips silently
+	// rather than mutating or denying the request.
+	sourcePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "src-pvc",
+			Namespace:   "default",
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			StorageClassName: &[]string{"wcpglobal-storage-profile"}[0],
+		},
+	}
+
 	// Create admission request
 	pvcBytes, _ := json.Marshal(testPVC)
 	req := admission.Request{
@@ -1042,6 +1168,9 @@ func TestMutateNewPVC_LinkedCloneDisabled_Success(t *testing.T) {
 	mockCOInterface := &MockCOCommonInterface{}
 	mockCryptoClient := &MockCryptoClient{}
 
+	// Mock GetVolumeSnapshotPVCSource to return source PVC without topology annotation
+	mockCOInterface.On("GetVolumeSnapshotPVCSource", ctx, "default", "vs-1").Return(sourcePVC, nil)
+
 	// Create webhook handler
 	webhook := &CSISupervisorMutationWebhook{
 		coCommonInterface: mockCOInterface,
@@ -1052,7 +1181,204 @@ func TestMutateNewPVC_LinkedCloneDisabled_Success(t *testing.T) {
 	response := webhook.mutateNewPVC(ctx, req)
 
 	// Verify response - should be allowed without mutations since feature is disabled
+	// (no linked-clone label added, and the source PVC has no topology to propagate)
 	assert.True(t, response.Allowed)
+
+	mockCOInterface.AssertExpectations(t)
+}
+
+// TestMutateNewPVC_PlainSnapshotRestore_PropagatesTopology covers this webhook's main
+// behavior: a plain (non-linked-clone) PVC restored from a VolumeSnapshot inherits the
+// source PVC's accessible topology as its requested topology, so vm-operator can constrain
+// the consuming VM to a zone where the snapshot's data is actually reachable.
+//
+// The PVC deliberately carries no annotations at all, which is the common shape for a
+// restore into a different storage class. That exercises the nil-annotations map path,
+// where writing the propagated annotation would otherwise panic the webhook.
+func TestMutateNewPVC_PlainSnapshotRestore_PropagatesTopology(t *testing.T) {
+	ctx := context.Background()
+
+	originalFeatureGate := featureIsLinkedCloneSupportEnabled
+	featureIsLinkedCloneSupportEnabled = true
+	defer func() {
+		featureIsLinkedCloneSupportEnabled = originalFeatureGate
+	}()
+
+	// No linked-clone annotation, and no annotations map whatsoever.
+	testPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restored-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			DataSource: &corev1.TypedLocalObjectReference{
+				Name:     "vs-1",
+				Kind:     "VolumeSnapshot",
+				APIGroup: func() *string { s := common.VolumeSnapshotApiGroup; return &s }(),
+			},
+			StorageClassName: &[]string{"other-storage-profile"}[0],
+		},
+	}
+
+	sourcePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "src-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				common.AnnVolumeAccessibleTopology: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			StorageClassName: &[]string{"wcpglobal-storage-profile"}[0],
+		},
+	}
+
+	dataSourceRef := &corev1.ObjectReference{
+		Name:       "vs-1",
+		Namespace:  "default",
+		Kind:       "VolumeSnapshot",
+		APIVersion: common.VolumeSnapshotApiGroup,
+	}
+
+	pvcBytes, _ := json.Marshal(testPVC)
+	req := admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+			Operation: v1.Create,
+			Object:    runtime.RawExtension{Raw: pvcBytes},
+		},
+	}
+
+	mockCOInterface := &MockCOCommonInterface{}
+	mockCryptoClient := &MockCryptoClient{}
+	mockCOInterface.On("GetVolumeSnapshotPVCSource", ctx, "default", "vs-1").Return(sourcePVC, nil)
+
+	patches := gomonkey.ApplyFunc(
+		k8sorchestrator.GetPVCDataSource, func(ctx context.Context,
+			pvc *corev1.PersistentVolumeClaim) (*corev1.ObjectReference, error) {
+			return dataSourceRef, nil
+		})
+	defer patches.Reset()
+
+	webhook := &CSISupervisorMutationWebhook{
+		coCommonInterface: mockCOInterface,
+		CryptoClient:      mockCryptoClient,
+	}
+
+	// Must not panic even though the incoming PVC has a nil annotations map.
+	var response admission.Response
+	assert.NotPanics(t, func() {
+		response = webhook.mutateNewPVC(ctx, req)
+	})
+
+	// The request is allowed and patched with the source PVC's accessible topology.
+	assert.True(t, response.Allowed)
+	assert.NotEmpty(t, response.Patches)
+
+	// The patch creates the annotations map and carries the source PVC's topology verbatim.
+	assert.Equal(t, 1, len(response.Patches))
+	assert.Equal(t, "/metadata/annotations", response.Patches[0].Path)
+	patchJSON, err := json.Marshal(response.Patches)
+	assert.NoError(t, err)
+	assert.Contains(t, string(patchJSON), common.AnnGuestClusterRequestedTopology)
+	assert.Contains(t, string(patchJSON), "zone-1")
+
+	// No linked-clone label is added for a plain restore.
+	assert.NotContains(t, string(patchJSON), common.LinkedClonePVCLabel)
+
+	mockCOInterface.AssertExpectations(t)
+}
+
+// TestMutateNewPVC_PlainSnapshotRestore_SourcePVCUnresolvable_Allowed verifies that a plain
+// restore is allowed through when the source PVC cannot be resolved — the case for a
+// pre-provisioned snapshot, which is bound to a VolumeSnapshotContent and has no source PVC
+// in this cluster. There is no topology to propagate, so the webhook skips the hint rather
+// than blocking the request; the CSI driver still fails fast later if the zone genuinely
+// cannot reach the data. Contrast with the linked-clone path, which denies (see
+// TestMutateNewPVC_LinkedClone_Error_GetSourcePVCFails).
+func TestMutateNewPVC_PlainSnapshotRestore_SourcePVCUnresolvable_Allowed(t *testing.T) {
+	ctx := context.Background()
+
+	originalFeatureGate := featureIsLinkedCloneSupportEnabled
+	featureIsLinkedCloneSupportEnabled = true
+	defer func() {
+		featureIsLinkedCloneSupportEnabled = originalFeatureGate
+	}()
+
+	testPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restored-from-preprovisioned",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			DataSource: &corev1.TypedLocalObjectReference{
+				Name:     "preprovisioned-snap",
+				Kind:     "VolumeSnapshot",
+				APIGroup: func() *string { s := common.VolumeSnapshotApiGroup; return &s }(),
+			},
+			StorageClassName: &[]string{"wcpglobal-storage-profile"}[0],
+		},
+	}
+
+	dataSourceRef := &corev1.ObjectReference{
+		Name:       "preprovisioned-snap",
+		Namespace:  "default",
+		Kind:       "VolumeSnapshot",
+		APIVersion: common.VolumeSnapshotApiGroup,
+	}
+
+	pvcBytes, _ := json.Marshal(testPVC)
+	req := admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+			Operation: v1.Create,
+			Object:    runtime.RawExtension{Raw: pvcBytes},
+		},
+	}
+
+	mockCOInterface := &MockCOCommonInterface{}
+	mockCryptoClient := &MockCryptoClient{}
+
+	// A pre-provisioned snapshot has no source PVC, so the lookup returns an error.
+	mockCOInterface.On("GetVolumeSnapshotPVCSource", ctx, "default", "preprovisioned-snap").
+		Return(nil, fmt.Errorf("volumesnapshot default/preprovisioned-snap has no source PVC "+
+			"(pre-provisioned from a VolumeSnapshotContent)"))
+
+	patches := gomonkey.ApplyFunc(
+		k8sorchestrator.GetPVCDataSource, func(ctx context.Context,
+			pvc *corev1.PersistentVolumeClaim) (*corev1.ObjectReference, error) {
+			return dataSourceRef, nil
+		})
+	defer patches.Reset()
+
+	webhook := &CSISupervisorMutationWebhook{
+		coCommonInterface: mockCOInterface,
+		CryptoClient:      mockCryptoClient,
+	}
+
+	response := webhook.mutateNewPVC(ctx, req)
+
+	// Allowed, with no topology annotation invented and no denial.
+	assert.True(t, response.Allowed)
+	assert.Empty(t, response.Patches)
 
 	mockCOInterface.AssertExpectations(t)
 }

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -373,7 +373,7 @@ func TestMutateNewPVC_LinkedClone_Success_SetTopologyAnnotation(t *testing.T) {
 			Name:      "src-pvc",
 			Namespace: "default",
 			Annotations: map[string]string{
-				common.AnnVolumeAccessibleTopology: "zone-1",
+				common.AnnVolumeAccessibleTopology: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -469,7 +469,7 @@ func TestMutateNewPVC_LinkedClone_Success_ValidateTopologyAnnotation(t *testing.
 			Namespace: "default",
 			Annotations: map[string]string{
 				common.AnnKeyLinkedClone:                "true",
-				common.AnnGuestClusterRequestedTopology: "zone-1",
+				common.AnnGuestClusterRequestedTopology: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -494,7 +494,7 @@ func TestMutateNewPVC_LinkedClone_Success_ValidateTopologyAnnotation(t *testing.
 			Name:      "src-pvc",
 			Namespace: "default",
 			Annotations: map[string]string{
-				common.AnnVolumeAccessibleTopology: "zone-1",
+				common.AnnVolumeAccessibleTopology: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -579,7 +579,7 @@ func TestMutateNewPVC_LinkedClone_Error_TopologyMismatch(t *testing.T) {
 			Namespace: "default",
 			Annotations: map[string]string{
 				common.AnnKeyLinkedClone:                "true",
-				common.AnnGuestClusterRequestedTopology: "zone-2", // Different from source
+				common.AnnGuestClusterRequestedTopology: `[{"topology.kubernetes.io/zone":"zone-2"}]`, // Different from source
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -604,7 +604,8 @@ func TestMutateNewPVC_LinkedClone_Error_TopologyMismatch(t *testing.T) {
 			Name:      "src-pvc",
 			Namespace: "default",
 			Annotations: map[string]string{
-				common.AnnVolumeAccessibleTopology: "zone-1", // Different from linked clone request
+				// Different from linked clone request
+				common.AnnVolumeAccessibleTopology: `[{"topology.kubernetes.io/zone":"zone-1"}]`,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -662,7 +663,7 @@ func TestMutateNewPVC_LinkedClone_Error_TopologyMismatch(t *testing.T) {
 
 	// Verify response - should be denied due to topology mismatch
 	assert.False(t, response.Allowed)
-	assert.Contains(t, response.Result.Message, "expected accessibility requirement: zone-1 but got zone-2")
+	assert.Contains(t, response.Result.Message, "expected accessibility requirement to be a subset of")
 
 	mockCOInterface.AssertExpectations(t)
 }
@@ -735,7 +736,7 @@ func TestMutateNewPVC_LinkedClone_Error_GetDataSourceFails(t *testing.T) {
 
 	// Verify response - should be denied due to error getting data source
 	assert.False(t, response.Allowed)
-	assert.Contains(t, response.Result.Message, "failed to retrieve the linked clone source volumesnapshot")
+	assert.Contains(t, response.Result.Message, "failed to retrieve the PVC data source")
 
 	mockCOInterface.AssertExpectations(t)
 }
@@ -1019,6 +1020,27 @@ func TestMutateNewPVC_LinkedCloneDisabled_Success(t *testing.T) {
 		},
 	}
 
+	// Create source PVC without topology annotation. The generalized snapshot-restore
+	// topology propagation is independent of the linked-clone feature gate, so it still
+	// runs here (best-effort); since the source lacks the annotation, it skips silently
+	// rather than mutating or denying the request.
+	sourcePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "src-pvc",
+			Namespace:   "default",
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			StorageClassName: &[]string{"wcpglobal-storage-profile"}[0],
+		},
+	}
+
 	// Create admission request
 	pvcBytes, _ := json.Marshal(testPVC)
 	req := admission.Request{
@@ -1033,6 +1055,9 @@ func TestMutateNewPVC_LinkedCloneDisabled_Success(t *testing.T) {
 	mockCOInterface := &MockCOCommonInterface{}
 	mockCryptoClient := &MockCryptoClient{}
 
+	// Mock GetVolumeSnapshotPVCSource to return source PVC without topology annotation
+	mockCOInterface.On("GetVolumeSnapshotPVCSource", ctx, "default", "vs-1").Return(sourcePVC, nil)
+
 	// Create webhook handler
 	webhook := &CSISupervisorMutationWebhook{
 		coCommonInterface: mockCOInterface,
@@ -1043,6 +1068,7 @@ func TestMutateNewPVC_LinkedCloneDisabled_Success(t *testing.T) {
 	response := webhook.mutateNewPVC(ctx, req)
 
 	// Verify response - should be allowed without mutations since feature is disabled
+	// (no linked-clone label added, and the source PVC has no topology to propagate)
 	assert.True(t, response.Allowed)
 
 	mockCOInterface.AssertExpectations(t)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixes an intermittent failure where a WaitForFirstConsumer PVC restored from a `VolumeSnapshot` gets stuck `Pending` when its consuming VM Service VM is scheduled into a vSphere zone that cannot physically reach the snapshot's source data (isolated per-cluster vSAN, `MultipleClustersPerVsphereZone` enabled).

Root cause: vm-operator schedules the VM based on DRS capacity alone, with no awareness of the PVC's snapshot origin. When the VM lands in a zone that cannot see the snapshot's datastore, `getAccessibleClustersForSnapshot` resolves zero accessible clusters, both `CnsVolumeCreateSpec.Datastores` and `.ActiveClusters` end up empty, and CNS rejects the request with an opaque `ServerFaultCode: A specified parameter was not correct: createSpecs.datastores`. Because the outcome depends entirely on which zone DRS happens to pick at schedule time, the failure is non-deterministic — it passes whenever the VM lands in the snapshot's original zone and fails otherwise.

**The fix is on the scheduling side.** Generalize the CNS-CSI mutating webhook's zone propagation (`cnscsi_admissionhandler.go`, `mutateNewPVC`). Previously only `linked-clone` PVCs had their `csi.vsphere.volume-requested-topology` annotation auto-populated from the source PVC's `csi.vsphere.volume-accessible-topology`. This now applies to **any** PVC restoring from a `VolumeSnapshot`. Since vm-operator's `GetPVCZoneConstraints` already reads `volume-requested-topology` to constrain VM placement (`Placement()` in `zone_placement.go`), this closes the loop: the VM can no longer be placed in a zone where the snapshot data is unreachable in the first place. No vm-operator changes were needed — it already consumes this annotation correctly, it just was not being set for plain (non-linked-clone) restores.

Generalizing that code path surfaced several latent defects in it, fixed here:

- **Webhook panic on a nil annotations map.** Writing the propagated annotation onto a restored PVC that carries no annotations at all — the common shape when restoring into a different storage class — panicked the webhook and failed the PVC create with `admission webhook "mutation.csi.vsphere.vmware.com" denied the request: panic: assignment to entry in nil map`. This is what broke WCP precheckin #1871 on `Volume restore using snapshot on a different storageclass`.
- **Webhook panic on pre-provisioned snapshots.** `K8sOrchestrator.GetVolumeSnapshotPVCSource` dereferenced `VolumeSnapshot.Spec.Source.PersistentVolumeClaimName` without a nil check. `VolumeSnapshotSource` is a union, so that pointer is nil for a snapshot bound via `volumeSnapshotContentName`. Broadening the caller from linked-clone-only to every snapshot restore made this reachable. It now returns a descriptive error, and a plain restore logs and skips topology propagation — there is no source PVC to derive a zone from, which is fine. This matches how the sibling `validateLinkedClone` webhook already treats statically-provisioned snapshots (`validatepvc.go`, "If the VolumeSnapshot is statically provisioned, we don't need to validate based on the source PVC").
- **Exact-string topology comparison.** The linked-clone validation used `strings.Compare` for an exact match between requested and accessible topology, which false-positive-rejects on harmless JSON key/array reordering and disallows a legitimately narrower (subset) request. Replaced with a zone-set subset check.
- **False denial of non-zone topologies.** That subset check treated "no `topology.kubernetes.io/zone` segments" as a failure, but both annotations legitimately carry host-scoped segments (`kubernetes.io/hostname`) for host-local storage — written by `wcpguest/controller.go` and read by `csinodetopology_controller.go`. Zone validation is now skipped when either side has no zone segments, since there is no zone constraint to compare.
- **`GetPVCDataSource` nil dereference** when a linked-clone-annotated PVC had no data source at all. Now returns a clean `Denied` response.
- **Dead linked-clone label guard.** `if _, ok := Labels[AnnKeyLinkedClone]` tested an *annotation* key against the labels map, so it never matched and the guarded write always ran. Now checks `LinkedClonePVCLabel`, the key actually being set. Same fix applied to the identical guard in `k8sorchestrator.go`.
- Typos in a denial message (`accessiblity`, `requrirement`) and two log strings (`volumesnaphot`).

**No behavioral change in `CreateVolume`.** An earlier revision of this PR added `len(vSphereClusterMorefs) == 0` fail-fast checks in the `MultipleClustersPerVsphereZone` path. Those were **removed** during review — see "Special notes" below. All that remains in `controller.go` is a diagnostic log, emitted only when *every* placement mechanism is empty (no candidate hosts, no candidate datastores, no active clusters), which records the request shape so the subsequent CNS failure is attributable. It does not reject the request; CNS remains the authority on whether a create spec is valid.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

- `make build` — clean (Linux CSI, Windows CSI, syncer).
- `make check` — **0 issues** (fmt, mdlint, shellcheck, staticcheck, vet, golangci-lint including `lll` and `misspell`).
- `make unit-test` — **42 packages pass, 0 failures.**

New tests:

| Test | Expected outcome |
| --- | --- |
| `TestGetVolumeSnapshotPVCSource/dynamic_snapshot_resolves_its_source_PVC` | Returns the source PVC, no error |
| `TestGetVolumeSnapshotPVCSource/pre-provisioned_snapshot_errors_instead_of_panicking` | Returns `(nil, error)` and does **not** panic |
| `TestGetVolumeSnapshotPVCSource/empty_source_PVC_name_errors_instead_of_a_bogus_lookup` | Returns `(nil, error)` rather than issuing a `Get("")` |
| `TestGetVolumeSnapshotPVCSource/missing_snapshot_errors` | Returns `(nil, error)` |
| `TestGetVolumeSnapshotPVCSource/empty_snapshot_name_errors` | Returns `(nil, error)` |
| `TestMutateNewPVC_PlainSnapshotRestore_PropagatesTopology` | PVC with a **nil annotations map** restored from a snapshot is allowed, does not panic, and receives exactly one patch at `/metadata/annotations` carrying the source's zone; no linked-clone label is added |
| `TestMutateNewPVC_PlainSnapshotRestore_SourcePVCUnresolvable_Allowed` | Pre-provisioned snapshot restore is allowed with zero patches and no denial |
| `TestMutateNewPVC_LinkedClone_Success_HostScopedTopologySkipsZoneValidation` | Host-scoped topologies with mismatched hostnames and no zone segments are allowed, not denied |

Modified tests:

| Test | Change |
| --- | --- |
| `TestRestoreFromHostLocalSnapshotPinsPlacementToSourceHost/shared_target_supplies_source_host_datastores_instead_of_clusters` | Now also asserts `status.Code(err) != codes.FailedPrecondition`, so a host-pinned restore can never be rejected by a placement pre-check. Deliberately not `err == nil`: the subtest tolerates unrelated simulator provisioning failures, so only the error *class* is durable |
| `TestMutateNewPVC_LinkedClone_Error_TopologyMismatch` | Fixtures use the real annotation JSON; assertion updated from exact-match to subset semantics |
| `TestMutateNewPVC_LinkedClone_Error_GetDataSourceFails` | Assertion updated — the data-source lookup is no longer linked-clone-specific |
| `TestMutateNewPVC_LinkedClone_Error_SourcePVCMissingTopologyAnnotation` | Assertion updated for the `accessiblity` → `accessibility` typo fix |
| `TestMutateNewPVC_LinkedClone_Success_SetTopologyAnnotation`, `..._ValidateTopologyAnnotation` | Fixtures changed from bare `"zone-1"` to `[{"topology.kubernetes.io/zone":"zone-1"}]`, the format the annotation actually uses |
| `TestMutateNewPVC_LinkedCloneDisabled_Success` | Added a `GetVolumeSnapshotPVCSource` mock, since topology propagation now runs independently of the linked-clone feature gate |

The strengthened `FailedPrecondition` assertion was verified to actually catch the regression it targets: temporarily reintroducing the removed guard makes that subtest fail with `a host-pinned restore must not be rejected by a placement precondition`.

Precheckin pipelines:

- WCP Pre-checkins (PASS): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1918/
- VKS Pre-checkins (PASS): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1461/
**Special notes for your reviewer**:


**Release note**:
```release-note
```

