### PR TITLE
Memory Optimization: Reduce syncer PVC/PV memory on large supervisors

### DIFF
--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -50,6 +50,8 @@ type FakeK8SOrchestrator struct {
 	csiNodeTopologyInstances []interface{}
 	// PVCs for testing
 	pvcs []*v1.PersistentVolumeClaim
+	// PVs for testing
+	pvs []*v1.PersistentVolume
 	// NodeNameToHostMoID is the node name -> ESXi host MoID map returned by
 	// GetNodeNameToHostMoIDMap in tests. Nil returns an empty map.
 	NodeNameToHostMoID map[string]string

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -145,6 +145,13 @@ func (c *FakeK8SOrchestrator) IsFakeAttachAllowed(
 
 func (c *FakeK8SOrchestrator) GetPvcObjectByName(ctx context.Context,
 	pvcName string, namespace string) (*v1.PersistentVolumeClaim, error) {
+	// SetPVCs fixtures take priority over the magic-name fixtures below.
+	for _, pvc := range c.pvcs {
+		if pvc.Name == pvcName && pvc.Namespace == namespace {
+			return pvc, nil
+		}
+	}
+
 	if pvcName == "pvc-rwx" {
 		pvc := &v1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
@@ -281,6 +288,21 @@ func (c *FakeK8SOrchestrator) GetPvcObjectByName(ctx context.Context,
 		},
 	}
 	return pvc, nil
+}
+
+// GetPvObjectByName looks up a PV registered via SetPVs by name.
+func (c *FakeK8SOrchestrator) GetPvObjectByName(ctx context.Context, pvName string) (*v1.PersistentVolume, error) {
+	for _, pv := range c.pvs {
+		if pv.Name == pvName {
+			return pv, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(v1.Resource("persistentvolume"), pvName)
+}
+
+// SetPVs sets the PVs for testing
+func (c *FakeK8SOrchestrator) SetPVs(pvs []*v1.PersistentVolume) {
+	c.pvs = pvs
 }
 
 // MarkFakeAttached marks the volume as fake attached.

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -125,6 +125,9 @@ type COCommonInterface interface {
 	GetActiveClustersForNamespaceInRequestedZones(ctx context.Context, ns string, zones []string) ([]string, error)
 	// GetPvcObjectByName return PVC object for the given PVC name
 	GetPvcObjectByName(ctx context.Context, pvcName string, namespace string) (*v1.PersistentVolumeClaim, error)
+	// GetPvObjectByName returns the PV object for the given PV name. The returned
+	// object is read-only — DeepCopy before mutating.
+	GetPvObjectByName(ctx context.Context, pvName string) (*v1.PersistentVolume, error)
 	HandleLateEnablementOfCapability(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, capability,
 		gcPort, gcEndpoint string)
 	// IsDPOServiceInstalled returns whether the Data Protection Operator service is installed on the cluster.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1727,6 +1727,17 @@ func (c *K8sOrchestrator) GetPvcObjectByName(ctx context.Context, pvcName string
 
 }
 
+// GetPvObjectByName returns the PV object for the given PV name.
+func (c *K8sOrchestrator) GetPvObjectByName(ctx context.Context, pvName string) (*v1.PersistentVolume, error) {
+	log := logger.GetLogger(ctx)
+	pvObj, err := c.informerManager.GetPVLister().Get(pvName)
+	if err != nil {
+		log.Errorf("failed to get pv: %s. err=%v", pvName, err)
+		return nil, err
+	}
+	return pvObj, nil
+}
+
 // IsFakeAttachAllowed checks if the volume is eligible to be fake attached
 // and returns a bool value.
 func (c *K8sOrchestrator) IsFakeAttachAllowed(ctx context.Context, volumeID string,

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -23,6 +23,7 @@ import (
 
 	snapclientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	"github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/informers"
 	v1 "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -33,6 +34,24 @@ import (
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
+
+// TransformStripManagedFields drops metadata.managedFields, which this driver never
+// reads but which can dominate a cached object's size at scale.
+func TransformStripManagedFields(obj interface{}) (interface{}, error) {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		if d.Obj == nil {
+			return obj, nil
+		}
+		if accessor, err := meta.Accessor(d.Obj); err == nil {
+			accessor.SetManagedFields(nil)
+		}
+		return d, nil
+	}
+	if accessor, err := meta.Accessor(obj); err == nil {
+		accessor.SetManagedFields(nil)
+	}
+	return obj, nil
+}
 
 const (
 	// resyncPeriodConfigMapInformer is the time interval between each resync
@@ -141,6 +160,9 @@ func (im *InformerManager) AddPVCListener(ctx context.Context, add func(obj inte
 	log := logger.GetLogger(ctx)
 	if im.pvcInformer == nil {
 		im.pvcInformer = im.informerFactory.Core().V1().PersistentVolumeClaims().Informer()
+		if err := im.pvcInformer.SetTransform(TransformStripManagedFields); err != nil {
+			log.Warnf("failed to set managedFields-stripping transform on PVC informer: %v", err)
+		}
 	}
 	im.pvcSynced = im.pvcInformer.HasSynced
 
@@ -161,6 +183,9 @@ func (im *InformerManager) AddPVListener(ctx context.Context, add func(obj inter
 	log := logger.GetLogger(ctx)
 	if im.pvInformer == nil {
 		im.pvInformer = im.informerFactory.Core().V1().PersistentVolumes().Informer()
+		if err := im.pvInformer.SetTransform(TransformStripManagedFields); err != nil {
+			log.Warnf("failed to set managedFields-stripping transform on PV informer: %v", err)
+		}
 	}
 	im.pvSynced = im.pvInformer.HasSynced
 

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler_test.go
@@ -263,6 +263,15 @@ func (m *MockCOCommonInterface) GetPvcObjectByName(ctx context.Context,
 	return args.Get(0).(*corev1.PersistentVolumeClaim), args.Error(1)
 }
 
+func (m *MockCOCommonInterface) GetPvObjectByName(ctx context.Context,
+	pvName string) (*corev1.PersistentVolume, error) {
+	args := m.Called(ctx, pvName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*corev1.PersistentVolume), args.Error(1)
+}
+
 func (m *MockCOCommonInterface) HandleLateEnablementOfCapability(ctx context.Context,
 	clusterFlavor cnstypes.CnsClusterFlavor, capability, gcPort, gcEndpoint string) {
 	m.Called(ctx, clusterFlavor, capability, gcPort, gcEndpoint)

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -260,7 +260,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 				instance.Name, instance.Spec.VMName)
 			// Fetch the PVC and PV instance and get volume ID
 			skipConfigureVolumeACL := false
-			volumeID, err := util.GetVolumeID(ctx, r.client, instance.Spec.PvcName, instance.Namespace)
+			volumeID, err := util.GetVolumeID(ctx, instance.Spec.PvcName, instance.Namespace)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					// If PVC instance is NotFound (deleted), then there is no need to configure ACL on file volume.
@@ -328,7 +328,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 	if instance.DeletionTimestamp != nil {
 		log.Infof("CnsFileAccessConfig instance %q has deletion timestamp set", instance.Name)
 		volumeExists := true
-		volumeID, err := util.GetVolumeID(ctx, r.client, instance.Spec.PvcName, instance.Namespace)
+		volumeID, err := util.GetVolumeID(ctx, instance.Spec.PvcName, instance.Namespace)
 		if err != nil {
 			if ifFileVolumesWithVmserviceVmsSupported &&
 				apierrors.IsNotFound(err) {
@@ -436,7 +436,7 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 	log.Infof("Reconciling CnsFileAccessConfig with instance: %q from namespace: %q. timeout %q seconds",
 		instance.Name, instance.Namespace, timeout)
 	if !instance.Status.Done {
-		volumeID, err := util.GetVolumeID(ctx, r.client, instance.Spec.PvcName, instance.Namespace)
+		volumeID, err := util.GetVolumeID(ctx, instance.Spec.PvcName, instance.Namespace)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to get volumeID from pvcName: %q. Error: %+v", instance.Spec.PvcName, err)
 			log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -290,9 +290,8 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 			// CNS PVC protection finalizer exist. If the finalizer does not exist, it incurs that
 			// the attachment object was created with an older CSI. Hence we add the
 			// CNS PVC protection finalizer on the SV PVC in the current reconciliation loop.
-			pvc := &v1.PersistentVolumeClaim{}
-			err = r.client.Get(internalCtx, k8stypes.NamespacedName{Name: instance.Spec.VolumeName,
-				Namespace: instance.Namespace}, pvc)
+			pvc, err := commonco.ContainerOrchestratorUtility.GetPvcObjectByName(internalCtx,
+				instance.Spec.VolumeName, instance.Namespace)
 			if err != nil {
 				msg := fmt.Sprintf("failed to get PVC with volumename: %q on namespace: %q. Err: %+v",
 					instance.Spec.VolumeName, instance.Namespace, err)
@@ -310,7 +309,8 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 				}
 			}
 			if !cnsPvcFinalizerExists {
-				faulttype, err := addFinalizerToPVC(internalCtx, r.client, pvc)
+				// DeepCopy: pvc is a cache-owned object, not safe to mutate directly.
+				faulttype, err := addFinalizerToPVC(internalCtx, r.client, pvc.DeepCopy())
 				if err != nil {
 					msg := fmt.Sprintf("failed to add %q finalizer on the PVC with volumename: %q on namespace: %q. Err: %+v",
 						cnsoptypes.CNSPvcFinalizer, instance.Spec.VolumeName, instance.Namespace, err)
@@ -409,7 +409,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 				recordEvent(internalCtx, r, instance, v1.EventTypeWarning, msg)
 				return reconcile.Result{RequeueAfter: timeout}, csifault.CSIVmNotFoundFault, nil
 			}
-			volumeID, faulttype, err := getVolumeID(internalCtx, r.client, instance.Spec.VolumeName, instance.Namespace)
+			volumeID, faulttype, err := getVolumeID(internalCtx, instance.Spec.VolumeName, instance.Namespace)
 			if err != nil {
 				msg := fmt.Sprintf("Failed to get volumeID. Error: %s", err)
 				instance.Status.Error = err.Error()
@@ -451,9 +451,8 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 				return reconcile.Result{RequeueAfter: timeout}, faulttype, nil
 			}
 
-			pvc := &v1.PersistentVolumeClaim{}
-			err = r.client.Get(internalCtx, k8stypes.NamespacedName{Name: instance.Spec.VolumeName,
-				Namespace: instance.Namespace}, pvc)
+			pvc, err := commonco.ContainerOrchestratorUtility.GetPvcObjectByName(internalCtx,
+				instance.Spec.VolumeName, instance.Namespace)
 			if err != nil {
 				msg := fmt.Sprintf("failed to get PVC with volumename: %q on namespace: %q. Err: %+v",
 					instance.Spec.VolumeName, instance.Namespace, err)
@@ -469,7 +468,8 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 				}
 			}
 			if !cnsPvcFinalizerExists {
-				_, err = addFinalizerToPVC(internalCtx, r.client, pvc)
+				// DeepCopy: pvc is a cache-owned object, not safe to mutate directly.
+				_, err = addFinalizerToPVC(internalCtx, r.client, pvc.DeepCopy())
 				if err != nil {
 					msg := fmt.Sprintf("failed to add %q finalizer on the PVC with volumename: %q on namespace: %q. Err: %+v",
 						cnsoptypes.CNSPvcFinalizer, instance.Spec.VolumeName, instance.Namespace, err)
@@ -526,8 +526,8 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 		if instance.DeletionTimestamp != nil {
 			pvc := &v1.PersistentVolumeClaim{}
 			var pvcDeleted bool
-			err = r.client.Get(internalCtx, k8stypes.NamespacedName{Name: instance.Spec.VolumeName,
-				Namespace: instance.Namespace}, pvc)
+			fetchedPVC, err := commonco.ContainerOrchestratorUtility.GetPvcObjectByName(internalCtx,
+				instance.Spec.VolumeName, instance.Namespace)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					pvcDeleted = true
@@ -537,6 +537,9 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 					recordEvent(internalCtx, r, instance, v1.EventTypeWarning, msg)
 					return reconcile.Result{RequeueAfter: timeout}, csifault.CSIApiServerOperationFault, nil
 				}
+			} else {
+				// DeepCopy: pvc is a cache-owned object, mutated below by removeFinalizerFromPVC.
+				pvc = fetchedPVC.DeepCopy()
 			}
 			volumeOpType = prometheus.PrometheusDetachVolumeOpType
 			nodeVM, err := getVMByUUIDFromVCenter(internalCtx, dc, nodeUUID)
@@ -616,7 +619,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 					instance.Status.AttachmentMetadata)
 				// Try to get volumeID using getVolumeID function
 				var err error
-				cnsVolumeID, faulttype, err = getVolumeID(internalCtx, r.client,
+				cnsVolumeID, faulttype, err = getVolumeID(internalCtx,
 					instance.Spec.VolumeName, instance.Namespace)
 				if err != nil {
 					msg := fmt.Sprintf("Failed to get CNS volume ID for PVC: %q in "+
@@ -751,9 +754,8 @@ func (r *ReconcileCnsNodeVMAttachment) applyAttachedPvcLabelToInstance(ctx conte
 		}
 	}
 
-	pvc := &v1.PersistentVolumeClaim{}
-	err := r.client.Get(ctx, k8stypes.NamespacedName{Name: instance.Spec.VolumeName,
-		Namespace: instance.Namespace}, pvc)
+	pvc, err := commonco.ContainerOrchestratorUtility.GetPvcObjectByName(ctx, instance.Spec.VolumeName,
+		instance.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Infof("PVC %s is already deleted. Skip adding label to instance %s", instance.Spec.VolumeName,
@@ -1022,12 +1024,11 @@ func getVCDatacentersFromConfig(cfg *config.Config) (map[string][]string, error)
 }
 
 // getVolumeID gets the volume ID from the PV that is bound to PVC by pvcName.
-func getVolumeID(ctx context.Context, client client.Client, pvcName string,
+func getVolumeID(ctx context.Context, pvcName string,
 	namespace string) (string, string, error) {
 	log := logger.GetLogger(ctx)
 	// Get PVC by pvcName from namespace.
-	pvc := &v1.PersistentVolumeClaim{}
-	err := client.Get(ctx, k8stypes.NamespacedName{Name: pvcName, Namespace: namespace}, pvc)
+	pvc, err := commonco.ContainerOrchestratorUtility.GetPvcObjectByName(ctx, pvcName, namespace)
 	if err != nil {
 		log.Errorf("failed to get PVC with volumename: %q on namespace: %q. Err: %s",
 			pvcName, namespace, err)
@@ -1043,8 +1044,7 @@ func getVolumeID(ctx context.Context, client client.Client, pvcName string,
 	}
 
 	// Get PV by name.
-	pv := &v1.PersistentVolume{}
-	err = client.Get(ctx, k8stypes.NamespacedName{Name: pvc.Spec.VolumeName, Namespace: ""}, pv)
+	pv, err := commonco.ContainerOrchestratorUtility.GetPvObjectByName(ctx, pvc.Spec.VolumeName)
 	if err != nil {
 		log.Errorf("failed to get PV with name: %q for PVC: %q. Err: %s",
 			pvc.Spec.VolumeName, pvcName, err)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	cnsopapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 
 	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
@@ -130,6 +131,17 @@ func TestReconcileDetachWithVolumeIDFallback(t *testing.T) {
 		WithStatusSubresource(instance).
 		WithRuntimeObjects(instance, pvc, pv).
 		Build()
+
+	// getVolumeID reads PVC/PV via commonco, not r.client — register fixtures there too.
+	fakeCOIf, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+	fakeCO, ok := fakeCOIf.(*unittestcommon.FakeK8SOrchestrator)
+	require.True(t, ok)
+	origCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = fakeCO
+	defer func() { commonco.ContainerOrchestratorUtility = origCO }()
+	fakeCO.SetPVCs([]*v1.PersistentVolumeClaim{pvc})
+	fakeCO.SetPVs([]*v1.PersistentVolume{pv})
 
 	// Initialize backOffDuration map (required by controller)
 	backOffDuration = make(map[k8stypes.NamespacedName]time.Duration)
@@ -243,8 +255,9 @@ func TestReconcileDetachWithVolumeIDFallbackFailure(t *testing.T) {
 			Finalizers:        []string{"cns.vmware.com/cnsnodevmattachment"},
 		},
 		Spec: v1a1.CnsNodeVmAttachmentSpec{
-			NodeUUID:   "test-node-uuid",
-			VolumeName: "nonexistent-pvc", // This PVC doesn't exist
+			NodeUUID: "test-node-uuid",
+			// "not-found-error" is FakeK8SOrchestrator's NotFound sentinel name.
+			VolumeName: "not-found-error",
 		},
 		Status: v1a1.CnsNodeVmAttachmentStatus{
 			// AttachmentMetadata is missing CNS volume ID - this triggers the fallback
@@ -259,6 +272,15 @@ func TestReconcileDetachWithVolumeIDFallbackFailure(t *testing.T) {
 		WithStatusSubresource(instance).
 		WithRuntimeObjects(instance).
 		Build()
+
+	// getVolumeID reads PVC/PV via commonco, not r.client.
+	fakeCOIf, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+	fakeCO, ok := fakeCOIf.(*unittestcommon.FakeK8SOrchestrator)
+	require.True(t, ok)
+	origCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = fakeCO
+	defer func() { commonco.ContainerOrchestratorUtility = origCO }()
 
 	// Initialize backOffDuration map (required by controller)
 	backOffDuration = make(map[k8stypes.NamespacedName]time.Duration)
@@ -424,6 +446,16 @@ func TestApplyAttachedPvcLabelToInstance(t *testing.T) {
 	_ = cnsopapis.AddToScheme(scheme)
 	_ = v1.AddToScheme(scheme)
 
+	// applyAttachedPvcLabelToInstance reads the PVC via commonco; each subtest registers
+	// what it needs via SetPVCs.
+	fakeCOIf, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+	fakeCO, ok := fakeCOIf.(*unittestcommon.FakeK8SOrchestrator)
+	require.True(t, ok)
+	origCO := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = fakeCO
+	defer func() { commonco.ContainerOrchestratorUtility = origCO }()
+
 	testPVCUID := "test-pvc-uid"
 
 	// Base instance (attached state toggled inside tests)
@@ -490,6 +522,7 @@ func TestApplyAttachedPvcLabelToInstance(t *testing.T) {
 				UID:       k8stypes.UID(testPVCUID),
 			},
 		}
+		fakeCO.SetPVCs([]*v1.PersistentVolumeClaim{pvc})
 
 		clientFake := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -510,6 +543,9 @@ func TestApplyAttachedPvcLabelToInstance(t *testing.T) {
 	t.Run("returns error when PVC fetch fails", func(t *testing.T) {
 		instance := baseInstance.DeepCopy()
 		instance.Status.Attached = true // triggers PVC lookup
+		// "not-found-error" is FakeK8SOrchestrator's NotFound sentinel name.
+		instance.Spec.VolumeName = "not-found-error"
+		fakeCO.SetPVCs(nil)
 
 		clientFake := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -534,6 +570,7 @@ func TestApplyAttachedPvcLabelToInstance(t *testing.T) {
 				UID:       k8stypes.UID(testPVCUID),
 			},
 		}
+		fakeCO.SetPVCs([]*v1.PersistentVolumeClaim{pvc})
 
 		clientFake := fake.NewClientBuilder().
 			WithScheme(scheme).

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -489,6 +489,10 @@ func (m *mockCOCommon) GetPvcObjectByName(ctx context.Context, pvcName string,
 	return nil, nil
 }
 
+func (m *mockCOCommon) GetPvObjectByName(ctx context.Context, pvName string) (*corev1.PersistentVolume, error) {
+	return nil, nil
+}
+
 func (m *mockCOCommon) GetVolumeIDFromPVCName(namespace string, pvcName string) (string, bool) {
 	return "vol-1", true
 }

--- a/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -396,23 +396,15 @@ func (r *ReconcileVirtualMachineSnapshot) syncVolumesAndUpdateCNSVolumeInfo(ctx 
 		if vmVolume.VirtualMachineVolumeSource.PersistentVolumeClaim == nil {
 			continue
 		}
-		pvcKey := apitypes.NamespacedName{
-			Namespace: vm.Namespace,
-			Name:      vmVolume.VirtualMachineVolumeSource.PersistentVolumeClaim.ClaimName,
-		}
-		pvc := &corev1.PersistentVolumeClaim{}
-		err = r.client.Get(ctx, pvcKey, pvc, &client.GetOptions{})
+		pvc, err := commonco.ContainerOrchestratorUtility.GetPvcObjectByName(ctx,
+			vmVolume.VirtualMachineVolumeSource.PersistentVolumeClaim.ClaimName, vm.Namespace)
 		if err != nil {
 			log.Errorf("syncVolumesAndUpdateCNSVolumeInfo: failed get pvc %s/%s. error: %v",
 				vm.Namespace, vmVolume.Name, err)
 			return err
 		}
 		if pvc.Spec.VolumeName != "" {
-			pvKey := apitypes.NamespacedName{
-				Name: pvc.Spec.VolumeName,
-			}
-			pv := &corev1.PersistentVolume{}
-			err = r.client.Get(ctx, pvKey, pv, &client.GetOptions{})
+			pv, err := commonco.ContainerOrchestratorUtility.GetPvObjectByName(ctx, pvc.Spec.VolumeName)
 			if err != nil {
 				log.Errorf("syncVolumesAndUpdateCNSVolumeInfo: could not get the volume "+
 					"for pvc %s/%s error: %v", pvc.Namespace, vm.Name, err)

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -27,11 +27,14 @@ import (
 	"github.com/fsnotify/fsnotify"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -422,6 +425,20 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		},
+		// No controller here watches PVC/PV, only Get()s them, so don't let the manager
+		// cache them — at 120K+ PVC scale that cache alone costs 1GB+.
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.PersistentVolumeClaim{},
+					&corev1.PersistentVolume{},
+				},
+			},
+		},
+		// managedFields is never read; strip it from what this manager still caches.
+		Cache: ctrlcache.Options{
+			DefaultTransform: k8s.TransformStripManagedFields,
 		},
 	})
 	if err != nil {

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -30,7 +30,6 @@ import (
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -97,14 +96,10 @@ const (
 var ErrNetworkSettingsUnavailable = errors.New("NetworkSettings CR is unavailable or provider is not set")
 
 // GetVolumeID gets the volume ID from the PV that is bound to PVC by pvcName.
-func GetVolumeID(ctx context.Context, client client.Client, pvcName string, namespace string) (string, error) {
+func GetVolumeID(ctx context.Context, pvcName string, namespace string) (string, error) {
 	log := logger.GetLogger(ctx)
 	// Get PVC by pvcName from namespace.
-	pvc := &v1.PersistentVolumeClaim{}
-	// TODO:
-	// Enhancements to use informers instead of API server invocations is tracked here:
-	// https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/599
-	err := client.Get(ctx, apitypes.NamespacedName{Name: pvcName, Namespace: namespace}, pvc)
+	pvc, err := commonco.ContainerOrchestratorUtility.GetPvcObjectByName(ctx, pvcName, namespace)
 	if err != nil {
 		log.Errorf("failed to get PVC with volumename: %q on namespace: %q. Err: %+v",
 			pvcName, namespace, err)
@@ -112,8 +107,7 @@ func GetVolumeID(ctx context.Context, client client.Client, pvcName string, name
 	}
 
 	// Get PV by name.
-	pv := &v1.PersistentVolume{}
-	err = client.Get(ctx, apitypes.NamespacedName{Name: pvc.Spec.VolumeName, Namespace: ""}, pv)
+	pv, err := commonco.ContainerOrchestratorUtility.GetPvObjectByName(ctx, pvc.Spec.VolumeName)
 	if err != nil {
 		log.Errorf("failed to get PV with name: %q for PVC: %q. Err: %+v",
 			pvc.Spec.VolumeName, pvcName, err)

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -714,6 +714,10 @@ func (m *mockCOCommonForFullSync) GetPvcObjectByName(
 	return nil, nil
 }
 
+func (m *mockCOCommonForFullSync) GetPvObjectByName(ctx context.Context, pvName string) (*v1.PersistentVolume, error) {
+	return nil, nil
+}
+
 func (m *mockCOCommonForFullSync) GetVolumeIDFromPVCName(namespace, pvcName string) (string, bool) {
 	return "", false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

On supervisors with very large volume counts (observed: 120K PVs / 120K PVCs), the
`vsphere-syncer` leader holds multiple GB of live heap in **redundant** PVC/PV informer
caches, plus several `cnsoperator` reconcilers reading PVC/PV directly from the API server
on every reconcile.

Root cause (found via live `pprof` heap analysis on an affected cluster):
1. **PVCs cached twice** — the CNS Operator's controller-runtime manager silently starts its
   own cluster-wide PVC/PV informer the first time any controller calls `client.Get()` on a
   PVC/PV, even though none of those controllers actually *watch* PVC/PV. This duplicates the
   cache the syncer's own `client-go` `InformerManager` already maintains.
2. **`metadata.managedFields` never stripped** in either cache, despite never being read by
   this driver — at 120K-object scale this can dominate a cached object's size.
3. Several `cnsoperator` reconcilers read PVC/PV straight from the API server on every
   reconcile instead of from any cache.

This PR:
- Strips `managedFields` from the client-go PVC/PV informers via a new
  `k8s.TransformStripManagedFields` (`SetTransform`).
- Disables the CNS Operator manager's own PVC/PV cache (`Client.Cache.DisableFor`) so it
  stops duplicating the informer above, and strips `managedFields` from the CRDs it still
  caches (`DefaultTransform`).
- Adds `commonco.COCommonInterface.GetPvObjectByName` (alongside the existing
  `GetPvcObjectByName`), both backed by the single, deduplicated, `managedFields`-stripped
  informer cache, and routes every PVC/PV read in `cnsoperator` through it instead of a
  direct `client.Get()`: `cnsnodevmattachment`'s `getVolumeID`,
  `applyAttachedPvcLabelToInstance`, and all three finalizer add/remove sites in
  `Reconcile`; `cnsoperator/util.GetVolumeID` (used by `cnsfileaccessconfig`); and
  `virtualmachinesnapshot`'s `syncVolumesAndUpdateCNSVolumeInfo`.
- The finalizer add/remove sites mutate the fetched PVC in place. A lister-returned object
  is a pointer into the informer's own store, not a copy (unlike controller-runtime's cached
  client, which deep-copies automatically) — each of those sites now calls `.DeepCopy()`
  immediately after the cache read, before any mutation, so the shared cache is never
  corrupted for other readers.
- Leaves exactly one PVC read on a direct `client.Get()`, by design: the conflict-retry
  re-fetch in `updateSVPVC`, which exists specifically to observe the latest
  `resourceVersion` after a write conflict and must therefore be live, not cached.



**Testing done**:
- `go build ./pkg/...` and `go vet ./pkg/...` — clean.
- `go test ./pkg/...` — full suite, zero regressions.
- Extended `FakeK8SOrchestrator` with fixture-backed `GetPvcObjectByName`/`GetPvObjectByName`
  (`SetPVCs`/new `SetPVs`), checked ahead of its legacy magic-name fixtures so no existing
  test's behavior changes; updated the affected controller tests
  (`cnsnodevmattachment_controller_test.go`, `cnsfileaccessconfig_controller_test.go`) to
  register matching fixtures there instead of relying only on the fake controller-runtime
  client.
- Root cause and expected memory savings were sized against a live `pprof` heap profile
  pulled from an affected supervisor (120K PV/PVC/CnsVolumeInfo scale) — see numbers below.
- Not yet done: a live before/after heap comparison on a redeployed supervisor at the same
  scale. Recommend as a pre-merge or post-merge validation step (see reviewer notes).

**Special notes for your reviewer**:
- `DisableFor(PVC, PV)` means the `cnsoperator` controllers' `Get()` calls now go straight to
  the API server instead of a cache. Quantified separately: bounded by each controller's own
  `MaxConcurrentReconciles` (20/10/10 by default), not by cluster scale — worst case ~40
  concurrent API calls system-wide, not thousands, and typical load is driven by
  attach/detach/snapshot event *rate*, not by the 120K object count.
- The `CnsVolumeInfo` dynamic-informer cache (unstructured, ~1.1 GB at 120K scale) is **out
  of scope** for this PR — its `managedFields` cost isn't cleanly separable from generic
  `map[string]interface{}` decode via `pprof`, and fixing it (type it, or add a transform)
  is tracked as separate follow-up work.
- Would appreciate a second pair of eyes specifically on the three `DeepCopy()` insertion
  points in `cnsnodevmattachment_controller.go` — correctness there depends on catching
  every mutation path downstream of the cache read.

**Release note**:
```release-note
Reduce vsphere-syncer memory usage on large supervisors by removing a redundant PVC/PV
informer cache in the CNS Operator, stripping unused managedFields from cached PVC/PV/CRD
objects, and serving CNS Operator's PVC/PV lookups from the existing shared cache instead of
the API server.
```


## What actually changes, end to end

| | Before | After |
|---|---|---|
| PVC/PV caches in the syncer process | **2** (client-go `InformerManager` + CNS Operator's own controller-runtime cache) | **1** (client-go `InformerManager` only) |
| `managedFields` in cached PVC/PV/CRD objects | present, unstripped | stripped everywhere cached |
| Informer-cache memory floor (measured, 120K scale) | **~3,246 MB** | **~1,941 MB** (**−1.26 GB, ≈39.7%**) |
| Direct-to-apiserver PVC/PV `Get()` calls from `cnsoperator` | 6 call sites across 3 controllers | **0** (except the by-design conflict-retry re-fetch) |
| API load from those reads | one apiserver round-trip per reconcile | served from local cache; apiserver load only from the initial informer LIST/WATCH, shared with everything else already reading that cache |
| Reconcile *behavior/outcomes* | — | **unchanged** — same finalizer semantics, same error handling, same requeue/backoff; only where the data comes from changed |
| Risk introduced | — | cache staleness is bounded by the same informer every other reconciler already trusts (µs–ms typically); no new correctness class beyond what `CnsNodeVMBatchAttachment`/`CnsVolumeMetadata` already accept using raw clientset reads today |

The number that matters most for the original OOM investigation: **the live heap floor drops by ~1.26 GB at 120K-object scale**, which.

**Follow on fix** `spew.Sdump` fix and the still-outstanding  `reconcileAllMutex` goroutine-pileup fix from the storagepool listener — is one of the two independent contributors to the syncer's memory pressure on the controller.