### PR TITLE
Fix FIPS-only TLS enforcement regression on CNS-CSI admission webhook

### DIFF
--- a/pkg/syncer/admissionhandler/fipsonly_on.go
+++ b/pkg/syncer/admissionhandler/fipsonly_on.go
@@ -1,5 +1,13 @@
-//go:build fips
+//go:build boringcrypto
 
 package admissionhandler
 
+// This file restricts TLS to FIPS-approved settings whenever the binary is compiled with
+// GOEXPERIMENT=boringcrypto, which is how every production build (images/driver/Dockerfile,
+// images/syncer/Dockerfile, hack/cover-images.sh, Makefile) already compiles this package.
+// Do not gate this on any other build tag (e.g. a custom "fips" tag): crypto/tls/fipsonly
+// itself only exists under the "boringcrypto" tag, and no build in this repo passes any tag
+// other than what GOEXPERIMENT=boringcrypto implies. Gating on a tag that nothing sets
+// silently drops FIPS-only TLS enforcement without failing any build or test - see
+// fipsonly_on_test.go.
 import _ "crypto/tls/fipsonly"

--- a/pkg/syncer/admissionhandler/fipsonly_on_test.go
+++ b/pkg/syncer/admissionhandler/fipsonly_on_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionhandler
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fipsonly_on.go's import of crypto/tls/fipsonly restricts the CNS-CSI admission webhook
+// (port 9883) to FIPS-approved TLS settings, in particular excluding TLS_CHACHA20_POLY1305_SHA256
+// from TLS 1.3, which is not FIPS-approved despite the AES-only CipherSuites list configured in
+// cnscsi_admissionhandler.go (that field only governs TLS 1.0-1.2, not 1.3).
+//
+// crypto/tls/fipsonly itself only exists under Go's "boringcrypto" build tag, and every
+// production build in this repo already compiles with GOEXPERIMENT=boringcrypto (see
+// images/driver/Dockerfile, images/syncer/Dockerfile, hack/cover-images.sh, and the top-level
+// Makefile). This file must therefore be gated on "boringcrypto" and nothing else: gating it on
+// a different tag that no build passes silently drops FIPS-only TLS enforcement in every real
+// build, without failing go build, go vet, or any unit or e2e test - only an external TLS scan
+// (e.g. nmap --script ssl-enum-ciphers) against a live webhook would ever notice. This test
+// guards against that regression without requiring a live network probe.
+func TestFipsonlyOnGatedOnBoringcryptoBuildTag(t *testing.T) {
+	data, err := os.ReadFile("fipsonly_on.go")
+	require.NoError(t, err, "reading fipsonly_on.go")
+
+	assert.Regexp(t, `(?m)^//go:build boringcrypto\s*$`, string(data),
+		"fipsonly_on.go must be gated on the \"boringcrypto\" build tag (set automatically by "+
+			"GOEXPERIMENT=boringcrypto) so its crypto/tls/fipsonly import is actually compiled "+
+			"into every production binary; gating it on any other tag means nothing in this "+
+			"repo's build scripts will ever activate it")
+
+	assert.Contains(t, string(data), `import _ "crypto/tls/fipsonly"`,
+		"fipsonly_on.go must import crypto/tls/fipsonly to enforce FIPS-only TLS settings")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Restores FIPS-only TLS enforcement (crypto/tls/fipsonly) on the CNS-CSI admission webhook (port 9883) by fixing the build tag on pkg/syncer/admissionhandler/fipsonly_on.go, and adds a regression test.

crypto/tls/fipsonly restricts crypto/tls to FIPS-approved settings — in particular, it excludes TLS_CHACHA20_POLY1305_SHA256 from TLS 1.3, which the webhook's own CipherSuites list (in cnscsi_admissionhandler.go) cannot do, since that field only governs TLS 1.0–1.2.

#4117 ("Update all dependency") extracted this import from an unconditional location in cnscsi_admissionhandler.go into a new file, fipsonly_on.go, gated behind //go:build fips — intending to fix go build/go vet failures on toolchains without BoringCrypto (per that PR's own description: "standard (non-FIPS) builds no longer fail on platforms without a BoringCrypto toolchain").

That fix used the wrong tag. crypto/tls/fipsonly itself only exists under Go's boringcrypto build tag — and nothing in this repo ever passes -tags fips (checked images/driver/Dockerfile, images/syncer/Dockerfile, hack/cover-images.sh, and the root Makefile). Every one of those already sets GOEXPERIMENT=boringcrypto directly. So gating on fips achieved the stated goal (non-boringcrypto builds skip the file) but as a side effect silently dropped FIPS enforcement from every real build, since nothing ever satisfies that tag.

This went undetected because it's a runtime security-policy change, not a compile or functional regression — go build, go vet, and every unit/e2e test behave identically either way. The only way to observe it is a live TLS scan (nmap --script ssl-enum-ciphers) against a deployed webhook, which isn't part of this repo's pre-checkin pipeline (confirmed by inspecting a pre-checkin log: it runs make images + a 15-spec smoke subset of test-e2e, all PVC/volume-expansion functional tests, nothing touching TLS). It surfaced externally via TestValidateSupervisorOpenPorts in the Supervisor stability suite.

**Fix**
Change the build tag from fips → boringcrypto.
This restores exact pre-regression behavior in every production build (all of which already set GOEXPERIMENT=boringcrypto) while still satisfying #4117's original goal — a plain go build/go vet without that experiment set still skips this file cleanly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1876/ (passed)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1427/ (passed)

Fix verified on the live testbed. The regression reproduced before the patch and is gone after it.

Probe (TLS 1.3, port 9883) | Before patch | After patch
-- | -- | --
CHACHA20_POLY1305 (non-FIPS) | ✅ ACCEPTED | ❌ REJECTED (handshake_failure)
AES_256_GCM | ACCEPTED | ACCEPTED
AES_128_GCM | ACCEPTED | ACCEPTED

Confirmed on both webhook pods and the ClusterIP service the apiserver actually uses. The server's own log is the direct confirmation:
`tls: no cipher suite supported by both client and server; client offered: [1303]`

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
