### PR TITLE
Tag CSI images as v3.6.4 to prepare for release

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -149,7 +149,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.6.4-rc.1
+          image: registry.k8s.io/csi-vsphere/syncer:v3.6.4
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -279,7 +279,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.6.4-rc.1
+          image: registry.k8s.io/csi-vsphere/driver:v3.6.4
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -340,7 +340,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:v3.6.4-rc.1
+          image: registry.k8s.io/csi-vsphere/syncer:v3.6.4
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -475,7 +475,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.6.4-rc.1
+          image: registry.k8s.io/csi-vsphere/driver:v3.6.4
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -624,7 +624,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: vsphere-csi-node
-          image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:v3.6.4-rc.1
+          image: registry.k8s.io/csi-vsphere/driver:v3.6.4
           command:
             - "csi.exe"
           args:


### PR DESCRIPTION
Tag CSI images as v3.6.4 to prepare for release

Testing Done: Yes
vsan block tests results with rc tags:
https://gist.github.com/anuj087/4636ffbc0d93922eca28286a345cc689#file-gistfile1-txt