### PR TITLE
Fix linked-clone creation from snapshot for host-local volumes

### DIFF
--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -442,3 +442,88 @@ func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
 		})
 	}
 }
+
+// TestCreateBlockVolumeLinkedCloneHostLocalUsesDatastoresNotHosts verifies that, for a host-local
+// linked-clone-from-snapshot request, CreateBlockVolumeUtil populates CnsVolumeCreateSpec.Datastores
+// (from the resolved source-volume datastore supplied via sharedDatastores) and does not set
+// CnsVolumeCreateSpec.Hosts, even though spec.Hosts (the host-local candidate host set) is non-empty.
+// CNS rejects a linked-clone create spec that sets `hosts` ("volumeCreateSpec only accepts datastores
+// when creating linkedClone").
+func TestCreateBlockVolumeLinkedCloneHostLocalUsesDatastoresNotHosts(t *testing.T) {
+	datastoreMoRef := types.ManagedObjectReference{Type: "Datastore", Value: "datastore-hostlocal"}
+	datastoreURL := "ds:///vmfs/volumes/hostlocal-datastore/"
+	hostMoRef := types.ManagedObjectReference{Type: "HostSystem", Value: "host-1"}
+
+	// Mock getVCenterInternal to return a mock VirtualCenter.
+	originalGetVCenter := getVCenterInternal
+	getVCenterInternal = func(_ context.Context, _ *Manager) (*vsphere.VirtualCenter, error) {
+		return &vsphere.VirtualCenter{
+			Config: &vsphere.VirtualCenterConfig{
+				Host:            "test-vc",
+				DatacenterPaths: []string{},
+			},
+		}, nil
+	}
+	defer func() { getVCenterInternal = originalGetVCenter }()
+
+	// Mock queryVolumeByIDInternal to return the datastore URL of the source volume.
+	originalQueryVolumeByID := queryVolumeByIDInternal
+	queryVolumeByIDInternal = func(_ context.Context, _ cnsvolume.Manager, _ string,
+		_ *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
+		return &cnstypes.CnsVolume{DatastoreUrl: datastoreURL}, nil
+	}
+	defer func() { queryVolumeByIDInternal = originalQueryVolumeByID }()
+
+	// Track the create spec passed to CreateVolume.
+	var capturedCreateSpec *cnstypes.CnsVolumeCreateSpec
+	mockVolumeManager := &mockVolumeManager{
+		createVolumeFunc: func(_ context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+			_ interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+			capturedCreateSpec = spec
+			return &cnsvolume.CnsVolumeInfo{VolumeID: cnstypes.CnsVolumeId{Id: "test-volume-id"}}, "", nil
+		},
+	}
+
+	manager := &Manager{
+		VolumeManager: mockVolumeManager,
+		CnsConfig:     &config.Config{},
+	}
+	manager.CnsConfig.Global.ClusterID = "test-cluster"
+	manager.CnsConfig.VirtualCenter = map[string]*config.VirtualCenterConfig{
+		"test-vc": {User: "test-user"},
+	}
+
+	hostLocalDatastoreInfo := &vsphere.DatastoreInfo{
+		Datastore: &vsphere.Datastore{Datastore: object.NewDatastore(nil, datastoreMoRef)},
+		Info:      &types.DatastoreInfo{Url: datastoreURL},
+	}
+
+	// spec.Hosts mirrors what the WCP controller resolves for a host-local request; despite being
+	// non-empty here, it must not end up on the create spec for a linked clone.
+	spec := &CreateVolumeSpec{
+		Name:                    "test-volume",
+		CapacityMB:              1024,
+		VolumeType:              BlockVolumeType,
+		ContentSourceSnapshotID: "source-volume-id+snapshot-id",
+		ScParams:                &StorageClassParams{},
+		IsLinkedCloneRequest:    true,
+		Hosts:                   []types.ManagedObjectReference{hostMoRef},
+	}
+
+	// sharedDatastores mirrors what getDatastoresForHostLocalLinkedClone resolves in the WCP
+	// controller: the single host-local datastore of the source volume.
+	sharedDatastores := []*vsphere.DatastoreInfo{hostLocalDatastoreInfo}
+
+	_, _, err := CreateBlockVolumeUtil(context.Background(), cnstypes.CnsClusterFlavorWorkload,
+		manager, spec, sharedDatastores, []string{}, CreateBlockVolumeOptions{},
+		&cnsvolume.CreateVolumeExtraParams{IsMultipleClustersPerVsphereZoneEnabled: true})
+
+	assert.NoError(t, err, "CreateBlockVolumeUtil should not return an error")
+	assert.NotNil(t, capturedCreateSpec, "Create spec should have been captured")
+	assert.Len(t, capturedCreateSpec.Datastores, 1, "Datastores should be set to the source volume's datastore")
+	assert.Equal(t, datastoreMoRef, capturedCreateSpec.Datastores[0])
+	assert.Empty(t, capturedCreateSpec.Hosts, "Hosts must not be set on a linked clone create spec")
+	snapshotVolumeSource, ok := capturedCreateSpec.VolumeSource.(*cnstypes.CnsSnapshotVolumeSource)
+	assert.True(t, ok, "VolumeSource should be a CnsSnapshotVolumeSource")
+	assert.True(t, snapshotVolumeSource.LinkedClone, "LinkedClone should be true")
+}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -809,6 +809,14 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			// ("createSpecs.hosts and createSpecs.activeClusters cannot both be set"). For a
 			// host-local request the candidate hosts (built below) are supplied instead of
 			// clusters, so vSphereClusterMorefs is intentionally left empty here.
