### PR TITLE
Improve error message in batch attach result

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -3924,7 +3924,7 @@ func compileBatchAttachTaskResult(ctx context.Context, m *defaultManager, result
 		log.Errorf("failed to attach cns volume: %q to node vm: %q. fault: %q. opId: %q",
 			volumeId, vm.String(), faultType, activationId)
 		msg := fmt.Sprintf("failed to attach cns volume: %q Error: %s",
-			volumeId, volumeOperationResult.Fault.LocalizedMessage)
+			volumeId, ExtractDetailedFaultMessage(ctx, volumeOperationResult.Fault))
 		batchAttachResult.Error = errors.New(msg)
 		log.Infof("Constructed batch attach result for volume %s with failure", volumeId)
 		return batchAttachResult, nil

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -19,6 +19,7 @@ package volume
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -429,6 +430,41 @@ func ExtractFaultTypeFromVolumeResponseResult(ctx context.Context,
 	}
 	log.Info("No fault in resp %+v", resp)
 	return ""
+}
+
+// ExtractDetailedFaultMessage builds a detailed error message for a LocalizedMethodFault.
+// LocalizedMessage on the fault is often a generic, templated string (for example
+// vim.fault.InvalidDeviceSpec always reports "Invalid configuration for device '<index>'."
+// regardless of the underlying cause). The actual root cause is frequently found one level
+// down, in the nested MethodFault's FaultMessage entries or its immediate FaultCause, which
+// this function appends to the generic message so callers get an actionable error.
+func ExtractDetailedFaultMessage(ctx context.Context, fault *types.LocalizedMethodFault) string {
+	log := logger.GetLogger(ctx)
+	if fault == nil {
+		return ""
+	}
+	msg := fault.LocalizedMessage
+	if fault.Fault == nil {
+		return msg
+	}
+	methodFault := fault.Fault.GetMethodFault()
+	if methodFault == nil {
+		return msg
+	}
+	var details []string
+	for _, faultMsg := range methodFault.FaultMessage {
+		if faultMsg.Message != "" {
+			details = append(details, faultMsg.Message)
+		}
+	}
+	if methodFault.FaultCause != nil && methodFault.FaultCause.LocalizedMessage != "" {
+		details = append(details, methodFault.FaultCause.LocalizedMessage)
+	}
+	if len(details) > 0 {
+		msg = fmt.Sprintf("%s Details: %s", msg, strings.Join(details, "; "))
+	}
+	log.Debugf("Extracted detailed fault message: %q from fault: %+v", msg, fault)
+	return msg
 }
 
 // invokeCNSCreateSnapshot invokes CreateSnapshot operation for that volume on CNS.

