### PR TITLE
Disable RecoverVolumeExpansionFailure for resizer in supervisor

### DIFF
--- a/manifests/supervisorcluster/1.31/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.31/cns-csi.yaml
@@ -392,6 +392,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--feature-gates=RecoverVolumeExpansionFailure=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -418,6 +418,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--feature-gates=RecoverVolumeExpansionFailure=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -436,6 +436,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--feature-gates=RecoverVolumeExpansionFailure=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -436,6 +436,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--feature-gates=RecoverVolumeExpansionFailure=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -436,6 +436,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--feature-gates=RecoverVolumeExpansionFailure=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR disables RecoverVolumeExpansionFailure on supervisor as this feature requires a fix in spherlet as well as guest cluster. Due to an async upgrade, resize could stay blocked forever.

**Testing done**:

Supervisor cluster & guest cluster - Ensured that back to back PVC expansion is successful.

WCP precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1898/
VKS precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1445/