+			linkedCloneDatastores, err := c.getDatastoresForHostLocalLinkedClone(ctx, req,
+				linkedCloneSupportEnabled, isLinkedCloneRequest)
+			if err != nil {
+				return nil, csifault.CSIInternalFault, err
+			}
+			if linkedCloneDatastores != nil {
+				sharedDatastores = linkedCloneDatastores
+			}
 		} else if zoneLabelPresent {
 			if !isWorkloadDomainIsolationEnabled {
 				if storageTopologyType == "" {
@@ -914,6 +922,14 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			}
 		} else if hostnameLabelPresent {
 			log.Infof("Host Local volume provisioning with requirement: %+v", topologyRequirement)
+			linkedCloneDatastores, err := c.getDatastoresForHostLocalLinkedClone(ctx, req,
+				linkedCloneSupportEnabled, isLinkedCloneRequest)
+			if err != nil {
+				return nil, csifault.CSIInternalFault, err
+			}
+			if linkedCloneDatastores != nil {
+				sharedDatastores = linkedCloneDatastores
+			}
 		} else {
 			// No topology labels present in the topologyRequirement
 			if isWorkloadDomainIsolationEnabled {
@@ -1186,13 +1202,8 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			// For host-local volumes, build the PV node affinity (zone + hostname) from the host
 			// that CNS selected, reported in the placement result. Publishing both keys pins pods
 			// to the specific host the volume was provisioned on.
-			var segments map[string]string
-			if volumeInfo.Host != nil {
-				segments, err = getHostLocalAccessibleTopology(ctx, *volumeInfo.Host, hostMoIDToTopology)
-			} else {
-				err = logger.LogNewErrorf(log, "CNS did not return a host in the placement result "+
-					"for host-local volume %q", volumeInfo.VolumeID.Id)
-			}
+			segments, err := resolveHostLocalAccessibleTopologySegments(ctx, isLinkedCloneRequest,
+				hostMoRefs, hostMoIDToTopology, volumeInfo.Host, volumeInfo.VolumeID.Id)
 			if err != nil {
 				// The provisioned volume is unusable without correct host affinity, so clean it up.
 				log.Errorf("Encountered error building host-local topology after creating volume. Cleaning up...")
@@ -1602,6 +1613,34 @@ func (c *controller) getDatastoreForLinkedCloneRequest(
 
 	return nil, logger.LogNewErrorf(log,
 		"getDatastoreForLinkedCloneRequest: datastore with URL %q not found in any datacenter", datastoreURL)
+}
+
+// getDatastoresForHostLocalLinkedClone resolves the datastore(s) to supply in the
+// CnsVolumeCreateSpec for a host-local linked-clone request. CNS only accepts `datastores` (not
+// `hosts`) when creating a linked clone. For a host-local volume, this is the datastore exclusive
+// to the single ESX host that owns the source volume - not a datastore shared across hosts, despite
+// the name of the `sharedDatastores` variable it feeds into at the call site, which is only reused
+// here as plumbing to reach CreateBlockVolumeUtil's Datastores-based code path.
+//
+// Returns nil if the request is not a linked-clone-from-snapshot request.
+func (c *controller) getDatastoresForHostLocalLinkedClone(ctx context.Context, req *csi.CreateVolumeRequest,
+	linkedCloneSupportEnabled, isLinkedCloneRequest bool) ([]*cnsvsphere.DatastoreInfo, error) {
+	if req.GetVolumeContentSource() == nil || !linkedCloneSupportEnabled || !isLinkedCloneRequest {
+		return nil, nil
+	}
+	log := logger.GetLogger(ctx)
+	snapshotSource := req.GetVolumeContentSource().GetSnapshot()
+	if snapshotSource == nil || snapshotSource.GetSnapshotId() == "" {
+		return nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
+			"linked clone request must specify a snapshot as VolumeContentSource")
+	}
+	snapshotID := snapshotSource.GetSnapshotId()
+	datastoreInfo, err := c.getDatastoreForLinkedCloneRequest(ctx, snapshotID)
+	if err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to retrieve datastore for linked clone request (snapshot: %q): %v", snapshotID, err)
+	}
+	return []*cnsvsphere.DatastoreInfo{datastoreInfo}, nil
 }
 
 // createFileVolume creates a file volume based on the CreateVolumeRequest.

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -591,6 +591,34 @@ func getHostLocalAccessibleTopology(ctx context.Context, hostRef vimtypes.Manage
 	return segments, nil
 }
 
+// resolveHostLocalAccessibleTopologySegments returns the topology segments (zone + hostname) to
+// publish as PV node affinity for a host-local volume.
+//
+// For ordinary host-local volumes, CNS is supplied a candidate host set via `hosts` and reports the
+// host it selected in the placement result (selectedHost); the segments are looked up from that host.
+//
+// For linked-clone host-local volumes, CNS is instead supplied `datastores` (CNS rejects `hosts` when
+// creating a linked clone), so the placement result never reports a selected host. The target host is
+// nonetheless already known deterministically: it's the same host as the source volume, i.e. the
+// single candidate host resolved from the accessibility requirement (hostMoRefs).
+func resolveHostLocalAccessibleTopologySegments(ctx context.Context, isLinkedCloneRequest bool,
+	hostMoRefs []vimtypes.ManagedObjectReference, hostMoIDToTopology map[string]map[string]string,
+	selectedHost *vimtypes.ManagedObjectReference, volumeID string) (map[string]string, error) {
+	log := logger.GetLogger(ctx)
+	if isLinkedCloneRequest {
+		if len(hostMoRefs) != 1 {
+			return nil, logger.LogNewErrorf(log, "expected exactly one candidate host for host-local "+
+				"linked clone volume %q, got %d", volumeID, len(hostMoRefs))
+		}
+		return getHostLocalAccessibleTopology(ctx, hostMoRefs[0], hostMoIDToTopology)
+	}
+	if selectedHost == nil {
+		return nil, logger.LogNewErrorf(log, "CNS did not return a host in the placement result "+
+			"for host-local volume %q", volumeID)
+	}
+	return getHostLocalAccessibleTopology(ctx, *selectedHost, hostMoIDToTopology)
+}
+
 // GetVolumeToHostMapping returns a map containing VM MoID to host MoID and VolumeID
 // and VM MoID. This map is constructed by fetching all virtual machines belonging to each host.
 // Look up for VMs will be performed in the supplied list of clusterComputeResourceMoIds

--- a/pkg/csi/service/wcp/controller_helper_test.go
+++ b/pkg/csi/service/wcp/controller_helper_test.go
@@ -453,3 +453,52 @@ func TestGetHostLocalAccessibleTopology(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+// TestResolveHostLocalAccessibleTopologySegments verifies that the PV node-affinity segments for a
+// host-local volume are derived correctly for both the ordinary case (from the host CNS reports in
+// the placement result) and the linked-clone case, where CNS never reports a selected host because
+// only `datastores` (not `hosts`) is supplied for a linked clone create request - the segments must
+// instead come from the single candidate host already known from the accessibility requirement.
+func TestResolveHostLocalAccessibleTopologySegments(t *testing.T) {
+	ctx := context.Background()
+	hostTopo := map[string]map[string]string{
+		"host-1": {v1.LabelHostname: "node-a", v1.LabelTopologyZone: "zone-1"},
+		"host-2": {v1.LabelHostname: "node-b", v1.LabelTopologyZone: "zone-2"},
+	}
+	hostRef1 := vimtypes.ManagedObjectReference{Type: "HostSystem", Value: "host-1"}
+	hostRef2 := vimtypes.ManagedObjectReference{Type: "HostSystem", Value: "host-2"}
+
+	t.Run("ordinary_host_local_uses_selected_host", func(t *testing.T) {
+		segments, err := resolveHostLocalAccessibleTopologySegments(ctx, false,
+			[]vimtypes.ManagedObjectReference{hostRef1, hostRef2}, hostTopo, &hostRef2, "vol-1")
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{v1.LabelHostname: "node-b", v1.LabelTopologyZone: "zone-2"}, segments)
+	})
+
+	t.Run("ordinary_host_local_no_selected_host_errors", func(t *testing.T) {
+		_, err := resolveHostLocalAccessibleTopologySegments(ctx, false,
+			[]vimtypes.ManagedObjectReference{hostRef1}, hostTopo, nil, "vol-1")
+		assert.Error(t, err)
+	})
+
+	t.Run("linked_clone_uses_single_candidate_host_ignoring_selected_host", func(t *testing.T) {
+		// Linked clone requests never get a selected host back from CNS (nil here), but the segments
+		// should still resolve from the sole candidate host.
+		segments, err := resolveHostLocalAccessibleTopologySegments(ctx, true,
+			[]vimtypes.ManagedObjectReference{hostRef1}, hostTopo, nil, "vol-1")
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{v1.LabelHostname: "node-a", v1.LabelTopologyZone: "zone-1"}, segments)
+	})
+
+	t.Run("linked_clone_with_no_candidate_hosts_errors", func(t *testing.T) {
+		_, err := resolveHostLocalAccessibleTopologySegments(ctx, true,
+			nil, hostTopo, nil, "vol-1")
+		assert.Error(t, err)
+	})
+
+	t.Run("linked_clone_with_multiple_candidate_hosts_errors", func(t *testing.T) {
+		_, err := resolveHostLocalAccessibleTopologySegments(ctx, true,
+			[]vimtypes.ManagedObjectReference{hostRef1, hostRef2}, hostTopo, nil, "vol-1")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -1425,6 +1425,130 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 	}
 }
 
+// TestGetDatastoresForHostLocalLinkedClone verifies the datastore resolution used by the host-local
+// linked-clone-from-snapshot path: it must resolve to the single datastore of the source volume when
+// the request is an eligible linked-clone-from-snapshot request, and return nil otherwise.
+func TestGetDatastoresForHostLocalLinkedClone(t *testing.T) {
+	ct := getControllerTest(t)
+
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         map[string]string{},
+		VolumeCapabilities: capabilities,
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	volID := respCreate.Volume.VolumeId
+	defer func() {
+		if _, err := ct.controller.DeleteVolume(ctx, &csi.DeleteVolumeRequest{VolumeId: volID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	reqCreateSnapshot := &csi.CreateSnapshotRequest{
+		SourceVolumeId: volID,
+		Name:           "snapshot-" + uuid.New().String(),
+		Parameters: map[string]string{
+			common.VolumeSnapshotNamespaceKey: "default",
+		},
+	}
+	respCreateSnapshot, err := ct.controller.CreateSnapshot(ctx, reqCreateSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapID := respCreateSnapshot.Snapshot.SnapshotId
+	defer func() {
+		if _, err := ct.controller.DeleteSnapshot(ctx, &csi.DeleteSnapshotRequest{SnapshotId: snapID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	contentSource := &csi.VolumeContentSource{
+		Type: &csi.VolumeContentSource_Snapshot{
+			Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: snapID},
+		},
+	}
+
+	t.Run("nil_when_no_content_source", func(t *testing.T) {
+		datastores, err := ct.controller.getDatastoresForHostLocalLinkedClone(ctx,
+			&csi.CreateVolumeRequest{}, true, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if datastores != nil {
+			t.Fatalf("expected nil datastores, got: %+v", datastores)
+		}
+	})
+
+	t.Run("nil_when_linked_clone_support_disabled", func(t *testing.T) {
+		req := &csi.CreateVolumeRequest{VolumeContentSource: contentSource}
+		datastores, err := ct.controller.getDatastoresForHostLocalLinkedClone(ctx, req, false, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if datastores != nil {
+			t.Fatalf("expected nil datastores, got: %+v", datastores)
+		}
+	})
+
+	t.Run("nil_when_not_a_linked_clone_request", func(t *testing.T) {
+		req := &csi.CreateVolumeRequest{VolumeContentSource: contentSource}
+		datastores, err := ct.controller.getDatastoresForHostLocalLinkedClone(ctx, req, true, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if datastores != nil {
+			t.Fatalf("expected nil datastores, got: %+v", datastores)
+		}
+	})
+
+	t.Run("resolves_source_volume_datastore_for_eligible_request", func(t *testing.T) {
+		req := &csi.CreateVolumeRequest{VolumeContentSource: contentSource}
+		datastores, err := ct.controller.getDatastoresForHostLocalLinkedClone(ctx, req, true, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if len(datastores) != 1 {
+			t.Fatalf("expected exactly one resolved datastore, got: %d", len(datastores))
+		}
+
+		expectedDatastore, err := ct.controller.getDatastoreForLinkedCloneRequest(ctx, snapID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if datastores[0].Info.Url != expectedDatastore.Info.Url {
+			t.Fatalf("expected resolved datastore URL %q to match source volume's datastore URL %q",
+				datastores[0].Info.Url, expectedDatastore.Info.Url)
+		}
+	})
+
+	t.Run("error_on_malformed_snapshot_id", func(t *testing.T) {
+		req := &csi.CreateVolumeRequest{
+			VolumeContentSource: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Snapshot{
+					Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: "malformed-snapshot-id"},
+				},
+			},
+		}
+		_, err := ct.controller.getDatastoresForHostLocalLinkedClone(ctx, req, true, true)
+		if err == nil {
+			t.Fatal("expected an error for a malformed snapshot ID, got nil")
+		}
+	})
+}
+
 func TestWCPDeleteVolumeWithSnapshots(t *testing.T) {
 	ct := getControllerTest(t)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CNS rejects CnsVolumeCreateSpec.Hosts when volumeSource.linkedClone is true, requiring Datastores instead. For host-local linked-clone requests, resolve the source volume's (host-exclusive) datastore via getDatastoreForLinkedCloneRequest and supply it as Datastores, and derive the PV's host-local topology from the known candidate host instead of relying on CNS to report a placement Host.


**Testing done**:
After replacing image with this change. new linked clone PVC is getting created from snapshot of hostlocal PVC.

```
# k describe pvc -n ns-for-auto csi.hostlocal.snapshotlinkedclonetest-lc-193563981  
Name:          csi.hostlocal.snapshotlinkedclonetest-lc-193563981
Namespace:     ns-for-auto
StorageClass:  host-local-profile
Status:        Bound
Volume:        pvc-d13cd551-4c8f-474f-9fea-0ac625575148
Labels:        linked-clone=true
Annotations:   csi.vsphere.volume-accessible-topology:
                 [{"kubernetes.io/hostname":"lvn-dvm-10-192-53-74.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]
               csi.vsphere.volume-requested-topology:
                 [{"kubernetes.io/hostname":"lvn-dvm-10-192-53-74.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]
               csi.vsphere.volume/fast-provisioning: true
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      2Gi
Access Modes:  RWO
VolumeMode:    Filesystem
DataSource:
  APIGroup:  snapshot.storage.k8s.io
  Kind:      VolumeSnapshot
  Name:      csi.hostlocal.snapshotlinkedclonetest-snap1-733311680
Used By:     <none>
Events:
  Type     Reason                 Age                     From                                                                                          Message
  ----     ------                 ----                    ----                                                                                          -------
  Normal   ExternalProvisioning   2m44s (x3782 over 15h)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal   Provisioning           2m32s (x260 over 15h)   csi.vsphere.vmware.com_422de9edff966480a1ea19961f05743f_3c9c81cc-f0c1-4329-94ff-c76b7308f7b4  External provisioner is provisioning volume for claim "ns-for-auto/csi.hostlocal.snapshotlinkedclonetest-lc-193563981"
  Warning  ProvisioningFailed     2m31s (x260 over 15h)   csi.vsphere.vmware.com_422de9edff966480a1ea19961f05743f_3c9c81cc-f0c1-4329-94ff-c76b7308f7b4  rpc error: code = Internal desc = failed to create volume. Error: ServerFaultCode: A specified parameter was not correct: volumeCreateSpec.datastores
  Warning  ProvisioningFailed     67s (x4 over 74s)       csi.vsphere.vmware.com_422de9edff966480a1ea19961f05743f_ead27fde-cd77-44df-98c2-1d1a36f7efe1  rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:29000: connect: connection refused"
  Normal   Provisioning           52s (x6 over 74s)       csi.vsphere.vmware.com_422de9edff966480a1ea19961f05743f_ead27fde-cd77-44df-98c2-1d1a36f7efe1  External provisioner is provisioning volume for claim "ns-for-auto/csi.hostlocal.snapshotlinkedclonetest-lc-193563981"

```

**Special notes for your reviewer**:

Pre-checkin 

- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1874/ 
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```

- https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1428/

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix linked-clone creation from snapshot for host-local volumes
```
