### PR TITLE
Fix volume creation from a host-local snapshot with a shared policy

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -697,6 +697,10 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		isLinkedCloneRequest      bool
 		linkedCloneSupportEnabled bool
 		isHostLocalRequest        bool
+		// snapshotSourceHostMoRef is the ESX host that exclusively mounts the datastore of the
+		// snapshot's source volume, when restoring from a host-local volume. The restore is a disk
+		// copy that only that host can run, so the candidate host set is narrowed to it below.
+		snapshotSourceHostMoRef *types.ManagedObjectReference
 	)
 	linkedCloneSupportEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupport)
 	// Support case insensitive parameters.
@@ -816,6 +820,14 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			}
 			if linkedCloneDatastores != nil {
 				sharedDatastores = linkedCloneDatastores
+			} else {
+				snapshotSourceHostMoRef, err = c.getSnapshotSourceHostToPinPlacement(ctx, req)
+				if err != nil {
+					if status.Code(err) == codes.InvalidArgument {
+						return nil, csifault.CSIInvalidArgumentFault, err
+					}
+					return nil, csifault.CSIInternalFault, err
+				}
 			}
 		} else if zoneLabelPresent {
 			if !isWorkloadDomainIsolationEnabled {
@@ -898,17 +910,71 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 							return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 								"failed to retrieve datastore for linked clone request (snapshot: %q): %v", snapshotID, err)
 						}
+						// This branch is only reached when the request is not host-local: host-local
+						// requests carry hostname labels and take the branches above.
+						//
+						// Gated on the supports_host_local_storage capability: without it no volume can
+						// live on a host-exclusive datastore, so skip the check entirely and keep the
+						// existing behaviour - this also avoids the extra property-collector call on
+						// supervisors without the capability.
+						if isHostLocalStorageSupportEnabled {
+							hostExclusive, err := isHostExclusiveDatastore(ctx, datastoreInfo)
+							if err != nil {
+								return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+									"failed to determine host mounts of datastore %q for linked clone request "+
+										"(snapshot: %q): %v", datastoreInfo.Info.Url, snapshotID, err)
+							}
+							if hostExclusive {
+								// A linked clone is always created on the source volume's datastore. That
+								// datastore is exclusive to a single ESX host, so the clone is only usable
+								// under a host-local storage policy, which pins PV node affinity to that
+								// host. A shared policy is never compatible with a host-exclusive datastore,
+								// so reject here with the real reason rather than letting
+								// isDataStoreCompatible fail later with a node-accessibility message.
+								return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCodef(log,
+									codes.InvalidArgument,
+									"linked clone of snapshot %q cannot be provisioned with storage policy %q: "+
+										"the source volume resides on host-exclusive datastore %q, so the linked "+
+										"clone requires a host-local storage policy",
+									snapshotID, storagePolicyID, datastoreInfo.Info.Url)
+							}
+						}
 						sharedDatastores = []*cnsvsphere.DatastoreInfo{datastoreInfo}
 						log.Infof("datastores: %v for linked clone request: (snapshot: %q)", sharedDatastores, snapshotID)
 					} else {
-						vSphereClusterMorefs, err = c.getAccessibleClustersForSnapshot(
-							ctx, snapshotID, pvcNamespace, zones)
+						sourceHost, err := c.getSnapshotSourceHostToPinPlacement(ctx, req)
 						if err != nil {
-							return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-								"failed to find active clusters for the namespace: %q, err :%v", pvcNamespace, err)
+							if status.Code(err) == codes.InvalidArgument {
+								return nil, csifault.CSIInvalidArgumentFault, err
+							}
+							return nil, csifault.CSIInternalFault, err
 						}
-						log.Infof("vSphere clusters: %v for the namespace %q accessible to snapshot: %q", vSphereClusterMorefs,
-							pvcNamespace, req.GetVolumeContentSource().GetSnapshot().GetSnapshotId())
+						if sourceHost != nil {
+							// The source volume is on a host-exclusive datastore (host-local storage
+							// policy). The restore copy can only run on that host, so the destination
+							// must be a datastore it mounts. Supplying activeClusters instead lets CNS
+							// pick any policy-compatible datastore in the cluster, and vpxd then fails
+							// the copy with "No common host found between source and target datastores".
+							// PBM narrows this union down to the datastores that satisfy the requested
+							// (non host-local) storage policy.
+							sharedDatastores, err = getDatastoresAccessibleToHost(ctx, vc, *sourceHost)
+							if err != nil {
+								return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+									"failed to find datastores accessible to host %q owning the source volume "+
+										"of snapshot %q: %v", sourceHost.Value, snapshotID, err)
+							}
+							log.Infof("datastores: %v accessible to host %q owning the source volume of "+
+								"snapshot: %q", sharedDatastores, sourceHost.Value, snapshotID)
+						} else {
+							vSphereClusterMorefs, err = c.getAccessibleClustersForSnapshot(
+								ctx, snapshotID, pvcNamespace, zones)
+							if err != nil {
+								return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+									"failed to find active clusters for the namespace: %q, err :%v", pvcNamespace, err)
+							}
+							log.Infof("vSphere clusters: %v for the namespace %q accessible to snapshot: %q",
+								vSphereClusterMorefs, pvcNamespace, snapshotID)
+						}
 					}
 				} else {
 					vSphereClusterMorefs, err = commonco.ContainerOrchestratorUtility.
@@ -929,6 +995,14 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			}
 			if linkedCloneDatastores != nil {
 				sharedDatastores = linkedCloneDatastores
+			} else {
+				snapshotSourceHostMoRef, err = c.getSnapshotSourceHostToPinPlacement(ctx, req)
+				if err != nil {
+					if status.Code(err) == codes.InvalidArgument {
+						return nil, csifault.CSIInvalidArgumentFault, err
+					}
+					return nil, csifault.CSIInternalFault, err
+				}
 			}
 		} else {
 			// No topology labels present in the topologyRequirement
@@ -1093,6 +1167,18 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		if err != nil {
 			log.Errorf("failed to resolve candidate hosts for host-local volume %q. Error: %+v", req.Name, err)
 			return nil, csifault.CSIInternalFault, err
+		}
+		if snapshotSourceHostMoRef != nil {
+			// Restoring from a host-exclusive datastore: only the host that mounts it can run the
+			// copy, so replace the candidate set with that single host. Leaving the full set would
+			// let CNS place the restored volume on a host that cannot see the source datastore,
+			// which vpxd rejects with "No common host found between source and target datastores".
+			hostMoRefs, err = narrowToSnapshotSourceHost(ctx, hostMoRefs, *snapshotSourceHostMoRef)
+			if err != nil {
+				return nil, csifault.CSIInvalidArgumentFault, err
+			}
+			log.Infof("Pinned host-local volume %q to host %q owning the snapshot's source volume",
+				req.Name, snapshotSourceHostMoRef.Value)
 		}
 	}
 
