### PR TITLE
Fix quota counting in cnsregistervolume

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -971,25 +971,41 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 				return reconcile.Result{RequeueAfter: timeout}, nil
 			}
 			finalStoragePolicyUsageCR = currentStoragePolicyUsageCR.DeepCopy()
-			// Decrease the Reserved field for StoragePolicyUsageCR
-			finalStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Sub(
-				*resource.NewQuantity(currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Value(),
-					currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Format))
-			// Increase the Used field for StoragePolicyUsageCR
-			finalStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Used.Add(
-				*currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved)
-			err = syncer.PatchStoragePolicyUsage(ctx, cnsOperatorClient, storagePolicyUsageCR, finalStoragePolicyUsageCR)
+			// Decrease the Reserved field, and increase the Used field, by this PVC's own
+			// capacity only. Reserved is a pool shared across every disk in the same (e.g.
+			// multi-disk VM import) batch, so it may transiently hold other PVCs'
+			// still-outstanding reservations at the moment of this Get; draining the CR's
+			// entire current Reserved value here (instead of just this PVC's pvCapacity
+			// share) would steal those sibling reservations and double-count them into Used.
+			reservedBeforeTransfer := finalStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved
+			if reservedBeforeTransfer.Cmp(pvCapacity) < 0 {
+				// Reserved should always be at least this PVC's own pvCapacity, since it was
+				// added there earlier in this same reconcile. If it isn't, the shared pool is
+				// already inconsistent for reasons outside this PVC's transition; clamp to
+				// zero instead of underflowing Reserved negative, and surface it loudly so the
+				// inconsistency is visible rather than silently compounding.
+				log.Errorf("StoragePolicyUsage CR %q in namespace %q has Reserved (%s) less than "+
+					"this PVC's own capacity (%s) being transferred to Used; the Reserved pool is "+
+					"inconsistent. Clamping Reserved to zero instead of underflowing negative.",
+					currentStoragePolicyUsageCR.Name, currentStoragePolicyUsageCR.Namespace,
+					reservedBeforeTransfer.String(), pvCapacity.String())
+				*finalStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved = resource.Quantity{}
+			} else {
+				finalStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Sub(pvCapacity)
+			}
+			finalStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Used.Add(pvCapacity)
+			err = syncer.PatchStoragePolicyUsage(ctx, cnsOperatorClient, currentStoragePolicyUsageCR,
+				finalStoragePolicyUsageCR)
 			if err != nil {
 				log.Errorf("patching operation failed for StoragePolicyUsage CR: %q in namespace: %q. err: %v",
 					currentStoragePolicyUsageCR.Name, currentStoragePolicyUsageCR.Namespace, err)
 			} else {
-				reservedQty := currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved
 				log.Infof("Successfully decreased the reserved field by %s "+
 					"for storagepolicyusage CR: %q in namespace: %q",
-					reservedQty.String(), finalStoragePolicyUsageCR.Name, finalStoragePolicyUsageCR.Namespace)
+					pvCapacity.String(), finalStoragePolicyUsageCR.Name, finalStoragePolicyUsageCR.Namespace)
 				log.Infof("Successfully increased the used field by %s "+
 					"for storagepolicyusage CR: %q in namespace: %q",
-					reservedQty.String(), finalStoragePolicyUsageCR.Name, finalStoragePolicyUsageCR.Namespace)
+					pvCapacity.String(), finalStoragePolicyUsageCR.Name, finalStoragePolicyUsageCR.Namespace)
 			}
 		}
 	} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The "decrease reserved / increase used" step was subtracting the CR's entire current Reserved field value from itself (zeroing it) and adding that same whole-pool value to Used — instead of transferring only pvCapacity (this PVC's own declared size, which was correctly used in the earlier "increase reserved" step a few lines up). Since Reserved is a pool shared by every disk in the same batch, whichever PVC's reconcile happened to run this step while a sibling's reservation was still parked in the CR would drain the sibling's share too — permanently, since the field was zeroed rather than decremented.


Fix: both the Reserved.Sub(...) and Used.Add(...) now use pvCapacity — this PVC's own capacity — never the CR's current pool-wide value.
Race hardening: the merge-patch diff base was also fixed to use the freshly-fetched currentStoragePolicyUsageCR instead of the stale storagePolicyUsageCR read from earlier in the function.
Safeguard: added a defensive check — if Reserved < pvCapacity at transfer time (meaning the shared pool is already inconsistent for some other reason), it logs an error and clamps Reserved to zero instead of silently underflowing negative, rather than letting a bad state compound quietly.
Updated the two log lines to report pvCapacity (the actual amount now transferred) instead of the pre-fix Reserved snapshot.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Pre-check-in - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1878/

Replaced the syncer image on a testbed for manual verification:
```
root@420d3662f89c4bf217a83e9579ac45ea [ ~ ]# kubectl get pods -n vmware-system-csi -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\n"}{end}'
vsphere-csi-controller-78865f6df5-86rb7	localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1 localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1 localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v2.1.0_vmware.1 localhost:5000/vmware/vsphere-csi:vsphere9u1-088199ff localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1 cns-docker-dev-local.packages.vcfd.broadcom.net/chethanv/syncer-quota-counting-fix:aug3 localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
vsphere-csi-controller-78865f6df5-zkt9j	localhost:5000/vmware/csi-provisioner/csi-provisioner:v6.3.0_vmware.1 localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1 localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v2.1.0_vmware.1 localhost:5000/vmware/vsphere-csi:vsphere9u1-088199ff localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1 cns-docker-dev-local.packages.vcfd.broadcom.net/chethanv/syncer-quota-counting-fix:aug3 localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
vsphere-csi-webhook-5fdd9747-lmdfw	localhost:5000/vmware/syncer:vsphere9u1-088199ff
vsphere-csi-webhook-5fdd9747-qrxzr	localhost:5000/vmware/syncer:vsphere9u1-088199ff
```
The tests are passing now. it is calculating the quota correctly.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix quota counting in cnsregistervolume
```
