### PR TITLE
Document CreateVolume's delete-and-retry on CnsVolumeAlreadyExistsFault

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -715,7 +715,11 @@ func (m *defaultManager) createVolumeWithImprovedIdempotency(ctx context.Context
 		spec.Metadata.ContainerClusterArray[0].ClusterId)
 }
 
-// createVolumeWithTransaction creates volume with supplied PVC UUID as VolumeID in the CreateVolumeSpec
+// createVolumeWithTransaction creates a volume using the PVC UID as a
+// deterministic VolumeId (supplied via CnsVolumeCreateSpec.VolumeId), making
+// CreateVolume idempotent across retries — see IsCnsVolumeAlreadyExistsFault
+// for how a retry with different placement candidates is detected and
+// recovered from.
 func (m *defaultManager) createVolumeWithTransaction(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
 	extraParams interface{}) (resp *CnsVolumeInfo, faultType string, finalErr error) {
 	log := logger.GetLogger(ctx)
@@ -1050,6 +1054,19 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 					log.Errorf("failed to create volume with VolumeID: %q, faultType: %q, err: %v",
 						spec.VolumeId.Id, faultType, err)
 					if IsCnsVolumeAlreadyExistsFault(ctx, faultType) {
+						// CSI Transaction Support derives VolumeId deterministically from the
+						// PVC UID (see ExtractVolumeIDFromPVName) so a CreateVolume retry after
+						// a lost response, timeout, or CSI restart is idempotent instead of
+						// producing a duplicate FCD. But a retry can carry different placement
+						// candidates than the original attempt (e.g. the scheduler picked a
+						// different host, or the set of compatible datastores/clusters changed
+						// between attempts), so the volume CNS already created under this
+						// VolumeId may no longer satisfy the current request's placement scope.
+						// CNS reports that mismatch as CnsVolumeAlreadyExistsFault rather than
+						// silently reusing the volume. Delete it and recreate: VolumeId is
+						// unique to this PVC, so deleting it cannot affect any other volume,
+						// and the recreate lands the volume within the scope this request
+						// actually asked for.
 						log.Infof("Observed volume with Id: %q is already Exists. Deleting Volume.", spec.VolumeId.Id)
 						deleteFaultType, deleteError := m.deleteVolume(ctx, spec.VolumeId.Id, true)
 						if deleteError != nil {

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -633,7 +633,24 @@ func IsNotSupportedFaultType(ctx context.Context, faultType string) bool {
 	return faultType == "vim25:NotSupported"
 }
 
-// IsCnsVolumeAlreadyExistsFault returns true if a given faultType value is vim.fault.CnsVolumeAlreadyExistsFault
+// IsCnsVolumeAlreadyExistsFault returns true if a given faultType value is vim.fault.CnsVolumeAlreadyExistsFault.
+//
+// CNS CreateVolume throws this fault when a volume with the requested VolumeId
+// already exists (either just created by this call, or left over from an
+// earlier attempt that used the same deterministic VolumeId), but that volume
+// lives on a datastore, cluster, or host outside the placement scope requested
+// in the current CnsVolumeCreateSpec:
+//   - the volume's datastore is not in the requested Datastores list, or
+//   - none of the clusters backing the volume's datastore are in the requested
+//     ActiveClusters (multiple clusters per vSphere Zone), or
+//   - the volume's host is not in the requested Hosts (host-local placement).
+//
+// CNS cannot silently reuse such a volume, since doing so would place the
+// workload's data outside the domain/zone/host actually requested, so it fails
+// the request instead. Callers respond by deleting the out-of-scope volume and
+// retrying CreateVolume so a fresh volume lands within the current request's
+// scope — see createVolumeWithTransaction in manager.go and
+// CreateBlockVolumeUtilForMultiVC in vsphereutil.go.
 func IsCnsVolumeAlreadyExistsFault(ctx context.Context, faultType string) bool {
 	log := logger.GetLogger(ctx)
 	log.Infof("Checking fault type: %q is vim.fault.CnsVolumeAlreadyExistsFault", faultType)

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -557,6 +557,11 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{},
 		log.Errorf("failed to create disk %s on vCenter %q with error %+v faultType %q",
 			params.Spec.Name, params.Vcenter.Config.Host, err, faultType)
 		if cnsvolume.IsCnsVolumeAlreadyExistsFault(ctx, faultType) {
+			// The volume for this deterministic VolumeId exists but outside the
+			// placement scope of the current request (see IsCnsVolumeAlreadyExistsFault
+			// and createVolumeWithTransaction in cns-lib/volume/manager.go for why
+			// this can happen on a retry). Delete the out-of-scope volume and retry
+			// CreateVolume so it is placed within the current request's scope.
 			log.Infof("Observed volume with Id: %q is already Exists. Deleting Volume.", createSpec.VolumeId.Id)
 			_, deleteError := params.VolumeManager.DeleteVolume(ctx, createSpec.VolumeId.Id, true)
 			if deleteError != nil {


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Explain why CNS throws this fault (existing volume placed outside the requested datastore/cluster/host scope) and why the driver's response of deleting the deterministic-VolumeId volume and retrying is safe, in cns-lib/volume and the multi-VC CreateVolume helper.


**Testing done**:
Doc changes only


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Document CreateVolume's delete-and-retry on CnsVolumeAlreadyExistsFault
```
