### PR TITLE
Enable TLS for vSphere Syncer

### DIFF
--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -393,6 +393,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-client-certs
+              readOnly: true
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1
           args:
@@ -511,6 +514,9 @@ spec:
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-client-certs
+              readOnly: true
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
@@ -594,6 +600,9 @@ spec:
             - mountPath: /etc/vmware/wcp/webhook-certs/client-ca
               name: client-ca
               readOnly: true
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-server-certs
+              readOnly: true
         - name: csi-snapshotter
           image: localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
           args:
@@ -632,6 +641,12 @@ spec:
             items:
             - key: "ca.crt"
               path: "ca.crt"
+        - name: k8s-cloud-operator-server-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-server-cert
+        - name: k8s-cloud-operator-client-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
@@ -725,6 +740,75 @@ metadata:
   namespace: vmware-system-csi
 spec:
   selfSigned: {}
+---
+# The following resources issue the mTLS identities for the K8sCloudOperator
+# gRPC service (vsphere-syncer, port 29000): a root CA (bootstrapped off the
+# existing vmware-system-csi-selfsigned-issuer above, which is stateless and
+# can mint any number of independent CAs), and two leaf certificates signed
+# by that CA - one server identity for vsphere-syncer, one client identity
+# shared by callers within this Pod (vsphere-csi-controller). Only a
+# certificate whose CommonName matches the client identity below is
+# authorized to call any RPC on this service.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-cert
+  namespace: vmware-system-csi
+spec:
+  isCA: true
+  commonName: vmware-system-csi-k8scloudoperator-ca
+  secretName: vmware-system-csi-k8scloudoperator-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-selfsigned-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-issuer
+  namespace: vmware-system-csi
+spec:
+  ca:
+    secretName: vmware-system-csi-k8scloudoperator-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-server-cert
+  namespace: vmware-system-csi
+spec:
+  dnsNames:
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
+  commonName: vmware-system-csi-k8scloudoperator-server
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-client-cert
+  namespace: vmware-system-csi
+spec:
+  commonName: vmware-system-csi-k8scloudoperator-client
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -393,6 +393,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-client-certs
+              readOnly: true
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1
           args:
@@ -511,6 +514,9 @@ spec:
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-client-certs
+              readOnly: true
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
@@ -594,6 +600,9 @@ spec:
             - mountPath: /etc/vmware/wcp/webhook-certs/client-ca
               name: client-ca
               readOnly: true
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-server-certs
+              readOnly: true
         - name: csi-snapshotter
           image: localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
           args:
@@ -632,6 +641,12 @@ spec:
             items:
             - key: "ca.crt"
               path: "ca.crt"
+        - name: k8s-cloud-operator-server-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-server-cert
+        - name: k8s-cloud-operator-client-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
@@ -725,6 +740,75 @@ metadata:
   namespace: vmware-system-csi
 spec:
   selfSigned: {}
+---
+# The following resources issue the mTLS identities for the K8sCloudOperator
+# gRPC service (vsphere-syncer, port 29000): a root CA (bootstrapped off the
+# existing vmware-system-csi-selfsigned-issuer above, which is stateless and
+# can mint any number of independent CAs), and two leaf certificates signed
+# by that CA - one server identity for vsphere-syncer, one client identity
+# shared by callers within this Pod (vsphere-csi-controller). Only a
+# certificate whose CommonName matches the client identity below is
+# authorized to call any RPC on this service.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-cert
+  namespace: vmware-system-csi
+spec:
+  isCA: true
+  commonName: vmware-system-csi-k8scloudoperator-ca
+  secretName: vmware-system-csi-k8scloudoperator-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-selfsigned-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-issuer
+  namespace: vmware-system-csi
+spec:
+  ca:
+    secretName: vmware-system-csi-k8scloudoperator-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-server-cert
+  namespace: vmware-system-csi
+spec:
+  dnsNames:
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
+  commonName: vmware-system-csi-k8scloudoperator-server
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-client-cert
+  namespace: vmware-system-csi
+spec:
+  commonName: vmware-system-csi-k8scloudoperator-client
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -393,6 +393,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-client-certs
+              readOnly: true
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1
           args:
@@ -511,6 +514,9 @@ spec:
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-client-certs
+              readOnly: true
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
@@ -594,6 +600,9 @@ spec:
             - mountPath: /etc/vmware/wcp/webhook-certs/client-ca
               name: client-ca
               readOnly: true
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-server-certs
+              readOnly: true
         - name: csi-snapshotter
           image: localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
           args:
@@ -632,6 +641,12 @@ spec:
             items:
             - key: "ca.crt"
               path: "ca.crt"
+        - name: k8s-cloud-operator-server-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-server-cert
+        - name: k8s-cloud-operator-client-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
@@ -725,6 +740,74 @@ metadata:
   namespace: vmware-system-csi
 spec:
   selfSigned: {}
+---
+# The following resources issue the mTLS identities for the K8sCloudOperator
+# gRPC service (vsphere-syncer, port 29000): 
+# 1. A root CA (bootstrapped off the
+# existing vmware-system-csi-selfsigned-issuer)
+# 2. Leaf certificates signed by the CA created above.
+# One of them has a server identity for vsphere-syncer, the other has client identity for 
+# vsphere CSI controller.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-cert
+  namespace: vmware-system-csi
+spec:
+  isCA: true
+  commonName: vmware-system-csi-k8scloudoperator-ca
+  secretName: vmware-system-csi-k8scloudoperator-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-selfsigned-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-issuer
+  namespace: vmware-system-csi
+spec:
+  ca:
+    secretName: vmware-system-csi-k8scloudoperator-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-server-cert
+  namespace: vmware-system-csi
+spec:
+  dnsNames:
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
+  commonName: vmware-system-csi-k8scloudoperator-server
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-client-cert
+  namespace: vmware-system-csi
+spec:
+  commonName: vmware-system-csi-k8scloudoperator-client
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -511,6 +511,9 @@ spec:
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-client-certs
+              readOnly: true
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
@@ -594,6 +597,9 @@ spec:
             - mountPath: /etc/vmware/wcp/webhook-certs/client-ca
               name: client-ca
               readOnly: true
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-server-certs
+              readOnly: true
         - name: csi-snapshotter
           image: localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
           args:
@@ -632,6 +638,12 @@ spec:
             items:
             - key: "ca.crt"
               path: "ca.crt"
+        - name: k8s-cloud-operator-server-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-server-cert
+        - name: k8s-cloud-operator-client-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
@@ -724,6 +736,75 @@ metadata:
   namespace: vmware-system-csi
 spec:
   selfSigned: {}