--- a/pkg/common/cns-lib/volume/util_fault_test.go
+++ b/pkg/common/cns-lib/volume/util_fault_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// TestExtractDetailedFaultMessageNilFault verifies that a nil LocalizedMethodFault
+// returns an empty string without panicking.
+func TestExtractDetailedFaultMessageNilFault(t *testing.T) {
+	got := ExtractDetailedFaultMessage(context.Background(), nil)
+	if got != "" {
+		t.Errorf("expected empty string for nil fault, got %q", got)
+	}
+}
+
+// TestExtractDetailedFaultMessageNoNestedFault verifies that when Fault.Fault is nil,
+// only the top-level LocalizedMessage is returned.
+func TestExtractDetailedFaultMessageNoNestedFault(t *testing.T) {
+	fault := &types.LocalizedMethodFault{
+		LocalizedMessage: "generic failure",
+	}
+	got := ExtractDetailedFaultMessage(context.Background(), fault)
+	want := "generic failure"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+// TestExtractDetailedFaultMessageWithFaultMessages verifies that FaultMessage entries on
+// the nested MethodFault are appended to the generic LocalizedMessage. This mirrors the
+// real vim.fault.InvalidDeviceSpec case where LocalizedMessage is a generic templated
+// string ("Invalid configuration for device '2'.") and the actual root cause is only
+// present in FaultMessage.
+func TestExtractDetailedFaultMessageWithFaultMessages(t *testing.T) {
+	fault := &types.LocalizedMethodFault{
+		LocalizedMessage: "Invalid configuration for device '2'.",
+		Fault: &types.InvalidDeviceSpec{
+			InvalidVmConfig: types.InvalidVmConfig{
+				VmConfigFault: types.VmConfigFault{
+					VimFault: types.VimFault{
+						MethodFault: types.MethodFault{
+							FaultMessage: []types.LocalizableMessage{
+								{Message: "Provided backing file is not accessible from host."},
+								{Message: "Device: VirtualDisk."},
+							},
+						},
+					},
+				},
+				Property: "deviceChange[2].device.backing.fileName",
+			},
+			DeviceIndex: 2,
+		},
+	}
+
+	got := ExtractDetailedFaultMessage(context.Background(), fault)
+	want := "Invalid configuration for device '2'. Details: " +
+		"Provided backing file is not accessible from host.; Device: VirtualDisk."
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+// TestExtractDetailedFaultMessageWithFaultCause verifies that a non-empty FaultCause
+// LocalizedMessage is appended when the nested MethodFault has no FaultMessage entries.
+func TestExtractDetailedFaultMessageWithFaultCause(t *testing.T) {
+	fault := &types.LocalizedMethodFault{
+		LocalizedMessage: "resource is in use",
+		Fault: &types.ResourceInUse{
+			VimFault: types.VimFault{
+				MethodFault: types.MethodFault{
+					FaultCause: &types.LocalizedMethodFault{
+						LocalizedMessage: "disk is attached to another VM",
+					},
+				},
+			},
+			Type: "VirtualDisk",
+			Name: "disk-1",
+		},
+	}
+
+	got := ExtractDetailedFaultMessage(context.Background(), fault)
+	want := "resource is in use Details: disk is attached to another VM"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+// TestExtractDetailedFaultMessageWithFaultMessagesAndFaultCause verifies that both
+// FaultMessage entries and a FaultCause LocalizedMessage are appended together, in that
+// order, when both are present on the nested MethodFault.
+func TestExtractDetailedFaultMessageWithFaultMessagesAndFaultCause(t *testing.T) {
+	fault := &types.LocalizedMethodFault{
+		LocalizedMessage: "generic failure",
+		Fault: &types.ResourceInUse{
+			VimFault: types.VimFault{
+				MethodFault: types.MethodFault{
+					FaultMessage: []types.LocalizableMessage{
+						{Message: "detail one"},
+					},
+					FaultCause: &types.LocalizedMethodFault{
+						LocalizedMessage: "underlying cause",
+					},
+				},
+			},
+		},
+	}
+
+	got := ExtractDetailedFaultMessage(context.Background(), fault)
+	want := "generic failure Details: detail one; underlying cause"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+// TestExtractDetailedFaultMessageIgnoresEmptyFaultMessageAndCause verifies that empty
+// FaultMessage entries and an empty FaultCause LocalizedMessage do not produce a
+// "Details:" suffix, and a FaultCause with an empty LocalizedMessage is skipped.
+func TestExtractDetailedFaultMessageIgnoresEmptyFaultMessageAndCause(t *testing.T) {
+	fault := &types.LocalizedMethodFault{
+		LocalizedMessage: "generic failure",
+		Fault: &types.ResourceInUse{
+			VimFault: types.VimFault{
+				MethodFault: types.MethodFault{
+					FaultMessage: []types.LocalizableMessage{
+						{Message: ""},
+					},
+					FaultCause: &types.LocalizedMethodFault{
+						LocalizedMessage: "",
+					},
+				},
+			},
+		},
+	}
+
+	got := ExtractDetailedFaultMessage(context.Background(), fault)
+	want := "generic failure"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

ExtractDetailedFaultMessage builds a detailed error message for a LocalizedMethodFault.
LocalizedMessage on the fault is often a generic, templated string (for example vim.fault.InvalidDeviceSpec always reports "Invalid configuration for device '<index>'." regardless of the underlying cause). 

The actual root cause is frequently found one level down, in the MethodFault's FaultMessage entries which this function appends to the generic message so callers get an actionable error.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Pending