@@ -1466,6 +1552,10 @@ func (c *controller) getDatastoreAccessibleTopologyForSnapshot(ctx context.Conte
 // 4. Finds active clusters in the specified namespace and zones.
 // 5. For each active cluster, queries accessible datastores.
 // 6. Determines which clusters have access to the snapshot's datastore and returns those clusters.
+//
+// Callers must not use this for a snapshot whose source volume is on a host-exclusive datastore:
+// that datastore is never in the all-hosts intersection GetCandidateDatastoresInCluster reports, so
+// no cluster matches. See getHostExclusiveSnapshotSourceHost for how those restores are placed.
 func (c *controller) getAccessibleClustersForSnapshot(
 	ctx context.Context,
 	contentSourceSnapshotID string,
@@ -1524,7 +1614,7 @@ func (c *controller) getAccessibleClustersForSnapshot(
 	// TODO: Improve this code using cache backed by property collector, instead of making
 	// explicit call to vCenter to get candidate datastores from cluster
 	for _, clusterMoRef := range activeClusterMoRefs {
-		candidateDatastores, _, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterMoRef, false)
+		candidateDatastores, _, err := getCandidateDatastores(ctx, vc, clusterMoRef, false)
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"getAccessibleClustersForSnapshot: failed to get candidate datastores for cluster %q. Error: %+v",
@@ -1542,6 +1632,72 @@ func (c *controller) getAccessibleClustersForSnapshot(
 	log.Infof("getAccessibleClustersForSnapshot: snapshot %q is accessible in clusters: %v",
 		contentSourceSnapshotID, accessibleClusters)
 	return accessibleClusters, nil
+}
+
+// getSnapshotSourceHostToPinPlacement returns the ESX host a host-local restore must be pinned to,
+// or nil when no pinning is needed.
+//
+// It returns nil unless the request restores from a snapshot whose source volume sits on a
+// host-exclusive datastore, and only consults vCenter when the supports_host_local_storage
+// capability is enabled - without it no volume can live on such a datastore, so ordinary
+// provisioning keeps its existing behaviour and makes no extra calls.
+//
+// Callers must not use this for a linked clone: those are placed on the source volume's datastore
+// directly and CNS rejects `hosts` on a linked clone create spec.
+func (c *controller) getSnapshotSourceHostToPinPlacement(ctx context.Context,
+	req *csi.CreateVolumeRequest) (*types.ManagedObjectReference, error) {
+	if req.GetVolumeContentSource() == nil || !isHostLocalStorageSupportEnabled {
+		return nil, nil
+	}
+	log := logger.GetLogger(ctx)
+	snapshotSource := req.GetVolumeContentSource().GetSnapshot()
+	if snapshotSource == nil || snapshotSource.GetSnapshotId() == "" {
+		return nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
+			"restore request must specify a snapshot as VolumeContentSource")
+	}
+	return c.getHostExclusiveSnapshotSourceHost(ctx, snapshotSource.GetSnapshotId())
+}
+
+// getHostExclusiveSnapshotSourceHost returns the ESX host that exclusively mounts the datastore of
+// the snapshot's source volume, or nil when more than one host mounts it (an ordinary shared
+// datastore, where placement needs no host constraint).
+//
+// A restore is a disk copy and vCenter can only run it on a host that mounts both the source and
+// the destination datastore. When the source datastore is host-exclusive - the backing of a
+// host-local storage policy - that host is the only one that can serve the restore, so callers must
+// constrain placement to it. Otherwise vpxd fails the copy with "No common host found between
+// source and target datastores".
+func (c *controller) getHostExclusiveSnapshotSourceHost(ctx context.Context,
+	contentSourceSnapshotID string) (*types.ManagedObjectReference, error) {
+	log := logger.GetLogger(ctx)
+
+	datastoreInfo, err := c.getDatastoreForLinkedCloneRequest(ctx, contentSourceSnapshotID)
+	if err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to find the datastore of the source volume of snapshot %q: %v",
+			contentSourceSnapshotID, err)
+	}
+	hostMounts, err := datastoreHostMounts(ctx, datastoreInfo)
+	if err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to retrieve host mounts for datastore %q of snapshot %q: %v",
+			datastoreInfo.Info.Url, contentSourceSnapshotID, err)
+	}
+	if len(hostMounts) == 0 {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"datastore %q of snapshot %q has no host mounts", datastoreInfo.Info.Url,
+			contentSourceSnapshotID)
+	}
+	if len(hostMounts) > 1 {
+		log.Debugf("getHostExclusiveSnapshotSourceHost: datastore %q of snapshot %q is mounted by %d "+
+			"hosts, placement needs no host constraint", datastoreInfo.Info.Url, contentSourceSnapshotID,
+			len(hostMounts))
+		return nil, nil
+	}
+	sourceHost := hostMounts[0].Key
+	log.Infof("getHostExclusiveSnapshotSourceHost: datastore %q of snapshot %q is exclusive to host %q",
+		datastoreInfo.Info.Url, contentSourceSnapshotID, sourceHost.Value)
+	return &sourceHost, nil
 }
 
 // getDatastoreForLinkedCloneRequest returns the DatastoreInfo object corresponding to

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -591,6 +591,61 @@ func getHostLocalAccessibleTopology(ctx context.Context, hostRef vimtypes.Manage
 	return segments, nil
 }
 