+---
+# The following resources issue the mTLS identities for the K8sCloudOperator
+# gRPC service (vsphere-syncer, port 29000): a root CA (bootstrapped off the
+# existing vmware-system-csi-selfsigned-issuer above, which is stateless and
+# can mint any number of independent CAs), and two leaf certificates signed
+# by that CA - one server identity for vsphere-syncer, one client identity
+# shared by callers within this Pod (vsphere-csi-controller). Only a
+# certificate whose CommonName matches the client identity below is
+# authorized to call any RPC on this service.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-cert
+  namespace: vmware-system-csi
+spec:
+  isCA: true
+  commonName: vmware-system-csi-k8scloudoperator-ca
+  secretName: vmware-system-csi-k8scloudoperator-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-selfsigned-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-issuer
+  namespace: vmware-system-csi
+spec:
+  ca:
+    secretName: vmware-system-csi-k8scloudoperator-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-server-cert
+  namespace: vmware-system-csi
+spec:
+  dnsNames:
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
+  commonName: vmware-system-csi-k8scloudoperator-server
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-client-cert
+  namespace: vmware-system-csi
+spec:
+  commonName: vmware-system-csi-k8scloudoperator-client
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -393,6 +393,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-client-certs
+              readOnly: true
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1
           args:

--- a/pkg/common/certwatcher/certwatcher.go
+++ b/pkg/common/certwatcher/certwatcher.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certwatcher
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// LoadCertificateAndCAPool reads and parses the certificate,
+// private key, and CA bundle from the given paths.
+func LoadCertificateAndCAPool(certPath, keyPath, caPath string) (tls.Certificate, *x509.CertPool, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return tls.Certificate{}, nil, fmt.Errorf("failed to load X509 key pair: %w", err)
+	}
+
+	caBytes, err := os.ReadFile(caPath)
+	if err != nil {
+		return tls.Certificate{}, nil, fmt.Errorf("failed to read CA certificate file: %w", err)
+	}
+	caCertPool := x509.NewCertPool()
+	if ok := caCertPool.AppendCertsFromPEM(caBytes); !ok {
+		return tls.Certificate{}, nil, errors.New("failed to parse CA certificate: invalid PEM format")
+	}
+
+	return cert, caCertPool, nil
+}
+
+// CertWatcher watches a certificate, private key, and CA bundle on disk for
+// changes and keeps an in-memory copy up to date.
+type CertWatcher struct {
+	sync.RWMutex
+
+	currentCert       *tls.Certificate
+	currentCACertPool *x509.CertPool
+
+	watcher *fsnotify.Watcher
+
+	certPath string
+	keyPath  string
+	caPath   string
+}
+
+// New returns a new CertWatcher for the given certificate, key, and CA bundle
+// paths. It performs an initial read of all three files before
+// returning, so a returned error means the identity is not yet available on
+// disk.
+func New(certPath, keyPath, caPath string) (*CertWatcher, error) {
+	cw := &CertWatcher{
+		certPath: certPath,
+		keyPath:  keyPath,
+		caPath:   caPath,
+	}
+
+	if err := cw.reload(); err != nil {
+		return nil, err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fsnotify watcher: %w", err)
+	}
+	cw.watcher = watcher
+
+	// The CA path is not watched directly: cert-manager only rewrites ca.crt
+	// in the same Secret update as the leaf cert/key, so re-reading it
+	// whenever cert/key change is sufficient to observe CA rotation too.
+	for _, f := range []string{certPath, keyPath} {
+		if err := cw.watcher.Add(f); err != nil {
+			cw.watcher.Close()
+			return nil, fmt.Errorf("failed to watch %q: %w", f, err)
+		}
+	}
+
+	return cw, nil
+}
+
+// GetCertificate returns the currently loaded certificate.
+func (cw *CertWatcher) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cw.RLock()
+	defer cw.RUnlock()
+	if cw.currentCert == nil {
+		return nil, errors.New("no certificate available")
+	}
+	return cw.currentCert, nil
+}
+
+// GetCACertPool returns the currently loaded CA certificate pool, used to
+// verify peer certificates in mTLS.
+func (cw *CertWatcher) GetCACertPool() (*x509.CertPool, error) {
+	cw.RLock()
+	defer cw.RUnlock()
+	if cw.currentCACertPool == nil {
+		return nil, errors.New("no CA certificate pool available")
+	}
+	return cw.currentCACertPool, nil
+}
+
+// Start begins reacting to filesystem events for the certificate and key
+// files and blocks until ctx is cancelled.
+func (cw *CertWatcher) Start(ctx context.Context) error {
+	log := logger.GetLogger(ctx)
+
+	go cw.watch(ctx)
+
+	log.Infof("Started certificate watcher for cert: %s, key: %s, ca: %s", cw.certPath, cw.keyPath, cw.caPath)
+	<-ctx.Done()
+
+	log.Infof("Stopping certificate watcher for cert: %s", cw.certPath)
+	return cw.watcher.Close()
+}
+
+func (cw *CertWatcher) watch(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+	for {
+		select {
+		case event, ok := <-cw.watcher.Events:
+			if !ok {
+				return
+			}
+			switch {
+			case event.Op.Has(fsnotify.Write), event.Op.Has(fsnotify.Create):
+				// fall through to reload below
+			case event.Op.Has(fsnotify.Chmod), event.Op.Has(fsnotify.Remove):
+				// Kubernetes Secret volume updates replace the file via a
+				// symlink swap, which can surface as remove; re-add the
+				// watch on the file at the same path.
+				if err := cw.watcher.Add(event.Name); err != nil {
+					log.Errorf("failed to re-watch %q after change: %v", event.Name, err)
+				}
+			default:
+				continue
+			}
+
+			// Kubernetes Secret volume updates are not atomic across files
+			// in the same directory; give the kubelet a brief moment to
+			// finish updating all of them before reloading.
+			time.Sleep(100 * time.Millisecond)
+			if err := cw.reload(); err != nil {
+				log.Errorf("failed to reload certificate after change: %v", err)
+			} else {
+				log.Infof("Reloaded certificate from %s", cw.certPath)
+			}
+		case err, ok := <-cw.watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Errorf("certificate watcher error: %v", err)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (cw *CertWatcher) reload() error {
+	cert, caCertPool, err := LoadCertificateAndCAPool(cw.certPath, cw.keyPath, cw.caPath)
+	if err != nil {
+		return err
+	}
+
+	cw.Lock()
+	cw.currentCert = &cert
+	cw.currentCACertPool = caCertPool
+	cw.Unlock()
+	return nil
+}

--- a/pkg/common/certwatcher/certwatcher.go
+++ b/pkg/common/certwatcher/certwatcher.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package certwatcher provides a helper to load an mTLS identity (certificate,
+// private key, and CA bundle) from disk, with optional hot-reload on file
+// change so long-lived servers can pick up cert-manager-rotated certificates
+// without a restart.
+package certwatcher
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// LoadCertificateAndCAPool synchronously reads and parses the certificate,
+// private key, and CA bundle from the given paths. It performs a single,
+// one-shot read with no filesystem watching, so it is suitable for
+// short-lived clients that re-dial (and therefore naturally re-read the
+// files) on every call.
+func LoadCertificateAndCAPool(certPath, keyPath, caPath string) (tls.Certificate, *x509.CertPool, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return tls.Certificate{}, nil, fmt.Errorf("failed to load X509 key pair: %w", err)
+	}
+
+	caBytes, err := os.ReadFile(caPath)
+	if err != nil {
+		return tls.Certificate{}, nil, fmt.Errorf("failed to read CA certificate file: %w", err)
+	}
+	caCertPool := x509.NewCertPool()
+	if ok := caCertPool.AppendCertsFromPEM(caBytes); !ok {
+		return tls.Certificate{}, nil, errors.New("failed to parse CA certificate: invalid PEM format")
+	}
+
+	return cert, caCertPool, nil
+}
+
+// CertWatcher watches a certificate, private key, and CA bundle on disk for
+// changes and keeps an in-memory copy up to date, enabling zero-downtime
+// certificate rotation for long-lived gRPC servers: new connections
+// automatically use the latest certificate/CA without a process restart.
+type CertWatcher struct {
+	sync.RWMutex
+
+	currentCert       *tls.Certificate
+	currentCACertPool *x509.CertPool
+
+	watcher *fsnotify.Watcher
+
+	certPath string
+	keyPath  string
+	caPath   string
+}
+
+// New returns a new CertWatcher for the given certificate, key, and CA bundle
+// paths. It performs an initial synchronous read of all three files before
+// returning, so a returned error means the identity is not yet available on
+// disk.
+func New(certPath, keyPath, caPath string) (*CertWatcher, error) {
+	cw := &CertWatcher{
+		certPath: certPath,
+		keyPath:  keyPath,
+		caPath:   caPath,
+	}
+
+	if err := cw.reload(); err != nil {
+		return nil, err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fsnotify watcher: %w", err)
+	}
+	cw.watcher = watcher
+
+	// Register watches synchronously here, rather than in Start, so that by
+	// the time New returns, a concurrent write to certPath/keyPath is
+	// guaranteed to be observed even if Start hasn't been scheduled yet.
+	//
+	// The CA path is not watched directly: cert-manager only rewrites ca.crt
+	// in the same Secret update as the leaf cert/key, so re-reading it
+	// whenever cert/key change is sufficient to observe CA rotation too.
+	for _, f := range []string{certPath, keyPath} {
+		if err := cw.watcher.Add(f); err != nil {
+			return nil, fmt.Errorf("failed to watch %q: %w", f, err)
+		}
+	}
+
+	return cw, nil
+}
+
+// GetCertificate returns the currently loaded certificate. It is designed to
+// be used as a tls.Config.GetCertificate callback.
+func (cw *CertWatcher) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cw.RLock()
+	defer cw.RUnlock()
+	if cw.currentCert == nil {
+		return nil, errors.New("no certificate available")
+	}
+	return cw.currentCert, nil
+}
+
+// GetCACertPool returns the currently loaded CA certificate pool, used to
+// verify peer certificates in mTLS.
+func (cw *CertWatcher) GetCACertPool() (*x509.CertPool, error) {
+	cw.RLock()
+	defer cw.RUnlock()
+	if cw.currentCACertPool == nil {
+		return nil, errors.New("no CA certificate pool available")
+	}
+	return cw.currentCACertPool, nil
+}
+
+// Start begins reacting to filesystem events for the certificate and key
+// files (watched since New was called) and blocks until ctx is cancelled.
+// Callers should invoke this in its own goroutine.
+func (cw *CertWatcher) Start(ctx context.Context) error {
+	log := logger.GetLogger(ctx)
+
+	go cw.watch(ctx)
+
+	log.Infof("Started certificate watcher for cert: %s, key: %s, ca: %s", cw.certPath, cw.keyPath, cw.caPath)
+	<-ctx.Done()
+
+	log.Infof("Stopping certificate watcher for cert: %s", cw.certPath)
+	return cw.watcher.Close()
+}
+
+func (cw *CertWatcher) watch(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+	for {
+		select {
+		case event, ok := <-cw.watcher.Events:
+			if !ok {
+				return
+			}
+			switch {
+			case event.Op.Has(fsnotify.Write), event.Op.Has(fsnotify.Create):
+				// fall through to reload below
+			case event.Op.Has(fsnotify.Chmod), event.Op.Has(fsnotify.Remove):
+				// Kubernetes Secret volume updates replace the file via a
+				// symlink swap, which can surface as remove; re-add the
+				// watch on the (new) file at the same path.
+				if err := cw.watcher.Add(event.Name); err != nil {
+					log.Errorf("failed to re-watch %q after change: %v", event.Name, err)
+				}
+			default:
+				continue
+			}
+
+			// Kubernetes Secret volume updates are not atomic across files
+			// in the same directory; give the kubelet a brief moment to
+			// finish updating all of them before reloading.
+			time.Sleep(100 * time.Millisecond)
+			if err := cw.reload(); err != nil {
+				log.Errorf("failed to reload certificate after change: %v", err)
+			} else {
+				log.Infof("Reloaded certificate from %s", cw.certPath)
+			}
+		case err, ok := <-cw.watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Errorf("certificate watcher error: %v", err)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (cw *CertWatcher) reload() error {
+	cert, caCertPool, err := LoadCertificateAndCAPool(cw.certPath, cw.keyPath, cw.caPath)
+	if err != nil {
+		return err
+	}
+
+	cw.Lock()
+	cw.currentCert = &cert
+	cw.currentCACertPool = caCertPool
+	cw.Unlock()
+	return nil
+}

--- a/pkg/common/certwatcher/certwatcher_test.go
+++ b/pkg/common/certwatcher/certwatcher_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certwatcher
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// generateCA returns a PEM-encoded self-signed CA certificate and the key
+// used to sign it, for building test leaf certificates.
+func generateCA(t *testing.T, commonName string) ([]byte, *ecdsa.PrivateKey, *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), key, cert
+}
+
+// generateLeaf returns PEM-encoded leaf certificate and key, signed by the
+// given CA, with commonName as its Subject CommonName.
+func generateLeaf(t *testing.T, commonName string, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) ([]byte, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+// writeIdentity writes tls.crt/tls.key/ca.crt into dir with the given
+// contents, mirroring the shape of a cert-manager-issued Secret volume mount.
+func writeIdentity(t *testing.T, dir string, certPEM, keyPEM, caPEM []byte) (certPath, keyPath, caPath string) {
+	t.Helper()
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+	caPath = filepath.Join(dir, "ca.crt")
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+	require.NoError(t, os.WriteFile(caPath, caPEM, 0o600))
+	return certPath, keyPath, caPath
+}
+
+func TestLoadCertificateAndCAPool(t *testing.T) {
+	caPEM, caKey, caCert := generateCA(t, "test-ca")
+	leafCertPEM, leafKeyPEM := generateLeaf(t, "test-leaf", caCert, caKey)
+
+	t.Run("valid identity loads successfully", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath, caPath := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+
+		cert, pool, err := LoadCertificateAndCAPool(certPath, keyPath, caPath)
+		require.NoError(t, err)
+		require.NotNil(t, cert.Certificate)
+		require.NotNil(t, pool)
+
+		parsed, err := x509.ParseCertificate(cert.Certificate[0])
+		require.NoError(t, err)
+		require.Equal(t, "test-leaf", parsed.Subject.CommonName)
+	})
+
+	t.Run("missing cert file errors", func(t *testing.T) {
+		dir := t.TempDir()
+		_, keyPath, caPath := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+		_, _, err := LoadCertificateAndCAPool(filepath.Join(dir, "missing.crt"), keyPath, caPath)
+		require.Error(t, err)
+	})
+
+	t.Run("missing CA file errors", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath, _ := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+		_, _, err := LoadCertificateAndCAPool(certPath, keyPath, filepath.Join(dir, "missing.crt"))
+		require.Error(t, err)
+	})
+
+	t.Run("invalid PEM in CA file errors", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath, caPath := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+		require.NoError(t, os.WriteFile(caPath, []byte("not a pem"), 0o600))
+		_, _, err := LoadCertificateAndCAPool(certPath, keyPath, caPath)
+		require.Error(t, err)
+	})
+}
+
+func TestCertWatcher_InitialLoad(t *testing.T) {
+	caPEM, caKey, caCert := generateCA(t, "test-ca")
+	leafCertPEM, leafKeyPEM := generateLeaf(t, "test-leaf-1", caCert, caKey)
+
+	dir := t.TempDir()
+	certPath, keyPath, caPath := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+
+	cw, err := New(certPath, keyPath, caPath)
+	require.NoError(t, err)
+
+	cert, err := cw.GetCertificate(nil)
+	require.NoError(t, err)
+	parsed, err := x509.ParseCertificate(cert.Certificate[0])
+	require.NoError(t, err)
+	require.Equal(t, "test-leaf-1", parsed.Subject.CommonName)
+
+	pool, err := cw.GetCACertPool()
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+}
+
+func TestCertWatcher_MissingFiles(t *testing.T) {
+	dir := t.TempDir()
+	_, err := New(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"), filepath.Join(dir, "ca.crt"))
+	require.Error(t, err)
+}
+
+func TestCertWatcher_RotationIsPickedUp(t *testing.T) {
+	caPEM, caKey, caCert := generateCA(t, "test-ca")
+	leafCertPEM1, leafKeyPEM1 := generateLeaf(t, "test-leaf-1", caCert, caKey)
+	leafCertPEM2, leafKeyPEM2 := generateLeaf(t, "test-leaf-2", caCert, caKey)
+
+	dir := t.TempDir()
+	certPath, keyPath, caPath := writeIdentity(t, dir, leafCertPEM1, leafKeyPEM1, caPEM)
+
+	cw, err := New(certPath, keyPath, caPath)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = cw.Start(ctx)
+	}()
+
+	// Simulate a cert-manager Secret volume rotation: rewrite cert and key.
+	require.NoError(t, os.WriteFile(certPath, leafCertPEM2, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, leafKeyPEM2, 0o600))
+
+	require.Eventually(t, func() bool {
+		cert, err := cw.GetCertificate(nil)
+		if err != nil {
+			return false
+		}
+		parsed, err := x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			return false
+		}
+		return parsed.Subject.CommonName == "test-leaf-2"
+	}, 5*time.Second, 50*time.Millisecond, "expected certificate watcher to pick up rotated certificate")
+}

--- a/pkg/common/certwatcher/certwatcher_test.go
+++ b/pkg/common/certwatcher/certwatcher_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certwatcher
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// generateCA returns a PEM-encoded self-signed CA certificate and the key
+// used to sign it, for building test leaf certificates.
+func generateCA(t *testing.T, commonName string) ([]byte, *ecdsa.PrivateKey, *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), key, cert
+}
+
+// generateLeaf returns PEM-encoded leaf certificate and key, signed by the
+// given CA, with commonName as its Subject CommonName.
+func generateLeaf(t *testing.T, commonName string, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) ([]byte, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+// writeIdentity writes tls.crt/tls.key/ca.crt into dir with the given
+// contents, mirroring the shape of a cert-manager-issued Secret volume mount.
+func writeIdentity(t *testing.T, dir string, certPEM, keyPEM, caPEM []byte) (certPath, keyPath, caPath string) {
+	t.Helper()
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+	caPath = filepath.Join(dir, "ca.crt")
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+	require.NoError(t, os.WriteFile(caPath, caPEM, 0o600))
+	return certPath, keyPath, caPath
+}
+
+func TestLoadCertificateAndCAPool(t *testing.T) {
+	caPEM, caKey, caCert := generateCA(t, "test-ca")
+	leafCertPEM, leafKeyPEM := generateLeaf(t, "test-leaf", caCert, caKey)
+
+	t.Run("valid identity loads successfully", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath, caPath := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+
+		cert, pool, err := LoadCertificateAndCAPool(certPath, keyPath, caPath)
+		require.NoError(t, err)
+		require.NotNil(t, cert.Certificate)
+		require.NotNil(t, pool)
+
+		parsed, err := x509.ParseCertificate(cert.Certificate[0])
+		require.NoError(t, err)
+		require.Equal(t, "test-leaf", parsed.Subject.CommonName)
+
+		// Confirm that the CA can validate a certificate
+		// genuinely signed by this CA.
+		_, err = parsed.Verify(x509.VerifyOptions{Roots: pool, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny}})
+		require.NoError(t, err)
+	})
+
+	t.Run("missing cert file errors", func(t *testing.T) {
+		dir := t.TempDir()
+		_, keyPath, caPath := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+		_, _, err := LoadCertificateAndCAPool(filepath.Join(dir, "missing.crt"), keyPath, caPath)
+		require.Error(t, err)
+	})
+
+	t.Run("missing CA file errors", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath, _ := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+		_, _, err := LoadCertificateAndCAPool(certPath, keyPath, filepath.Join(dir, "missing.crt"))
+		require.Error(t, err)
+	})
+
+	t.Run("invalid PEM in CA file errors", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath, caPath := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+		require.NoError(t, os.WriteFile(caPath, []byte("not a pem"), 0o600))
+		_, _, err := LoadCertificateAndCAPool(certPath, keyPath, caPath)
+		require.Error(t, err)
+	})
+}
+
+func TestCertWatcher_InitialLoad(t *testing.T) {
+	caPEM, caKey, caCert := generateCA(t, "test-ca")
+	leafCertPEM, leafKeyPEM := generateLeaf(t, "test-leaf-1", caCert, caKey)
+
+	dir := t.TempDir()
+	certPath, keyPath, caPath := writeIdentity(t, dir, leafCertPEM, leafKeyPEM, caPEM)
+
+	cw, err := New(certPath, keyPath, caPath)
+	require.NoError(t, err)
+
+	cert, err := cw.GetCertificate(nil)
+	require.NoError(t, err)
+	parsed, err := x509.ParseCertificate(cert.Certificate[0])
+	require.NoError(t, err)
+	require.Equal(t, "test-leaf-1", parsed.Subject.CommonName)
+
+	pool, err := cw.GetCACertPool()
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+}
+
+func TestCertWatcher_MissingFiles(t *testing.T) {
+	dir := t.TempDir()
+	_, err := New(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"), filepath.Join(dir, "ca.crt"))
+	require.Error(t, err)
+}
+
+func TestCertWatcher_RotationIsPickedUp(t *testing.T) {
+	caPEM, caKey, caCert := generateCA(t, "test-ca")
+	leafCertPEM1, leafKeyPEM1 := generateLeaf(t, "test-leaf-1", caCert, caKey)
+	leafCertPEM2, leafKeyPEM2 := generateLeaf(t, "test-leaf-2", caCert, caKey)
+
+	dir := t.TempDir()
+	certPath, keyPath, caPath := writeIdentity(t, dir, leafCertPEM1, leafKeyPEM1, caPEM)
+
+	cw, err := New(certPath, keyPath, caPath)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = cw.Start(ctx)
+	}()
+
+	// Simulate a cert-manager Secret volume rotation: rewrite cert and key.
+	require.NoError(t, os.WriteFile(certPath, leafCertPEM2, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, leafKeyPEM2, 0o600))
+
+	require.Eventually(t, func() bool {
+		cert, err := cw.GetCertificate(nil)
+		if err != nil {
+			return false
+		}
+		parsed, err := x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			return false
+		}
+		return parsed.Subject.CommonName == "test-leaf-2"
+	}, 5*time.Second, 50*time.Millisecond, "expected certificate watcher to pick up rotated certificate")
+}

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -18,6 +18,7 @@ package wcp
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"strconv"
@@ -31,7 +32,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -42,6 +43,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/certwatcher"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
@@ -51,6 +53,11 @@ import (
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
 )
