### PR TITLE
Fix CNSRegisterVolume for VKSRegisterVolume: use use VolumeId instead of BackingDiskId

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -1834,6 +1834,10 @@ func TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityEn
 		},
 	}
 
+	origSharedDisk, origCapability := isSharedDiskEnabled, isVSphereDPLPModernAppEnabled
+	t.Cleanup(func() {
+		isSharedDiskEnabled, isVSphereDPLPModernAppEnabled = origSharedDisk, origCapability
+	})
 	isSharedDiskEnabled = false
 	isVSphereDPLPModernAppEnabled = true
 	err := validateCnsRegisterVolumeSpec(context.TODO(), instance)
@@ -1857,6 +1861,10 @@ func TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityDi
 		},
 	}
 
+	origSharedDisk, origCapability := isSharedDiskEnabled, isVSphereDPLPModernAppEnabled
+	t.Cleanup(func() {
+		isSharedDiskEnabled, isVSphereDPLPModernAppEnabled = origSharedDisk, origCapability
+	})
 	isSharedDiskEnabled = false
 	isVSphereDPLPModernAppEnabled = false
 	err := validateCnsRegisterVolumeSpec(context.TODO(), instance)
@@ -1865,7 +1873,9 @@ func TestValidateCnsRegisterVolumeSpecWithBothVolumeIDAndDiskURLPathCapabilityDi
 
 // TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityEnabled verifies that
 // when both VolumeID and DiskURLPath are set and the VSphereDPLPModernApp WCP capability
-// is active, BackingObjectDetails carries both fields.
+// is active, the UUID goes on CnsVolumeCreateSpec.VolumeId (not BackingObjectDetails.BackingDiskId
+// — CNS rejects BackingDiskId combined with BackingDiskUrlPath, see Bugzilla 3766210) and
+// BackingObjectDetails carries only BackingDiskUrlPath.
 func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityEnabled(t *testing.T) {
 	volumeID := "fcd-uuid-123456"
 	diskURL := "https://vc-ip/folder/path/disk.vmdk?dcPath=dc&dsName=ds"
@@ -1892,11 +1902,16 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityE
 		configInfo: &config.ConfigurationInfo{Cfg: cfg},
 	}
 
+	origCapability := isVSphereDPLPModernAppEnabled
+	t.Cleanup(func() { isVSphereDPLPModernAppEnabled = origCapability })
 	isVSphereDPLPModernAppEnabled = true
 	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	if assert.NotNil(t, spec.VolumeId, "VolumeId should be set") {
+		assert.Equal(t, volumeID, spec.VolumeId.Id, "VolumeId.Id should be VolumeID")
+	}
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
-	assert.Equal(t, volumeID, backing.BackingDiskId, "BackingDiskId should be VolumeID")
+	assert.Equal(t, "", backing.BackingDiskId, "BackingDiskId must NOT be set alongside BackingDiskUrlPath")
 	assert.Equal(t, diskURL, backing.BackingDiskUrlPath, "BackingDiskUrlPath should be DiskURLPath")
 }
 
@@ -1930,8 +1945,11 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityD
 		configInfo: &config.ConfigurationInfo{Cfg: cfg},
 	}
 
+	origCapability := isVSphereDPLPModernAppEnabled
+	t.Cleanup(func() { isVSphereDPLPModernAppEnabled = origCapability })
 	isVSphereDPLPModernAppEnabled = false
 	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	assert.Nil(t, spec.VolumeId, "VolumeId should not be set on the legacy VolumeID-only path")
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
 	assert.Equal(t, volumeID, backing.BackingDiskId, "BackingDiskId should be VolumeID")

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -367,11 +367,12 @@ func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegister
 	if instance.Spec.VolumeID != "" && instance.Spec.DiskURLPath != "" &&
 		isVSphereDPLPModernAppEnabled {
 		// Both fields supplied and VSphereDPLPModernApp WCP capability is active:
-		// CNS locates the VMDK by URL and stamps the provided FCD UUID onto it
+		// CNS locates the VMDK by URL and stamps the provided UUID onto it
 		// (VKSRegisterVolume restore path — ss-metadata-manager supplies both fields).
-		// Guard is required: older vCenters do not support both fields and would return an error.
+		// Guard is required: older vCenters do not support this combination and would
+		// return an error.
+		createSpec.VolumeId = &cnstypes.CnsVolumeId{Id: instance.Spec.VolumeID}
 		createSpec.BackingObjectDetails = &cnstypes.CnsBlockBackingDetails{
-			BackingDiskId:      instance.Spec.VolumeID,
 			BackingDiskUrlPath: instance.Spec.DiskURLPath,
 		}
 	} else if instance.Spec.VolumeID != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CNSRegisterVolume for VKSRegisterVolume: BackingDiskId can't combine with BackingDiskUrlPath, use VolumeId instead


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
e2e test :
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1429 - PASS
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1881 - PASS

manual testing

