### PR TITLE
Match host-local storage policies via new StorageLocality capability

### DIFF
--- a/pkg/common/cns-lib/vsphere/pbm.go
+++ b/pkg/common/cns-lib/vsphere/pbm.go
@@ -240,28 +240,61 @@ func PbmSimplifyProfileContent(ctx context.Context, profiles []pbmtypes.BasePbmP
 }
 
 const (
-	// hostLocalStorageNamespace and hostLocalStorageCapabilityID identify the SPBM capability
-	// that marks a storage policy as host-local storage. This mirrors the check used by the WCP
-	// control plane; the hostlocalstorage namespace defines exactly one capability
-	// (hostLocalStorage) and it carries no constraint/property instances, so it must be matched
-	// directly against the capability id rather than via PbmRetrieveContent/SpbmPolicyContent,
-	// which only emits a rule per PropertyInstance and would silently drop a property-less
-	// capability like this one. This does NOT match vSAN Direct or vSAN locality/SNA policies.
-	hostLocalStorageNamespace    = "com.vmware.storage.hostlocalstorage"
-	hostLocalStorageCapabilityID = "hostLocalStorage"
+	volumeAllocationNamespace = "com.vmware.storage.volumeallocation"
+	// storageLocalityID is both the capability id and the property id in this schema.
+	storageLocalityID        = "StorageLocality"
+	storageLocalityHostLocal = "HostLocalStorage"
 )
 