+
+// defaultK8sCloudOperatorClientCertDir is the directory containing the mTLS
+// identity (tls.crt, tls.key) this client presents to the K8sCloudOperator
+// gRPC service, and the CA bundle (ca.crt) used to authenticate the server.
+const defaultK8sCloudOperatorClientCertDir = k8scloudoperator.DefaultK8sCloudOperatorCertDir
 
 // validateCreateBlockReqParam is a helper function used to validate the parameter
 // name received in the CreateVolume request for block volumes on WCP CSI driver.
@@ -246,8 +253,12 @@ func validateWCPListSnapshotRequest(ctx context.Context, req *csi.ListSnapshotsR
 // getK8sCloudOperatorClientConnection is a helper function that creates a
 // clientConnection to k8sCloudOperator GRPC service running on syncer container.
 func getK8sCloudOperatorClientConnection(ctx context.Context) (*grpc.ClientConn, error) {
+	transportCreds, err := newClientTransportCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("failed to set up TLS credentials for k8s cloud operator gRPC client: %w", err)
+	}
 	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts = append(opts, grpc.WithTransportCredentials(transportCreds))
 	port := common.GetK8sCloudOperatorServicePort(ctx)
 	k8sCloudOperatorServiceAddr := "127.0.0.1:" + strconv.Itoa(port)
 	// Connect to k8s cloud operator gRPC service.
@@ -256,6 +267,32 @@ func getK8sCloudOperatorClientConnection(ctx context.Context) (*grpc.ClientConn,
 		return nil, err
 	}
 	return conn, nil
+}
+
+// newClientTransportCredentials builds the mTLS client
+// credentials used to authenticate this client to the K8sCloudOperator gRPC
+// service and to verify the server's identity.
+func newClientTransportCredentials() (credentials.TransportCredentials, error) {
+	certPath := defaultK8sCloudOperatorClientCertDir + "/tls.crt"
+	keyPath := defaultK8sCloudOperatorClientCertDir + "/tls.key"
+	caPath := defaultK8sCloudOperatorClientCertDir + "/ca.crt"
+
+	cert, caCertPool, err := certwatcher.LoadCertificateAndCAPool(certPath, keyPath, caPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return credentials.NewTLS(&tls.Config{
+		MinVersion: tls.VersionTLS12,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+		},
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}), nil
 }
 
 // GetsvMotionPlanFromK8sCloudOperatorService gets storage vMotion plan from

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -18,6 +18,7 @@ package wcp
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"strconv"
@@ -31,7 +32,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -42,6 +43,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/certwatcher"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
@@ -51,6 +53,14 @@ import (
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
 )
