### PR TITLE
Update cns-csi.yaml to use v6.3.0+vmware.2 provisioner

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -336,7 +336,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -354,7 +354,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -354,7 +354,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -354,7 +354,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update cns-csi.yaml to use v6.3.0+vmware.2 provisioner for the below k8s versions:

- 1.35
- 1.34
- 1.33
- 1.32

**Testing done**:
Will be done as part of the internal spec bump

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update cns-csi.yaml to use v6.3.0+vmware.2 provisioner
```
