### PR TITLE
Fix storage quota calculations for cases when PVC is deleted which was migrated from one datastore to another using VAC.

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -3816,6 +3816,22 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 		updateSpec.VolumeId.Id, spew.Sdump(updateSpec))
 }
 
+// deriveStoragePolicyUsageKeyForDeletion returns the key (StorageClass name, or
+// "vac-"+VolumeAttributesClass name) of the StoragePolicyUsage CR that owns a
+// volume's quota, for use when decrementing "Used" on volume deletion. When the
+// VM/PVC storage-policy mutability FSS is enabled, a volume's quota can be tracked
+// under the VAC-keyed SPU once it has a VolumeAttributesClass (e.g. after a
+// storage-policy migration via ModifyVolume); otherwise it stays on the
+// StorageClass-keyed SPU. This must stay consistent with the key derivation in
+// handleVACChangeForVolumeInfo, or a migrated volume's usage will be decremented
+// from the wrong (stale) SPU on deletion.
+func deriveStoragePolicyUsageKeyForDeletion(ctx context.Context, storageClassName, vacName string) string {
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VMPVCStoragePolicyMutability) && vacName != "" {
+		return "vac-" + vacName
+	}
+	return storageClassName
+}
+
 // csiPVDeleted deletes volume metadata on VC when volume has been deleted on
 // Vanills k8s and supervisor cluster.
 func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *metadataSyncInformer) {
@@ -3837,8 +3853,9 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 			return
 		}
 
-		// Fetch StoragePolicyUsage instance for storageClass associated with the volume.
-		storagePolicyUsageInstanceName := volumeInfo.Spec.StorageClassName + "-" +
+		// Fetch StoragePolicyUsage instance owning this volume's quota.
+		storagePolicyUsageInstanceName := deriveStoragePolicyUsageKeyForDeletion(ctx,
+			volumeInfo.Spec.StorageClassName, volumeInfo.Spec.VolumeAttributeClassName) + "-" +
 			storagepolicyv1alpha3.NameSuffixForPVC
 		storagePolicyUsageCR := &storagepolicyv1alpha3.StoragePolicyUsage{}
 		err = cnsOperatorClient.Get(ctx, k8stypes.NamespacedName{
@@ -4867,102 +4884,121 @@ func storagePolicyUsageCRSync(ctx context.Context, metadataSyncer *metadataSyncI
 			}
 		}
 	}