-// IsHostLocalStorageCapabilityPolicy reports whether the SPBM capability subprofile constraints
-// contain the com.vmware.storage.hostlocalstorage/hostLocalStorage capability.
+// IsHostLocalStorageCapabilityPolicy returns true if the policy contains the
+// com.vmware.storage.volumeallocation/StorageLocality SPBM capability with its property value set
+// to HostLocalStorage. The StorageLocality capability also allows the value None (its default),
+// which means no locality preference must NOT be treated as host-local.
+// This function does NOT match vSAN Direct or vSAN locality/SNA policies.
 func IsHostLocalStorageCapabilityPolicy(subprofiles *pbmtypes.PbmCapabilitySubProfileConstraints) bool {
 	if subprofiles == nil {
 		return false
 	}
 	for _, subprofile := range subprofiles.SubProfiles {
 		for _, capIns := range subprofile.Capability {
-			if capIns.Id.Namespace == hostLocalStorageNamespace && capIns.Id.Id == hostLocalStorageCapabilityID {
-				return true
+			if capIns.Id.Namespace != volumeAllocationNamespace || capIns.Id.Id != storageLocalityID {
+				continue
 			}
+			for _, constraint := range capIns.Constraint {
+				for _, propInstance := range constraint.PropertyInstance {
+					if propInstance.Id == storageLocalityID && storageLocalityValueIsHostLocal(propInstance.Value) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// storageLocalityValueIsHostLocal reports whether an SPBM property instance value denotes
+// HostLocalStorage. SPBM may encode a discrete-set-constrained string property either as a
+// scalar or wrapped in a PbmCapabilityDiscreteSet.
+func storageLocalityValueIsHostLocal(value vimtypes.AnyType) bool {
+	switch v := value.(type) {
+	case string:
+		return v == storageLocalityHostLocal
+	case pbmtypes.PbmCapabilityDiscreteSet:
+		return discreteSetHasHostLocal(&v)
+	case *pbmtypes.PbmCapabilityDiscreteSet:
+		return discreteSetHasHostLocal(v)
+	}
+	return false
+}
+
+// discreteSetHasHostLocal reports whether any member of the set equals HostLocalStorage.
+func discreteSetHasHostLocal(set *pbmtypes.PbmCapabilityDiscreteSet) bool {
+	if set == nil {
+		return false
+	}
+	for _, member := range set.Values {
+		if s, ok := member.(string); ok && s == storageLocalityHostLocal {
+			return true
 		}
 	}
 	return false

--- a/pkg/common/cns-lib/vsphere/pbm_test.go
+++ b/pkg/common/cns-lib/vsphere/pbm_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -604,13 +605,48 @@ func TestPbmQueryMatchingHub_LoggingBehavior(t *testing.T) {
 	})
 }
 
-func TestIsHostLocalStorageCapabilityPolicy(t *testing.T) {
-	hostLocalCapability := pbmtypes.PbmCapabilityInstance{
-		Id: pbmtypes.PbmCapabilityMetadataUniqueId{
-			Namespace: "com.vmware.storage.hostlocalstorage",
-			Id:        "hostLocalStorage",
+// capability builds a capability instance in the given namespace, carrying a single property
+// instance with the given id and value. A nil value means the capability carries no
+// constraint/property instances at all.
+func capability(namespace, capID, propID string, value vimtypes.AnyType) pbmtypes.PbmCapabilityInstance {
+	capIns := pbmtypes.PbmCapabilityInstance{
+		Id: pbmtypes.PbmCapabilityMetadataUniqueId{Namespace: namespace, Id: capID},
+	}
+	if value != nil {
+		capIns.Constraint = []pbmtypes.PbmCapabilityConstraintInstance{
+			{PropertyInstance: []pbmtypes.PbmCapabilityPropertyInstance{{Id: propID, Value: value}}},
+		}
+	}
+	return capIns
+}
+
+// The SPBM schema strings are spelled out literally here rather than reused from the constants in
+// pbm.go: these are the identifiers vCenter sends, so a test built from the constants would only
+// prove the matcher is self-consistent and would still pass if a constant held the wrong value.
+const (
+	testVolumeAllocationNs   = "com.vmware.storage.volumeallocation"
+	testStorageLocalityID    = "StorageLocality"
+	testHostLocalStorage     = "HostLocalStorage"
+	testStorageLocalityNone  = "None"
+	testVolumeAllocationType = "VolumeAllocationType"
+)
+
+// storageLocalitySubProfiles wraps a single StorageLocality capability with the given property
+// value into subprofile constraints, mirroring what SPBM returns for such a policy.
+func storageLocalitySubProfiles(value vimtypes.AnyType) *pbmtypes.PbmCapabilitySubProfileConstraints {
+	return &pbmtypes.PbmCapabilitySubProfileConstraints{
+		SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
+			{Capability: []pbmtypes.PbmCapabilityInstance{
+				capability(testVolumeAllocationNs, testStorageLocalityID, testStorageLocalityID, value),
+			}},
 		},
 	}
+}
+
+func TestIsHostLocalStorageCapabilityPolicy(t *testing.T) {
+	hostLocalCapability := capability(testVolumeAllocationNs, testStorageLocalityID,
+		testStorageLocalityID, testHostLocalStorage)
+	vsanCapability := capability("VSAN", "hostFailuresToTolerate", "hostFailuresToTolerate", int32(1))
 
 	tests := []struct {
 		name        string
@@ -618,7 +654,7 @@ func TestIsHostLocalStorageCapabilityPolicy(t *testing.T) {
 		want        bool
 	}{
 		{
-			name: "hostLocalStorage capability present",
+			name: "StorageLocality set to HostLocalStorage",
 			subprofiles: &pbmtypes.PbmCapabilitySubProfileConstraints{
 				SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
 					{Capability: []pbmtypes.PbmCapabilityInstance{hostLocalCapability}},
@@ -627,23 +663,49 @@ func TestIsHostLocalStorageCapabilityPolicy(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "hostLocalStorage capability alongside other capabilities",
+			name: "HostLocalStorage alongside other capabilities",
 			subprofiles: &pbmtypes.PbmCapabilitySubProfileConstraints{
 				SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
-					{Capability: []pbmtypes.PbmCapabilityInstance{
-						{Id: pbmtypes.PbmCapabilityMetadataUniqueId{Namespace: "VSAN", Id: "hostFailuresToTolerate"}},
-						hostLocalCapability,
-					}},
+					{Capability: []pbmtypes.PbmCapabilityInstance{vsanCapability, hostLocalCapability}},
 				},
 			},
 			want: true,
 		},
 		{
-			name: "no hostLocalStorage capability",
+			name:        "StorageLocality set to None (default, no locality preference)",
+			subprofiles: storageLocalitySubProfiles(testStorageLocalityNone),
+			want:        false,
+		},
+		{
+			name: "HostLocalStorage wrapped in a discrete set",
+			subprofiles: storageLocalitySubProfiles(pbmtypes.PbmCapabilityDiscreteSet{
+				Values: []vimtypes.AnyType{testHostLocalStorage},
+			}),
+			want: true,
+		},
+		{
+			name:        "StorageLocality capability with no property instances",
+			subprofiles: storageLocalitySubProfiles(nil),
+			want:        false,
+		},
+		{
+			name: "sibling capability in the same namespace (VolumeAllocationType)",
 			subprofiles: &pbmtypes.PbmCapabilitySubProfileConstraints{
 				SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
 					{Capability: []pbmtypes.PbmCapabilityInstance{
-						{Id: pbmtypes.PbmCapabilityMetadataUniqueId{Namespace: "VSAN", Id: "hostFailuresToTolerate"}},
+						capability(testVolumeAllocationNs, testVolumeAllocationType,
+							testVolumeAllocationType, "thickProvision"),
+					}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "vSAN locality capability, not host-local storage",
+			subprofiles: &pbmtypes.PbmCapabilitySubProfileConstraints{
+				SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
+					{Capability: []pbmtypes.PbmCapabilityInstance{
+						capability("VSAN", "locality", "locality", testStorageLocalityNone),
 					}},
 				},
 			},
@@ -654,22 +716,75 @@ func TestIsHostLocalStorageCapabilityPolicy(t *testing.T) {
 			subprofiles: nil,
 			want:        false,
 		},
-		{
-			name: "matching id but different namespace (vSAN locality, not host-local storage)",
-			subprofiles: &pbmtypes.PbmCapabilitySubProfileConstraints{
-				SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
-					{Capability: []pbmtypes.PbmCapabilityInstance{
-						{Id: pbmtypes.PbmCapabilityMetadataUniqueId{Namespace: "VSAN", Id: "locality"}},
-					}},
-				},
-			},
-			want: false,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, IsHostLocalStorageCapabilityPolicy(tt.subprofiles))
+		})
+	}
+}
+
+// TestProfilesContainHostLocal feeds raw SPBM profiles, as PbmRetrieveContentRaw returns them,
+// through ProfilesContainHostLocal. This covers the two type assertions the profile walk relies
+// on: a BasePbmProfile that is not a *PbmCapabilityProfile, and a capability profile whose
+// Constraints are not subprofile constraints. Both must be skipped rather than reported as
+// host-local.
+func TestProfilesContainHostLocal(t *testing.T) {
+	// storageLocalityProfile builds the profile SPBM returns for a policy carrying the
+	// StorageLocality capability with the given property value.
+	storageLocalityProfile := func(value vimtypes.AnyType) *pbmtypes.PbmCapabilityProfile {
+		return &pbmtypes.PbmCapabilityProfile{
+			PbmProfile:  pbmtypes.PbmProfile{ProfileId: pbmtypes.PbmProfileId{UniqueId: "test-profile-id"}},
+			Constraints: storageLocalitySubProfiles(value),
+		}
+	}
+
+	tests := []struct {
+		name     string
+		profiles []pbmtypes.BasePbmProfile
+		want     bool
+	}{
+		{
+			name:     "host-local capability profile",
+			profiles: []pbmtypes.BasePbmProfile{storageLocalityProfile(testHostLocalStorage)},
+			want:     true,
+		},
+		{
+			name: "host-local profile is not the first in the result",
+			profiles: []pbmtypes.BasePbmProfile{
+				storageLocalityProfile(testStorageLocalityNone),
+				storageLocalityProfile(testHostLocalStorage),
+			},
+			want: true,
+		},
+		{
+			name:     "StorageLocality set to None",
+			profiles: []pbmtypes.BasePbmProfile{storageLocalityProfile(testStorageLocalityNone)},
+			want:     false,
+		},
+		{
+			name:     "profile is not a capability profile",
+			profiles: []pbmtypes.BasePbmProfile{&pbmtypes.PbmProfile{}},
+			want:     false,
+		},
+		{
+			name: "capability profile without subprofile constraints",
+			profiles: []pbmtypes.BasePbmProfile{&pbmtypes.PbmCapabilityProfile{
+				Constraints: &pbmtypes.PbmCapabilityConstraints{},
+			}},
+			want: false,
+		},
+		{
+			name:     "no profiles",
+			profiles: nil,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ProfilesContainHostLocal(tt.profiles))
 		})
 	}
 }

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -4304,11 +4304,45 @@ func TestCheckDatastorePolicyCompatibility(t *testing.T) {
 	})
 }
 
+// newStorageLocalityProfile builds the SPBM profile vCenter returns for a policy carrying the
+// com.vmware.storage.volumeallocation/StorageLocality capability with the given property value
+// (HostLocalStorage or None).
+func newStorageLocalityProfile(value string) *pbmtypes.PbmCapabilityProfile {
+	return &pbmtypes.PbmCapabilityProfile{
+		PbmProfile: pbmtypes.PbmProfile{ProfileId: pbmtypes.PbmProfileId{UniqueId: "host-local-policy-id"}},
+		Constraints: &pbmtypes.PbmCapabilitySubProfileConstraints{
+			SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
+				{Capability: []pbmtypes.PbmCapabilityInstance{
+					{
+						Id: pbmtypes.PbmCapabilityMetadataUniqueId{
+							Namespace: "com.vmware.storage.volumeallocation",
+							Id:        "StorageLocality",
+						},
+						Constraint: []pbmtypes.PbmCapabilityConstraintInstance{
+							{PropertyInstance: []pbmtypes.PbmCapabilityPropertyInstance{
+								{Id: "StorageLocality", Value: value},
+							}},
+						},
+					},
+				}},
+			},
+		},
+	}
+}
+
 // newHostLocalReconcileFixture wires a reconciler and the patches common to a host-local reconcile
-// test: capability enabled, VC instance, create spec, volume query (host-local policy),
-// IsHostLocalStoragePolicy=true, datastore resolution, and setInstanceError/cleanup observers.
+// test: capability enabled, VC instance, create spec, volume query (host-local policy), datastore
+// resolution, and setInstanceError/cleanup observers.
+//
+// storageLocality is the StorageLocality property value of the storage policy the volume uses
+// ("HostLocalStorage" or "None"). Rather than stubbing IsHostLocalStoragePolicy, the fixture stubs
+// PbmRetrieveContentRaw with the SPBM profile such a policy produces, so the reconcile exercises the
+// real detection chain: IsHostLocalStoragePolicy -> ProfilesContainHostLocal ->
+// IsHostLocalStorageCapabilityPolicy. Patching PbmRetrieveContentRaw also keeps ConnectPbm out of
+// the path, so the fake VC client is sufficient.
+//
 // Callers add PBM/topology behavior and must `defer func(){ fssEnabledOverride = nil }()`.
-func newHostLocalReconcileFixture(patches *gomonkey.Patches) (
+func newHostLocalReconcileFixture(patches *gomonkey.Patches, storageLocality string) (
 	*ReconcileCnsRegisterVolume, *bool, *bool) {
 	// Initialize backOffDuration map to prevent nil map assignment panic when a test runs alone.
 	backOffDuration = make(map[types.NamespacedName]time.Duration)
@@ -4332,6 +4366,10 @@ func newHostLocalReconcileFixture(patches *gomonkey.Patches) (
 	r := &ReconcileCnsRegisterVolume{
 		client: fakeClient,
 		scheme: scheme,
+		// Empty clientset: a reconcile that gets past the host-local block stops at the storage
+		// class lookup rather than dereferencing a nil client.
+		k8sclient:  k8sfake.NewSimpleClientset(),
+		configInfo: &config.ConfigurationInfo{Cfg: &config.Config{}},
 		volumeManager: &mockVolumeManager{
 			createVolumeFunc: func(_ context.Context, _ *cnstypes.CnsVolumeCreateSpec,
 				_ interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
@@ -4359,9 +4397,9 @@ func newHostLocalReconcileFixture(patches *gomonkey.Patches) (
 			},
 		}, nil
 	})
-	patches.ApplyMethod(reflect.TypeOf(&cnsvsphere.VirtualCenter{}), "IsHostLocalStoragePolicy",
-		func(_ *cnsvsphere.VirtualCenter, _ context.Context, _ string) (bool, error) {
-			return true, nil
+	patches.ApplyMethod(reflect.TypeOf(&cnsvsphere.VirtualCenter{}), "PbmRetrieveContentRaw",
+		func(_ *cnsvsphere.VirtualCenter, _ context.Context, _ []string) ([]pbmtypes.BasePbmProfile, error) {
+			return []pbmtypes.BasePbmProfile{newStorageLocalityProfile(storageLocality)}, nil
 		})
 	patches.ApplyFunc(cnsvsphere.GetDatastoreInfoByURL, func(_ context.Context, vc *cnsvsphere.VirtualCenter,
 		_ []string, url string) (*cnsvsphere.DatastoreInfo, error) {
@@ -4392,7 +4430,7 @@ func TestReconcileHostLocalPBMIncompatible(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	r, setErrCalled, cleanupCalled := newHostLocalReconcileFixture(patches)
+	r, setErrCalled, cleanupCalled := newHostLocalReconcileFixture(patches, "HostLocalStorage")
 	defer func() { fssEnabledOverride = nil }()
 
 	checkDatastorePolicyCompatibilityFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
@@ -4410,6 +4448,103 @@ func TestReconcileHostLocalPBMIncompatible(t *testing.T) {
 	assert.True(t, *cleanupCalled, "cleanupCNSVolume should be called for a PBM-incompatible host-local volume")
 }
 
+// TestReconcileHostLocalDetectedFromNewSchemaPolicy verifies that a storage policy carrying the
+// com.vmware.storage.volumeallocation/StorageLocality = HostLocalStorage capability is recognized
+// through the real detection chain (IsHostLocalStoragePolicy -> ProfilesContainHostLocal ->
+// IsHostLocalStorageCapabilityPolicy) and drives the host-local branch of the reconcile: the
+// datastore is PBM-checked against the policy and the PV topology is derived from the host the
+// datastore is mounted on, instead of the shared-datastore accessibility path.
+func TestReconcileHostLocalDetectedFromNewSchemaPolicy(t *testing.T) {
+	ctx := context.Background()
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	r, _, cleanupCalled := newHostLocalReconcileFixture(patches, "HostLocalStorage")
+	defer func() { fssEnabledOverride = nil }()
+
+	compatChecked := false
+	checkDatastorePolicyCompatibilityFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ *cnsvsphere.DatastoreInfo, _ string) (bool, error) {
+		compatChecked = true
+		return true, nil
+	}
+	defer func() { checkDatastorePolicyCompatibilityFn = checkDatastorePolicyCompatibility }()
+
+	var resolvedTopology []map[string]string
+	getHostLocalAccessibleTopologyFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ *cnsvsphere.DatastoreInfo, _ map[string]string) ([]map[string]string, error) {
+		resolvedTopology = []map[string]string{{
+			corev1.LabelTopologyZone: "zone-a",
+			corev1.LabelHostname:     "host-1",
+		}}
+		return resolvedTopology, nil
+	}
+	defer func() { getHostLocalAccessibleTopologyFn = getHostLocalAccessibleTopology }()
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-volume", Namespace: "test-ns"}}
+	_, err := r.Reconcile(ctx, req)
+
+	assert.NoError(t, err)
+	assert.True(t, compatChecked,
+		"host-local branch should PBM-check the datastore against the StorageLocality policy")
+	assert.NotEmpty(t, resolvedTopology,
+		"host-local branch should derive the PV topology from the datastore's host")
+	// The reconcile continues past the host-local block and stops at the storage class lookup (no
+	// StorageClass exists in the fixture), which requeues without cleanup. So a cleanup here would
+	// mean the host-local block itself rejected the volume.
+	assert.False(t, *cleanupCalled, "host-local block should accept the volume and not clean it up")
+}
+
+// TestReconcileHostLocalNotDetectedForStorageLocalityNone verifies that StorageLocality = None (the
+// capability's default, meaning no locality preference) is not treated as host-local: the
+// host-local branch is skipped entirely and the reconcile falls through to the pre-existing
+// shared-datastore path.
+func TestReconcileHostLocalNotDetectedForStorageLocalityNone(t *testing.T) {
+	ctx := context.Background()
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	r, _, _ := newHostLocalReconcileFixture(patches, "None")
+	defer func() { fssEnabledOverride = nil }()
+
+	// Pin the non-host-local route to the shared-datastore accessibility gate and observe it.
+	origStretch := syncer.IsPodVMOnStretchSupervisorFSSEnabled
+	syncer.IsPodVMOnStretchSupervisorFSSEnabled = false
+	defer func() { syncer.IsPodVMOnStretchSupervisorFSSEnabled = origStretch }()
+
+	sharedDatastoreGateChecked := false
+	patches.ApplyFunc(isDatastoreAccessibleToCluster, func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ string, _ string) bool {
+		sharedDatastoreGateChecked = true
+		return true
+	})
+
+	compatChecked := false
+	checkDatastorePolicyCompatibilityFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ *cnsvsphere.DatastoreInfo, _ string) (bool, error) {
+		compatChecked = true
+		return true, nil
+	}
+	defer func() { checkDatastorePolicyCompatibilityFn = checkDatastorePolicyCompatibility }()
+
+	topologyResolved := false
+	getHostLocalAccessibleTopologyFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,
+		_ *cnsvsphere.DatastoreInfo, _ map[string]string) ([]map[string]string, error) {
+		topologyResolved = true
+		return nil, nil
+	}
+	defer func() { getHostLocalAccessibleTopologyFn = getHostLocalAccessibleTopology }()
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-volume", Namespace: "test-ns"}}
+	_, err := r.Reconcile(ctx, req)
+
+	assert.NoError(t, err)
+	assert.False(t, compatChecked, "StorageLocality None must not enter the host-local branch")
+	assert.False(t, topologyResolved, "StorageLocality None must not derive host-local topology")
+	assert.True(t, sharedDatastoreGateChecked,
+		"StorageLocality None should fall through to the shared-datastore accessibility gate")
+}
+
 // TestReconcileHostLocalTopologyError verifies that when the host-local topology cannot be derived
 // (e.g. no cluster-derived zone), the reconcile fails permanently and the CNS volume is cleaned up.
 func TestReconcileHostLocalTopologyError(t *testing.T) {
@@ -4417,7 +4552,7 @@ func TestReconcileHostLocalTopologyError(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	r, setErrCalled, cleanupCalled := newHostLocalReconcileFixture(patches)
+	r, setErrCalled, cleanupCalled := newHostLocalReconcileFixture(patches, "HostLocalStorage")
 	defer func() { fssEnabledOverride = nil }()
 
 	checkDatastorePolicyCompatibilityFn = func(_ context.Context, _ *cnsvsphere.VirtualCenter,


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

SPBM moved the host-local storage capability out of its dedicated com.vmware.storage.hostlocalstorage namespace and into the existing com.vmware.storage.volumeallocation namespace, re-modeling it as a value-bearing StorageLocality property (allowed values HostLocalStorage and None, defaulting to None) instead of a bare marker capability.

IsHostLocalStorageCapabilityPolicy still matched the old namespace and capability id only, so against a VC carrying the new schema it always returned false, silently breaking host-local detection in the CNSRegisterVolume controller.

Match the new namespace/capability/property/value instead, treating the None value as not host-local. The property value is compared tolerantly: PbmCapabilityPropertyInstance.Value is an AnyType, so a scalar string and a value wrapped in a PbmCapabilityDiscreteSet are both accepted. The legacy namespace is no longer honored.




**Testing done**:
Manual testing

Created VM with new host-local policy change and imported VM to supervisor namespace with that policy assigned.

```
root@422c096bbabaa5b104f2a4bacc199087 [ ~ ]# kubectl get vm -n divyen-ns
NAME      POWER-STATE   AGE
test-vm   PoweredOn     57s
root@422c096bbabaa5b104f2a4bacc199087 [ ~ ]# kubectl get pvc -n divyen-ns
NAME               STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS      VOLUMEATTRIBUTESCLASS   AGE
test-vm-61a529f6   Bound    static-pv-159d7834-3fd2-48f4-8c64-26e5c1795bf9   16Gi       RWO            host-local-vmfs   <unset>                 58s
```

Pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1884/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Match host-local storage policies via new StorageLocality capability
```
