### PR TITLE
Enhance validate ExpandVolumeRequest for vanilla k8s

### DIFF
--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -73,6 +73,12 @@ func validateVanillaControllerExpandVolumeRequest(ctx context.Context,
 		return err
 	}
 
+	// Vanilla does not support expansion of file volumes.
+	if common.IsFileVolumeRequest(ctx, []*csi.VolumeCapability{req.GetVolumeCapability()}) {
+		return logger.LogNewErrorCode(log, codes.Unimplemented,
+			"volume expansion is only supported for block volume type")
+	}
+
 	// Check online extend FSS and vCenter support.
 	if isOnlineExpansionEnabled && isOnlineExpansionSupported {
 		return nil

--- a/pkg/csi/service/vanilla/controller_helper_test.go
+++ b/pkg/csi/service/vanilla/controller_helper_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vanilla
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestValidateVanillaControllerExpandVolumeRequest_RejectsFileVolume(t *testing.T) {
+	ctx := context.Background()
+	req := &csi.ControllerExpandVolumeRequest{
+		VolumeId: "test-file-volume-id",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 3221225472,
+		},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			},
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					FsType: "nfs4",
+				},
+			},
+		},
+	}
+
+	err := validateVanillaControllerExpandVolumeRequest(ctx, req, false, false)
+	if err == nil {
+		t.Fatalf("expected expansion of a file volume to be rejected, got nil error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected a grpc status error, got %v", err)
+	}
+	if st.Code() != codes.Unimplemented {
+		t.Fatalf("expected code %v, got %v (%v)", codes.Unimplemented, st.Code(), st.Message())
+	}
+}
+
+func TestValidateVanillaControllerExpandVolumeRequest_AllowsBlockVolume(t *testing.T) {
+	ctx := context.Background()
+	req := &csi.ControllerExpandVolumeRequest{
+		VolumeId: "test-block-volume-id",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 3221225472,
+		},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					FsType: "ext4",
+				},
+			},
+		},
+	}
+
+	// isOnlineExpansionEnabled=true, isOnlineExpansionSupported=true short-circuits the
+	// node-attachment lookup so this exercises only the file-volume gate added by this test.
+	err := validateVanillaControllerExpandVolumeRequest(ctx, req, true, true)
+	if err != nil {
+		t.Fatalf("expected block volume expansion to be allowed, got error: %v", err)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- validateVanillaControllerExpandVolumeRequest now rejects any expand request whose VolumeCapability indicates a file volume (RWX/ROX access mode), returning codes.Unimplemented with the same message text the WCP driver already uses for its equivalent legacy-file-volume rejection 
- Reused the existing common.IsFileVolumeRequest helper rather than duplicating logic, since common.ValidateControllerExpandVolumeRequest already guarantees VolumeCapability is non-nil before this point.
- Added pkg/csi/service/vanilla/controller_helper_test.go with two unit tests: one confirming an RWX/nfs4 request is rejected with Unimplemented, one confirming a normal block-volume request still passes through unaffected.

**Testing done**:
```
03:19:12  ------------------------------
03:19:12  • [620.454 seconds]
03:19:12  Volume Expansion Test [csi-file-vanilla] [ef-file-vanilla][pq-n1-vanilla-file][pq-n2-vanilla-file]Verify file volume expansion is not supported [p1, file, vanilla, core, vc70]
03:19:12  /home/worker/workspace/vsan-file/Results/375/vsphere-csi-driver/tests/e2e/vsphere_volume_expansion.go:296
03:19:12  
03:19:12    Timeline >>
03:19:12    STEP: Creating a kubernetes client @ 08/07/26 10:08:48.27
03:19:12    I0807 10:08:48.270202  436444 util.go:414] >>> kubeConfig: /home/worker/workspace/vsan-file/Results/375/gc-kubeconfig.yaml
03:19:12    STEP: Building a namespace api object, basename volume-expansion @ 08/07/26 10:08:48.274
03:19:12    I0807 10:08:48.355792  436444 framework.go:384] Skipping waiting for service account
03:19:12    I0807 10:08:48.357173  436444 connection.go:72] Creating new VC session
03:19:12    I0807 10:08:48.743046  436444 vsphere.go:378] storage policy id: aa6d5a82-1c88-45da-85d3-3d74b91a5bad for storage policy name is: vSAN Default Storage Policy
03:19:12    I0807 10:08:48.851058  436444 util.go:4586] Looking for default datastore in DC: "VSAN-DC"
03:19:12    I0807 10:08:48.993186  436444 util.go:4590] Datstore found for DS URL:"ds:///vmfs/volumes/vsan:fbf5c774916611f1-8e4902005c3feb27/"
03:19:12    I0807 10:08:49.073497  436444 vsphere.go:378] storage policy id: aa6d5a82-1c88-45da-85d3-3d74b91a5bad for storage policy name is: vSAN Default Storage Policy
03:19:12    STEP: Invoking Test for Unsupported File Volume Expansion @ 08/07/26 10:08:49.119
03:19:12    STEP: Creating Storage Class and PVC with allowVolumeExpansion is true and filesystem type is nfs4FSType @ 08/07/26 10:08:49.119
03:19:12    STEP: Creating StorageClass  with scParameters: map[csi.storage.k8s.io/fstype:nfs4] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: true @ 08/07/26 10:08:49.119
03:19:12    STEP: Creating PVC using the Storage Class sc-6m9bw with disk size  and labels: map[] accessMode: ReadWriteMany @ 08/07/26 10:08:49.157
03:19:12    I0807 10:08:49.255578  436444 util.go:909] PVC created: pvc-hwrmf in namespace: volume-expansion-5943
03:19:12    STEP: Waiting for all claims to be in bound state @ 08/07/26 10:08:49.255
03:19:12    I0807 10:08:49.255661  436444 pv.go:790] Waiting up to timeout=5m0s for PersistentVolumeClaims [pvc-hwrmf] to have phase Bound
03:19:12    I0807 10:08:49.374616  436444 pv.go:806] PersistentVolumeClaim pvc-hwrmf found but phase is Pending instead of Bound.
03:19:12    I0807 10:08:51.397605  436444 pv.go:806] PersistentVolumeClaim pvc-hwrmf found but phase is Pending instead of Bound.
03:19:12    I0807 10:08:53.415990  436444 pv.go:806] PersistentVolumeClaim pvc-hwrmf found but phase is Pending instead of Bound.
03:19:12    I0807 10:08:55.460634  436444 pv.go:806] PersistentVolumeClaim pvc-hwrmf found but phase is Pending instead of Bound.
03:19:12    I0807 10:08:57.482633  436444 pv.go:806] PersistentVolumeClaim pvc-hwrmf found but phase is Pending instead of Bound.
03:19:12    I0807 10:08:59.501066  436444 pv.go:806] PersistentVolumeClaim pvc-hwrmf found but phase is Pending instead of Bound.
03:19:12    I0807 10:09:01.533087  436444 pv.go:806] PersistentVolumeClaim pvc-hwrmf found but phase is Pending instead of Bound.
03:19:12    I0807 10:09:03.580942  436444 pv.go:806] PersistentVolumeClaim pvc-hwrmf found but phase is Pending instead of Bound.
03:19:12    I0807 10:09:05.693727  436444 pv.go:806] PersistentVolumeClaim pvc-hwrmf found but phase is Pending instead of Bound.
03:19:12    I0807 10:09:07.728812  436444 pv.go:801] PersistentVolumeClaim pvc-hwrmf found and phase=Bound (18.473109857s)
03:19:12    STEP: Verify expanding file volume pvc is not supported @ 08/07/26 10:09:07.819
03:19:12    I0807 10:09:07.819903  436444 vsphere_volume_expansion.go:4207] currentPvcSize {{2147483648 0} {<nil>} 2Gi BinarySI}, newSize {{3221225472 0} {<nil>}  BinarySI}
03:19:12    STEP: Verify if controller resize failed @ 08/07/26 10:09:07.974
03:19:12    I0807 10:19:08.032427  436444 pv.go:205] Deleting PersistentVolumeClaim "pvc-hwrmf"
03:19:12    STEP: Destroying namespace "volume-expansion-5943" for this suite. @ 08/07/26 10:19:08.622
03:19:12    << Timeline
03:19:12  ------------------------------
03:19:12  SSSSSSSSSSSSSSSSSSSSSSSSSSSS
03:19:12  ------------------------------
03:19:12  [ReportAfterSuite] PASSED [0.088 seconds]
03:19:12  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
03:19:12  autogenerated by Ginkgo
03:19:12  ------------------------------
03:19:12  
03:19:12  Ran 1 of 1279 Specs in 620.827 seconds
03:19:12  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 1278 Skipped
03:19:12  
```
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vsan-file/375/console(internal link)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enhance validate ExpandVolumeRequest for vanilla k8s
```