+// datastoreHostMounts returns the ESX hosts that mount the given datastore. Declared as a
+// variable so tests can substitute a fake implementation without a live vCenter.
+var datastoreHostMounts = func(ctx context.Context,
+	dsInfo *vsphere.DatastoreInfo) ([]vimtypes.DatastoreHostMount, error) {
+	var dsMo mo.Datastore
+	if err := dsInfo.Properties(ctx, dsInfo.Reference(), []string{"host"}, &dsMo); err != nil {
+		return nil, err
+	}
+	return dsMo.Host, nil
+}
+
+// isHostExclusiveDatastore reports whether the datastore is mounted by exactly one ESX host.
+// Host-local storage policies place volumes on such host-exclusive datastores; a datastore
+// shared across the hosts of a cluster reports more than one mount.
+func isHostExclusiveDatastore(ctx context.Context, dsInfo *vsphere.DatastoreInfo) (bool, error) {
+	log := logger.GetLogger(ctx)
+	hostMounts, err := datastoreHostMounts(ctx, dsInfo)
+	if err != nil {
+		return false, logger.LogNewErrorf(log,
+			"failed to retrieve host mounts for datastore %q: %v", dsInfo.Info.Url, err)
+	}
+	if len(hostMounts) == 0 {
+		return false, logger.LogNewErrorf(log, "datastore %q has no host mounts", dsInfo.Info.Url)
+	}
+	return len(hostMounts) == 1, nil
+}
+
+// getDatastoresAccessibleToHost returns the datastores mounted by the given ESX host. Used to
+// constrain a restore from a host-exclusive datastore to destinations that host can reach, so the
+// disk copy has a host in common with the source.
+func getDatastoresAccessibleToHost(ctx context.Context, vc *vsphere.VirtualCenter,
+	hostMoRef vimtypes.ManagedObjectReference) ([]*vsphere.DatastoreInfo, error) {
+	host := &vsphere.HostSystem{
+		HostSystem: object.NewHostSystem(vc.Client.Client, hostMoRef),
+	}
+	return vsphere.GetAllAccessibleDatastoresForHosts(ctx, []*vsphere.HostSystem{host})
+}
+
+// narrowToSnapshotSourceHost reduces the candidate host set of a host-local volume to the single
+// host that owns the snapshot's source volume. That host is the only one that can run the restore
+// copy, so it must be one of the hosts the accessibility requirement allows.
+func narrowToSnapshotSourceHost(ctx context.Context, candidates []vimtypes.ManagedObjectReference,
+	sourceHost vimtypes.ManagedObjectReference) ([]vimtypes.ManagedObjectReference, error) {
+	log := logger.GetLogger(ctx)
+	for _, candidate := range candidates {
+		if candidate.Value == sourceHost.Value {
+			return []vimtypes.ManagedObjectReference{candidate}, nil
+		}
+	}
+	return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+		"host %q owning the source volume of the snapshot is not among the candidate hosts %v "+
+			"allowed by the accessibility requirement; the restore can only run on that host",
+		sourceHost.Value, candidates)
+}
+
 // resolveHostLocalAccessibleTopologySegments returns the topology segments (zone + hostname) to
 // publish as PV node affinity for a host-local volume.
 //

