### PR TITLE
Add PVC finalizer concurrently while processing batch attach

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -582,7 +582,24 @@ func (r *Reconciler) processBatchAttach(ctx context.Context, k8sClient kubernete
 		log.Infof("Successfully attached all volumes")
 	}
 
-	// Update instance based on the result of BatchAttach
+	// Update instance based on the result of BatchAttach. Adding the PVC
+	// protection finalizer involves multiple sequential API-server round trips
+	// per PVC (see addPvcFinalizer), so PVCs are processed concurrently (up to
+	// maxConcurrentPVCFinalizers at a time) to keep this from scaling linearly
+	// with the number of disks attached to a VM. Each PVC holds its own
+	// VolumeLock and the API calls are independent, so this is safe.
+	type attachStatusResult struct {
+		volumeName   string
+		pvcName      string
+		volumeID     string
+		diskUUID     string
+		attachErr    error // error from the CNS attach itself, as reported in batchAttachResult
+		finalizerErr error // error from addPvcFinalizer; only attempted when attachErr == nil
+	}
+	results := make(chan attachStatusResult, len(batchAttachResult))
+	sem := make(chan struct{}, maxConcurrentPVCFinalizers)
+	var wg sync.WaitGroup
+
 	for _, result := range batchAttachResult {
 		pvcName, ok := volumeIdsInAttachList[result.VolumeID]
 		if !ok {
@@ -596,23 +613,48 @@ func (r *Reconciler) processBatchAttach(ctx context.Context, k8sClient kubernete
 
 		}
 
+		result := result
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			attachRes := attachStatusResult{
+				volumeName: volumeName,
+				pvcName:    pvcName,
+				volumeID:   result.VolumeID,
+				diskUUID:   result.DiskUUID,
+				attachErr:  result.Error,
+			}
+			// If attach was successful, add finalizer to the PVC.
+			if attachRes.attachErr == nil {
+				if pvcErr := addPvcFinalizer(ctx, r.client, k8sClient, pvcName, instance.Namespace,
+					instance.Spec.InstanceUUID); pvcErr != nil {
+					log.Errorf("failed to add finalizer %s on PVC %s", cnsoperatortypes.CNSPvcFinalizer, pvcName)
+					attachRes.finalizerErr = pvcErr
+				}
+			}
+			results <- attachRes
+		}()
+	}
+
+	go func() { wg.Wait(); close(results) }()
+
+	for res := range results {
 		reason := v1alpha1.ReasonAttachFailed
-		// If attach was successful, add finalizer to the PVC.
-		if result.Error == nil {
+		statusErr := res.attachErr
+		if res.attachErr == nil {
 			reason = ""
-			// Add finalizer on PVC as attach was successful.
-			err = addPvcFinalizer(ctx, r.client, k8sClient, pvcName, instance.Namespace, instance.Spec.InstanceUUID)
-			if err != nil {
-				log.Errorf("failed to add finalizer %s on PVC %s", cnsoperatortypes.CNSPvcFinalizer, pvcName)
-				result.Error = err
+			if res.finalizerErr != nil {
+				statusErr = res.finalizerErr
 				attachErr = errors.Join(attachErr,
-					fmt.Errorf("failure during attach of PVC %s", pvcName))
+					fmt.Errorf("failure during attach of PVC %s", res.pvcName))
 			}
 		}
 		// Update instance with attach result.
-		updateInstanceVolumeStatus(ctx, instance, volumeName, pvcName, result.VolumeID, result.DiskUUID, result.Error,
+		updateInstanceVolumeStatus(ctx, instance, res.volumeName, res.pvcName, res.volumeID, res.diskUUID, statusErr,
 			v1alpha1.ConditionAttached, reason)
-
 	}
 	return attachErr
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

processBatchAttach's post-attach loop now processes PVCs concurrently (bounded to maxConcurrentPVCFinalizers = 20 at a time) instead of sequentially, mirroring the existing pattern already used in removePvcProtectionFinalizersForTrackedPVCs for the detach path.

Each per-PVC attach result is dispatched to a goroutine that calls addPvcFinalizer under a semaphore.
Results flow through a buffered channel back to a single sequential drain loop, which is the only place that mutates the shared instance.Status (via updateInstanceVolumeStatus) and accumulates attachErr — so there's no concurrent access to shared state, same safety property as the existing detach-path code.
Error semantics are preserved exactly: reason/attachErr are only affected by a finalizer-add failure when the underlying CNS attach itself succeeded, matching the original sequential logic.

**Testing done**:
Pre-check-in:
```
<br> PR 4216<br>
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```

Perf team testing results:
```

vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:00.120463905Z stderr F {"level":"info","time":"2026-08-12T09:50:00.120401926Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:264","msg":"Acquired lock for instance ns-perfauto-1/csibench-vm-75000-7-7","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:00.165403914Z stderr F {"level":"info","time":"2026-08-12T09:50:00.165281165Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:723","msg":"Obtained VM object for VM 1b5653ba-9116-4965-b8f9-eb93dcb514aa from VC","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:00.174097932Z stderr F {"level":"info","time":"2026-08-12T09:50:00.173952867Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:742","msg":"List of attached FCDs map[d11a7b20-f4d1-4a8c-951f-54eea9907821:{DiskMode:persistent SharingMode:sharingNone ControllerKey:1000 UnitNumber:0}] to VM 1b5653ba-9116-4965-b8f9-eb93dcb514aa","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:00.174307743Z stderr F {"level":"info","time":"2026-08-12T09:50:00.174192035Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:254","msg":"Obtained volumes to detach map[] for instance csibench-vm-75000-7-7","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:00.174323411Z stderr F {"level":"info","time":"2026-08-12T09:50:00.174217421Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:437","msg":"Obtained volumes to detach map[] for instance csibench-vm-75000-7-7","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:00.174335519Z stderr F {"level":"info","time":"2026-08-12T09:50:00.174227752Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:796","msg":"Volumes to be detached map[] for instance csibench-vm-75000-7-7","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:00.17453483Z stderr F {"level":"info","time":"2026-08-12T09:50:00.174375473Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:328","msg":"Obtained volumes to attach map[csibench-vol-13786-52-3:9db3d06d-b992-4d75-b54c-0d76ce499a8d csibench-vol-1391-44-100:b282b573-0a8d-40db-863a-23a86753f173 csibench-vol-1391-44-9:cbaf07b4-23bc-4c0d-80b2-f4c37662b651 csibench-vol-14595-9-83:cf4dcfc3-e70b-4b89-82c0-21f9e2732236 csibench-vol-15470-49-70:7497b533-6bba-4a49-a0d7-59b140cf6a6f csibench-vol-17406-5-31:e0a51f18-dda4-433e-8b65-ea135970e069 csibench-vol-28-3-23:029b5e70-7f95-4a06-abe9-617abc935ebb csibench-vol-29015-31-27:a506fbf0-4a0b-4e26-9358-47ca0787673c csibench-vol-3078-18-112:4cc1f509-68c7-41d7-b1be-0f30f841baa3 csibench-vol-3078-18-14:f288c6bd-c317-4274-970f-71df2e4fc462 csibench-vol-3078-18-36:7eef83c0-ebca-4bbe-a5d7-c50ed0185125 csibench-vol-31596-13-22:1b0c5988-2b4f-4ad9-90ab-52d53bbfe6e6 csibench-vol-39112-19-103:7a84b761-d7a9-40e0-8315-e77c19e25e75 csibench-vol-39112-19-12:b3ac2a52-f883-4cc8-9790-57aff04085c6 csibench-vol-39241-41-29:b7adf55e-7fd7-4a0f-930a-54751dcdcb5d csibench-vol-4173-14-16:d45844d3-938b-4f42-ab75-dab049f3e05f csibench-vol-4173-14-67:72a1ccc4-aadc-4b16-8515-7a65a1c34077 csibench-vol-43464-57-68:f8d32046-fdb7-47ba-b7f0-3a84b6f4fee9 csibench-vol-53099-17-88:28243852-becd-4617-8969-d39998a62269 csibench-vol-53227-61-32:71a52b9a-a298-47ec-8ade-56ebe12c10a3 csibench-vol-56010-4-14:d66a12bc-6c9a-4cb2-a575-c30234f3147c csibench-vol-5862-24-107:a096c86b-9774-4538-9611-6cb87f86caa3 csibench-vol-5862-24-89:1bfa9980-9428-4f44-822d-92e69c4d5304 csibench-vol-60410-25-116:7ca09940-e588-4bca-940f-c74deaa9fc62 csibench-vol-60844-33-99:8a82044d-2949-4c67-8e4e-fbe9b82a4e77 csibench-vol-61844-30-1:7b56425d-ea6c-4fe9-aa3b-30d6fef1329b csibench-vol-61844-30-44:0207b4cc-4b8b-4a5d-aba2-441460eb0b09 csibench-vol-64126-23-27:af89298f-37a5-45b4-8daf-0e936c2d59ba csibench-vol-64345-42-94:628acf9b-3555-48d5-a5bf-d75a4beb78bc csibench-vol-6757-47-109:448286f1-4501-474e-ba98-a680e6f9a35a csibench-vol-6757-47-77:76a20930-3981-4101-ab37-a40584fa9484 csibench-vol-69138-21-13:4503c0a1-9b55-4ece-807c-2e5e67aa8151 csibench-vol-69138-21-64:aa4a91f9-cefe-4c85-a770-669a83f5a0ca csibench-vol-70306-50-59:3cafec22-d251-4b8e-9552-fc493bd20819 csibench-vol-73610-36-11:e1da9d1e-8c17-422c-9204-869fa4c02e2d csibench-vol-73610-36-117:87ad3825-1d01-4b94-8ebb-e1a8d1f86846 csibench-vol-73610-36-7:94197178-3d85-4f4b-b0f8-a1cc3fb36a26 csibench-vol-79079-8-16:2e165a19-2aa9-4505-a944-2e01d22e855c csibench-vol-79079-8-89:4b4b760d-7b20-4c0c-8571-66afdec19ccf csibench-vol-80093-39-19:5649f92e-1f74-4275-889a-3490341f2965 csibench-vol-80093-39-33:d36ea785-a3d9-4457-8216-7282a0549011 csibench-vol-80093-39-99:bf69db05-1c06-447b-82bb-2f5d64afd1d7 csibench-vol-81637-51-10:1b63920d-677c-43c1-89b9-8f24d6ad54e1 csibench-vol-81637-51-74:52d3feaa-6649-42bf-a09e-e628a6eac2b9 csibench-vol-82455-43-13:bd39716e-fd95-463b-b97a-320f4f6e1f64 csibench-vol-82455-43-79:768c1289-8581-4d19-8925-21b79fb180c0 csibench-vol-83052-34-15:577f0675-418e-4c57-a1ee-6b1e7039ca70 csibench-vol-83052-34-80:10ba6ce4-417e-493f-a25f-cd4da081b67f csibench-vol-84724-63-108:ea3d4d60-bd02-4ce6-bbd0-6e70545bbeda csibench-vol-84724-63-53:00cd3df1-08fb-45c3-ac2f-08cf49aec2af csibench-vol-84724-63-60:53db62b4-190b-4f45-b263-3f9626f271d1 csibench-vol-88096-45-21:336e08d9-0179-41e9-897c-07288f2ac416 csibench-vol-88096-45-87:570f68fa-e684-4e7b-a10a-d865e6becbe5 csibench-vol-90356-46-56:cfff1d36-eba2-4824-aa41-f32a948510ce csibench-vol-90356-46-63:2bfe1814-b8b3-43a1-a5cf-e95eb7894369 csibench-vol-93153-32-0:c415e313-ec9d-45c2-8a76-6e7ffd23cb86 csibench-vol-93153-32-8:b840e069-09d0-4403-bad8-fbe67886e843 csibench-vol-97694-0-90:cb996017-e287-41e6-adc1-36106b071cfb csibench-vol-98933-20-77:71d26bc9-898a-4932-b362-e6acf555ac77] for instance csibench-vm-75000-7-7","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:00.250097694Z stderr F {"level":"info","time":"2026-08-12T09:50:00.249937063Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:1215","msg":"VM CR csibench-vm-75000-7-7 with instance UUID 1b5653ba-9116-4965-b8f9-eb93dcb514aa found in namespace ns-perfauto-1","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:00.25402808Z stderr F {"level":"info","time":"2026-08-12T09:50:00.249972291Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:624","msg":"Constructing batch attach request for instance csibench-vm-75000-7-7","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
...........
...........
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:07.070519625Z stderr F {"level":"info","time":"2026-08-12T09:50:07.070353519Z","caller":"volume/manager.go:4072","msg":"BatchAttach: all volumes attached successfully with opID 9bf88cf5","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
...........
...........
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:07.071382368Z stderr F {"level":"info","time":"2026-08-12T09:50:07.071294609Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:908","msg":"Acquired lock for PVC ns-perfauto-1/csibench-vol-4173-14-67","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:07.071955495Z stderr F {"level":"info","time":"2026-08-12T09:50:07.071858207Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:835","msg":"Adding annotation cns.vmware.com/usedby-vm-1b5653ba-9116-4965-b8f9-eb93dcb514aa on PVC csibench-vol-4173-14-67","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:07.071971591Z stderr F {"level":"info","time":"2026-08-12T09:50:07.071915234Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:854","msg":"Patching PVC csibench-vol-4173-14-67 with updated annotation","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
.......
.......
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:07.71697111Z stderr F {"level":"info","time":"2026-08-12T09:50:07.716902226Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go:1143","msg":"Adding a new entry for volumeName csibench-vol-82455-43-13 with PVC csibench-vol-82455-43-13","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:07.771951931Z stderr F {"level":"info","time":"2026-08-12T09:50:07.771817046Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:673","msg":"Event type Normal","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}
vsphere-csi-controller_vsphere-syncer_10.160.92.21.0.log.gz:2026-08-12T09:50:07.77198227Z stderr F {"level":"info","time":"2026-08-12T09:50:07.771887877Z","caller":"cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go:267","msg":"Released lock for instance ns-perfauto-1/csibench-vm-75000-7-7","TraceId":"bce5b897-d692-42e6-b9ba-82729b86a624"}


All the PVC annotations for 59 disks are taking time in milliseconds now.





Without changes :-


| filename                                                            | tag | threads | runNumber | optype           | passrate | count |     min |      q1 |    mean |  median |      q3 |     p95 |     p99 |     max |
| wl5_detachvm-attachvm_thd01/csibench-1threads-cns.json              |     |         |           | VM_ATTACH_VOLUME |      100 |    13 |   8.979 |   9.421 |  10.607 |   9.896 |  10.086 |  13.866 |  13.866 |  13.871 |
| wl5_detachvm-attachvm_thd16/csibench-16threads-cns.json             |     |         |           | VM_ATTACH_VOLUME |      100 |   161 |  10.594 |  11.998 |  13.077 |  12.809 |  13.624 |  15.736 |  20.223 |  23.761 |
| wl5_detachvm-attachvm_thd64/csibench-64threads-cns.json             |     |         |           | VM_ATTACH_VOLUME |      100 |   164 |  19.232 |  68.544 |  81.772 |  76.940 |  92.456 | 129.951 | 195.408 | 197.293 |



With changes :-


| filename                                                            | tag | threads | runNumber | optype           | passrate | count |     min |      q1 |    mean |  median |      q3 |     p95 |     p99 |     max |
| wl5_detachvm-attachvm_thd01/csibench-1threads-cns.json              |     |         |           | VM_ATTACH_VOLUME |      100 |    14 |   6.930 |   7.516 |   7.928 |   7.646 |   8.047 |   9.631 |   9.631 |  10.595 |
| wl5_detachvm-attachvm_thd16/csibench-16threads-cns.json             |     |         |           | VM_ATTACH_VOLUME |      100 |   163 |   3.217 |   8.657 |   9.505 |   9.275 |   9.963 |  12.528 |  14.277 |  14.466 |
| wl5_detachvm-attachvm_thd64/csibench-64threads-cns.json             |     |         |           | VM_ATTACH_VOLUME |      100 |   201 |  13.206 |  45.364 |  62.528 |  58.967 |  67.690 | 126.463 | 130.850 | 134.202 |



Significant improvement is seen in the VM_ATTACH_VOLUME latency with the fix .
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add PVC finalizer concurrently while processing batch attach
```
