### PR TITLE
Enhance host zone requirements forwarding to the Supervisor during CreateVolume invoked from Guest

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -352,6 +352,13 @@ const (
 	// AnnGuestClusterRequestedTopology is the key for guest cluster requested topology
 	AnnGuestClusterRequestedTopology = "csi.vsphere.volume-requested-topology"
 
+	// ControlPlaneNodeRoleLabel marks a guest cluster Node as a control plane node.
+	// Used to identify hosts/zones that only run control plane VMs, so that host/zone
+	// topology requirements pinned solely to such hosts/zones (where no worker node,
+	// and therefore no workload pod, will ever be scheduled) can be discarded from
+	// volume provisioning requests.
+	ControlPlaneNodeRoleLabel = "node-role.kubernetes.io/control-plane"
+
 	// AnnVolumeAccessibleTopology is the annotation set by the supervisor cluster on PVC
 	AnnVolumeAccessibleTopology = "csi.vsphere.volume-accessible-topology"
 

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -566,14 +566,35 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					!isLinkedCloneRequest && // the cns-csi mutation webhook in supervisor will automatically set it.
 					(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolationFSS) ||
 						!isFileVolumeRequest) {
+					// Drop any host requirement that is only satisfied by control plane nodes.
+					// Workload pods are never scheduled onto control plane nodes, so a host
+					// with no worker node present can never actually run the pod that needs
+					// this volume; forwarding it to the Supervisor would pin the volume to a
+					// host it can never be attached from. Filtering it out here means the
+					// remaining (if any) worker-eligible host requirements are honored instead,
+					// without requiring every control-plane host to also have a worker node.
+					// Scoped to host-local storage (host-scoped topology) only: plain
+					// zone-scoped topology requests are unaffected and behave as before.
+					filteredPreferred := req.AccessibilityRequirements.Preferred
+					if isHostLocalStorageSupportFSSEnabled {
+						var err error
+						filteredPreferred, err = filterOutControlPlaneOnlyTopologySegments(ctx, c.guestClient,
+							req.AccessibilityRequirements.Preferred)
+						if err != nil {
+							msg := fmt.Sprintf("failed to filter control-plane-only topology segments for pvc "+
+								"with name: %s on namespace: %s. Error: %+v",
+								supervisorPVCName, c.supervisorNamespace, err)
+							return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
+						}
+					}
 					// Reject the request if it carries the VKS host-scoped topology key while the
 					// host-local-storage-support FSS/capability is disabled. Silently dropping the
 					// host key here would let the volume be provisioned without honoring the
 					// topology constraint the guest scheduler required (e.g. a pod already bound to
 					// a specific node via WaitForFirstConsumer), which is worse than failing fast.
 					// Mirrors the equivalent rejection in pkg/csi/service/wcp/controller.go.
-					translatedPreferred := make([]*csi.Topology, 0, len(req.AccessibilityRequirements.Preferred))
-					for _, t := range req.AccessibilityRequirements.Preferred {
+					translatedPreferred := make([]*csi.Topology, 0, len(filteredPreferred))
+					for _, t := range filteredPreferred {
 						if _, hasHostKey := t.Segments[common.GuestClusterTopologyLabelHost]; hasHostKey &&
 							!isHostLocalStorageSupportFSSEnabled {
 							msg := fmt.Sprintf("host-local storage policy volume provisioning is not supported: "+

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -308,6 +308,84 @@ func translateTopologyHostKey(segments map[string]string, fromKey, toKey string,
 	return translated
 }
 
+// getWorkerNodeHostValues lists guest cluster Nodes and returns the set of
+// distinct common.GuestClusterTopologyLabelHost values observed on worker
+// nodes (i.e. nodes without common.ControlPlaneNodeRoleLabel). Host values
+// that only ever appear on control plane nodes are absent from the result.
+// The returned workerNodeCount is the total number of worker nodes seen,
+// regardless of whether they carry the host label.
+func getWorkerNodeHostValues(ctx context.Context, guestClient clientset.Interface) (
+	workerHostValues map[string]bool, workerNodeCount int, err error) {
+	nodeList, err := guestClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list nodes in guest cluster: %v", err)
+	}
+	workerHostValues = make(map[string]bool)
+	for _, node := range nodeList.Items {
+		if _, isControlPlane := node.Labels[common.ControlPlaneNodeRoleLabel]; isControlPlane {
+			continue
+		}
+		workerNodeCount++
+		if val, ok := node.Labels[common.GuestClusterTopologyLabelHost]; ok && val != "" {
+			workerHostValues[val] = true
+		}
+	}
+	return workerHostValues, workerNodeCount, nil
+}
+
+// filterOutControlPlaneOnlyTopologySegments drops any topology segment that
+// is pinned to a host where only control plane VMs are deployed. Workload
+// pods are never scheduled onto control plane nodes, so a volume provisioned
+// against a host with no worker node present can never actually be attached
+// to the pod that requested it. Segments without the host key (plain
+// zone-scoped topology) are left untouched; the caller is expected to only
+// invoke this for host-scoped requests, gated on the host-local-storage-
+// support FSS/capability being enabled.
+//
+// If the guest cluster currently has zero worker nodes, host-local topology
+// aware provisioning cannot succeed at all (every segment would be dropped,
+// including any that a caller might otherwise expect to survive), so this
+// returns an error instead of silently emptying the result.
+func filterOutControlPlaneOnlyTopologySegments(ctx context.Context, guestClient clientset.Interface,
+	segments []*csi.Topology) ([]*csi.Topology, error) {
+	log := logger.GetLogger(ctx)
+	if len(segments) == 0 || guestClient == nil {
+		return segments, nil
+	}
+	hasHostKeySegment := false
+	for _, topology := range segments {
+		if host, ok := topology.Segments[common.GuestClusterTopologyLabelHost]; ok && host != "" {
+			hasHostKeySegment = true
+			break
+		}
+	}
+	if !hasHostKeySegment {
+		// Plain zone-scoped topology request: no host-local requirement to
+		// evaluate, so behave exactly as before this filtering existed.
+		return segments, nil
+	}
+
+	workerHostValues, workerNodeCount, err := getWorkerNodeHostValues(ctx, guestClient)
+	if err != nil {
+		return nil, err
+	}
+	if workerNodeCount == 0 {
+		return nil, fmt.Errorf("unable to provision a topology aware volume: no worker nodes found in guest cluster")
+	}
+
+	filtered := make([]*csi.Topology, 0, len(segments))
+	for _, topology := range segments {
+		host, hasHostKey := topology.Segments[common.GuestClusterTopologyLabelHost]
+		if hasHostKey && host != "" && !workerHostValues[host] {
+			log.Infof("filterOutControlPlaneOnlyTopologySegments: dropping topology segment %+v because "+
+				"host %q has no worker nodes (control plane VMs only)", topology.Segments, host)
+			continue
+		}
+		filtered = append(filtered, topology)
+	}
+	return filtered, nil
+}
+
 // generateGuestClusterRequestedTopologyJSON translates the topology into a json string to be set on the supervisor
 // PVC
 func generateGuestClusterRequestedTopologyJSON(topologies []*csi.Topology) (string, error) {

--- a/pkg/csi/service/wcpguest/controller_hostlocal_test.go
+++ b/pkg/csi/service/wcpguest/controller_hostlocal_test.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
@@ -46,6 +47,17 @@ const (
 // the same array-of-segment-maps shape) carrying hostKey and the standard zone key.
 func hostLocalWantAnnotation(hostKey string) string {
 	return `[{"` + hostKey + `":"` + hostLocalHostValue + `","topology.kubernetes.io/zone":"` + hostLocalZoneValue + `"}]`
+}
+
+// seedHostLocalWorkerNode creates a worker (non-control-plane) guest cluster
+// Node labeled with hostLocalHostValue, so that filterOutControlPlaneOnlyTopologySegments
+// treats the host as eligible instead of erroring out on zero worker nodes.
+func seedHostLocalWorkerNode(t *testing.T, c *controller) {
+	t.Helper()
+	node := makeGuestNode("worker-1", hostLocalHostValue, hostLocalZoneValue, false)
+	if _, err := c.guestClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed worker node: %v", err)
+	}
 }
 
 // hostLocalCreateRequest builds a CreateVolumeRequest carrying the VKS host
@@ -232,6 +244,7 @@ func TestCreateVolume_HostLocal_RequestedTopology_TranslatesHostKey(t *testing.T
 	if err := co.EnableFSS(context.Background(), common.HostLocalStorageSupportFSS); err != nil {
 		t.Fatalf("failed to enable FSS: %v", err)
 	}
+	seedHostLocalWorkerNode(t, c)
 
 	req := hostLocalCreateRequest(hostLocalAccessMode, hostLocalZoneValue, hostLocalHostValue)
 	pvc, _, err := runCreateVolumeAndBindSupervisorPVC(t, c, req)
@@ -311,6 +324,7 @@ func TestCreateVolume_HostLocal_AccessibleTopology_TranslatesBack(t *testing.T) 
 	if err := co.EnableFSS(context.Background(), common.HostLocalStorageSupportFSS); err != nil {
 		t.Fatalf("failed to enable FSS: %v", err)
 	}
+	seedHostLocalWorkerNode(t, c)
 
 	req := hostLocalCreateRequest(hostLocalAccessMode, hostLocalZoneValue, hostLocalHostValue)
 	accessibleTopologyAnnotation := hostLocalWantAnnotation(v1.LabelHostname)
@@ -340,6 +354,7 @@ func TestCreateVolume_HostLocal_AccessibleTopology_TranslatesBack_FSSDisabledAtR
 	if err := co.EnableFSS(context.Background(), common.HostLocalStorageSupportFSS); err != nil {
 		t.Fatalf("failed to enable FSS: %v", err)
 	}
+	seedHostLocalWorkerNode(t, c)
 
 	req := hostLocalCreateRequest(hostLocalAccessMode, hostLocalZoneValue, hostLocalHostValue)
 	accessibleTopologyAnnotation := hostLocalWantAnnotation(v1.LabelHostname)
@@ -369,5 +384,107 @@ func assertAccessibleTopologyHasHostKey(t *testing.T, resp *csi.CreateVolumeResp
 	}
 	if !reflect.DeepEqual(segments, want) {
 		t.Fatalf("AccessibleTopology segments = %+v, want %+v", segments, want)
+	}
+}
+
+// --- filterOutControlPlaneOnlyTopologySegments helper tests ---------------
+
+// makeGuestNode builds a guest cluster Node with the given host/zone topology
+// labels; controlPlane marks it with common.ControlPlaneNodeRoleLabel.
+func makeGuestNode(name, host, zone string, controlPlane bool) *v1.Node {
+	labels := map[string]string{}
+	if host != "" {
+		labels[common.GuestClusterTopologyLabelHost] = host
+	}
+	if zone != "" {
+		labels[v1.LabelTopologyZone] = zone
+	}
+	if controlPlane {
+		labels[common.ControlPlaneNodeRoleLabel] = ""
+	}
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+}
+
+func TestFilterOutControlPlaneOnlyTopologySegments(t *testing.T) {
+	cpOnlyHost := "cp-only-host"
+	workerHost := "worker-host"
+	cpOnlyZone := "cp-only-zone"
+	workerZone := "worker-zone"
+
+	tests := []struct {
+		name    string
+		nodes   []*v1.Node
+		in      []*csi.Topology
+		want    []*csi.Topology
+		wantErr bool
+	}{
+		{
+			name: "drops a host segment with no worker node on that host",
+			nodes: []*v1.Node{
+				makeGuestNode("cp-1", cpOnlyHost, workerZone, true),
+				makeGuestNode("worker-1", workerHost, workerZone, false),
+			},
+			in: []*csi.Topology{
+				{Segments: map[string]string{common.GuestClusterTopologyLabelHost: cpOnlyHost, v1.LabelTopologyZone: workerZone}},
+				{Segments: map[string]string{common.GuestClusterTopologyLabelHost: workerHost, v1.LabelTopologyZone: workerZone}},
+			},
+			want: []*csi.Topology{
+				{Segments: map[string]string{common.GuestClusterTopologyLabelHost: workerHost, v1.LabelTopologyZone: workerZone}},
+			},
+		},
+		{
+			// Zone-only segments (no host key at all) are never subject to this
+			// filtering, so it must not even consult Node state for them -
+			// proven here by a cluster that would otherwise error out (zero
+			// worker nodes) still returning the input unchanged.
+			name: "zone-only segments are left untouched regardless of worker node state",
+			nodes: []*v1.Node{
+				makeGuestNode("cp-1", cpOnlyHost, cpOnlyZone, true),
+			},
+			in: []*csi.Topology{
+				{Segments: map[string]string{v1.LabelTopologyZone: cpOnlyZone}},
+				{Segments: map[string]string{v1.LabelTopologyZone: workerZone}},
+			},
+			want: []*csi.Topology{
+				{Segments: map[string]string{v1.LabelTopologyZone: cpOnlyZone}},
+				{Segments: map[string]string{v1.LabelTopologyZone: workerZone}},
+			},
+		},
+		{
+			name: "errors out when a host segment is requested but the cluster has zero worker nodes",
+			nodes: []*v1.Node{
+				makeGuestNode("cp-1", cpOnlyHost, cpOnlyZone, true),
+			},
+			in: []*csi.Topology{
+				{Segments: map[string]string{common.GuestClusterTopologyLabelHost: cpOnlyHost, v1.LabelTopologyZone: cpOnlyZone}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			guestClient := testclient.NewClientset()
+			for _, n := range tc.nodes {
+				if _, err := guestClient.CoreV1().Nodes().Create(context.Background(), n, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to seed node %s: %v", n.Name, err)
+				}
+			}
+			got, err := filterOutControlPlaneOnlyTopologySegments(context.Background(), guestClient, tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got result: %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("filterOutControlPlaneOnlyTopologySegments failed: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("filterOutControlPlaneOnlyTopologySegments() = %+v, want %+v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Filtering out control plane nodes when pvc creation with host-key topology is requested & gated on the host_local_support FSS:

**filterOutControlPlaneOnlyTopologySegments** first checks whether any segment actually carries common.GuestClusterTopologyLabelHost. If none of the segment has host keys (pure zone-scoped topology), it returns the topology request untouched & it matches the existing behavior.

2. Fail PVC creation with host topology keys, when No worker nodes exist in VKS cluster



**Tests updated/added:**

TestFilterOutControlPlaneOnlyTopologySegments: replaced the old "fail open" case with two cases — zone-only segments proven untouched even against a zero-worker cluster, and a new case asserting the zero-worker-nodes error when a host segment is present.
TestCreateVolume_HostLocal_RequestedTopology_TranslatesHostKey, TestCreateVolume_HostLocal_AccessibleTopology_TranslatesBack, and its FSS-disabled-at-read-time variant now seed a worker Node (seedHostLocalWorkerNode) since they exercise the host-key + FSS-enabled path that now requires at least one worker node to succeed.
TestCreateVolume_HostLocal_FSSDisabled_RejectsHostKey and TestCreateVolume_HostLocal_NoHostKey_Unaffected needed no changes — they never reach the filter (FSS disabled, or no host key present respectively).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Replaced the images on a VKS cluster by enabling the host local support FSS.

[1] Host local VKS cluster has 1 worker node & 1 control plane node
```
 k get clusters -A
NAMESPACE       NAME                      CLUSTERCLASS             AVAILABLE   CP DESIRED   CP AVAILABLE   CP UP-TO-DATE   W DESIRED   W AVAILABLE   W UP-TO-DATE   PHASE         AGE   VERSION
test-chethanv   kubernetes-cluster-t64q   builtin-generic-v3.8.0   True        1            1              1               1           1             1              Provisioned   55m   v1.35.6+vmware.2

```


Pasting the host topology value for both master & worker csinodetopologies:
```
root@4225e4be8ff8a6f4191d5264730fb533 [ ~ ]# k get csinodetopologies -o yaml | grep broadcom.net
      value: lvn-dvm-10-161-24-159.dvm.lvn.broadcom.net. >>>> WORKER NODE
      value: lvn-dvm-10-161-27-209.dvm.lvn.broadcom.net >>>> MASTER NODE
```

Created 4 PVCs & all of them land on the worker node's nodeAffinity
```
root@4225e4be8ff8a6f4191d5264730fb533 [ ~ ]# k get pv  -o yaml | grep broadcom.net
            - lvn-dvm-10-161-24-159.dvm.lvn.broadcom.net
            - lvn-dvm-10-161-24-159.dvm.lvn.broadcom.net
            - lvn-dvm-10-161-24-159.dvm.lvn.broadcom.net
            - lvn-dvm-10-161-24-159.dvm.lvn.broadcom.net

```

[2] Host Local VKS cluster has just 1 control plane node
```
k get clusters -A
NAMESPACE         NAME                      CLUSTERCLASS             AVAILABLE   CP DESIRED   CP AVAILABLE   CP UP-TO-DATE   W DESIRED   W AVAILABLE   W UP-TO-DATE   PHASE         AGE   VERSION
test-chethanv     kubernetes-cluster-vg64   builtin-generic-v3.8.0   True        1            1              1                                                        Provisioned   16h   v1.35.6+vmware.2

```

Created a PVC & observed the expected error:
```
k describe pvc
Name:          example-rwo-pvc-4
Namespace:     default
StorageClass:  host-local
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age               From                                                                                                 Message
  ----     ------                ----              ----                                                                                                 -------
  Normal   ExternalProvisioning  5s (x2 over 12s)  persistentvolume-controller                                                                          Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal   Provisioning          5s (x4 over 12s)  csi.vsphere.vmware.com_vsphere-csi-controller-79649cf4c5-mvddq_74faa5c8-22bb-4aa3-a486-1cc1d22faf20  External provisioner is provisioning volume for claim "default/example-rwo-pvc-4"
  Warning  ProvisioningFailed    5s (x4 over 12s)  csi.vsphere.vmware.com_vsphere-csi-controller-79649cf4c5-mvddq_74faa5c8-22bb-4aa3-a486-1cc1d22faf20  rpc error: code = Internal desc = failed to filter control-plane-only topology segments for pvc with name: 71f5b8fb-aa03-461f-8cd2-82cf27ec5359-49a6f75a-e358-4ee3-911e-6f556b8d6d84 on namespace: test-chethanv. Error: unable to provision a topology aware volume: no worker nodes found in guest cluster
```
**Special notes for your reviewer**:
Pre-checkin pipeline has passed : https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1435/


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enhance host zone requirements forwarding to the Supervisor during CreateVolume invoked from Guest
```