--- a/pkg/csi/service/wcp/controller_helper_test.go
+++ b/pkg/csi/service/wcp/controller_helper_test.go
@@ -7,12 +7,15 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -450,6 +453,96 @@ func TestGetHostLocalAccessibleTopology(t *testing.T) {
 	t.Run("incomplete_topology_errors", func(t *testing.T) {
 		_, err := getHostLocalAccessibleTopology(ctx,
 			vimtypes.ManagedObjectReference{Type: "HostSystem", Value: "host-2"}, hostTopo)
+		assert.Error(t, err)
+	})
+}
+
+// TestIsHostExclusiveDatastore verifies the host-mount count check used to tell a host-exclusive
+// datastore (the backing of a host-local storage policy) apart from a datastore shared across the
+// hosts of a cluster.
+func TestIsHostExclusiveDatastore(t *testing.T) {
+	ctx := context.Background()
+	dsInfo := &cnsvsphere.DatastoreInfo{
+		Datastore: &cnsvsphere.Datastore{},
+		Info:      &vimtypes.DatastoreInfo{Url: "ds:///vmfs/volumes/host-local-1/"},
+	}
+	hostMount := func(id string) vimtypes.DatastoreHostMount {
+		return vimtypes.DatastoreHostMount{
+			Key: vimtypes.ManagedObjectReference{Type: "HostSystem", Value: id},
+		}
+	}
+
+	original := datastoreHostMounts
+	t.Cleanup(func() { datastoreHostMounts = original })
+
+	t.Run("single_host_mount_is_host_exclusive", func(t *testing.T) {
+		datastoreHostMounts = func(_ context.Context,
+			_ *cnsvsphere.DatastoreInfo) ([]vimtypes.DatastoreHostMount, error) {
+			return []vimtypes.DatastoreHostMount{hostMount("host-1")}, nil
+		}
+		hostExclusive, err := isHostExclusiveDatastore(ctx, dsInfo)
+		assert.NoError(t, err)
+		assert.True(t, hostExclusive)
+	})
+
+	t.Run("multiple_host_mounts_is_not_host_exclusive", func(t *testing.T) {
+		datastoreHostMounts = func(_ context.Context,
+			_ *cnsvsphere.DatastoreInfo) ([]vimtypes.DatastoreHostMount, error) {
+			return []vimtypes.DatastoreHostMount{hostMount("host-1"), hostMount("host-2")}, nil
+		}
+		hostExclusive, err := isHostExclusiveDatastore(ctx, dsInfo)
+		assert.NoError(t, err)
+		assert.False(t, hostExclusive)
+	})
+
+	t.Run("no_host_mounts_errors", func(t *testing.T) {
+		datastoreHostMounts = func(_ context.Context,
+			_ *cnsvsphere.DatastoreInfo) ([]vimtypes.DatastoreHostMount, error) {
+			return nil, nil
+		}
+		_, err := isHostExclusiveDatastore(ctx, dsInfo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no host mounts")
+	})
+
+	t.Run("property_fetch_error_is_propagated", func(t *testing.T) {
+		datastoreHostMounts = func(_ context.Context,
+			_ *cnsvsphere.DatastoreInfo) ([]vimtypes.DatastoreHostMount, error) {
+			return nil, assert.AnError
+		}
+		_, err := isHostExclusiveDatastore(ctx, dsInfo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to retrieve host mounts")
+	})
+}
+
+// TestNarrowToSnapshotSourceHost verifies that a host-local restore is pinned to the host owning
+// the snapshot's source volume. That host mounts the host-exclusive source datastore, so it is the
+// only one that can run the restore copy; leaving the full candidate set lets CNS pick a host that
+// cannot see the source datastore, which vpxd rejects with "No common host found between source
+// and target datastores".
+func TestNarrowToSnapshotSourceHost(t *testing.T) {
+	ctx := context.Background()
+	hostRef := func(id string) vimtypes.ManagedObjectReference {
+		return vimtypes.ManagedObjectReference{Type: "HostSystem", Value: id}
+	}
+	candidates := []vimtypes.ManagedObjectReference{hostRef("host-1"), hostRef("host-2"), hostRef("host-3")}
+
+	t.Run("narrows_to_the_source_host", func(t *testing.T) {
+		narrowed, err := narrowToSnapshotSourceHost(ctx, candidates, hostRef("host-2"))
+		assert.NoError(t, err)
+		assert.Equal(t, []vimtypes.ManagedObjectReference{hostRef("host-2")}, narrowed)
+	})
+
+	t.Run("source_host_outside_the_candidate_set_errors", func(t *testing.T) {
+		_, err := narrowToSnapshotSourceHost(ctx, candidates, hostRef("host-99"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "host-99")
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("empty_candidate_set_errors", func(t *testing.T) {
+		_, err := narrowToSnapshotSourceHost(ctx, nil, hostRef("host-1"))
 		assert.Error(t, err)
 	})
 }

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -32,6 +33,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/pbm"
+	vim25types "github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -40,6 +42,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -1545,6 +1548,715 @@ func TestGetDatastoresForHostLocalLinkedClone(t *testing.T) {
 		_, err := ct.controller.getDatastoresForHostLocalLinkedClone(ctx, req, true, true)
 		if err == nil {
 			t.Fatal("expected an error for a malformed snapshot ID, got nil")
+		}
+	})
+}
+
+// fakeCOOverrides layers a fixed active-cluster list and per-feature FSS values on top of the
+// standard fake orchestrator, whose GetActiveClustersForNamespaceInRequestedZones always returns an
+// empty list and whose feature set does not include linked-clone support.
+type fakeCOOverrides struct {
+	commonco.COCommonInterface
+	clusters           []string
+	err                error
+	fssOverrides       map[string]bool
+	nodeNameToHostMoID map[string]string
+}
+
+func (f *fakeCOOverrides) GetNodeNameToHostMoIDMap(ctx context.Context) map[string]string {
+	if f.nodeNameToHostMoID == nil {
+		return f.COCommonInterface.GetNodeNameToHostMoIDMap(ctx)
+	}
+	return f.nodeNameToHostMoID
+}
+
+func (f *fakeCOOverrides) GetActiveClustersForNamespaceInRequestedZones(ctx context.Context,
+	targetNS string, requestedZones []string) ([]string, error) {
+	return f.clusters, f.err
+}
+
+func (f *fakeCOOverrides) IsFSSEnabled(ctx context.Context, featureName string) bool {
+	if enabled, ok := f.fssOverrides[featureName]; ok {
+		return enabled
+	}
+	return f.COCommonInterface.IsFSSEnabled(ctx, featureName)
+}
+
+// TestGetAccessibleClustersForSnapshot verifies which vSphere clusters are handed to CNS as
+// activeClusters when restoring a volume from a snapshot.
+//
+// A host-local volume lives on a host-exclusive datastore, which is never part of the all-hosts
+// datastore intersection that GetCandidateDatastoresInCluster reports. Narrowing on datastore
+// accessibility therefore matches no cluster at all, and returning that empty list left CNS with a
+// CnsVolumeCreateSpec carrying no datastores, no activeClusters and no hosts - rejected with
+// "A specified parameter was not correct: createSpecs.datastores". Falling back to every active
+// cluster of the namespace lets CNS place the restored volume on a policy-compatible datastore.
+func TestGetAccessibleClustersForSnapshot(t *testing.T) {
+	ct := getControllerTest(t)
+
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         map[string]string{},
+		VolumeCapabilities: capabilities,
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	volID := respCreate.Volume.VolumeId
+	defer func() {
+		if _, err := ct.controller.DeleteVolume(ctx, &csi.DeleteVolumeRequest{VolumeId: volID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	reqCreateSnapshot := &csi.CreateSnapshotRequest{
+		SourceVolumeId: volID,
+		Name:           "snapshot-" + uuid.New().String(),
+		Parameters: map[string]string{
+			common.VolumeSnapshotNamespaceKey: "default",
+		},
+	}
+	respCreateSnapshot, err := ct.controller.CreateSnapshot(ctx, reqCreateSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapID := respCreateSnapshot.Snapshot.SnapshotId
+	defer func() {
+		if _, err := ct.controller.DeleteSnapshot(ctx, &csi.DeleteSnapshotRequest{SnapshotId: snapID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// The datastore the snapshot's source volume resides on.
+	sourceDatastore, err := ct.controller.getDatastoreForLinkedCloneRequest(ctx, snapID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	activeClusters := []string{"domain-c8", "domain-c9"}
+	originalCO := commonco.ContainerOrchestratorUtility
+	originalGetCandidateDatastores := getCandidateDatastores
+	originalHostLocalSupport := isHostLocalStorageSupportEnabled
+	t.Cleanup(func() {
+		commonco.ContainerOrchestratorUtility = originalCO
+		getCandidateDatastores = originalGetCandidateDatastores
+		isHostLocalStorageSupportEnabled = originalHostLocalSupport
+	})
+	commonco.ContainerOrchestratorUtility = &fakeCOOverrides{
+		COCommonInterface: originalCO,
+		clusters:          activeClusters,
+	}
+
+	t.Run("no_matching_cluster_returns_empty_without_widening", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = true
+		// No active cluster reports the snapshot's datastore among its shared datastores.
+		getCandidateDatastores = func(_ context.Context, _ *cnsvsphere.VirtualCenter, _ string,
+			_ bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+			return []*cnsvsphere.DatastoreInfo{
+				{
+					Datastore: &cnsvsphere.Datastore{},
+					Info:      &vim25types.DatastoreInfo{Url: "ds:///vmfs/volumes/some-other-shared-ds/"},
+				},
+			}, nil, nil
+		}
+
+		// Widening to every active cluster here is what let CNS place a restored volume on a
+		// datastore no host shares with the source, which vpxd rejects with "No common host found
+		// between source and target datastores". Host-exclusive sources never reach this function.
+		clusters, err := ct.controller.getAccessibleClustersForSnapshot(ctx, snapID, "default", []string{"zone-1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if len(clusters) != 0 {
+			t.Fatalf("expected no clusters when the snapshot datastore matches none, got %v", clusters)
+		}
+	})
+
+	t.Run("shared_source_is_still_narrowed_to_matching_clusters", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = true
+		// Only the first active cluster can see the snapshot's datastore.
+		getCandidateDatastores = func(_ context.Context, _ *cnsvsphere.VirtualCenter, clusterMoRef string,
+			_ bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+			if clusterMoRef == activeClusters[0] {
+				return []*cnsvsphere.DatastoreInfo{sourceDatastore}, nil, nil
+			}
+			return nil, nil, nil
+		}
+
+		clusters, err := ct.controller.getAccessibleClustersForSnapshot(ctx, snapID, "default", []string{"zone-1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if !reflect.DeepEqual(clusters, []string{activeClusters[0]}) {
+			t.Fatalf("expected narrowing to %v, got %v", []string{activeClusters[0]}, clusters)
+		}
+	})
+
+	t.Run("candidate_datastore_error_is_propagated", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = true
+		getCandidateDatastores = func(_ context.Context, _ *cnsvsphere.VirtualCenter, _ string,
+			_ bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+			return nil, nil, fmt.Errorf("cluster unreachable")
+		}
+
+		if _, err := ct.controller.getAccessibleClustersForSnapshot(ctx, snapID, "default",
+			[]string{"zone-1"}); err == nil {
+			t.Fatal("expected the candidate datastore error to propagate, got nil")
+		}
+	})
+}
+
+// TestLinkedCloneOnHostExclusiveDatastoreRequiresHostLocalPolicy verifies that a linked clone whose
+// source volume sits on a host-exclusive datastore is rejected when the request is not host-local.
+// A linked clone is always created on the source volume's datastore, so a shared storage policy can
+// never be satisfied; rejecting in the controller reports that reason instead of the misleading
+// "not accessible to all nodes" PBM failure raised later by isDataStoreCompatible.
+func TestLinkedCloneOnHostExclusiveDatastoreRequiresHostLocalPolicy(t *testing.T) {
+	ct := getControllerTest(t)
+
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         map[string]string{},
+		VolumeCapabilities: capabilities,
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	volID := respCreate.Volume.VolumeId
+	defer func() {
+		if _, err := ct.controller.DeleteVolume(ctx, &csi.DeleteVolumeRequest{VolumeId: volID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	respCreateSnapshot, err := ct.controller.CreateSnapshot(ctx, &csi.CreateSnapshotRequest{
+		SourceVolumeId: volID,
+		Name:           "snapshot-" + uuid.New().String(),
+		Parameters: map[string]string{
+			common.VolumeSnapshotNamespaceKey: "default",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapID := respCreateSnapshot.Snapshot.SnapshotId
+	defer func() {
+		if _, err := ct.controller.DeleteSnapshot(ctx, &csi.DeleteSnapshotRequest{SnapshotId: snapID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	originalCO := commonco.ContainerOrchestratorUtility
+	originalMultiCluster := IsMultipleClustersPerVsphereZoneFSSEnabled
+	originalHostLocalSupport := isHostLocalStorageSupportEnabled
+	originalHostMounts := datastoreHostMounts
+	t.Cleanup(func() {
+		commonco.ContainerOrchestratorUtility = originalCO
+		IsMultipleClustersPerVsphereZoneFSSEnabled = originalMultiCluster
+		isHostLocalStorageSupportEnabled = originalHostLocalSupport
+		datastoreHostMounts = originalHostMounts
+	})
+
+	IsMultipleClustersPerVsphereZoneFSSEnabled = true
+	commonco.ContainerOrchestratorUtility = &fakeCOOverrides{
+		COCommonInterface: originalCO,
+		clusters:          []string{"domain-c8"},
+		fssOverrides:      map[string]bool{common.LinkedCloneSupport: true},
+	}
+
+	// A linked clone request restoring from the snapshot above, with a zone-only accessibility
+	// requirement - i.e. a StorageClass that is not host-local.
+	linkedCloneReq := func() *csi.CreateVolumeRequest {
+		return &csi.CreateVolumeRequest{
+			Name: testVolumeName + "-" + uuid.New().String(),
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: 1 * common.GbInBytes,
+			},
+			Parameters: map[string]string{
+				common.AttributePvcNamespace:        "default",
+				common.AttributeIsLinkedCloneKey:    "true",
+				common.AttributeStoragePolicyID:     "shared-policy-id",
+				common.AttributeStorageTopologyType: "zonal",
+			},
+			VolumeCapabilities: capabilities,
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{Segments: map[string]string{v1.LabelTopologyZone: "zone-1"}},
+				},
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{v1.LabelTopologyZone: "zone-1"}},
+				},
+			},
+			VolumeContentSource: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Snapshot{
+					Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: snapID},
+				},
+			},
+		}
+	}
+
+	hostMount := func(id string) vim25types.DatastoreHostMount {
+		return vim25types.DatastoreHostMount{
+			Key: vim25types.ManagedObjectReference{Type: "HostSystem", Value: id},
+		}
+	}
+
+	t.Run("host_exclusive_source_is_rejected", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = true
+		datastoreHostMounts = func(_ context.Context,
+			_ *cnsvsphere.DatastoreInfo) ([]vim25types.DatastoreHostMount, error) {
+			return []vim25types.DatastoreHostMount{hostMount("host-1")}, nil
+		}
+
+		_, _, err := ct.controller.createBlockVolume(ctx, linkedCloneReq(), true, clusterComputeResourceMoIds)
+		if err == nil {
+			t.Fatal("expected a linked clone of a host-exclusive datastore under a shared policy to be rejected")
+		}
+		statusErr, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("unable to convert the error: %+v into a grpc status error type", err)
+		}
+		if statusErr.Code() != codes.InvalidArgument {
+			t.Fatalf("expected %s, got %s: %v", codes.InvalidArgument, statusErr.Code(), err)
+		}
+		if !strings.Contains(err.Error(), "host-exclusive datastore") {
+			t.Fatalf("expected the error to name the host-exclusive datastore, got: %v", err)
+		}
+	})
+
+	t.Run("shared_source_passes_the_guard", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = true
+		datastoreHostMounts = func(_ context.Context,
+			_ *cnsvsphere.DatastoreInfo) ([]vim25types.DatastoreHostMount, error) {
+			return []vim25types.DatastoreHostMount{hostMount("host-1"), hostMount("host-2")}, nil
+		}
+
+		// Provisioning may still fail further down against the simulator; all that matters here is
+		// that it is not rejected by the host-exclusive guard.
+		_, _, err := ct.controller.createBlockVolume(ctx, linkedCloneReq(), true, clusterComputeResourceMoIds)
+		if err != nil && strings.Contains(err.Error(), "host-exclusive datastore") {
+			t.Fatalf("a datastore mounted by several hosts must not be rejected as host-exclusive: %v", err)
+		}
+	})
+
+	t.Run("guard_is_skipped_when_capability_is_disabled", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = false
+		called := false
+		datastoreHostMounts = func(_ context.Context,
+			_ *cnsvsphere.DatastoreInfo) ([]vim25types.DatastoreHostMount, error) {
+			called = true
+			return []vim25types.DatastoreHostMount{hostMount("host-1")}, nil
+		}
+
+		_, _, err := ct.controller.createBlockVolume(ctx, linkedCloneReq(), true, clusterComputeResourceMoIds)
+		if called {
+			t.Fatal("host mounts must not be fetched when supports_host_local_storage is disabled")
+		}
+		if err != nil && strings.Contains(err.Error(), "host-exclusive datastore") {
+			t.Fatalf("the guard must not fire when supports_host_local_storage is disabled: %v", err)
+		}
+	})
+}
+
+// TestRestoreFromHostLocalSnapshotPinsPlacementToSourceHost covers the placement constraints a
+// non-linked-clone restore must obey when the snapshot's source volume lives on a host-exclusive
+// datastore (the backing of a host-local storage policy).
+//
+// The restore is a disk copy and vCenter can only run it on a host that mounts both the source and
+// the destination datastore. Leaving CNS free to choose - via activeClusters for a shared target
+// StorageClass, or via the full candidate host set for a host-local one - lets it pick a
+// destination no host shares with the source, which vpxd rejects with "No common host found
+// between source and target datastores".
+func TestRestoreFromHostLocalSnapshotPinsPlacementToSourceHost(t *testing.T) {
+	ct := getControllerTest(t)
+
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         map[string]string{},
+		VolumeCapabilities: capabilities,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	volID := respCreate.Volume.VolumeId
+	defer func() {
+		if _, err := ct.controller.DeleteVolume(ctx, &csi.DeleteVolumeRequest{VolumeId: volID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	respCreateSnapshot, err := ct.controller.CreateSnapshot(ctx, &csi.CreateSnapshotRequest{
+		SourceVolumeId: volID,
+		Name:           "snapshot-" + uuid.New().String(),
+		Parameters: map[string]string{
+			common.VolumeSnapshotNamespaceKey: "default",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapID := respCreateSnapshot.Snapshot.SnapshotId
+	defer func() {
+		if _, err := ct.controller.DeleteSnapshot(ctx, &csi.DeleteSnapshotRequest{SnapshotId: snapID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Real simulator hosts, so the datastore lookups below hit actual inventory.
+	hosts, err := ct.vcenter.GetHostsByCluster(ctx, clusterComputeResourceMoIds[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hosts) == 0 {
+		t.Fatal("expected at least one host in the simulator cluster")
+	}
+	sourceHostRef := hosts[0].Reference()
+
+	originalCO := commonco.ContainerOrchestratorUtility
+	originalMultiCluster := IsMultipleClustersPerVsphereZoneFSSEnabled
+	originalHostLocalSupport := isHostLocalStorageSupportEnabled
+	originalHostMounts := datastoreHostMounts
+	originalGetCandidateDatastores := getCandidateDatastores
+	t.Cleanup(func() {
+		commonco.ContainerOrchestratorUtility = originalCO
+		IsMultipleClustersPerVsphereZoneFSSEnabled = originalMultiCluster
+		isHostLocalStorageSupportEnabled = originalHostLocalSupport
+		datastoreHostMounts = originalHostMounts
+		getCandidateDatastores = originalGetCandidateDatastores
+	})
+
+	hostMount := func(ref vim25types.ManagedObjectReference) vim25types.DatastoreHostMount {
+		return vim25types.DatastoreHostMount{Key: ref}
+	}
+	// hostExclusiveSource reports the snapshot's datastore as mounted by exactly one host, which is
+	// what a host-local storage policy produces.
+	hostExclusiveSource := func(_ context.Context,
+		_ *cnsvsphere.DatastoreInfo) ([]vim25types.DatastoreHostMount, error) {
+		return []vim25types.DatastoreHostMount{hostMount(sourceHostRef)}, nil
+	}
+	snapshotContentSource := &csi.VolumeContentSource{
+		Type: &csi.VolumeContentSource_Snapshot{
+			Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: snapID},
+		},
+	}
+
+	t.Run("getHostExclusiveSnapshotSourceHost", func(t *testing.T) {
+		t.Run("single_mount_returns_that_host", func(t *testing.T) {
+			datastoreHostMounts = hostExclusiveSource
+			host, err := ct.controller.getHostExclusiveSnapshotSourceHost(ctx, snapID)
+			if err != nil {
+				t.Fatalf("unexpected error: %+v", err)
+			}
+			if host == nil || host.Value != sourceHostRef.Value {
+				t.Fatalf("expected source host %q, got %+v", sourceHostRef.Value, host)
+			}
+		})
+
+		t.Run("multiple_mounts_need_no_pinning", func(t *testing.T) {
+			datastoreHostMounts = func(_ context.Context,
+				_ *cnsvsphere.DatastoreInfo) ([]vim25types.DatastoreHostMount, error) {
+				return []vim25types.DatastoreHostMount{
+					hostMount(sourceHostRef),
+					hostMount(vim25types.ManagedObjectReference{Type: "HostSystem", Value: "host-other"}),
+				}, nil
+			}
+			host, err := ct.controller.getHostExclusiveSnapshotSourceHost(ctx, snapID)
+			if err != nil {
+				t.Fatalf("unexpected error: %+v", err)
+			}
+			if host != nil {
+				t.Fatalf("expected no pinning for a shared datastore, got %+v", host)
+			}
+		})
+
+		t.Run("no_mounts_errors", func(t *testing.T) {
+			datastoreHostMounts = func(_ context.Context,
+				_ *cnsvsphere.DatastoreInfo) ([]vim25types.DatastoreHostMount, error) {
+				return nil, nil
+			}
+			if _, err := ct.controller.getHostExclusiveSnapshotSourceHost(ctx, snapID); err == nil {
+				t.Fatal("expected an error for a datastore with no host mounts")
+			}
+		})
+
+		t.Run("malformed_snapshot_id_errors", func(t *testing.T) {
+			datastoreHostMounts = hostExclusiveSource
+			if _, err := ct.controller.getHostExclusiveSnapshotSourceHost(ctx, "malformed"); err == nil {
+				t.Fatal("expected an error for a malformed snapshot ID")
+			}
+		})
+	})
+
+	t.Run("getSnapshotSourceHostToPinPlacement", func(t *testing.T) {
+		datastoreHostMounts = hostExclusiveSource
+
+		t.Run("nil_without_content_source", func(t *testing.T) {
+			isHostLocalStorageSupportEnabled = true
+			host, err := ct.controller.getSnapshotSourceHostToPinPlacement(ctx, &csi.CreateVolumeRequest{})
+			if err != nil {
+				t.Fatalf("unexpected error: %+v", err)
+			}
+			if host != nil {
+				t.Fatalf("expected no pinning without a content source, got %+v", host)
+			}
+		})
+
+		t.Run("nil_when_capability_disabled", func(t *testing.T) {
+			isHostLocalStorageSupportEnabled = false
+			called := false
+			datastoreHostMounts = func(c context.Context,
+				d *cnsvsphere.DatastoreInfo) ([]vim25types.DatastoreHostMount, error) {
+				called = true
+				return hostExclusiveSource(c, d)
+			}
+			defer func() { datastoreHostMounts = hostExclusiveSource }()
+
+			host, err := ct.controller.getSnapshotSourceHostToPinPlacement(ctx,
+				&csi.CreateVolumeRequest{VolumeContentSource: snapshotContentSource})
+			if err != nil {
+				t.Fatalf("unexpected error: %+v", err)
+			}
+			if host != nil {
+				t.Fatalf("expected no pinning when supports_host_local_storage is disabled, got %+v", host)
+			}
+			if called {
+				t.Fatal("host mounts must not be fetched when supports_host_local_storage is disabled")
+			}
+		})
+
+		t.Run("resolves_source_host_for_a_restore", func(t *testing.T) {
+			isHostLocalStorageSupportEnabled = true
+			host, err := ct.controller.getSnapshotSourceHostToPinPlacement(ctx,
+				&csi.CreateVolumeRequest{VolumeContentSource: snapshotContentSource})
+			if err != nil {
+				t.Fatalf("unexpected error: %+v", err)
+			}
+			if host == nil || host.Value != sourceHostRef.Value {
+				t.Fatalf("expected source host %q, got %+v", sourceHostRef.Value, host)
+			}
+		})
+
+		t.Run("non_snapshot_content_source_is_invalid_argument", func(t *testing.T) {
+			isHostLocalStorageSupportEnabled = true
+			// A VolumeContentSource of type Volume (not Snapshot) reaching a host-local or
+			// zone-topology restore branch is a caller error, not an internal failure.
+			_, err := ct.controller.getSnapshotSourceHostToPinPlacement(ctx, &csi.CreateVolumeRequest{
+				VolumeContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Volume{
+						Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: volID},
+					},
+				},
+			})
+			if err == nil {
+				t.Fatal("expected an error for a non-snapshot content source")
+			}
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("expected %s, got %s: %v", codes.InvalidArgument, status.Code(err), err)
+			}
+		})
+	})
+
+	t.Run("getDatastoresAccessibleToHost_returns_the_hosts_datastores", func(t *testing.T) {
+		datastores, err := getDatastoresAccessibleToHost(ctx, ct.vcenter, sourceHostRef)
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if len(datastores) == 0 {
+			t.Fatal("expected the source host to mount at least one datastore")
+		}
+	})
+
+	t.Run("shared_target_supplies_source_host_datastores_instead_of_clusters", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = true
+		IsMultipleClustersPerVsphereZoneFSSEnabled = true
+		datastoreHostMounts = hostExclusiveSource
+		commonco.ContainerOrchestratorUtility = &fakeCOOverrides{
+			COCommonInterface: originalCO,
+			clusters:          []string{"domain-c8"},
+		}
+		clusterPathTaken := false
+		getCandidateDatastores = func(c context.Context, vc *cnsvsphere.VirtualCenter, id string,
+			b bool) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+			clusterPathTaken = true
+			return originalGetCandidateDatastores(c, vc, id, b)
+		}
+
+		// Provisioning may still fail further down against the simulator; what matters is that the
+		// host-scoped datastore path was taken rather than the activeClusters one.
+		_, _, err := ct.controller.createBlockVolume(ctx, &csi.CreateVolumeRequest{
+			Name: testVolumeName + "-" + uuid.New().String(),
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: 1 * common.GbInBytes,
+			},
+			Parameters: map[string]string{
+				common.AttributePvcNamespace:        "default",
+				common.AttributeStorageTopologyType: "zonal",
+			},
+			VolumeCapabilities: capabilities,
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{Segments: map[string]string{v1.LabelTopologyZone: "zone-1"}},
+				},
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{v1.LabelTopologyZone: "zone-1"}},
+				},
+			},
+			VolumeContentSource: snapshotContentSource,
+		}, true, clusterComputeResourceMoIds)
+		if clusterPathTaken {
+			t.Fatalf("a host-exclusive source must not fall through to the activeClusters path (err: %v)", err)
+		}
+	})
+
+	hostLocalRestoreReq := func() *csi.CreateVolumeRequest {
+		return &csi.CreateVolumeRequest{
+			Name: testVolumeName + "-" + uuid.New().String(),
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: 1 * common.GbInBytes,
+			},
+			Parameters: map[string]string{
+				common.AttributePvcNamespace:    "default",
+				common.AttributeHostLocalPolicy: "true",
+			},
+			VolumeCapabilities: capabilities,
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{Segments: map[string]string{
+						v1.LabelTopologyZone: "zone-1",
+						v1.LabelHostname:     "node-a",
+					}},
+					{Segments: map[string]string{
+						v1.LabelTopologyZone: "zone-1",
+						v1.LabelHostname:     "node-b",
+					}},
+				},
+			},
+			VolumeContentSource: snapshotContentSource,
+		}
+	}
+
+	t.Run("host_local_target_reports_invalid_argument_for_a_non_snapshot_content_source", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = true
+		IsMultipleClustersPerVsphereZoneFSSEnabled = true
+		commonco.ContainerOrchestratorUtility = &fakeCOOverrides{
+			COCommonInterface: originalCO,
+			clusters:          []string{"domain-c8"},
+		}
+
+		req := hostLocalRestoreReq()
+		req.VolumeContentSource = &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: volID},
+			},
+		}
+		_, faultType, err := ct.controller.createBlockVolume(ctx, req, true, clusterComputeResourceMoIds)
+		if err == nil {
+			t.Fatal("expected an error for a non-snapshot content source")
+		}
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected %s, got %s: %v", codes.InvalidArgument, status.Code(err), err)
+		}
+		if faultType != csifault.CSIInvalidArgumentFault {
+			t.Fatalf("expected fault %q, got %q (err: %v)", csifault.CSIInvalidArgumentFault, faultType, err)
+		}
+	})
+
+	t.Run("host_local_target_narrows_to_the_source_host", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = true
+		IsMultipleClustersPerVsphereZoneFSSEnabled = true
+		datastoreHostMounts = hostExclusiveSource
+		// node-b maps to the host owning the snapshot's source volume, so the candidate set
+		// [node-a, node-b] must be narrowed to it rather than left for CNS to choose from.
+		commonco.ContainerOrchestratorUtility = &fakeCOOverrides{
+			COCommonInterface: originalCO,
+			clusters:          []string{"domain-c8"},
+			nodeNameToHostMoID: map[string]string{
+				"node-a": "host-not-the-source",
+				"node-b": sourceHostRef.Value,
+			},
+		}
+
+		// Provisioning may still fail further down against the simulator; what matters is that the
+		// candidate set was narrowed rather than rejected.
+		_, _, err := ct.controller.createBlockVolume(ctx, hostLocalRestoreReq(), true,
+			clusterComputeResourceMoIds)
+		if err != nil && strings.Contains(err.Error(), "not among the candidate hosts") {
+			t.Fatalf("the source host is in the requirement and must not be rejected: %v", err)
+		}
+	})
+
+	t.Run("host_local_target_rejects_a_source_host_outside_the_requirement", func(t *testing.T) {
+		isHostLocalStorageSupportEnabled = true
+		IsMultipleClustersPerVsphereZoneFSSEnabled = true
+		datastoreHostMounts = hostExclusiveSource
+		// The accessibility requirement allows only node-a, which maps to a different host than
+		// the one owning the snapshot's source volume.
+		commonco.ContainerOrchestratorUtility = &fakeCOOverrides{
+			COCommonInterface:  originalCO,
+			clusters:           []string{"domain-c8"},
+			nodeNameToHostMoID: map[string]string{"node-a": "host-not-the-source"},
+		}
+
+		_, _, err := ct.controller.createBlockVolume(ctx, &csi.CreateVolumeRequest{
+			Name: testVolumeName + "-" + uuid.New().String(),
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: 1 * common.GbInBytes,
+			},
+			Parameters: map[string]string{
+				common.AttributePvcNamespace:    "default",
+				common.AttributeHostLocalPolicy: "true",
+			},
+			VolumeCapabilities: capabilities,
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{Segments: map[string]string{
+						v1.LabelTopologyZone: "zone-1",
+						v1.LabelHostname:     "node-a",
+					}},
+				},
+			},
+			VolumeContentSource: snapshotContentSource,
+		}, true, clusterComputeResourceMoIds)
+		if err == nil {
+			t.Fatal("expected the restore to be rejected when the source host is outside the requirement")
+		}
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected %s, got %s: %v", codes.InvalidArgument, status.Code(err), err)
+		}
+		if !strings.Contains(err.Error(), "not among the candidate hosts") {
+			t.Fatalf("expected the error to explain the host mismatch, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Restoring a PVC with a shared storage policy from a snapshot whose source volume was provisioned with a host-local policy left the PVC Pending with:

    ServerFaultCode: A specified parameter was not correct:
    createSpecs.datastores

The CnsVolumeCreateSpec the controller now builds, by request shape:

1. New PVC from a host-local snapshot with a non-host-local policy - supply
   every datastore accessible to the host that owns the source volume, along
   with the storage policy. PBM narrows that set to the policy-compatible
   shared datastores, all of which the source host can reach.
2. New PVC from a host-local snapshot with a host-local policy - supply the
   host owning the datastore the source PVC is located on. The candidate set
   was previously every host in the accessibility requirement, which under
   Immediate binding let CNS choose a host that cannot see the source.
3. Linked clone from a host-local snapshot with a host-local policy - supply
   the source volume's datastore along with the policy. Unchanged; verified
   already correct on a testbed.
4. Linked clone from a host-local snapshot with a shared policy - rejected
   up front with InvalidArgument naming the host-exclusive datastore. A
   linked clone cannot leave the source datastore, so a shared policy can
   never be satisfied. This already failed, but deep inside
   CreateBlockVolumeUtil as a codes.Internal PBM error about datastores
   "not accessible to all nodes", which points at node accessibility rather
   than the real constraint.

Both non-linked-clone restores start from getHostExclusiveSnapshotSourceHost,
which resolves the snapshot's source datastore and returns the single host
that mounts it, or nil for an ordinary shared datastore - in which case both
paths behave exactly as before.

Under a non-host-local policy, that host's datastores are collected with
GetAllAccessibleDatastoresForHosts and passed as sharedDatastores, so
CreateBlockVolumeUtil takes its Datastores branch. Under a host-local policy
the host list built by getHostMoRefsForHostLocalVolume is narrowed to that
host instead, leaving sharedDatastores empty so the Hosts branch is taken with
a single host; CNS still reports that host in the placement result, so PV node
affinity is unaffected.

All of this is gated on the supports_host_local_storage capability: without
it no volume can live on a host-exclusive datastore, so ordinary provisioning
keeps its existing behaviour and makes no extra vCenter calls.

tests covering:
- narrowToSnapshotSourceHost: the source host inside and outside the
  candidate set, and an empty candidate set.
- getHostExclusiveSnapshotSourceHost: single, multiple and zero host mounts,
  plus a malformed snapshot ID.
- getSnapshotSourceHostToPinPlacement: no content source, the capability
  disabled (asserting no host-mount fetch), and a resolved source host.
- getDatastoresAccessibleToHost against real simulator inventory.
- createBlockVolume: a shared-policy restore from a host-exclusive source
  does not fall through to the activeClusters path; a host-local restore
  narrows a multi-host candidate set to the source host, and is rejected with
  InvalidArgument when the source host is outside the requirement.
- getAccessibleClustersForSnapshot: no matching cluster returns empty without
  widening, while the narrowing for a shared source is preserved.
- isHostExclusiveDatastore, getDatastoresForHostLocalLinkedClone and the
  linked-clone rejection guard keep their existing tests as the regression
  guard for the two linked-clone paths.




**Testing done**:

Created PVC using host-local policy. Created snapshot of the provisioned PVC

```
# kubectl get pvc volume-claim-tzr5 -n divyen-ns
NAME                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      VOLUMEATTRIBUTESCLASS   AGE
volume-claim-tzr5   Bound    pvc-f29c9824-fd0f-47b2-902f-590227ba203b   1Gi        RWO            hostlocalpolicy   <unset>                 6m40s
```

```
# kubectl get volumesnapshot -n divyen-ns
NAME                              READYTOUSE   SOURCEPVC           SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
volume-claim-tzr5-snapshot-5k6m   true         volume-claim-tzr5                           1Gi           volumesnapshotclass-delete   snapcontent-6b6d8882-44b7-440d-9b95-8c2bce7b29cb   4m8s           4m12s
```

Created new PVC using shared datastore policy from the snapshot created for host-local PVC

```
# kubectl describe pvc volume-claim-89jz  -n divyen-ns
Name:          volume-claim-89jz
Namespace:     divyen-ns
StorageClass:  vsan-default-storage-policy
Status:        Bound
Volume:        pvc-65d378e0-fdbc-4508-9eec-c37e2b7a0583
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"az1"}]
               csi.vsphere.volume-requested-topology: [{"topology.kubernetes.io/zone":"az1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Tue Aug 11 22:10:23 UTC 2026
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Block
DataSource:
  APIGroup:  snapshot.storage.k8s.io
  Kind:      VolumeSnapshot
  Name:      volume-claim-tzr5-snapshot-5k6m
Used By:     <none>
Events:
  Type    Reason                 Age                   From                                                                                          Message
  ----    ------                 ----                  ----                                                                                          -------
  Normal  Provisioning           2m19s                 csi.vsphere.vmware.com_4229e37408dc9dace53cee0230cfcd1c_df5e35b8-017d-4639-98c5-74e93f1c1ce3  External provisioner is provisioning volume for claim "divyen-ns/volume-claim-89jz"
  Normal  ExternalProvisioning   2m7s (x3 over 2m19s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  2m6s                  csi.vsphere.vmware.com_4229e37408dc9dace53cee0230cfcd1c_df5e35b8-017d-4639-98c5-74e93f1c1ce3  Successfully provisioned volume pvc-65d378e0-fdbc-4508-9eec-c37e2b7a0583
```


**Special notes for your reviewer**:

wcp precheckin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1897/ - SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked

vks precheckin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1446/ - SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix volume creation from a host-local snapshot with a shared policy
```