-	// Check if volumeInfoCRList is not empty
-	if len(volumeInfoCRList) > 0 {
-		// Iterate through storagePolicyUsageList
-		for _, storagePolicyUsage := range storagePolicyUsageList.Items {
-			totalUsedQty := resource.NewQuantity(int64(0), resource.BinarySI)
-			updateSpu := false
-			if storagePolicyUsage.Spec.ResourceKind == ResourceKindPVC {
-				// For every storagePolicyUsage, fetch "Bound" PVs in that namespace from k8sVolumesToNamespaceMap
-				if volumes, ok := namespaceToK8sVolumesMap[storagePolicyUsage.Namespace]; ok {
-					for _, pv := range volumes {
-						// Verify the StorageClass, StoragePolicyId match with the storagePolicyUsage spec
-						// using the cnsVolumeInfo CR for the volume
-						volumeHandle := pv.Spec.CSI.VolumeHandle
-						// For file volumes replace prefix "file:" with "file-", since CnsVolumeInfo CR
-						// is created as "file-<uuid>". For example, see below.
-						// cnsvolumeinfo name: file-e6a32a53-2783-42cd-a854-4df28582f04c
-						// pv.Spec.volumeHandle: file:e6a32a53-2783-42cd-a854-4df28582f04c
-						if strings.HasPrefix(pv.Spec.CSI.VolumeHandle, FileVolumePrefix) {
-							volumeHandle = strings.Replace(pv.Spec.CSI.VolumeHandle, ":", "-", 1)
-						}
-						if cnsVolumeInfo, ok := cnsVolumeInfoMap[volumeHandle]; ok {
-							// Check if this volume matches the SPU - either StorageClass-based or VAC-based
-							var matches bool
-							if storagePolicyUsage.Spec.StorageClassName != "" {
-								// StorageClass-based SPU: match by StorageClassName
-								matches = cnsVolumeInfo.Spec.StorageClassName == storagePolicyUsage.Spec.StorageClassName
-							} else if storagePolicyUsage.Spec.VolumeAttributesClassName != "" {
-								// VAC-based SPU: match by VolumeAttributeClassName
-								matches = cnsVolumeInfo.Spec.VolumeAttributeClassName == storagePolicyUsage.Spec.VolumeAttributesClassName
-							}
+	syncStoragePolicyUsageUsedValues(ctx, cnsOperatorClient, storagePolicyUsageList,
+		namespaceToK8sVolumesMap, cnsVolumeInfoMap, spuAggregatedSumMap)
+}
 
-							if matches &&
-								cnsVolumeInfo.Spec.StoragePolicyID == storagePolicyUsage.Spec.StoragePolicyId &&
-								cnsVolumeInfo.Spec.Namespace == storagePolicyUsage.Namespace {
-								// Compute the total used capacity for the voluems in the current namespace(iteration)
-								totalUsedQty.Add(*cnsVolumeInfo.Spec.Capacity)
-							} else {
-								continue
-							}
-						}
+// syncStoragePolicyUsageUsedValues recomputes and patches the "Used" field for every
+// StoragePolicyUsage CR in storagePolicyUsageList, from scratch, based on the given Bound-PV
+// and CNSVolumeInfo state. It is extracted from storagePolicyUsageCRSync so the recompute logic
+// can be unit-tested against a fake client without a live Kubernetes config.
+//
+// Every SPU is recomputed from scratch on every cycle - including SPUs whose
+// namespace/VAC/StorageClass no longer has any matching Bound PV (e.g. the last volume under
+// that SPU was deleted) - so that stale "Used" values left behind by other code paths (e.g.
+// volume deletion decrementing the wrong SPU after a storage-policy migration) get reset to 0
+// instead of being silently skipped. Map lookups below are safe when
+// namespaceToK8sVolumesMap/cnsVolumeInfoMap/spuAggregatedSumMap have no entry for the key: a
+// missing map key yields the zero value (nil slice/pointer, false for ok), and ranging over a
+// nil slice is simply zero iterations.
+func syncStoragePolicyUsageUsedValues(ctx context.Context, cnsOperatorClient client.Client,
+	storagePolicyUsageList *storagepolicyv1alpha3.StoragePolicyUsageList,
+	namespaceToK8sVolumesMap map[string][]*v1.PersistentVolume,
+	cnsVolumeInfoMap map[string]*cnsvolumeinfov1alpha1.CNSVolumeInfo,
+	spuAggregatedSumMap map[string]*resource.Quantity) {
+	log := logger.GetLogger(ctx)
+
+	// Guard against a transient CNSVolumeInfo informer cache that hasn't synced yet: if there
+	// are Bound PVs anywhere but cnsVolumeInfoMap has no entries at all, that is far more likely
+	// to be a not-yet-synced cache than a cluster with zero CNSVolumeInfo CRs, since every Bound
+	// CSI PV is expected to have a corresponding CNSVolumeInfo CR. Recomputing in that state would
+	// find no matches for any Bound PV and drive every PVC-kind SPU's Used to 0, which is unsafe
+	// for quota enforcement - skip this cycle entirely and let the next one retry once the cache
+	// has caught up.
+	if len(cnsVolumeInfoMap) == 0 {
+		for _, pvs := range namespaceToK8sVolumesMap {
+			if len(pvs) > 0 {
+				log.Errorf("syncStoragePolicyUsageUsedValues: Bound PVs exist but no CNSVolumeInfo CRs were " +
+					"found; skipping this sync cycle to avoid resetting Used values based on a possibly " +
+					"unsynced CNSVolumeInfo cache")
+				return
+			}
+		}
+	}
+
+	for _, storagePolicyUsage := range storagePolicyUsageList.Items {
+		totalUsedQty := resource.NewQuantity(int64(0), resource.BinarySI)
+		updateSpu := false
+		if storagePolicyUsage.Spec.ResourceKind == ResourceKindPVC {
+			// For every storagePolicyUsage, fetch "Bound" PVs in that namespace from k8sVolumesToNamespaceMap
+			for _, pv := range namespaceToK8sVolumesMap[storagePolicyUsage.Namespace] {
+				// Verify the StorageClass, StoragePolicyId match with the storagePolicyUsage spec
+				// using the cnsVolumeInfo CR for the volume
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				// For file volumes replace prefix "file:" with "file-", since CnsVolumeInfo CR
+				// is created as "file-<uuid>". For example, see below.
+				// cnsvolumeinfo name: file-e6a32a53-2783-42cd-a854-4df28582f04c
+				// pv.Spec.volumeHandle: file:e6a32a53-2783-42cd-a854-4df28582f04c
+				if strings.HasPrefix(pv.Spec.CSI.VolumeHandle, FileVolumePrefix) {
+					volumeHandle = strings.Replace(pv.Spec.CSI.VolumeHandle, ":", "-", 1)
+				}
+				if cnsVolumeInfo, ok := cnsVolumeInfoMap[volumeHandle]; ok {
+					// Check if this volume matches the SPU - either StorageClass-based or VAC-based
+					var matches bool
+					if storagePolicyUsage.Spec.StorageClassName != "" {
+						// StorageClass-based SPU: match by StorageClassName
+						matches = cnsVolumeInfo.Spec.StorageClassName == storagePolicyUsage.Spec.StorageClassName
+					} else if storagePolicyUsage.Spec.VolumeAttributesClassName != "" {
+						// VAC-based SPU: match by VolumeAttributeClassName
+						matches = cnsVolumeInfo.Spec.VolumeAttributeClassName == storagePolicyUsage.Spec.VolumeAttributesClassName
 					}
-					updateSpu = true
-				}
-			} else if isStorageQuotaM2FSSEnabled && storagePolicyUsage.Spec.ResourceKind == ResourceKindSnapshot {
-				// Generate SPU key - use StorageClassName for SC-based SPUs, "vac-" + VolumeAttributesClassName
-				// for VAC-based SPUs (prefix avoids collisions when a StorageClass and VolumeAttributesClass
-				// share the same name; must match generateSPUKey).
-				var keyComponent string
-				if storagePolicyUsage.Spec.StorageClassName != "" {
-					keyComponent = storagePolicyUsage.Spec.StorageClassName
-				} else {
-					keyComponent = "vac-" + storagePolicyUsage.Spec.VolumeAttributesClassName
-				}
-				spuKey := strings.Join([]string{keyComponent,
-					storagePolicyUsage.Spec.StoragePolicyId, storagePolicyUsage.Namespace}, "-")
-				if usedQty, ok := spuAggregatedSumMap[spuKey]; ok {
-					log.Infof("storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: %s "+
-						"in namespace: %s Total AggregatedSnapshotSize Sum is: %s", storagePolicyUsage.Name,
-						storagePolicyUsage.Namespace, usedQty.String())
-					totalUsedQty = usedQty
-					updateSpu = true
+
+					if matches &&
+						cnsVolumeInfo.Spec.StoragePolicyID == storagePolicyUsage.Spec.StoragePolicyId &&
+						cnsVolumeInfo.Spec.Namespace == storagePolicyUsage.Namespace {
+						// Compute the total used capacity for the volumes in the current namespace(iteration)
+						totalUsedQty.Add(*cnsVolumeInfo.Spec.Capacity)
+					} else {
+						continue
+					}
 				}
 			}
-			if updateSpu {
-				patchedStoragePolicyUsage := *storagePolicyUsage.DeepCopy()
-				if patchedStoragePolicyUsage.Status.ResourceTypeLevelQuotaUsage != nil {
-					// Compare the expected total used capacity vs the actual used capacity value in storagePolicyUsage CR
-					patchedStoragePolicyUsage.Status.ResourceTypeLevelQuotaUsage.Used = totalUsedQty
-					currentUsedCapacity := storagePolicyUsage.Status.ResourceTypeLevelQuotaUsage.Used
-					if currentUsedCapacity.Value() != totalUsedQty.Value() {
-						log.Infof("storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: %s in namespace: %s "+
-							"is not matching with the total capacity of all the k8s volumes in Bound state. Current: %s , "+
-							"Expected: %s", storagePolicyUsage.Name, storagePolicyUsage.Namespace,
-							currentUsedCapacity.String(), totalUsedQty.String())
-						err := PatchStoragePolicyUsage(ctx, cnsOperatorClient, &storagePolicyUsage,
-							&patchedStoragePolicyUsage)
-						if err != nil {
-							log.Errorf("storagePolicyUsageCRSync: Patching operation failed for StoragePolicyUsage CR: %s in "+
-								"namespace: %s. err: %v. Continuing..", storagePolicyUsage.Name, patchedStoragePolicyUsage.Namespace, err)
-							continue
-						}
-						log.Infof("storagePolicyUsageCRSync: Successfully updated the used field from %s to %s for StoragepolicyUsage "+
-							"CR: %s in namespace: %s", currentUsedCapacity.String(),
-							totalUsedQty.String(), patchedStoragePolicyUsage.Name, patchedStoragePolicyUsage.Namespace)
-					} else {
-						log.Infof("storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: %s in namespace: %s "+
-							"field is matching with the total capacity. Used: %s Skipping the Patch operation",
-							storagePolicyUsage.Name, storagePolicyUsage.Namespace,
-							storagePolicyUsage.Status.ResourceTypeLevelQuotaUsage.Used.String())
-					}
-				} else {
-					patchedStoragePolicyUsage.Status = storagepolicyv1alpha3.StoragePolicyUsageStatus{
-						ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha3.QuotaUsageDetails{
-							Used: totalUsedQty,
-						},
-					}
+			updateSpu = true
+		} else if isStorageQuotaM2FSSEnabled && storagePolicyUsage.Spec.ResourceKind == ResourceKindSnapshot {
+			// Generate SPU key - use StorageClassName for SC-based SPUs, "vac-" + VolumeAttributesClassName
+			// for VAC-based SPUs (prefix avoids collisions when a StorageClass and VolumeAttributesClass
+			// share the same name; must match generateSPUKey).
+			var keyComponent string
+			if storagePolicyUsage.Spec.StorageClassName != "" {
+				keyComponent = storagePolicyUsage.Spec.StorageClassName
+			} else {
+				keyComponent = "vac-" + storagePolicyUsage.Spec.VolumeAttributesClassName
+			}
+			spuKey := strings.Join([]string{keyComponent,
+				storagePolicyUsage.Spec.StoragePolicyId, storagePolicyUsage.Namespace}, "-")
+			// Same as the PVC branch above: always recompute (and patch) this snapshot SPU,
+			// even when spuAggregatedSumMap has no entry for its key (e.g. the last snapshot
+			// under it was deleted) - totalUsedQty naturally stays 0 in that case, resetting
+			// stale Used instead of leaving it untouched.
+			if usedQty, ok := spuAggregatedSumMap[spuKey]; ok {
+				log.Infof("storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: %s "+
+					"in namespace: %s Total AggregatedSnapshotSize Sum is: %s", storagePolicyUsage.Name,
+					storagePolicyUsage.Namespace, usedQty.String())
+				totalUsedQty = usedQty
+			}
+			updateSpu = true
+		}
+		if updateSpu {
+			patchedStoragePolicyUsage := *storagePolicyUsage.DeepCopy()
+			if patchedStoragePolicyUsage.Status.ResourceTypeLevelQuotaUsage != nil {
+				// Compare the expected total used capacity vs the actual used capacity value in storagePolicyUsage CR
+				patchedStoragePolicyUsage.Status.ResourceTypeLevelQuotaUsage.Used = totalUsedQty
+				currentUsedCapacity := storagePolicyUsage.Status.ResourceTypeLevelQuotaUsage.Used
+				if currentUsedCapacity.Value() != totalUsedQty.Value() {
+					log.Infof("storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: %s in namespace: %s "+
+						"is not matching with the total capacity of all the k8s volumes in Bound state. Current: %s , "+
+						"Expected: %s", storagePolicyUsage.Name, storagePolicyUsage.Namespace,
+						currentUsedCapacity.String(), totalUsedQty.String())
 					err := PatchStoragePolicyUsage(ctx, cnsOperatorClient, &storagePolicyUsage,
 						&patchedStoragePolicyUsage)
 					if err != nil {
@@ -4970,10 +5006,31 @@ func storagePolicyUsageCRSync(ctx context.Context, metadataSyncer *metadataSyncI
 							"namespace: %s. err: %v. Continuing..", storagePolicyUsage.Name, patchedStoragePolicyUsage.Namespace, err)
 						continue
 					}
-					log.Infof("storagePolicyUsageCRSync: Successfully updated the used field to %s for StoragepolicyUsage "+
-						"CR: %s in namespace: %s", totalUsedQty.String(), patchedStoragePolicyUsage.Name,
-						patchedStoragePolicyUsage.Namespace)
+					log.Infof("storagePolicyUsageCRSync: Successfully updated the used field from %s to %s for StoragepolicyUsage "+
+						"CR: %s in namespace: %s", currentUsedCapacity.String(),
+						totalUsedQty.String(), patchedStoragePolicyUsage.Name, patchedStoragePolicyUsage.Namespace)
+				} else {
+					log.Infof("storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: %s in namespace: %s "+
+						"field is matching with the total capacity. Used: %s Skipping the Patch operation",
+						storagePolicyUsage.Name, storagePolicyUsage.Namespace,
+						storagePolicyUsage.Status.ResourceTypeLevelQuotaUsage.Used.String())
 				}
+			} else {
+				patchedStoragePolicyUsage.Status = storagepolicyv1alpha3.StoragePolicyUsageStatus{
+					ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha3.QuotaUsageDetails{
+						Used: totalUsedQty,
+					},
+				}
+				err := PatchStoragePolicyUsage(ctx, cnsOperatorClient, &storagePolicyUsage,
+					&patchedStoragePolicyUsage)
+				if err != nil {
+					log.Errorf("storagePolicyUsageCRSync: Patching operation failed for StoragePolicyUsage CR: %s in "+
+						"namespace: %s. err: %v. Continuing..", storagePolicyUsage.Name, patchedStoragePolicyUsage.Namespace, err)
+					continue
+				}
+				log.Infof("storagePolicyUsageCRSync: Successfully updated the used field to %s for StoragepolicyUsage "+
+					"CR: %s in namespace: %s", totalUsedQty.String(), patchedStoragePolicyUsage.Name,
+					patchedStoragePolicyUsage.Namespace)
 			}
 		}
 	}

--- a/pkg/syncer/metadatasyncer_test.go
+++ b/pkg/syncer/metadatasyncer_test.go
@@ -2493,3 +2493,275 @@ func TestCsiPVDeleted_BlockVolume_ImprovedVolumeVisibility(t *testing.T) {
 			"DeleteVolume must still be called for block volumes when ImprovedVolumeVisibility is disabled")
 	})
 }
+
+// TestDeriveStoragePolicyUsageKeyForDeletion covers the SPU-key derivation used by
+// csiPVDeleted when decrementing "Used" on volume deletion. It must agree with the key
+// derivation in handleVACChangeForVolumeInfo (VAC-keyed SPU once a VolumeAttributesClass is
+// set and the mutability FSS is on; StorageClass-keyed SPU otherwise) - otherwise a migrated
+// volume's usage gets decremented from the wrong, stale SPU on deletion.
+func TestDeriveStoragePolicyUsageKeyForDeletion(t *testing.T) {
+	origCO := commonco.ContainerOrchestratorUtility
+	defer func() { commonco.ContainerOrchestratorUtility = origCO }()
+
+	newFakeCO := func(t *testing.T, fssEnabled bool) {
+		co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+		assert.NoError(t, err)
+		if fssEnabled {
+			assert.NoError(t, co.(interface {
+				EnableFSS(context.Context, string) error
+			}).EnableFSS(context.Background(), common.VMPVCStoragePolicyMutability))
+		}
+		commonco.ContainerOrchestratorUtility = co
+	}
+
+	cases := []struct {
+		name             string
+		fssEnabled       bool
+		storageClassName string
+		vacName          string
+		want             string
+	}{
+		{
+			name:             "FSS enabled, VAC set -> VAC-keyed SPU",
+			fssEnabled:       true,
+			storageClassName: "sc-old",
+			vacName:          "vac-gold",
+			want:             "vac-vac-gold",
+		},
+		{
+			name:             "FSS enabled, no VAC -> StorageClass-keyed SPU",
+			fssEnabled:       true,
+			storageClassName: "sc-old",
+			vacName:          "",
+			want:             "sc-old",
+		},
+		{
+			name:             "FSS disabled, VAC set -> still StorageClass-keyed SPU",
+			fssEnabled:       false,
+			storageClassName: "sc-old",
+			vacName:          "vac-gold",
+			want:             "sc-old",
+		},
+		{
+			name:             "FSS disabled, no VAC -> StorageClass-keyed SPU",
+			fssEnabled:       false,
+			storageClassName: "sc-old",
+			vacName:          "",
+			want:             "sc-old",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			newFakeCO(t, tc.fssEnabled)
+			got := deriveStoragePolicyUsageKeyForDeletion(context.Background(), tc.storageClassName, tc.vacName)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestSyncStoragePolicyUsageUsedValues covers the full-sync recompute logic extracted from
+// storagePolicyUsageCRSync. It specifically verifies the fix for stale "Used" values left
+// behind on a migrated-then-deleted volume: previously, an SPU whose namespace (or the whole
+// cluster) had no remaining Bound PVs was skipped instead of having its Used reset to 0.
+func TestSyncStoragePolicyUsageUsedValues(t *testing.T) {
+	const namespace = "test-ns"
+
+	mkSPU := func(name, scName, vacName, policyID, resourceKind string,
+		used resource.Quantity) *storagepolicyv1alpha3.StoragePolicyUsage {
+		return &storagepolicyv1alpha3.StoragePolicyUsage{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: storagepolicyv1alpha3.StoragePolicyUsageSpec{
+				StoragePolicyId:           policyID,
+				StorageClassName:          scName,
+				VolumeAttributesClassName: vacName,
+				ResourceKind:              resourceKind,
+			},
+			Status: storagepolicyv1alpha3.StoragePolicyUsageStatus{
+				ResourceTypeLevelQuotaUsage: &storagepolicyv1alpha3.QuotaUsageDetails{
+					Used: &used,
+				},
+			},
+		}
+	}
+
+	mkPV := func(name, namespace, volumeHandle string) *v1.PersistentVolume {
+		return &v1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: v1.PersistentVolumeSpec{
+				ClaimRef: &v1.ObjectReference{Namespace: namespace},
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					CSI: &v1.CSIPersistentVolumeSource{VolumeHandle: volumeHandle},
+				},
+			},
+		}
+	}
+
+	mkCVI := func(scName, vacName, policyID string, capacity resource.Quantity) *cnsvolumeinfov1alpha1.CNSVolumeInfo {
+		return &cnsvolumeinfov1alpha1.CNSVolumeInfo{
+			Spec: cnsvolumeinfov1alpha1.CNSVolumeInfoSpec{
+				Namespace:                namespace,
+				StorageClassName:         scName,
+				VolumeAttributeClassName: vacName,
+				StoragePolicyID:          policyID,
+				Capacity:                 &capacity,
+			},
+		}
+	}
+
+	newFakeClient := func(t *testing.T, objs ...client.Object) client.Client {
+		scheme := runtime.NewScheme()
+		assert.NoError(t, cnsoperatorv1alpha1.AddToScheme(scheme))
+		return fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objs...).
+			WithStatusSubresource(&storagepolicyv1alpha3.StoragePolicyUsage{}).
+			Build()
+	}
+
+	getUsed := func(t *testing.T, c client.Client, name string) int64 {
+		got := &storagepolicyv1alpha3.StoragePolicyUsage{}
+		assert.NoError(t, c.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, got))
+		return got.Status.ResourceTypeLevelQuotaUsage.Used.Value()
+	}
+
+	t.Run("orphaned namespace: SPU is reset to 0 when its namespace has no Bound PVs left", func(t *testing.T) {
+		cap10Gi := resource.MustParse("10Gi")
+		spu := mkSPU("sc-old-pvc-usage", "sc-old", "", "policy-uuid", ResourceKindPVC, cap10Gi.DeepCopy())
+		fakeClient := newFakeClient(t, spu)
+
+		// namespaceToK8sVolumesMap has no entry for "test-ns" at all - simulating that the
+		// migrated volume (the only one in this namespace) has already been deleted.
+		syncStoragePolicyUsageUsedValues(context.Background(), fakeClient,
+			&storagepolicyv1alpha3.StoragePolicyUsageList{Items: []storagepolicyv1alpha3.StoragePolicyUsage{*spu}},
+			map[string][]*v1.PersistentVolume{},
+			map[string]*cnsvolumeinfov1alpha1.CNSVolumeInfo{},
+			map[string]*resource.Quantity{})
+
+		assert.Equal(t, int64(0), getUsed(t, fakeClient, spu.Name),
+			"stale Used must be reset to 0 when the SPU's namespace has no remaining Bound PVs")
+	})
+
+	t.Run("unsynced CNSVolumeInfo cache: Bound PVs exist but cnsVolumeInfoMap is "+
+		"empty -> Used is left untouched", func(t *testing.T) {
+		cap10Gi := resource.MustParse("10Gi")
+		spu := mkSPU("sc-old-pvc-usage", "sc-old", "", "policy-uuid", ResourceKindPVC, cap10Gi.DeepCopy())
+		fakeClient := newFakeClient(t, spu)
+
+		// The volume is still Bound (namespaceToK8sVolumesMap has an entry for it), but its
+		// CNSVolumeInfo CR has not shown up in cnsVolumeInfoMap yet - simulating a CNSVolumeInfo
+		// informer cache that hasn't finished syncing. Without the guard, every PV would fail the
+		// cnsVolumeInfoMap lookup, totalUsedQty would compute to 0, and the SPU would be
+		// (wrongly) patched to Used=0, even though the volume is very much still consuming quota.
+		pv := mkPV("pv-1", namespace, "csi-handle-1")
+		syncStoragePolicyUsageUsedValues(context.Background(), fakeClient,
+			&storagepolicyv1alpha3.StoragePolicyUsageList{Items: []storagepolicyv1alpha3.StoragePolicyUsage{*spu}},
+			map[string][]*v1.PersistentVolume{namespace: {pv}},
+			map[string]*cnsvolumeinfov1alpha1.CNSVolumeInfo{},
+			map[string]*resource.Quantity{})
+
+		assert.Equal(t, cap10Gi.Value(), getUsed(t, fakeClient, spu.Name),
+			"Used must be left untouched (not reset to 0) when Bound PVs exist but cnsVolumeInfoMap "+
+				"is empty, since that signals an unsynced cache rather than genuinely zero usage")
+	})
+
+	t.Run("cluster-wide empty state: every SPU is reset to 0, not silently skipped", func(t *testing.T) {
+		cap5Gi := resource.MustParse("5Gi")
+		scSPU := mkSPU("sc-old-pvc-usage", "sc-old", "", "policy-uuid", ResourceKindPVC, cap5Gi.DeepCopy())
+		vacSPU := mkSPU("vac-vac-gold-pvc-usage", "", "vac-gold", "policy-uuid", ResourceKindPVC, cap5Gi.DeepCopy())
+		fakeClient := newFakeClient(t, scSPU, vacSPU)
+
+		// No PVs, no CNSVolumeInfo CRs anywhere in the cluster (the previous guard used to skip
+		// the whole recompute loop in this case).
+		syncStoragePolicyUsageUsedValues(context.Background(), fakeClient,
+			&storagepolicyv1alpha3.StoragePolicyUsageList{
+				Items: []storagepolicyv1alpha3.StoragePolicyUsage{*scSPU, *vacSPU},
+			},
+			map[string][]*v1.PersistentVolume{},
+			map[string]*cnsvolumeinfov1alpha1.CNSVolumeInfo{},
+			map[string]*resource.Quantity{})
+
+		assert.Equal(t, int64(0), getUsed(t, fakeClient, scSPU.Name))
+		assert.Equal(t, int64(0), getUsed(t, fakeClient, vacSPU.Name))
+	})
+
+	t.Run("VAC-keyed SPU: matching Bound PV keeps Used at its correct total", func(t *testing.T) {
+		cap10Gi := resource.MustParse("10Gi")
+		vacSPU := mkSPU("vac-vac-gold-pvc-usage", "", "vac-gold", "policy-uuid", ResourceKindPVC, cap10Gi.DeepCopy())
+		fakeClient := newFakeClient(t, vacSPU)
+
+		pv := mkPV("pv-1", namespace, "csi-handle-1")
+		cvi := mkCVI("sc-old", "vac-gold", "policy-uuid", cap10Gi)
+
+		syncStoragePolicyUsageUsedValues(context.Background(), fakeClient,
+			&storagepolicyv1alpha3.StoragePolicyUsageList{Items: []storagepolicyv1alpha3.StoragePolicyUsage{*vacSPU}},
+			map[string][]*v1.PersistentVolume{namespace: {pv}},
+			map[string]*cnsvolumeinfov1alpha1.CNSVolumeInfo{"csi-handle-1": cvi},
+			map[string]*resource.Quantity{})
+
+		assert.Equal(t, cap10Gi.Value(), getUsed(t, fakeClient, vacSPU.Name))
+	})
+
+	t.Run("VAC-keyed SPU: other volumes in the same namespace do not affect its Used", func(t *testing.T) {
+		cap10Gi := resource.MustParse("10Gi")
+		vacSPU := mkSPU("vac-vac-gold-pvc-usage", "", "vac-gold", "policy-uuid", ResourceKindPVC, cap10Gi.DeepCopy())
+		fakeClient := newFakeClient(t, vacSPU)
+
+		// pv-1 belongs to a different StorageClass (no VAC) and must not be counted towards
+		// the VAC-keyed SPU, even though it is Bound in the same namespace.
+		pv := mkPV("pv-1", namespace, "csi-handle-1")
+		cvi := mkCVI("sc-other", "", "policy-uuid-other", resource.MustParse("20Gi"))
+
+		syncStoragePolicyUsageUsedValues(context.Background(), fakeClient,
+			&storagepolicyv1alpha3.StoragePolicyUsageList{Items: []storagepolicyv1alpha3.StoragePolicyUsage{*vacSPU}},
+			map[string][]*v1.PersistentVolume{namespace: {pv}},
+			map[string]*cnsvolumeinfov1alpha1.CNSVolumeInfo{"csi-handle-1": cvi},
+			map[string]*resource.Quantity{})
+
+		assert.Equal(t, int64(0), getUsed(t, fakeClient, vacSPU.Name),
+			"VAC-keyed SPU must reset to 0 when the deleted volume was its only member, "+
+				"even though an unrelated PV remains Bound in the namespace")
+	})
+
+	t.Run("snapshot SPU: aggregated sum drives Used, resets to 0 with no snapshots left", func(t *testing.T) {
+		origM2 := isStorageQuotaM2FSSEnabled
+		isStorageQuotaM2FSSEnabled = true
+		defer func() { isStorageQuotaM2FSSEnabled = origM2 }()
+
+		cap3Gi := resource.MustParse("3Gi")
+		snapSPU := mkSPU("sc-old-snapshot-usage", "sc-old", "", "policy-uuid", ResourceKindSnapshot, cap3Gi.DeepCopy())
+		fakeClient := newFakeClient(t, snapSPU)
+
+		// No entry in spuAggregatedSumMap for this SPU's key - simulating that the last
+		// snapshot under it was deleted - must still reset stale Used to 0, not leave it be.
+		syncStoragePolicyUsageUsedValues(context.Background(), fakeClient,
+			&storagepolicyv1alpha3.StoragePolicyUsageList{Items: []storagepolicyv1alpha3.StoragePolicyUsage{*snapSPU}},
+			map[string][]*v1.PersistentVolume{},
+			map[string]*cnsvolumeinfov1alpha1.CNSVolumeInfo{},
+			map[string]*resource.Quantity{})
+
+		assert.Equal(t, int64(0), getUsed(t, fakeClient, snapSPU.Name),
+			"stale snapshot Used must be reset to 0 when spuAggregatedSumMap has no entry for its key")
+	})
+
+	t.Run("snapshot SPU: matching aggregated sum keeps Used at its correct total", func(t *testing.T) {
+		origM2 := isStorageQuotaM2FSSEnabled
+		isStorageQuotaM2FSSEnabled = true
+		defer func() { isStorageQuotaM2FSSEnabled = origM2 }()
+
+		cap3Gi := resource.MustParse("3Gi")
+		snapSPU := mkSPU("sc-old-snapshot-usage", "sc-old", "", "policy-uuid", ResourceKindSnapshot, cap3Gi.DeepCopy())
+		fakeClient := newFakeClient(t, snapSPU)
+
+		spuKey := generateSPUKey(mkCVI("sc-old", "", "policy-uuid", cap3Gi))
+		sum := cap3Gi.DeepCopy()
+
+		syncStoragePolicyUsageUsedValues(context.Background(), fakeClient,
+			&storagepolicyv1alpha3.StoragePolicyUsageList{Items: []storagepolicyv1alpha3.StoragePolicyUsage{*snapSPU}},
+			map[string][]*v1.PersistentVolume{},
+			map[string]*cnsvolumeinfov1alpha1.CNSVolumeInfo{},
+			map[string]*resource.Quantity{spuKey: &sum})
+
+		assert.Equal(t, cap3Gi.Value(), getUsed(t, fakeClient, snapSPU.Name))
+	})
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix storage quota calculations for cases when PVC is deleted which was migrated from one datastore to another using VAC.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

VKS pre-checkin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1438/ (passed)
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```
WCP pre-checkin pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1885/ (passed)
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```

manual testing logs:
https://gist.githubusercontent.com/vdkotkar/e823f0278cb0d282bc55bd8b0911199c/raw/bbac8b318c63fd5fbcaa290c9b65ee700f38a370/VAC_quota_calculations_fix

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix storage quota calculations for cases when PVC is deleted which was migrated from one datastore to another using VAC.
```
