### PR TITLE
Annotate all supervisor volumes with appropriate category

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -151,6 +151,7 @@ function build_driver_images_linux() {
 function build_syncer_image_linux() {
   echo "building ${SYNCER_IMAGE_NAME}:${VERSION} for linux"
   docker buildx build --platform "linux/$ARCH"\
+      --output "${LINUX_IMAGE_OUTPUT}" \
       -f images/syncer/Dockerfile \
       -t "${SYNCER_IMAGE_NAME}":"${VERSION}" \
       --build-arg "VERSION=${VERSION}" \

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -466,7 +466,7 @@ const (
 	// and is used to specify the `CnsBackingType` during volume attachment.
 	AnnKeyBackingDiskType = "cns.vmware.com.protected/disk-backing"
 
-	// AnnPrefixVKSWorkloadType is the common prefix for all PVC annotations
+	// AnnPrefixCsiVolumeType is the common prefix for all PVC annotations
 	// that classify a supervisor PVC according to its consumer workload type.
 	// Annotations under this prefix are managed by supervisor full-sync (see
 	// annotateSupervisorPVCsWithWorkloadType in pkg/syncer/fullsync.go) and
@@ -477,13 +477,24 @@ const (
 	// signal (e.g., a guest-cluster Pod volume that also gained a VM owner
 	// reference). Boolean tags let the syncer record both signals without
 	// information loss; consumers can OR / AND them as needed.
-	AnnPrefixVKSWorkloadType = "csi.vsphere.volume.type/"
+	AnnPrefixCsiVolumeType = "csi.vsphere.volume.type/"
 
-	// AnnKeyVKSNode is set to "true" on a supervisor PVC when at least one
-	// of its OwnerReferences has Kind == "VirtualMachine" or "VSphereMachine".
-	// This identifies PVCs backing VKS guest-cluster Node disks (the node VM
-	// is the volume's owner; deletion of the node VM cascades to the PVC).
-	AnnKeyVKSNode = AnnPrefixVKSWorkloadType + "vks-node"
+	// AnnKeyVKSNode is set to "true" on a supervisor PVC when it is owned
+	// (directly, via an OwnerReference of Kind "VirtualMachine" or
+	// "VSphereMachine") by a VKS guest-cluster Node VM. Since a PVC's
+	// OwnerReference can claim either Kind, the underlying VM is looked up
+	// and classified as a Node VM only if that VM itself is owned by a
+	// "VSphereMachine". Deletion of the node VM cascades to the PVC. See
+	// classifySupervisorPVC.
+	AnnKeyVKSNode = AnnPrefixCsiVolumeType + "vks-node"
+
+	// AnnKeySupervisorVMBootDisk is set to "true" on a supervisor PVC when
+	// it is owned (via an OwnerReference of Kind "VirtualMachine" or
+	// "VSphereMachine") by a standalone Supervisor VM (such as a VM Service
+	// VM) rather than a VKS guest-cluster Node VM — determined by looking
+	// up the VM and finding it has no OwnerReferences of its own. See
+	// classifySupervisorPVC.
+	AnnKeySupervisorVMBootDisk = AnnPrefixCsiVolumeType + "supervisor-vm-boot-disk"
 
 	// AnnKeyVKSWorkload is set to "true" on a supervisor PVC when one of its
 	// labels carries the "<guest-cluster-name>/TKGService" marker. This
@@ -491,27 +502,28 @@ const (
 	// running inside a VKS (TKGService) guest cluster. Such PVCs do not have
 	// a VM owner reference; their lifetime is tied to the guest-cluster PVC,
 	// not to any particular Node VM.
-	AnnKeyVKSWorkload = AnnPrefixVKSWorkloadType + "vks-workload"
+	AnnKeyVKSWorkload = AnnPrefixCsiVolumeType + "vks-workload"
 
 	// AnnKeySupervisorPodVM marks a PVC attached to a native Supervisor Pod (PodVM),
 	// detected via a VolumeAttachment reference (see classifySupervisorPVC).
-	AnnKeySupervisorPodVM = AnnPrefixVKSWorkloadType + "supervisor-podvm"
+	AnnKeySupervisorPodVM = AnnPrefixCsiVolumeType + "supervisor-podvm"
 
-	// AnnKeySupervisorVMServiceVM marks a PVC attached as a data disk to a standalone
+	// AnnKeySupervisorVM marks a PVC attached as a data disk to a standalone
 	// VM Service VM, detected via a referencing CnsNodeVMBatchAttachment CR (see
 	// classifySupervisorPVC).
-	AnnKeySupervisorVMServiceVM = AnnPrefixVKSWorkloadType + "supervisor-vmservice-vm"
+	AnnKeySupervisorVM = AnnPrefixCsiVolumeType + "supervisor-vm"
 
 	// AnnKeySupervisorWorkload is set to "true" on a supervisor PVC that
-	// matches none of AnnKeyVKSNode, AnnKeyVKSWorkload, AnnKeySupervisorPodVM,
-	// or AnnKeySupervisorVMServiceVM — i.e., the PVC was created directly on
+	// matches none of AnnKeyVKSNode, AnnKeySupervisorVMBootDisk,
+	// AnnKeyVKSWorkload, AnnKeySupervisorPodVM, or AnnKeySupervisorVM
+	// — i.e., the PVC was created directly on
 	// the supervisor cluster (by an admin, by a third-party operator, or is
 	// simply not yet attached to any consumer) rather than by a VKS guest
 	// cluster or a recognized Supervisor-side attach path. The annotation is
 	// set explicitly rather than implied by absence so that "annotation
 	// missing" reliably means "fullsync has not yet evaluated this PVC"
 	// rather than "this is a supervisor workload".
-	AnnKeySupervisorWorkload = AnnPrefixVKSWorkloadType + "supervisor-workload"
+	AnnKeySupervisorWorkload = AnnPrefixCsiVolumeType + "supervisor-workload"
 
 	// AnnValueTrue is the canonical value used for the boolean
 	// csi.vsphere.volume.type/* annotations.

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -30,6 +30,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	versioned "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"google.golang.org/grpc/codes"
@@ -2226,6 +2227,34 @@ func RemoveCNSFinalizerFromSnapIfTKGClusterDeleted(ctx context.Context, snapshot
 	}
 }
 
+// vmOwnerClassification is the cached result of resolving a VM Operator
+// VirtualMachine's ownership, keyed by "namespace/name" (see
+// annotateSupervisorPVCsWithWorkloadType's vmOwnerCache).
+type vmOwnerClassification struct {
+	isVKSNode              bool
+	isSupervisorVMBootDisk bool
+}
+
+// resolveVMOwnerFunc looks up the VM Operator VirtualMachine named vmName in
+// namespace — regardless of whether the PVC's OwnerReference claimed Kind
+// "VirtualMachine" or "VSphereMachine", both of which can appear directly on
+// a PVC — and reports how it should influence the owning PVC's
+// classification:
+//
+//   - isVKSNode is true if the VM itself has an OwnerReference with
+//     Kind == OwnerKindVSphereMachine, i.e. the VM is a VKS guest-cluster
+//     Node VM (managed by Cluster API).
+//
+//   - isSupervisorVMBootDisk is true if the VM has no OwnerReferences at
+//     all, i.e. it is a standalone Supervisor VM (e.g. a VM Service VM)
+//     rather than a VKS Node VM.
+//
+// Implementations are expected to cache VM lookups across calls within a
+// single classification pass, since many PVCs (one per attached disk) can
+// share the same owning VM.
+type resolveVMOwnerFunc func(ctx context.Context, namespace, vmName string) (
+	isVKSNode bool, isSupervisorVMBootDisk bool, err error)
+
 // classifySupervisorPVC examines the labels and ownerReferences of a
 // supervisor PVC and returns the set of csi.vsphere.volume.type/* annotation
 // keys that should be present on it. All returned keys map to AnnValueTrue;
@@ -2233,21 +2262,30 @@ func RemoveCNSFinalizerFromSnapIfTKGClusterDeleted(ctx context.Context, snapshot
 //
 // Classification rules (boolean tags, not mutually exclusive):
 //
-//   - AnnKeyVKSNode is included if any OwnerReference has
-//     Kind == OwnerKindVirtualMachine or Kind == OwnerKindVSphereMachine.
-//     This signals that the PVC is consumed as a Node-VM disk in a VKS
-//     guest cluster (lifetime tied to a specific Node VM).
+//   - A PVC's OwnerReference can directly have Kind == OwnerKindVirtualMachine
+//     or Kind == OwnerKindVSphereMachine. Either shape is resolved by looking
+//     up the underlying VM (via resolveVMOwner) and inspecting its own
+//     OwnerReferences:
+//     -- AnnKeyVKSNode is included if the VM is itself owned by a
+//     VSphereMachine (resolveVMOwner reports isVKSNode). This identifies
+//     the PVC as a Node-VM disk in a VKS guest cluster (lifetime tied to a
+//     specific Node VM).
+//     -- AnnKeySupervisorVMBootDisk is included if the VM has no
+//     OwnerReferences of its own (resolveVMOwner reports
+//     isSupervisorVMBootDisk). This identifies a disk owned by a
+//     standalone Supervisor VM (e.g. a VM Service VM) rather than a VKS
+//     guest-cluster Node VM.
 //
 //   - AnnKeyVKSWorkload is included if any label key contains
 //     TKGServiceLabelMarker. VKS guest-cluster Pod PVCs carry a label of
 //     the form "<gc-name>/TKGService" — the presence of that marker is
 //     authoritative even when the rest of the key has been redacted.
 //
-//   - AnnKeySupervisorPodVM is included if neither of the above applies and
+//   - AnnKeySupervisorPodVM is included if none of the above applies and
 //     pvc.Spec.VolumeName is referenced by a VolumeAttachment object.
 //
-//   - AnnKeySupervisorVMServiceVM is included if neither of the first two
-//     applies, pvc.OwnerReferences is empty, and some CnsNodeVMBatchAttachment
+//   - AnnKeySupervisorVM is included if none of the above applies,
+//     pvc.OwnerReferences is empty, and some CnsNodeVMBatchAttachment
 //     CR references this PVC by name.
 //
 //   - AnnKeySupervisorWorkload is included only when none of the above
@@ -2263,17 +2301,26 @@ func RemoveCNSFinalizerFromSnapIfTKGClusterDeleted(ctx context.Context, snapshot
 // supervisor-workload is set only when none match.
 // batchAttachedPVCs must already be scoped to pvc's own namespace (see
 // loadBatchAttachedPVCClaimNames) — its keys are bare PVC names, not "namespace/name".
-func classifySupervisorPVC(pvc *v1.PersistentVolumeClaim, attachedPVs map[string]struct{},
-	batchAttachedPVCs map[string]struct{}) map[string]string {
+func classifySupervisorPVC(ctx context.Context, pvc *v1.PersistentVolumeClaim, attachedPVs map[string]struct{},
+	batchAttachedPVCs map[string]struct{}, resolveVMOwner resolveVMOwnerFunc) (map[string]string, error) {
 	desired := make(map[string]string, 2)
 
 	hasVKSNode := false
+	hasSupervisorVMBootDisk := false
 	for _, owner := range pvc.OwnerReferences {
-		if owner.Kind == common.OwnerKindVirtualMachine ||
-			owner.Kind == common.OwnerKindVSphereMachine {
-			hasVKSNode = true
-			break
+		if owner.Kind != common.OwnerKindVirtualMachine && owner.Kind != common.OwnerKindVSphereMachine {
+			continue
 		}
+		// A PVC's OwnerReference can directly claim Kind "VirtualMachine" or
+		// "VSphereMachine" — either way, whether the disk belongs to a VKS
+		// Node VM or a standalone Supervisor VM can only be determined by
+		// looking up the VM itself and inspecting its own OwnerReferences.
+		vmIsVKSNode, vmIsSupervisorVMBootDisk, err := resolveVMOwner(ctx, pvc.Namespace, owner.Name)
+		if err != nil {
+			return nil, err
+		}
+		hasVKSNode = hasVKSNode || vmIsVKSNode
+		hasSupervisorVMBootDisk = hasSupervisorVMBootDisk || vmIsSupervisorVMBootDisk
 	}
 
 	hasVKSWorkload := false
@@ -2301,6 +2348,9 @@ func classifySupervisorPVC(pvc *v1.PersistentVolumeClaim, attachedPVs map[string
 	if hasVKSNode {
 		desired[common.AnnKeyVKSNode] = common.AnnValueTrue
 	}
+	if hasSupervisorVMBootDisk {
+		desired[common.AnnKeySupervisorVMBootDisk] = common.AnnValueTrue
+	}
 	if hasVKSWorkload {
 		desired[common.AnnKeyVKSWorkload] = common.AnnValueTrue
 	}
@@ -2308,18 +2358,18 @@ func classifySupervisorPVC(pvc *v1.PersistentVolumeClaim, attachedPVs map[string
 		desired[common.AnnKeySupervisorPodVM] = common.AnnValueTrue
 	}
 	if hasVMServiceAttachment {
-		desired[common.AnnKeySupervisorVMServiceVM] = common.AnnValueTrue
+		desired[common.AnnKeySupervisorVM] = common.AnnValueTrue
 	}
-	if !hasVKSNode && !hasVKSWorkload && !hasPodVMAttachment && !hasVMServiceAttachment {
+	if !hasVKSNode && !hasSupervisorVMBootDisk && !hasVKSWorkload && !hasPodVMAttachment && !hasVMServiceAttachment {
 		desired[common.AnnKeySupervisorWorkload] = common.AnnValueTrue
 	}
-	return desired
+	return desired, nil
 }
 
 // reconcilePVCWorkloadTypeAnnotations returns a Strategic-Merge-Patch byte
 // payload that, when applied to pvc, adds every annotation in desired and
 // removes every csi.vsphere.volume.type/* annotation that is NOT in desired.
-// Annotations outside the AnnPrefixVKSWorkloadType namespace are left
+// Annotations outside the AnnPrefixCsiVolumeType namespace are left
 // untouched. Returns (nil, false, nil) if no change is needed; the caller
 // can then skip the API patch entirely.
 //
@@ -2342,7 +2392,7 @@ func reconcilePVCWorkloadTypeAnnotations(pvc *v1.PersistentVolumeClaim,
 	//    in the desired set. In Strategic Merge Patch, setting a map key
 	//    to JSON null deletes that key.
 	for key := range pvc.Annotations {
-		if !strings.HasPrefix(key, common.AnnPrefixVKSWorkloadType) {
+		if !strings.HasPrefix(key, common.AnnPrefixCsiVolumeType) {
 			continue
 		}
 		if _, keep := desired[key]; !keep {
@@ -2441,6 +2491,41 @@ func annotateSupervisorPVCsWithWorkloadType(ctx context.Context,
 	// encountered below, rather than a single cluster-wide list.
 	batchAttachedPVCsByNamespace := map[string]map[string]struct{}{}
 
+	restClientConfig, err := k8s.GetKubeConfig(ctx)
+	if err != nil {
+		log.Errorf("annotateSupervisorPVCsWithWorkloadType: failed to initialize rest clientconfig. Err: %v", err)
+		return
+	}
+	vmOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, vmoperatortypes.GroupName)
+	if err != nil {
+		log.Errorf("annotateSupervisorPVCsWithWorkloadType: failed to get vmOperatorClient. Err: %v", err)
+		return
+	}
+	// Populated lazily, one VirtualMachine Get call per distinct owning VM
+	// encountered below — many PVCs (one per attached disk) commonly share
+	// the same owning VM.
+	vmOwnerCache := map[string]vmOwnerClassification{}
+	resolveVMOwner := func(ctx context.Context, namespace, vmName string) (bool, bool, error) {
+		key := namespace + "/" + vmName
+		if cached, ok := vmOwnerCache[key]; ok {
+			return cached.isVKSNode, cached.isSupervisorVMBootDisk, nil
+		}
+		vm, _, err := utils.GetVirtualMachine(ctx, types.NamespacedName{Namespace: namespace, Name: vmName}, vmOperatorClient)
+		if err != nil {
+			return false, false, err
+		}
+		isVKSNode := false
+		for _, owner := range vm.OwnerReferences {
+			if owner.Kind == common.OwnerKindVSphereMachine {
+				isVKSNode = true
+				break
+			}
+		}
+		isSupervisorVMBootDisk := len(vm.OwnerReferences) == 0
+		vmOwnerCache[key] = vmOwnerClassification{isVKSNode: isVKSNode, isSupervisorVMBootDisk: isSupervisorVMBootDisk}
+		return isVKSNode, isSupervisorVMBootDisk, nil
+	}
+
 	var patched, skipped, failed int
 	for _, pvc := range pvcs {
 		if pvc.ObjectMeta.DeletionTimestamp != nil {
@@ -2460,7 +2545,13 @@ func annotateSupervisorPVCsWithWorkloadType(ctx context.Context,
 			batchAttachedPVCsByNamespace[pvc.Namespace] = batchAttachedPVCs
 		}
 
-		desired := classifySupervisorPVC(pvc, attachedPVs, batchAttachedPVCs)
+		desired, err := classifySupervisorPVC(ctx, pvc, attachedPVs, batchAttachedPVCs, resolveVMOwner)
+		if err != nil {
+			log.Errorf("annotateSupervisorPVCsWithWorkloadType: failed to classify PVC %s/%s. Err: %v",
+				pvc.Namespace, pvc.Name, err)
+			failed++
+			continue
+		}
 		patchBytes, needsPatch, err := reconcilePVCWorkloadTypeAnnotations(pvc, desired)
 		if err != nil {
 			log.Errorf("annotateSupervisorPVCsWithWorkloadType: failed to build patch for PVC %s/%s. Err: %v",

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -1656,7 +1656,7 @@ func makePVCForClassification(labels map[string]string, ownerKinds []string,
 // vks-node, a TKGService marker in any label key implies vks-workload, a
 // bound PV present in the attachedPVs set implies supervisor-podvm, an
 // ownerRef-less PVC referenced by a CnsNodeVMBatchAttachment CR implies
-// supervisor-vmservice-vm, and the absence of all four implies
+// supervisor-vm, and the absence of all four implies
 // supervisor-workload. The classification is boolean-tag-based — any
 // combination of signals can co-occur, but supervisor-workload is mutually
 // exclusive with all of them.
@@ -1666,6 +1666,12 @@ func TestClassifySupervisorPVC(t *testing.T) {
 	// makePVCForClassification always names the PVC.
 	batchAttached := map[string]struct{}{"test-pvc": {}}
 
+	// vksNodeVM simulates a VM Operator VirtualMachine owned by a VSphereMachine
+	// (a VKS guest-cluster Node VM). supervisorBootDiskVM simulates a
+	// VirtualMachine with no OwnerReferences at all (a standalone Supervisor VM).
+	vksNodeVM := vmOwnerClassification{isVKSNode: true}
+	supervisorBootDiskVM := vmOwnerClassification{isSupervisorVMBootDisk: true}
+
 	tests := []struct {
 		name              string
 		labels            map[string]string
@@ -1674,20 +1680,38 @@ func TestClassifySupervisorPVC(t *testing.T) {
 		annotations       map[string]string
 		attachedPVs       map[string]struct{}
 		batchAttachedPVCs map[string]struct{}
+		vmOwnerByName     map[string]vmOwnerClassification
+		vmOwnerErr        error
 		wantKeys          []string
 		notWanted         []string
+		wantErr           bool
 	}{
 		{
-			name:      "vks node via VirtualMachine ownerRef",
-			owners:    []string{"VirtualMachine"},
-			wantKeys:  []string{common.AnnKeyVKSNode},
-			notWanted: []string{common.AnnKeyVKSWorkload, common.AnnKeySupervisorWorkload},
+			name:          "vks node via VSphereMachine ownerRef",
+			owners:        []string{"VSphereMachine"},
+			vmOwnerByName: map[string]vmOwnerClassification{"owner-VSphereMachine": vksNodeVM},
+			wantKeys:      []string{common.AnnKeyVKSNode},
+			notWanted: []string{common.AnnKeyVKSWorkload, common.AnnKeySupervisorWorkload,
+				common.AnnKeySupervisorVMBootDisk},
 		},
 		{
-			name:      "vks node via VSphereMachine ownerRef",
-			owners:    []string{"VSphereMachine"},
-			wantKeys:  []string{common.AnnKeyVKSNode},
-			notWanted: []string{common.AnnKeyVKSWorkload, common.AnnKeySupervisorWorkload},
+			name:          "supervisor VM boot disk via VirtualMachine ownerRef",
+			owners:        []string{"VirtualMachine"},
+			vmOwnerByName: map[string]vmOwnerClassification{"owner-VirtualMachine": supervisorBootDiskVM},
+			wantKeys:      []string{common.AnnKeySupervisorVMBootDisk},
+			notWanted:     []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload, common.AnnKeySupervisorWorkload},
+		},
+		{
+			name:      "VirtualMachine/VSphereMachine ownerRef with neither VM signal -> falls through to supervisor-workload",
+			owners:    []string{"VirtualMachine"},
+			wantKeys:  []string{common.AnnKeySupervisorWorkload},
+			notWanted: []string{common.AnnKeyVKSNode, common.AnnKeySupervisorVMBootDisk},
+		},
+		{
+			name:       "VM owner lookup error is propagated",
+			owners:     []string{"VirtualMachine"},
+			vmOwnerErr: errors.New("get VirtualMachine failed"),
+			wantErr:    true,
 		},
 		{
 			name:      "vks workload via TKGService label",
@@ -1709,14 +1733,15 @@ func TestClassifySupervisorPVC(t *testing.T) {
 			name:     "no signals -> supervisor-workload",
 			wantKeys: []string{common.AnnKeySupervisorWorkload},
 			notWanted: []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload, common.AnnKeySupervisorPodVM,
-				common.AnnKeySupervisorVMServiceVM},
+				common.AnnKeySupervisorVM},
 		},
 		{
-			name:      "both signals -> double-tagged, supervisor-workload NOT set",
-			labels:    map[string]string{"my-tkc/TKGService": "abc123"},
-			owners:    []string{"VirtualMachine"},
-			wantKeys:  []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload},
-			notWanted: []string{common.AnnKeySupervisorWorkload},
+			name:          "both signals -> double-tagged, supervisor-workload NOT set",
+			labels:        map[string]string{"my-tkc/TKGService": "abc123"},
+			owners:        []string{"VSphereMachine"},
+			vmOwnerByName: map[string]vmOwnerClassification{"owner-VSphereMachine": vksNodeVM},
+			wantKeys:      []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload},
+			notWanted:     []string{common.AnnKeySupervisorWorkload},
 		},
 		{
 			name:      "unrelated owner kind is ignored",
@@ -1729,7 +1754,7 @@ func TestClassifySupervisorPVC(t *testing.T) {
 			volumeName:  "pv-1",
 			attachedPVs: map[string]struct{}{"pv-1": {}},
 			wantKeys:    []string{common.AnnKeySupervisorPodVM},
-			notWanted: []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload, common.AnnKeySupervisorVMServiceVM,
+			notWanted: []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload, common.AnnKeySupervisorVM,
 				common.AnnKeySupervisorWorkload},
 		},
 		{
@@ -1737,18 +1762,18 @@ func TestClassifySupervisorPVC(t *testing.T) {
 			volumeName:  "pv-2",
 			attachedPVs: map[string]struct{}{"pv-1": {}},
 			wantKeys:    []string{common.AnnKeySupervisorWorkload},
-			notWanted:   []string{common.AnnKeySupervisorPodVM, common.AnnKeySupervisorVMServiceVM},
+			notWanted:   []string{common.AnnKeySupervisorPodVM, common.AnnKeySupervisorVM},
 		},
 		{
 			name:        "unbound PVC (no VolumeName) is never podvm-tagged",
 			attachedPVs: map[string]struct{}{"": {}},
 			wantKeys:    []string{common.AnnKeySupervisorWorkload},
-			notWanted:   []string{common.AnnKeySupervisorPodVM, common.AnnKeySupervisorVMServiceVM},
+			notWanted:   []string{common.AnnKeySupervisorPodVM, common.AnnKeySupervisorVM},
 		},
 		{
-			name:              "referenced by CnsNodeVMBatchAttachment CR -> supervisor-vmservice-vm",
+			name:              "referenced by CnsNodeVMBatchAttachment CR -> supervisor-vm",
 			batchAttachedPVCs: batchAttached,
-			wantKeys:          []string{common.AnnKeySupervisorVMServiceVM},
+			wantKeys:          []string{common.AnnKeySupervisorVM},
 			notWanted: []string{common.AnnKeyVKSNode, common.AnnKeyVKSWorkload, common.AnnKeySupervisorPodVM,
 				common.AnnKeySupervisorWorkload},
 		},
@@ -1757,36 +1782,50 @@ func TestClassifySupervisorPVC(t *testing.T) {
 			owners:            []string{"StatefulSet"},
 			batchAttachedPVCs: batchAttached,
 			wantKeys:          []string{common.AnnKeySupervisorWorkload},
-			notWanted:         []string{common.AnnKeySupervisorVMServiceVM},
+			notWanted:         []string{common.AnnKeySupervisorVM},
 		},
 		{
 			name:              "podvm and vmservice-vm signals co-occur -> double-tagged, supervisor-workload NOT set",
 			volumeName:        "pv-1",
 			attachedPVs:       map[string]struct{}{"pv-1": {}},
 			batchAttachedPVCs: batchAttached,
-			wantKeys:          []string{common.AnnKeySupervisorPodVM, common.AnnKeySupervisorVMServiceVM},
+			wantKeys:          []string{common.AnnKeySupervisorPodVM, common.AnnKeySupervisorVM},
 			notWanted:         []string{common.AnnKeySupervisorWorkload},
 		},
 		{
-			name:        "vks node and podvm signals co-occur -> double-tagged, supervisor-workload NOT set",
-			owners:      []string{"VirtualMachine"},
-			volumeName:  "pv-1",
-			attachedPVs: map[string]struct{}{"pv-1": {}},
-			wantKeys:    []string{common.AnnKeyVKSNode, common.AnnKeySupervisorPodVM},
-			notWanted:   []string{common.AnnKeySupervisorWorkload},
+			name:          "vks node and podvm signals co-occur -> double-tagged, supervisor-workload NOT set",
+			owners:        []string{"VSphereMachine"},
+			volumeName:    "pv-1",
+			attachedPVs:   map[string]struct{}{"pv-1": {}},
+			vmOwnerByName: map[string]vmOwnerClassification{"owner-VSphereMachine": vksNodeVM},
+			wantKeys:      []string{common.AnnKeyVKSNode, common.AnnKeySupervisorPodVM},
+			notWanted:     []string{common.AnnKeySupervisorWorkload},
 		},
 		{
 			name:              "vks node disk also referenced by a CnsNodeVMBatchAttachment CR -> vmservice-vm NOT set",
-			owners:            []string{"VirtualMachine"},
+			owners:            []string{"VSphereMachine"},
 			batchAttachedPVCs: batchAttached,
+			vmOwnerByName:     map[string]vmOwnerClassification{"owner-VSphereMachine": vksNodeVM},
 			wantKeys:          []string{common.AnnKeyVKSNode},
-			notWanted:         []string{common.AnnKeySupervisorVMServiceVM, common.AnnKeySupervisorWorkload},
+			notWanted:         []string{common.AnnKeySupervisorVM, common.AnnKeySupervisorWorkload},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pvc := makePVCForClassification(tt.labels, tt.owners, tt.volumeName, tt.annotations)
-			got := classifySupervisorPVC(pvc, tt.attachedPVs, tt.batchAttachedPVCs)
+			resolveVMOwner := func(_ context.Context, _, vmName string) (bool, bool, error) {
+				if tt.vmOwnerErr != nil {
+					return false, false, tt.vmOwnerErr
+				}
+				cls := tt.vmOwnerByName[vmName]
+				return cls.isVKSNode, cls.isSupervisorVMBootDisk, nil
+			}
+			got, err := classifySupervisorPVC(context.Background(), pvc, tt.attachedPVs, tt.batchAttachedPVCs, resolveVMOwner)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
 			for _, k := range tt.wantKeys {
 				v, ok := got[k]
 				assert.True(t, ok, "missing expected key %s in classification (got=%v)", k, got)
@@ -1984,7 +2023,7 @@ func TestReconcilePVCWorkloadTypeAnnotations(t *testing.T) {
 		// (for deletions of stale tags)
 		mustContainDeletion []string
 		// substrings the generated patch JSON must NOT contain (e.g.,
-		// annotations outside the AnnPrefixVKSWorkloadType namespace
+		// annotations outside the AnnPrefixCsiVolumeType namespace
 		// must never be mentioned)
 		mustNotContain []string
 	}{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Distinguishes VKS Node volumes from Supervisor VM boot-disk volumes in the workload-type annotations - 

Supervisor full-sync annotates every PVC with a csi.vsphere.volume.type/* annotation classifying its consumer workload (see annotateSupervisorPVCsWithWorkloadType). Previously, any PVC owned by a VirtualMachine or VSphereMachine object was tagged simply as vks-node, which conflated two distinct cases:

VKS Node volumes — disks attached to a Node VM that belongs to a VKS guest cluster.
Supervisor VM boot-disk volumes — disks attached to a plain, standalone Supervisor VM (e.g. a VM Service VM), which is not part of any VKS guest cluster.
This change teaches classifySupervisorPVC to tell the two apart. When a PVC's owner reference points at a VirtualMachine or VSphereMachine, the syncer now looks up the actual VM object and inspects its own owner references:

If the VM is itself owned by a VSphereMachine, the PVC is a genuine VKS Node volume → tagged csi.vsphere.volume.type/vks-node.
If the VM has no owner references at all, it's a standalone Supervisor VM → tagged with the new csi.vsphere.volume.type/supervisor-vm-boot-disk annotation.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-146-6.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume-requested-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-workload: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Sat Aug  1 02:42:17 UTC
        2026
    creationTimestamp: "2026-08-01T02:41:46Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      kubernetes-cluster-y2vm/TKGService: a877f757-ac51-46b8-9639-df49e09216c8
    name: a877f757-ac51-46b8-9639-df49e09216c8-62c8de4b-ef58-4e3a-925d-0138b154e399
    namespace: divyen-ns
    resourceVersion: "3678360"
    uid: c8fc334e-04a0-4012-af92-b472eec23c0c
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: host-local-vmfs
    volumeMode: Filesystem
    volumeName: pvc-c8fc334e-04a0-4012-af92-b472eec23c0c
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com/usedby-vm-8e787a64-29a5-485b-b0c4-02acff9283a2: ""
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-147-51.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/supervisor-vm: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 30 23:01:01 UTC
        2026
    creationTimestamp: "2026-07-30T22:56:21Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: host-local-pvc
    namespace: divyen-ns
    resourceVersion: "3620908"
    uid: b7d09eed-5703-43b6-b267-698090fb3858
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 5Gi
    storageClassName: host-local-vmfs
    volumeMode: Filesystem
    volumeName: pvc-b7d09eed-5703-43b6-b267-698090fb3858
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 5Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-2c8ef88b-77f6-4271-8bfb-11e17d28d830: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-147-51.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 30 22:36:00 UTC
        2026
    creationTimestamp: "2026-07-30T22:31:54Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: kubernetes-cluster-y2vm-8swt9-fbgpd-1b9d2e0e
    namespace: divyen-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: kubernetes-cluster-y2vm-8swt9-fbgpd
      uid: c2a0f6cd-c83c-4fba-9c71-074e78840b61
    resourceVersion: "3667749"
    uid: 469414b6-8d56-4308-8f9f-1013235b6dcf
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: kubernetes-cluster-y2vm-8swt9-fbgpd
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: kubernetes-cluster-y2vm-8swt9-fbgpd
    resources:
      requests:
        storage: 20Gi
    storageClassName: host-local-vmfs
    volumeMode: Block
    volumeName: static-pv-c4088115-ba30-4e7a-9d17-adb7cc2feaf7
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com/selected-node-is-zone: "false"
      cns.vmware.com/usedby-vm-2c8ef88b-77f6-4271-8bfb-11e17d28d830: ""
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-147-51.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: lvn-dvm-10-161-147-51.dvm.lvn.broadcom.net
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 30 22:36:00 UTC
        2026
    creationTimestamp: "2026-07-30T22:29:32Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: kubernetes-cluster-y2vm-8swt9-fbgpd-vol-2cd5
    namespace: divyen-ns
    ownerReferences:
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta2
      kind: VSphereMachine
      name: kubernetes-cluster-y2vm-8swt9-fbgpd
      uid: 93497a84-f733-425e-bf55-e1903f20e270
    resourceVersion: "3647191"
    uid: 5dec3d45-a3ab-4de5-ae02-44e8725f3580
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 20Gi
    storageClassName: host-local-vmfs-latebinding
    volumeMode: Filesystem
    volumeName: pvc-5dec3d45-a3ab-4de5-ae02-44e8725f3580
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com/selected-node-is-zone: "false"
      cns.vmware.com/usedby-vm-2c8ef88b-77f6-4271-8bfb-11e17d28d830: ""
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-147-51.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: lvn-dvm-10-161-147-51.dvm.lvn.broadcom.net
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 30 22:36:00 UTC
        2026
    creationTimestamp: "2026-07-30T22:29:33Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: kubernetes-cluster-y2vm-8swt9-fbgpd-vol-kl8y
    namespace: divyen-ns
    ownerReferences:
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta2
      kind: VSphereMachine
      name: kubernetes-cluster-y2vm-8swt9-fbgpd
      uid: 93497a84-f733-425e-bf55-e1903f20e270
    resourceVersion: "3647177"
    uid: eb79b64d-aef8-4fb3-9ddc-b19a24f18444
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 20Gi
    storageClassName: host-local-vmfs-latebinding
    volumeMode: Filesystem
    volumeName: pvc-eb79b64d-aef8-4fb3-9ddc-b19a24f18444
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-9ac0c4d9-c340-4f28-bae2-dbba0a456df9: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-151-72.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 30 22:41:00 UTC
        2026
    creationTimestamp: "2026-07-30T22:37:37Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: kubernetes-cluster-y2vm-kubernetes-cluster-y2vm-np-s4c-fa03873c
    namespace: divyen-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: kubernetes-cluster-y2vm-kubernetes-cluster-y2vm-np-s4cq-n8nvph9
      uid: 8fb9f1e5-c75a-4ad4-bf79-d500db32f957
    resourceVersion: "3667745"
    uid: 4deb188f-1218-4cb4-8527-04e833129179
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: kubernetes-cluster-y2vm-kubernetes-cluster-y2vm-np-s4cq-n8nvph9
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: kubernetes-cluster-y2vm-kubernetes-cluster-y2vm-np-s4cq-n8nvph9
    resources:
      requests:
        storage: 20Gi
    storageClassName: host-local-vmfs
    volumeMode: Block
    volumeName: static-pv-7286ce09-847f-4f74-81ff-9b54e73d0492
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com/selected-node-is-zone: "false"
      cns.vmware.com/usedby-vm-9ac0c4d9-c340-4f28-bae2-dbba0a456df9: ""
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-151-72.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: lvn-dvm-10-161-151-72.dvm.lvn.broadcom.net
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 30 22:40:59 UTC
        2026
    creationTimestamp: "2026-07-30T22:35:15Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: kubernetes-cluster-y2vm-kubernetes-cluster-y2vm-np-s4cq-n8nvph9-vol-89xm
    namespace: divyen-ns
    ownerReferences:
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta2
      kind: VSphereMachine
      name: kubernetes-cluster-y2vm-kubernetes-cluster-y2vm-np-s4cq-n8nvph9
      uid: cd68e63e-79a3-492a-a297-7aecd3b09f31
    resourceVersion: "3647189"
    uid: 3901f117-6240-48a5-aa1c-d4ccc6c5f0bc
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 20Gi
    storageClassName: host-local-vmfs-latebinding
    volumeMode: Filesystem
    volumeName: pvc-3901f117-6240-48a5-aa1c-d4ccc6c5f0bc
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com/selected-node-is-zone: "false"
      cns.vmware.com/usedby-vm-9ac0c4d9-c340-4f28-bae2-dbba0a456df9: ""
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-151-72.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: lvn-dvm-10-161-151-72.dvm.lvn.broadcom.net
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 30 22:41:00 UTC
        2026
    creationTimestamp: "2026-07-30T22:35:16Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: kubernetes-cluster-y2vm-kubernetes-cluster-y2vm-np-s4cq-n8nvph9-vol-qj88
    namespace: divyen-ns
    ownerReferences:
    - apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta2
      kind: VSphereMachine
      name: kubernetes-cluster-y2vm-kubernetes-cluster-y2vm-np-s4cq-n8nvph9
      uid: cd68e63e-79a3-492a-a297-7aecd3b09f31
    resourceVersion: "3647179"
    uid: a5baace5-dc3e-49b2-9dca-f8dc727c358b
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 20Gi
    storageClassName: host-local-vmfs-latebinding
    volumeMode: Filesystem
    volumeName: pvc-a5baace5-dc3e-49b2-9dca-f8dc727c358b
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-8e787a64-29a5-485b-b0c4-02acff9283a2: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-147-51.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/supervisor-vm-boot-disk: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 30 23:05:59 UTC
        2026
    creationTimestamp: "2026-07-30T23:04:32Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: vm-3z88-0354c73a
    namespace: divyen-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: vm-3z88
      uid: 12d4ab16-2284-44cc-96d3-569c709460de
    resourceVersion: "3620916"
    uid: 4e12770b-0cd1-4300-a0bb-a7beb63b89fb
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: vm-3z88
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: vm-3z88
    resources:
      requests:
        storage: 16Gi
    storageClassName: host-local-vmfs
    volumeMode: Block
    volumeName: static-pv-9539ba6e-cab1-4c0d-b302-ffbd2e697530
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 16Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"lvn-dvm-10-161-146-6.dvm.lvn.broadcom.net","topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume-requested-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/supervisor-workload: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Fri Jul 31 18:00:34 UTC
        2026
    creationTimestamp: "2026-07-31T17:59:13Z"
    finalizers:
    - kubernetes.io/pvc-protection
    name: volume-claim-bd69
    namespace: divyen-ns
    resourceVersion: "3544286"
    uid: 265df44f-0f7a-48d0-be3e-c752f4cb488a
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: host-local-vmfs
    volumeMode: Block
    volumeName: pvc-265df44f-0f7a-48d0-be3e-c752f4cb488a
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-e56fa251-0a32-4159-9f19-745be601dc7a: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/supervisor-vm-boot-disk: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Fri Jul 31 20:10:34 UTC
        2026
    creationTimestamp: "2026-07-31T20:07:21Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: vm-gctm-0aa7ce82
    namespace: test-chethanv
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: vm-gctm
      uid: 67a29628-dba5-4bb7-843a-1e40a08f3214
    resourceVersion: "3620910"
    uid: aa859b20-d30c-46a9-8eba-18a83078bd9e
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: vm-gctm
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: vm-gctm
    resources:
      requests:
        storage: 16Gi
    storageClassName: gc-storage-profile
    volumeMode: Block
    volumeName: static-pv-7fa97b25-5cb1-4344-8f3f-293d2a9c92ea
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 16Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com/usedby-vm-e56fa251-0a32-4159-9f19-745be601dc7a: ""
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume-requested-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/supervisor-vm: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Fri Jul 31 20:10:34 UTC
        2026
    creationTimestamp: "2026-07-31T20:06:28Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    labels:
      vm-selector: vm-gctm
    name: vm-gctm-pvc-0
    namespace: test-chethanv
    resourceVersion: "3620909"
    uid: 3a11da2f-9d74-4350-b8a0-b13ab0ca15e9
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: gc-storage-profile
    volumeMode: Block
    volumeName: pvc-3a11da2f-9d74-4350-b8a0-b13ab0ca15e9
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-0a5ef580-4810-4075-a332-345a94198ad9: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Tue Jul 28 00:48:37 UTC
        2026
    creationTimestamp: "2026-07-28T00:43:15Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-92848-f018abdc
    namespace: test-gc-e2e-demo-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-92848
      uid: 14885c80-981c-4e1e-b7bb-6c880bb3012d
    resourceVersion: "3667736"
    uid: 65abbefc-8024-40ca-9a8f-c6c751912bd5
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-92848
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-92848
    resources:
      requests:
        storage: 20Gi
    storageClassName: gc-storage-profile
    volumeMode: Block
    volumeName: static-pv-0c89a457-7af3-49c1-8b67-cf68e4da0dce
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-8a23d597-7b36-4e01-b8a0-66b44b1dae84: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Tue Jul 28 00:43:37 UTC
        2026
    creationTimestamp: "2026-07-28T00:43:00Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-lwrrv-f8858588
    namespace: test-gc-e2e-demo-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-lwrrv
      uid: 84dcbdeb-92ce-4e86-bdad-e848cf08913c
    resourceVersion: "3667751"
    uid: 30e6d84f-663a-4812-ae08-98f449d4ab2e
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-lwrrv
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-lwrrv
    resources:
      requests:
        storage: 20Gi
    storageClassName: gc-storage-profile
    volumeMode: Block
    volumeName: static-pv-1920eebc-e6b5-4dbf-8b92-adbf5c1b15b4
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-ce80712e-ae36-4449-9e8d-13bf7f66c639: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Tue Jul 28 00:43:37 UTC
        2026
    creationTimestamp: "2026-07-28T00:42:57Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-rknfq-4966a0e5
    namespace: test-gc-e2e-demo-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-rknfq
      uid: ff600eeb-3549-464a-b40b-542a12e51138
    resourceVersion: "3667748"
    uid: 35ab8a34-615c-4c66-afb4-ff2d806c167b
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-rknfq
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-node-pool-1-99zkr-lh5xn-rknfq
    resources:
      requests:
        storage: 20Gi
    storageClassName: gc-storage-profile
    volumeMode: Block
    volumeName: static-pv-ad2a9afa-87c4-40f9-bfb5-e9758f34e7b1
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-242920cb-41f8-4995-8f45-c9c83a68048a: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Tue Jul 28 00:53:37 UTC
        2026
    creationTimestamp: "2026-07-28T00:51:31Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: test-cluster-e2e-script-xnx72-96lrl-f967dc6d
    namespace: test-gc-e2e-demo-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: test-cluster-e2e-script-xnx72-96lrl
      uid: c9d49c38-d9c1-455d-971c-7f63806b23e0
    resourceVersion: "3667737"
    uid: 92285e99-d069-4837-82eb-f6fb928c555a
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-xnx72-96lrl
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-xnx72-96lrl
    resources:
      requests:
        storage: 20Gi
    storageClassName: gc-storage-profile
    volumeMode: Block
    volumeName: static-pv-8d97ffb5-a56c-4f75-8eab-e43ac99a0a80
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-3d91c774-bf09-4dd6-b433-785689892840: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Tue Jul 28 00:38:37 UTC
        2026
    creationTimestamp: "2026-07-28T00:36:47Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: test-cluster-e2e-script-xnx72-js5gh-aee34f81
    namespace: test-gc-e2e-demo-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: test-cluster-e2e-script-xnx72-js5gh
      uid: 966d241a-aec7-4791-b7a2-73476e34d046
    resourceVersion: "3667743"
    uid: fb36fb9a-4b67-4d79-8169-703d2138817c
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-xnx72-js5gh
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-xnx72-js5gh
    resources:
      requests:
        storage: 20Gi
    storageClassName: gc-storage-profile
    volumeMode: Block
    volumeName: static-pv-2ff15c93-9081-4c1e-9778-cdfb175b7f25
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com.protected/disk-backing: FlatVer2BackingInfo
      cns.vmware.com/usedby-vm-3c2e146b-aa9c-4d80-af2c-3588043b2285: ""
      cns.vmware.com/vm-delete-protection-cleared: "true"
      csi.vsphere.volume-accessible-topology: '[{"topology.kubernetes.io/zone":"az1"}]'
      csi.vsphere.volume.type/vks-node: "true"
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Tue Jul 28 00:48:37 UTC
        2026
    creationTimestamp: "2026-07-28T00:46:02Z"
    finalizers:
    - kubernetes.io/pvc-protection
    - cns.vmware.com/pvc-protection
    name: test-cluster-e2e-script-xnx72-w7tvv-45ec3780
    namespace: test-gc-e2e-demo-ns
    ownerReferences:
    - apiVersion: vmoperator.vmware.com/v1alpha6
      kind: VirtualMachine
      name: test-cluster-e2e-script-xnx72-w7tvv
      uid: 2ee3085d-2b3b-4641-8eb3-0881489c51d1
    resourceVersion: "3667750"
    uid: d5080dff-17cf-4d4c-adc2-0c8eec6fa002
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-xnx72-w7tvv
    dataSourceRef:
      apiGroup: vmoperator.vmware.com
      kind: VirtualMachine
      name: test-cluster-e2e-script-xnx72-w7tvv
    resources:
      requests:
        storage: 20Gi
    storageClassName: gc-storage-profile
    volumeMode: Block
    volumeName: static-pv-c0bab0d6-6dc1-471e-9f2e-4121542aa265
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 20Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Annotate all supervisor volumes with appropriate category
```