Tested on same setup, earlier where the CNSRegisterVolume CRs were failing with status error:
```
root@4213b6d76dd2a9152ed511a60887ab20 [ ~ ]# k -n test-gc-e2e-demo-ns get cnsregistervolume 998c9ad4-bd2a-46f2-a6d9-7f8638fdee23-reg-a617141302e2dc51 -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  creationTimestamp: "2026-08-03T23:29:32Z"
  finalizers:
  - cns.vmware.com/register-volume
  generation: 1
  labels:
    protectionandrecovery.vmware.com/protected-entity-snapshot: mock-pe-snapshot-id-1-0
    protectionandrecovery.vmware.com/snapservice-pvc-name: pod1-pvc1
    protectionandrecovery.vmware.com/snapservice-pvc-namespace: vks-guest-poc
    protectionandrecovery.vmware.com/snapservice-restore-id: 88d96e50-bee6-4f34-84e4-d3504d8162cb
  name: 998c9ad4-bd2a-46f2-a6d9-7f8638fdee23-reg-a617141302e2dc51
  namespace: test-gc-e2e-demo-ns
  resourceVersion: "5053064"
  uid: 8fa4359b-df75-4f5d-b756-8335631087eb
spec:
  accessMode: ReadWriteOnce
  diskURLPath: https://10.161.250.159/folder/ae606a6a-7ee5-01ac-b4f2-02005b118fab/4b437d4988ae4eb28c8c88ff0466ddb2.vmdk?dcPath=/wcp-sanity&dsName=vsanDatastore
  pvcName: 998c9ad4-bd2a-46f2-a6d9-7f8638fdee23-reg-a617141302e2dc51
  volumeID: 0ae6cdab-3354-47c5-a476-fb9b042d0ff8
status:
  error: 'failed to create CNS volume. Error: ServerFaultCode: A specified parameter
    was not correct: createSpecs.backingObjectDetails'
  registered: false
```

With this fix in PR:
CNSRegisterVolume is registered successfully:
```
root@42130f6e138a8d3d5df5f22a6824cea7 [ ~ ]# k -n test-gc-e2e-demo-ns get cnsregistervolume 998c9ad4-bd2a-46f2-a6d9-7f8638fdee23-reg-d7244e50c27a7a8d  -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  creationTimestamp: "2026-08-04T02:58:15Z"
  finalizers:
  - cns.vmware.com/register-volume
  generation: 1
  labels:
    protectionandrecovery.vmware.com/protected-entity-snapshot: mock-pe-snapshot-id-1-0
    protectionandrecovery.vmware.com/snapservice-pvc-name: pod2-pvc1
    protectionandrecovery.vmware.com/snapservice-pvc-namespace: vks-guest-poc
    protectionandrecovery.vmware.com/snapservice-restore-id: 82aa6f3c-ab8b-4d3f-82ae-ce0793dde110
  name: 998c9ad4-bd2a-46f2-a6d9-7f8638fdee23-reg-d7244e50c27a7a8d
  namespace: test-gc-e2e-demo-ns
  ownerReferences:
  - apiVersion: v1
    blockOwnerDeletion: true
    controller: true
    kind: PersistentVolumeClaim
    name: 998c9ad4-bd2a-46f2-a6d9-7f8638fdee23-reg-d7244e50c27a7a8d
    uid: 40303db4-6a47-4fbb-ad47-e3e67b84ede3
  resourceVersion: "5559682"
  uid: 00234309-b9e7-494c-a333-0cc623203dbd
spec:
  accessMode: ReadWriteOnce
  diskURLPath: https://10.161.250.159/folder/ae606a6a-7ee5-01ac-b4f2-02005b118fab/c6820c5232bc439f85b75624eef60554.vmdk?dcPath=/wcp-sanity&dsName=vsanDatastore
  pvcName: 998c9ad4-bd2a-46f2-a6d9-7f8638fdee23-reg-d7244e50c27a7a8d
  volumeID: ce13721e-adf9-49ef-8324-60e446a4c233
status:
  error: ""
  registered: true
```

On GC vksregistervolume is registered successfully :
```
root@42130f6e138a8d3d5df5f22a6824cea7 [ ~ ]# kubectl --kubeconfig=test-cluster-e2e-script-kubeconfig-kubeconfig.yaml -n vks-guest-poc get vksregistervolume  vksreg-pod2-pvc1-7763428306  -o yaml 
apiVersion: cns.vmware.com/v1alpha1
kind: VKSRegisterVolume
metadata:
  creationTimestamp: "2026-08-04T02:58:16Z"
  finalizers:
  - cns.vmware.com/vks-register-volume
  generation: 1
  labels:
    protectionandrecovery.vmware.com/protected-entity-snapshot: mock-pe-snapshot-id-1-0
    protectionandrecovery.vmware.com/snapservice-pvc-name: pod2-pvc1
    protectionandrecovery.vmware.com/snapservice-pvc-namespace: vks-guest-poc
    protectionandrecovery.vmware.com/snapservice-restore-id: 82aa6f3c-ab8b-4d3f-82ae-ce0793dde110
  name: vksreg-pod2-pvc1-7763428306
  namespace: vks-guest-poc
  resourceVersion: "1715050"
  uid: 1ca9b059-b4ab-4204-88fe-6fdd9f0a7f03
spec:
  cnsRegisterVolumeName: 998c9ad4-bd2a-46f2-a6d9-7f8638fdee23-reg-d7244e50c27a7a8d
  pvcName: pod2-pvc1
status:
  error: ""
  phase: Registered
  registered: true
root@42130f6e138a8d3d5df5f22a6824cea7 [ ~ ]# 
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
CNSRegisterVolume for VKSRegisterVolume: BackingDiskId can't combine with BackingDiskUrlPath, use VolumeId instead

```