+
+// defaultK8sCloudOperatorClientCertDir is the directory containing the mTLS
+// identity (tls.crt, tls.key) this client presents to the K8sCloudOperator
+// gRPC service, and the CA bundle (ca.crt) used to authenticate the server.
+// It is re-read on every dial, since each RPC call here dials a fresh
+// connection, so certificate rotation is picked up automatically with no
+// background watcher needed.
+const defaultK8sCloudOperatorClientCertDir = "/etc/vmware/wcp/k8s-cloud-operator-certs"
 
 // validateCreateBlockReqParam is a helper function used to validate the parameter
 // name received in the CreateVolume request for block volumes on WCP CSI driver.
@@ -246,8 +256,12 @@ func validateWCPListSnapshotRequest(ctx context.Context, req *csi.ListSnapshotsR
 // getK8sCloudOperatorClientConnection is a helper function that creates a
 // clientConnection to k8sCloudOperator GRPC service running on syncer container.
 func getK8sCloudOperatorClientConnection(ctx context.Context) (*grpc.ClientConn, error) {
+	transportCreds, err := newK8sCloudOperatorClientTransportCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("failed to set up TLS credentials for k8s cloud operator gRPC client: %w", err)
+	}
 	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts = append(opts, grpc.WithTransportCredentials(transportCreds))
 	port := common.GetK8sCloudOperatorServicePort(ctx)
 	k8sCloudOperatorServiceAddr := "127.0.0.1:" + strconv.Itoa(port)
 	// Connect to k8s cloud operator gRPC service.
@@ -256,6 +270,32 @@ func getK8sCloudOperatorClientConnection(ctx context.Context) (*grpc.ClientConn,
 		return nil, err
 	}
 	return conn, nil
+}
+
+// newK8sCloudOperatorClientTransportCredentials builds the mTLS client
+// credentials used to authenticate this client to the K8sCloudOperator gRPC
+// service and to verify the server's identity.
+func newK8sCloudOperatorClientTransportCredentials() (credentials.TransportCredentials, error) {
+	certPath := defaultK8sCloudOperatorClientCertDir + "/tls.crt"
+	keyPath := defaultK8sCloudOperatorClientCertDir + "/tls.key"
+	caPath := defaultK8sCloudOperatorClientCertDir + "/ca.crt"
+
+	cert, caCertPool, err := certwatcher.LoadCertificateAndCAPool(certPath, keyPath, caPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return credentials.NewTLS(&tls.Config{
+		MinVersion: tls.VersionTLS12,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+		},
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}), nil
 }
 
 // GetsvMotionPlanFromK8sCloudOperatorService gets storage vMotion plan from

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -18,6 +18,8 @@ package k8scloudoperator
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"net"
@@ -29,6 +31,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +41,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	api "k8s.io/kubernetes/pkg/apis/core"
 
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/certwatcher"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 
@@ -56,6 +60,17 @@ const (
 	vsanSnaType               = spTypePrefix + "vsan-sna"
 	spTypeLabelKey            = spTypePrefix + "StoragePoolType"
 	diskDecommissionModeField = "decommMode"
+
+	// DefaultK8sCloudOperatorCertDir is the directory containing the mTLS
+	// identity (tls.crt, tls.key) this gRPC server presents, and the CA
+	// bundle (ca.crt) used to authenticate calling clients.
+	DefaultK8sCloudOperatorCertDir = "/etc/vmware/wcp/k8s-cloud-operator-certs"
+
+	// k8sCloudOperatorClientCertCN is the expected CommonName on the client
+	// certificate presented by callers of this service. Only holders of a
+	// certificate issued for this identity are authorized to invoke any RPC,
+	// even though the CA also signs this server's own certificate.
+	k8sCloudOperatorClientCertCN = "vmware-system-csi-k8scloudoperator-client"
 )
 
 type k8sCloudOperator struct {
@@ -89,7 +104,12 @@ func InitK8sCloudOperatorService(ctx context.Context) error {
 		log.Errorf("failed to listen. Err: %v", err)
 		return err
 	}
-	grpcServer := grpc.NewServer()
+	serverCreds, err := newServerTransportCredentials(ctx)
+	if err != nil {
+		log.Errorf("failed to set up TLS credentials for K8s Cloud Operator gRPC service. Err: %v", err)
+		return err
+	}
+	grpcServer := grpc.NewServer(grpc.Creds(serverCreds))
 	server, err := initK8sCloudOperatorType(ctx)
 	if err != nil {
 		return err
@@ -101,6 +121,82 @@ func InitK8sCloudOperatorService(ctx context.Context) error {
 		return err
 	}
 	log.Infof("Successfully initialized the K8s Cloud Operator gRPC service")
+	return nil
+}
+
+// newServerTransportCredentials builds the mTLS server credentials for the
+// K8s Cloud Operator gRPC service. It requires and verifies a client
+// certificate on every connection, and additionally pins the accepted client
+// identity to k8sCloudOperatorClientCertCN so that only that specific
+// identity - not any certificate merely signed by the same CA - may call any
+// RPC on this service.
+func newServerTransportCredentials(ctx context.Context) (credentials.TransportCredentials, error) {
+	log := logger.GetLogger(ctx)
+	certPath := DefaultK8sCloudOperatorCertDir + "/tls.crt"
+	keyPath := DefaultK8sCloudOperatorCertDir + "/tls.key"
+	caPath := DefaultK8sCloudOperatorCertDir + "/ca.crt"
+
+	cw, err := certwatcher.New(certPath, keyPath, caPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load K8s Cloud Operator server certificate: %w", err)
+	}
+	go func() {
+		if err := cw.Start(ctx); err != nil {
+			log.Errorf("K8s Cloud Operator certificate watcher exited with error: %v", err)
+		}
+	}()
+
+	baseTLSConfig := func(clientCAs *x509.CertPool) *tls.Config {
+		return &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+			},
+			ClientAuth:       tls.RequireAndVerifyClientCert,
+			GetCertificate:   cw.GetCertificate,
+			ClientCAs:        clientCAs,
+			VerifyConnection: verifyK8sCloudOperatorClientConnection,
+			// Session resumption skips full certificate
+			// re-verification, which would let a client that completed a
+			// handshake before a CA rotation keep reconnecting afterwards
+			// without ever going through GetConfigForClient/VerifyConnection
+			// again - defeating the point of fetching a fresh CA pool per
+			// handshake. Disabling it forces every connection through a full
+			// handshake.
+			SessionTicketsDisabled: true,
+		}
+	}
+
+	initialCACertPool, err := cw.GetCACertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load K8s Cloud Operator CA certificate: %w", err)
+	}
+	tlsConfig := baseTLSConfig(initialCACertPool)
+	tlsConfig.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		clientCAs, err := cw.GetCACertPool()
+		if err != nil {
+			return nil, err
+		}
+		return baseTLSConfig(clientCAs), nil
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
+}
+
+// verifyK8sCloudOperatorClientConnection rejects any client certificate
+// whose CommonName does not match k8sCloudOperatorClientCertCN, even if it
+// chains to the trusted CA.
+func verifyK8sCloudOperatorClientConnection(cs tls.ConnectionState) error {
+	if len(cs.VerifiedChains) == 0 || len(cs.VerifiedChains[0]) == 0 {
+		return fmt.Errorf("no verified client certificate chain")
+	}
+	cn := cs.VerifiedChains[0][0].Subject.CommonName
+	if cn != k8sCloudOperatorClientCertCN {
+		return fmt.Errorf("unauthorized client certificate CommonName: %s", cn)
+	}
 	return nil
 }
 

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -18,6 +18,8 @@ package k8scloudoperator
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"net"
@@ -29,6 +31,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +41,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	api "k8s.io/kubernetes/pkg/apis/core"
 
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/certwatcher"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 
@@ -56,6 +60,17 @@ const (
 	vsanSnaType               = spTypePrefix + "vsan-sna"
 	spTypeLabelKey            = spTypePrefix + "StoragePoolType"
 	diskDecommissionModeField = "decommMode"
+
+	// DefaultK8sCloudOperatorCertDir is the directory containing the mTLS
+	// identity (tls.crt, tls.key) this gRPC server presents, and the CA
+	// bundle (ca.crt) used to authenticate calling clients.
+	DefaultK8sCloudOperatorCertDir = "/etc/vmware/wcp/k8s-cloud-operator-certs"
+
+	// k8sCloudOperatorClientCertCN is the expected CommonName on the client
+	// certificate presented by callers of this service. Only holders of a
+	// certificate issued for this identity are authorized to invoke any RPC,
+	// even though the CA also signs this server's own certificate.
+	k8sCloudOperatorClientCertCN = "vmware-system-csi-k8scloudoperator-client"
 )
 
 type k8sCloudOperator struct {
@@ -89,7 +104,12 @@ func InitK8sCloudOperatorService(ctx context.Context) error {
 		log.Errorf("failed to listen. Err: %v", err)
 		return err
 	}
-	grpcServer := grpc.NewServer()
+	serverCreds, err := newServerTransportCredentials(ctx)
+	if err != nil {
+		log.Errorf("failed to set up TLS credentials for K8s Cloud Operator gRPC service. Err: %v", err)
+		return err
+	}
+	grpcServer := grpc.NewServer(grpc.Creds(serverCreds))
 	server, err := initK8sCloudOperatorType(ctx)
 	if err != nil {
 		return err
@@ -101,6 +121,74 @@ func InitK8sCloudOperatorService(ctx context.Context) error {
 		return err
 	}
 	log.Infof("Successfully initialized the K8s Cloud Operator gRPC service")
+	return nil
+}
+
+// newServerTransportCredentials builds the mTLS server credentials for the
+// K8s Cloud Operator gRPC service. It requires and verifies a client
+// certificate on every connection, and additionally pins the accepted client
+// identity to k8sCloudOperatorClientCertCN so that only that specific
+// identity - not any certificate merely signed by the same CA - may call any
+// RPC on this cluster-admin-privileged service.
+func newServerTransportCredentials(ctx context.Context) (credentials.TransportCredentials, error) {
+	log := logger.GetLogger(ctx)
+	certPath := DefaultK8sCloudOperatorCertDir + "/tls.crt"
+	keyPath := DefaultK8sCloudOperatorCertDir + "/tls.key"
+	caPath := DefaultK8sCloudOperatorCertDir + "/ca.crt"
+
+	cw, err := certwatcher.New(certPath, keyPath, caPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load K8s Cloud Operator server certificate: %w", err)
+	}
+	go func() {
+		if err := cw.Start(ctx); err != nil {
+			log.Errorf("K8s Cloud Operator certificate watcher exited with error: %v", err)
+		}
+	}()
+
+	baseTLSConfig := func(clientCAs *x509.CertPool) *tls.Config {
+		return &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+			},
+			ClientAuth:            tls.RequireAndVerifyClientCert,
+			GetCertificate:        cw.GetCertificate,
+			ClientCAs:             clientCAs,
+			VerifyPeerCertificate: verifyK8sCloudOperatorClientCertificate,
+		}
+	}
+
+	initialCACertPool, err := cw.GetCACertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load K8s Cloud Operator CA certificate: %w", err)
+	}
+	tlsConfig := baseTLSConfig(initialCACertPool)
+	tlsConfig.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		clientCAs, err := cw.GetCACertPool()
+		if err != nil {
+			return nil, err
+		}
+		return baseTLSConfig(clientCAs), nil
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
+}
+
+// verifyK8sCloudOperatorClientCertificate rejects any client certificate
+// whose CommonName does not match k8sCloudOperatorClientCertCN, even if it
+// chains to the trusted CA.
+func verifyK8sCloudOperatorClientCertificate(_ [][]byte, verifiedChains [][]*x509.Certificate) error {
+	if len(verifiedChains) == 0 || len(verifiedChains[0]) == 0 {
+		return fmt.Errorf("no verified client certificate chain")
+	}
+	cn := verifiedChains[0][0].Subject.CommonName
+	if cn != k8sCloudOperatorClientCertCN {
+		return fmt.Errorf("unauthorized client certificate CommonName: %s", cn)
+	}
 	return nil
 }
 

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator_test.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8scloudoperator
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// makeCertWithCN returns a self-signed certificate with the given Subject
+// CommonName.
+func makeCertWithCN(t *testing.T, cn string) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	assert.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	assert.NoError(t, err)
+	return cert
+}
+
+// connStateWithChain builds a tls.ConnectionState carrying the given
+// certificate as the sole verified chain.
+func connStateWithChain(certs ...*x509.Certificate) tls.ConnectionState {
+	if len(certs) == 0 {
+		return tls.ConnectionState{}
+	}
+	return tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{certs}}
+}
+
+// TestVerifyK8sCloudOperatorClientConnection verifies that only a client
+// certificate whose CommonName matches k8sCloudOperatorClientCertCN is
+// authorized, even though a certificate chain reaching this callback has
+// already passed standard CA verification - the CommonName pin is the second,
+// independent check that stops a different CA-signed identity (e.g. this
+// service's own server certificate) from also being usable as a caller.
+func TestVerifyK8sCloudOperatorClientConnection(t *testing.T) {
+	t.Run("no verified chains", func(t *testing.T) {
+		err := verifyK8sCloudOperatorClientConnection(tls.ConnectionState{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no verified client certificate chain")
+	})
+
+	t.Run("empty first chain", func(t *testing.T) {
+		err := verifyK8sCloudOperatorClientConnection(
+			tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{}}})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no verified client certificate chain")
+	})
+
+	t.Run("matching CommonName is authorized", func(t *testing.T) {
+		cert := makeCertWithCN(t, k8sCloudOperatorClientCertCN)
+		err := verifyK8sCloudOperatorClientConnection(connStateWithChain(cert))
+		assert.NoError(t, err)
+	})
+
+	t.Run("wrong CommonName is rejected even though CA-valid", func(t *testing.T) {
+		cert := makeCertWithCN(t, "some-other-identity")
+		err := verifyK8sCloudOperatorClientConnection(connStateWithChain(cert))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unauthorized client certificate CommonName")
+		assert.Contains(t, err.Error(), "some-other-identity")
+	})
+
+	t.Run("server's own CommonName is rejected", func(t *testing.T) {
+		cert := makeCertWithCN(t, "vmware-system-csi-k8scloudoperator-server")
+		err := verifyK8sCloudOperatorClientConnection(connStateWithChain(cert))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unauthorized client certificate CommonName")
+	})
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The vsphere-csi-driver syncer exposes a gRPC K8sCloudOperator service on port 29000 (localhost) with no authentication or TLS.

This PR adds gRPC mTLS with client certificate authentication. After the fix, only authenticated callers can invoke K8sCloudOperator service.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

vDPp related sanity testing:

Sample instances PVCs are getting created and also ebing placed correctly on a storagepool by placement engine (which requires gRPC connection from provisioner to syncer):

```
{"level":"info","time":"2026-08-07T07:24:51.498599891Z","caller":"k8scloudoperator/[placement.go:1012](http://placement.go:1012/)","msg":"Picked sp [storagepool-vsandatastore-lvn-dvm-10-162-80-48.dvm.lvn.broadcom.net](http://storagepool-vsandatastore-lvn-dvm-10-162-80-48.dvm.lvn.broadcom.net/) for PVC data0-sample-1-0"}
{"level":"info","time":"2026-08-07T07:24:51.647305548Z","caller":"k8scloudoperator/[placement.go:1012](http://placement.go:1012/)","msg":"Picked sp [storagepool-vsandatastore-lvn-dvm-10-162-83-198.dvm.lvn.broadcom.net](http://storagepool-vsandatastore-lvn-dvm-10-162-83-198.dvm.lvn.broadcom.net/) for PVC data0-sample-1-2"}
{"level":"info","time":"2026-08-07T07:24:53.875556816Z","caller":"k8scloudoperator/[placement.go:1012](http://placement.go:1012/)","msg":"Picked sp [storagepool-vsandatastore-lvn-dvm-10-162-82-153.dvm.lvn.broadcom.net](http://storagepool-vsandatastore-lvn-dvm-10-162-82-153.dvm.lvn.broadcom.net/) for PVC data0-sample-1-1"}
{"level":"info","time":"2026-08-07T07:24:54.1455736Z","caller":"k8scloudoperator/[placement.go:1012](http://placement.go:1012/)","msg":"Picked sp [storagepool-vsandatastore-lvn-dvm-10-162-83-114.dvm.lvn.broadcom.net](http://storagepool-vsandatastore-lvn-dvm-10-162-83-114.dvm.lvn.broadcom.net/) for PVC data0-sample-1-3"}
{"level":"info","time":"2026-08-07T07:24:54.675570099Z","caller":"k8scloudoperator/[placement.go:1012](http://placement.go:1012/)","msg":"Picked sp [storagepool-vsandatastore-lvn-dvm-10-162-84-64.dvm.lvn.broadcom.net](http://storagepool-vsandatastore-lvn-dvm-10-162-84-64.dvm.lvn.broadcom.net/) for PVC data0-sample-1-4"}
```
Sample instance pods are also up and running:

```
root@4236027b57243f8b967092884ed60510 [ ~ ]# k get pod -n test -w
NAME         READY   STATUS    RESTARTS   AGE
sample-1-0   1/1     Running   0          59s
sample-1-1   1/1     Running   0          58s
sample-1-2   1/1     Running   0          58s
^Croot@4236027b57243f8b967092884ed60510 [ ~ ]# k get pvc -n test
NAME               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS               VOLUMEATTRIBUTESCLASS   AGE
data0-sample-1-0   Bound    pvc-047c990a-0376-4e41-8d1e-432d893ff2f0   1Gi        RWO            sample-vsan-direct-thick   <unset>                 65s
data0-sample-1-1   Bound    pvc-584b5d5c-7eff-4ed7-b777-bc536444800e   1Gi        RWO            sample-vsan-direct-thick   <unset>                 65s
data0-sample-1-2   Bound    pvc-abe0fb87-5a64-4851-bda6-ed2f5b3b02d5   1Gi        RWO            sample-vsan-direct-thick   <unset>                 65s
```


Testing for rotating certs:

Deleted the server cert so that it gets re-created with new credentials:

```
root@42197796a5f4d4f496a83e7e5759e4d4 [ ~ ]# kubectl delete secret vmware-system-csi-k8scloudoperator-server-cert -n vmware-system-csi
secret "vmware-system-csi-k8scloudoperator-server-cert" deleted from vmware-system-csi namespace
```

Gets re-created:
```
root@42197796a5f4d4f496a83e7e5759e4d4 [ ~ ]# kubectl get certificate vmware-system-csi-k8scloudoperator-server-cert -n vmware-system-csi -o jsonpath='{.status.renewalTime}{"\n"}{.status.notBefore}{"\n"}'
2026-10-09T10:27:49Z
2026-08-10T10:27:49Z
root@42197796a5f4d4f496a83e7e5759e4d4 [ ~ ]# date
Mon Aug 10 10:28:01 AM UTC 2026
root@42197796a5f4d4f496a83e7e5759e4d4 [ ~ ]# kubectl get secret vmware-system-csi-k8scloudoperator-server-cert -n vmware-system-csi -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -serial -dates
serial=7374D022D7333E875427B90A74A8A08ACFC85205
notBefore=Aug 10 10:27:49 2026 GMT
notAfter=Nov  8 10:27:49 2026 GMT
```


Logs for cert reload:

```
root@42197796a5f4d4f496a83e7e5759e4d4 [ ~ ]# k logs vsphere-csi-controller-79fd6d4784-86vq6 -n vmware-system-csi -c vsphere-syncer | grep "Reloaded certificate"
{"level":"info","time":"2026-08-10T10:28:04.919992125Z","caller":"certwatcher/[certwatcher.go:166](http://certwatcher.go:166/)","msg":"Reloaded certificate from /etc/vmware/wcp/k8s-cloud-operator-certs/tls.crt","TraceId":"1e9a54d1-97d1-4156-9ee8-3981efdd9689"}
{"level":"info","time":"2026-08-10T10:28:05.021141658Z","caller":"certwatcher/[certwatcher.go:166](http://certwatcher.go:166/)","msg":"Reloaded certificate from /etc/vmware/wcp/k8s-cloud-operator-certs/tls.crt","TraceId":"1e9a54d1-97d1-4156-9ee8-3981efdd9689"}
{"level":"info","time":"2026-08-10T10:28:05.122884916Z","caller":"certwatcher/[certwatcher.go:166](http://certwatcher.go:166/)","msg":"Reloaded certificate from /etc/vmware/wcp/k8s-cloud-operator-certs/tls.crt","TraceId":"1e9a54d1-97d1-4156-9ee8-3981efdd9689"}
root@42197796a5f4d4f496a83e7e5759e4d4 [ ~ ]#
```

Checked the cert mounted on CSI driver has the same serial number as what was observed on the secret:
```
root@42197796a5f4d4f496a83e7e5759e4d4 [ ~ ]# kubectl exec -it vsphere-csi-controller-79fd6d4784-dmkqd -n vmware-system-csi -c vsphere-csi-controller -- sh -c "echo | openssl s_client -connect 127.0.0.1:29000 -showcerts 2>/dev/null" | openssl x509 -noout -serial -dates
serial=7374D022D7333E875427B90A74A8A08ACFC85205
notBefore=Aug 10 10:27:49 2026 GMT
notAfter=Nov  8 10:27:49 2026 GMT
```

Also verified that with old provisioner image (not having secure connection), PVC creation fails.


WCP precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/instapp-run-pre-checkin-test/1/
VKS precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/instapp-run-pre-checkin-test/19/