### PR TITLE
[WIP] Fix nil pointer dereference in pvDeleted for unbound static PVs

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -151,6 +151,7 @@ data:
   "trigger-csi-fullsync": "false"
   "pv-to-backingdiskobjectid-mapping": "false"
   "high-pv-node-density": "false" # When enabled, increases the MAX_VOLUMES_PER_NODE from 59 to 255 for guest cluster nodes
+  "improved-volume-visibility": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1179,9 +1179,14 @@ func pvDeleted(obj interface{}) {
 		log.Debugf("k8sorchestrator: Deleted key %s from volumeIDToPvcMap", pv.Spec.CSI.VolumeHandle)
 		k8sOrchestratorInstance.volumeIDToNameMap.remove(pv.Spec.CSI.VolumeHandle)
 		log.Debugf("k8sorchestrator: Deleted key %s from volumeIDToNameMap", pv.Spec.CSI.VolumeHandle)
-		k8sOrchestratorInstance.pvcToVolumeIDMap.remove(pv.Spec.ClaimRef.Namespace + "/" + pv.Spec.ClaimRef.Name)
-		log.Debugf("k8sorchestrator: Deleted key %s from pvcToVolumeID",
-			pv.Spec.ClaimRef.Namespace+"/"+pv.Spec.ClaimRef.Name)
+		// A statically provisioned PV that was never bound to a PVC has a nil
+		// ClaimRef, and pvAdded only records a pvcToVolumeIDMap entry once the PV
+		// is Bound, so there is nothing to remove in that case.
+		if pv.Spec.ClaimRef != nil {
+			objVal := pv.Spec.ClaimRef.Namespace + "/" + pv.Spec.ClaimRef.Name
+			k8sOrchestratorInstance.pvcToVolumeIDMap.remove(objVal)
+			log.Debugf("k8sorchestrator: Deleted key %s from pvcToVolumeID", objVal)
+		}
 	}
 	if pv.Spec.VsphereVolume != nil {
 		k8sOrchestratorInstance.volumeIDToNameMap.remove(pv.Spec.VsphereVolume.VolumePath)

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -546,33 +546,58 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		err = fpv.WaitForPersistentVolumeDeleted(ctx, client, pvSpec.Name, poll, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Static PV deletion (ReclaimPolicy=Retain) no longer drives CNS
-		// unregister via full-sync (cns-health-initiative). Instead, once
-		// full-sync observes the PV is missing (after its two-cycle grace
-		// period), it labels the still-registered CNS volume pv_missing=true.
-		ginkgo.By(fmt.Sprintf("Waiting for pv_missing=true label to appear on CNS volume %s", fcdID))
-		err = e2eVSphere.waitForPVMissingLabel(ctx, pv.Spec.CSI.VolumeHandle)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// What happens to the CNS volume when a Retain static PV is deleted is
+		// gated by the improved-volume-visibility FSS (see csiPVDeleted in
+		// pkg/syncer/metadatasyncer.go):
+		//   enabled  - the CNS volume is retained and full-sync labels it
+		//              pv_missing=true after its two-cycle grace period.
+		//   disabled - the legacy path runs and the CNS volume is unregistered
+		//              immediately (the backing FCD is kept, so PV-2 can
+		//              re-register against it).
+		// The FSS ships disabled, so assert whichever contract is actually in
+		// force rather than assuming the feature is on.
+		improvedVolumeVisibility := isCsiFssEnabled(ctx, client,
+			GetAndExpectStringEnvVar(envCSINamespace), improvedVolumeVisibilityFss)
+		framework.Logf("%s FSS enabled: %t", improvedVolumeVisibilityFss, improvedVolumeVisibility)
 
-		ginkgo.By("Verify the CNS volume is still registered (not unregistered/deleted)")
-		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(queryResult.Volumes).To(gomega.HaveLen(1),
-			"CNS volume must remain registered after missing-PV labeling")
+		var pv2 *v1.PersistentVolume
 
-		ginkgo.By("Create the PV-2 pointing at the same FCD/CNS volume as PV-1")
-		pv2, err := client.CoreV1().PersistentVolumes().Create(ctx, pvSpec, metav1.CreateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if improvedVolumeVisibility {
+			ginkgo.By(fmt.Sprintf("Waiting for pv_missing=true label to appear on CNS volume %s", fcdID))
+			err = e2eVSphere.waitForPVMissingLabel(ctx, pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow full-sync to overwrite labels from the "+
-			"reappeared PV", fullSyncWaitTime))
-		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+			ginkgo.By("Verify the CNS volume is still registered (not unregistered/deleted)")
+			queryResult, err := e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(queryResult.Volumes).To(gomega.HaveLen(1),
+				"CNS volume must remain registered after missing-PV labeling")
 
-		ginkgo.By("Verify pv_missing label is cleared now that PV-2 matches the CNS volume")
-		labeled, err := e2eVSphere.hasPVMissingLabel(pv2.Spec.CSI.VolumeHandle)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(labeled).To(gomega.BeFalse(),
-			"pv_missing label must be cleared once a matching K8s PV (PV-2) exists")
+			ginkgo.By("Create the PV-2 pointing at the same FCD/CNS volume as PV-1")
+			pv2, err = client.CoreV1().PersistentVolumes().Create(ctx, pvSpec, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow full-sync to overwrite labels from the "+
+				"reappeared PV", fullSyncWaitTime))
+			time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+
+			ginkgo.By("Verify pv_missing label is cleared now that PV-2 matches the CNS volume")
+			labeled, err := e2eVSphere.hasPVMissingLabel(pv2.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(labeled).To(gomega.BeFalse(),
+				"pv_missing label must be cleared once a matching K8s PV (PV-2) exists")
+		} else {
+			ginkgo.By("Waiting for the CNS volume to be unregistered after PV-1 deletion")
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Create the PV-2")
+			pv2, err = client.CoreV1().PersistentVolumes().Create(ctx, pvSpec, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = e2eVSphere.waitForCNSVolumeToBeCreated(pv2.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 
 		ginkgo.By("Deleting PV-2")
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, pvSpec.Name, *metav1.NewDeleteOptions(0))

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -153,6 +153,7 @@ const (
 	healthStatusInAccessible                  = "inaccessible"
 	healthStatusWaitTime                      = 3 * time.Minute
 	hostdServiceName                          = "hostd"
+	improvedVolumeVisibilityFss               = "improved-volume-visibility"
 	invalidFSType                             = "ext10"
 	k8sPodTerminationTimeOut                  = 7 * time.Minute
 	k8sPodTerminationTimeOutLong              = 10 * time.Minute


### PR DESCRIPTION
**What this PR does / why we need it**:

pvDeleted() built the pvcToVolumeIDMap key from pv.Spec.ClaimRef without a nil check. ClaimRef is nil for a statically provisioned PV that was never bound to a PVC, so deleting such a PV panicked with a SIGSEGV inside the PV delete informer callback. Both the controller and the syncer register that informer, so every vsphere-csi-controller replica crashed:
```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x10]
  ...k8sorchestrator.pvDeleted(...)
      /build/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:1182
```

Guard the removal. This mirrors pvAdded() and pvUpdated(), which only add a pvcToVolumeIDMap entry when ClaimRef is non-nil and the PV is Bound; when ClaimRef is nil no entry was ever recorded, so there is nothing to remove. The volumeIDToPvcMap and volumeIDToNameMap removals are keyed on Spec.CSI.VolumeHandle and stay outside the guard, since an unbound CSI PV does have a volumeIDToNameMap entry that must still be cleaned up.

The crash had been masking a second problem. Killing the syncer before csiPVDeleted() runs means DeleteVolume is never issued, so the CNS volume survives and full-sync later labels it pv_missing=true - which is what the "same PV name twice" e2e spec asserts. The spec has therefore been passing because of the panic rather than because the feature works. Two further changes make that path honest:

  * improved-volume-visibility is added to the vanilla feature-state ConfigMap. The FSS gates the retain-vs-delete branch in csiPVDeleted, and was added to the guestcluster and supervisorcluster manifests but not to vanilla, leaving the code path unreachable there. It is shipped disabled, matching the other flavours.

  * csi_static_provisioning_basic.go now reads the FSS and asserts whichever contract is actually in force: pv_missing labeling when enabled, and immediate CNS unregistration when disabled. Previously it assumed the feature was on, so with the panic fixed and the FSS shipped disabled it would fail on a default install.

This commit was written in part with the assistance of generative AI
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4218

**Testing done**:
- [ ] E2E test runs 

**Special notes for your reviewer**:

**Release note**:
```release-note
```
