### PR TITLE
Pass argument to mkfs to avoid unmap operation at the startup, to avoid writes to disks that return incorrect CBT metadata

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -188,6 +188,11 @@ func (osUtils *OsUtils) xfsFormatAndMount(ctx context.Context, source string, ta
 				source,
 			}
 		}
+		// -K (nodiscard) skips the full-device SCSI UNMAP/TRIM that mkfs.xfs issues by
+		// default. On a freshly provisioned, empty volume there is nothing to reclaim, but
+		// vSphere's CBT engine treats that discard as a write and marks the entire disk as
+		// changed, which returns incorrect snapshot CBT metadata.
+		args = append([]string{"-K"}, args...)
 
 		log.Infof("xfsFormatAndMount: Disk %q appears to be unformatted, attempting to format as type: %q "+
 			"with options: %v", source, fstype, args)
@@ -207,6 +212,49 @@ func (osUtils *OsUtils) xfsFormatAndMount(ctx context.Context, source string, ta
 	err = osUtils.Mounter.Mount(source, target, fstype, opts)
 	if err != nil {
 		log.Errorf("xfsFormatAndMount: mount of disk %s failed: type:(%q) target:(%q) errcode:(%v)",
+			source, fstype, target, err)
+		return errors.New(err.Error())
+	}
+	return nil
+}
+
+// extFormatAndMount mounts volume to the staging path for ext4/ext3 fstype
+func (osUtils *OsUtils) extFormatAndMount(ctx context.Context, source string, target string,
+	fstype string, opts ...string) error {
+	log := logger.GetLogger(ctx)
+	// Check if the disk is already formatted
+	existingFormat, err := osUtils.getDiskFormat(ctx, source)
+	if err != nil {
+		errStr := fmt.Sprintf("failed to get disk format of disk %s: %v", source, err)
+		return errors.New(errStr)
+	}
+
+	if existingFormat == "" {
+		// Disk is unformatted so format it.
+		// -E nodiscard skips the full-device SCSI UNMAP/TRIM that mkfs.ext4/mkfs.ext3
+		// issue by default. On a freshly provisioned, empty volume there is nothing to
+		// reclaim, but vSphere's CBT engine treats that discard as a write and marks the
+		// entire disk as changed, which defeats GetMetadataAllocated/GetMetadataDelta.
+		args := []string{"-F", "-E", "nodiscard", source}
+
+		log.Infof("extFormatAndMount: Disk %q appears to be unformatted, attempting to format as type: %q "+
+			"with options: %v", source, fstype, args)
+		output, err := osUtils.Mounter.Exec.Command("mkfs."+fstype, args...).CombinedOutput()
+		if err != nil {
+			detailedErr := fmt.Sprintf("format of disk %q failed: type:(%q) errcode:(%v) output:(%v)",
+				source, fstype, err, string(output))
+			log.Errorf(detailedErr)
+			return errors.New(detailedErr)
+		}
+
+		log.Infof("extFormatAndMount: Disk successfully formatted (mkfs): %s - %s %s", fstype, source, target)
+	}
+
+	// Mount the disk
+	log.Infof("extFormatAndMount: Attempting to mount disk %s in %s format at %s", source, fstype, target)
+	err = osUtils.Mounter.Mount(source, target, fstype, opts)
+	if err != nil {
+		log.Errorf("extFormatAndMount: mount of disk %s failed: type:(%q) target:(%q) errcode:(%v)",
 			source, fstype, target, err)
 		return errors.New(err.Error())
 	}
@@ -281,19 +329,30 @@ func (osUtils *OsUtils) NodeStageBlockVolume(
 		// Format and mount the device.
 		log.Debugf("nodeStageBlockVolume: Format and mount the device %q at %q with mount flags %v",
 			dev.FullPath, params.StagingTarget, params.MntFlags)
-		if params.FsType == "xfs" {
+		switch params.FsType {
+		case "xfs":
 			// use internal function for XFS mount, as we want to provide few parameters for mkfs command
 			// which are specific to XFS filesystem
-			err := osUtils.xfsFormatAndMount(ctx, dev.FullPath, params.StagingTarget, params.FsType, params.MntFlags...)
+			err := osUtils.xfsFormatAndMount(ctx, dev.FullPath, params.StagingTarget, params.FsType,
+				params.MntFlags...)
 			if err != nil {
 				return nil, logger.LogNewErrorCodef(log, codes.Internal,
-					"error in formating and mounting volume. Parameters: %v err: %v", params, err)
+					"error in formatting and mounting volume. Parameters: %v err: %v", params, err)
 			}
-		} else {
+		case common.Ext4FsType, common.Ext3FsType:
+			// use internal function for ext4/ext3 mount, as we want to provide few parameters
+			// for mkfs command which are specific to the ext filesystem family
+			err := osUtils.extFormatAndMount(ctx, dev.FullPath, params.StagingTarget, params.FsType,
+				params.MntFlags...)
+			if err != nil {
+				return nil, logger.LogNewErrorCodef(log, codes.Internal,
+					"error in formatting and mounting volume. Parameters: %v err: %v", params, err)
+			}
+		default:
 			err := gofsutil.FormatAndMount(ctx, dev.FullPath, params.StagingTarget, params.FsType, params.MntFlags...)
 			if err != nil {
 				return nil, logger.LogNewErrorCodef(log, codes.Internal,
-					"error in formating and mounting volume. Parameters: %v err: %v", params, err)
+					"error in formatting and mounting volume. Parameters: %v err: %v", params, err)
 			}
 		}
 	} else {

--- a/pkg/csi/service/osutils/linux_os_utils_test.go
+++ b/pkg/csi/service/osutils/linux_os_utils_test.go
@@ -5,9 +5,304 @@ package osutils
 
 import (
 	"context"
+	"errors"
+	"slices"
 	"strconv"
 	"testing"
+
+	"k8s.io/mount-utils"
+	utilexec "k8s.io/utils/exec"
+	testingexec "k8s.io/utils/exec/testing"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 )
+
+// erroringMounter wraps a *mount.FakeMounter but fails Mount() with mountErr, when set.
+type erroringMounter struct {
+	*mount.FakeMounter
+	mountErr error
+}
+
+func (m *erroringMounter) Mount(source, target, fstype string, options []string) error {
+	if m.mountErr != nil {
+		return m.mountErr
+	}
+	return m.FakeMounter.Mount(source, target, fstype, options)
+}
+
+// fakeMkfsFailure returns a mkfs.<fstype> invocation that fails.
+func fakeMkfsFailure(err error) testingexec.FakeCommandAction {
+	return func(cmd string, args ...string) utilexec.Cmd {
+		return &testingexec.FakeCmd{
+			CombinedOutputScript: []testingexec.FakeAction{
+				func() ([]byte, []byte, error) { return []byte("mkfs failed"), nil, err },
+			},
+		}
+	}
+}
+
+// newFakeOsUtils builds an OsUtils backed by a fake mount.Interface and a fake
+// exec.Interface. blkidOutput/blkidErr control what getDiskFormat observes for the
+// "is the disk already formatted" check; mkfsAction (if non-nil) is invoked for the
+// subsequent mkfs.<fstype> call and can be used to capture/assert on its argv.
+func newFakeOsUtils(blkidOutput string, blkidErr error, mkfsAction testingexec.FakeCommandAction) *OsUtils {
+	commandScript := []testingexec.FakeCommandAction{
+		func(cmd string, args ...string) utilexec.Cmd {
+			return &testingexec.FakeCmd{
+				CombinedOutputScript: []testingexec.FakeAction{
+					func() ([]byte, []byte, error) { return []byte(blkidOutput), nil, blkidErr },
+				},
+			}
+		},
+	}
+	if mkfsAction != nil {
+		commandScript = append(commandScript, mkfsAction)
+	}
+	return &OsUtils{
+		Mounter: &mount.SafeFormatAndMount{
+			Interface: mount.NewFakeMounter(nil),
+			Exec:      &testingexec.FakeExec{CommandScript: commandScript},
+		},
+	}
+}
+
+// fakeMkfsSuccess records the argv it was invoked with into *argsOut and returns success.
+func fakeMkfsSuccess(argsOut *[]string) testingexec.FakeCommandAction {
+	return func(cmd string, args ...string) utilexec.Cmd {
+		*argsOut = args
+		return &testingexec.FakeCmd{
+			CombinedOutputScript: []testingexec.FakeAction{
+				func() ([]byte, []byte, error) { return []byte(""), nil, nil },
+			},
+		}
+	}
+}
+
+func TestXfsFormatAndMount(t *testing.T) {
+	var mkfsArgs []string
+	osUtils := newFakeOsUtils("", testingexec.FakeExitError{Status: 2}, fakeMkfsSuccess(&mkfsArgs))
+
+	err := osUtils.xfsFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", "xfs")
+	if err != nil {
+		t.Fatalf("xfsFormatAndMount returned unexpected error: %v", err)
+	}
+
+	if !slices.Contains(mkfsArgs, "-K") {
+		t.Errorf("expected -K in mkfs.xfs args, got %v", mkfsArgs)
+	}
+}
+
+func TestXfsFormatAndMount_SkipsMkfsWhenAlreadyFormatted(t *testing.T) {
+	mkfsCalled := false
+	osUtils := newFakeOsUtils("TYPE=xfs\n", nil, func(cmd string, args ...string) utilexec.Cmd {
+		mkfsCalled = true
+		return &testingexec.FakeCmd{
+			CombinedOutputScript: []testingexec.FakeAction{
+				func() ([]byte, []byte, error) { return []byte(""), nil, nil },
+			},
+		}
+	})
+
+	err := osUtils.xfsFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", "xfs")
+	if err != nil {
+		t.Fatalf("xfsFormatAndMount returned unexpected error: %v", err)
+	}
+	if mkfsCalled {
+		t.Error("expected mkfs.xfs not to be invoked for an already-formatted disk")
+	}
+}
+
+func TestExtFormatAndMount(t *testing.T) {
+	for _, fstype := range []string{common.Ext4FsType, common.Ext3FsType} {
+		t.Run(fstype, func(t *testing.T) {
+			var mkfsArgs []string
+			osUtils := newFakeOsUtils("", testingexec.FakeExitError{Status: 2}, fakeMkfsSuccess(&mkfsArgs))
+
+			err := osUtils.extFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", fstype)
+			if err != nil {
+				t.Fatalf("extFormatAndMount returned unexpected error: %v", err)
+			}
+
+			want := []string{"-F", "-E", "nodiscard", "/dev/fake"}
+			if !slices.Equal(mkfsArgs, want) {
+				t.Errorf("expected mkfs.%s args %v, got %v", fstype, want, mkfsArgs)
+			}
+		})
+	}
+}
+
+func TestExtFormatAndMount_SkipsMkfsWhenAlreadyFormatted(t *testing.T) {
+	mkfsCalled := false
+	osUtils := newFakeOsUtils("TYPE=ext4\n", nil, func(cmd string, args ...string) utilexec.Cmd {
+		mkfsCalled = true
+		return &testingexec.FakeCmd{
+			CombinedOutputScript: []testingexec.FakeAction{
+				func() ([]byte, []byte, error) { return []byte(""), nil, nil },
+			},
+		}
+	})
+
+	err := osUtils.extFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", common.Ext4FsType)
+	if err != nil {
+		t.Fatalf("extFormatAndMount returned unexpected error: %v", err)
+	}
+	if mkfsCalled {
+		t.Error("expected mkfs.ext4 not to be invoked for an already-formatted disk")
+	}
+}
+
+func TestGetDiskFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		blkidOutput string
+		blkidErr    error
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:     "unformatted disk (blkid exit code 2)",
+			blkidErr: testingexec.FakeExitError{Status: 2},
+			want:     "",
+		},
+		{
+			name:        "already formatted disk",
+			blkidOutput: "TYPE=ext4\n",
+			want:        "ext4",
+		},
+		{
+			name:        "disk with a partition table",
+			blkidOutput: "PTTYPE=gpt\n",
+			want:        "unknown data, probably partitions",
+		},
+		{
+			name:        "TYPE and PTTYPE both present: partition table wins",
+			blkidOutput: "TYPE=ext4\nPTTYPE=gpt\n",
+			want:        "unknown data, probably partitions",
+		},
+		{
+			name:     "blkid fails for a reason other than exit code 2",
+			blkidErr: errors.New("blkid: command not found"),
+			wantErr:  true,
+		},
+		{
+			name:        "blkid returns malformed output",
+			blkidOutput: "not-a-key-value-line\n",
+			wantErr:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			osUtils := newFakeOsUtils(test.blkidOutput, test.blkidErr, nil)
+
+			got, err := osUtils.getDiskFormat(context.Background(), "/dev/fake")
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("getDiskFormat returned unexpected error: %v", err)
+			}
+			if got != test.want {
+				t.Errorf("expected fstype %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func TestXfsFormatAndMount_Errors(t *testing.T) {
+	t.Run("getDiskFormat failure is propagated", func(t *testing.T) {
+		osUtils := newFakeOsUtils("", errors.New("blkid: command not found"), nil)
+
+		err := osUtils.xfsFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", "xfs")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("mkfs failure is propagated", func(t *testing.T) {
+		osUtils := newFakeOsUtils("", testingexec.FakeExitError{Status: 2},
+			fakeMkfsFailure(errors.New("mkfs.xfs: exit status 1")))
+
+		err := osUtils.xfsFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", "xfs")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("mount failure is propagated", func(t *testing.T) {
+		var mkfsArgs []string
+		commandScript := []testingexec.FakeCommandAction{
+			func(cmd string, args ...string) utilexec.Cmd {
+				return &testingexec.FakeCmd{
+					CombinedOutputScript: []testingexec.FakeAction{
+						func() ([]byte, []byte, error) { return []byte(""), nil, testingexec.FakeExitError{Status: 2} },
+					},
+				}
+			},
+			fakeMkfsSuccess(&mkfsArgs),
+		}
+		osUtils := &OsUtils{
+			Mounter: &mount.SafeFormatAndMount{
+				Interface: &erroringMounter{FakeMounter: mount.NewFakeMounter(nil), mountErr: errors.New("mount failed")},
+				Exec:      &testingexec.FakeExec{CommandScript: commandScript},
+			},
+		}
+
+		err := osUtils.xfsFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", "xfs")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+}
+
+func TestExtFormatAndMount_Errors(t *testing.T) {
+	t.Run("getDiskFormat failure is propagated", func(t *testing.T) {
+		osUtils := newFakeOsUtils("", errors.New("blkid: command not found"), nil)
+
+		err := osUtils.extFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", common.Ext4FsType)
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("mkfs failure is propagated", func(t *testing.T) {
+		osUtils := newFakeOsUtils("", testingexec.FakeExitError{Status: 2},
+			fakeMkfsFailure(errors.New("mkfs.ext4: exit status 1")))
+
+		err := osUtils.extFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", common.Ext4FsType)
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("mount failure is propagated", func(t *testing.T) {
+		var mkfsArgs []string
+		commandScript := []testingexec.FakeCommandAction{
+			func(cmd string, args ...string) utilexec.Cmd {
+				return &testingexec.FakeCmd{
+					CombinedOutputScript: []testingexec.FakeAction{
+						func() ([]byte, []byte, error) { return []byte(""), nil, testingexec.FakeExitError{Status: 2} },
+					},
+				}
+			},
+			fakeMkfsSuccess(&mkfsArgs),
+		}
+		osUtils := &OsUtils{
+			Mounter: &mount.SafeFormatAndMount{
+				Interface: &erroringMounter{FakeMounter: mount.NewFakeMounter(nil), mountErr: errors.New("mount failed")},
+				Exec:      &testingexec.FakeExec{CommandScript: commandScript},
+			},
+		}
+
+		err := osUtils.extFormatAndMount(context.Background(), "/dev/fake", "/mnt/fake", common.Ext4FsType)
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+}
 
 func TestUnescape(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
When using vSphere CSI with `volumeMode: Filesystem` PVCs (ext4 or xfs), the `GetMetadataAllocated` API call returns the full size of the disk as "allocated", instead of only the blocks with data.
When Kubernetes mounts a new Filesystem PVC, the Kubelet instructs the CSI driver to format the raw disk using `mkfs.ext4` or `mkfs.xfs`. Modern `mkfs` implementations default to issuing a massive `discard` (SCSI UNMAP/TRIM) command across the *entire* block device to optimize thin-provisioned storage. The underlying vSphere CBT engine interprets these `discard` operations as disk writes. Thus, vSphere marks the entire disk as modified, causing `GetMetadataAllocated` to return 100% block allocation.
This PR adds explicitly flags to disable the massive initial `discard` operationd during mkfs operation as below
- For `ext4`, use `-E nodiscard`.
- For `xfs`, use `-K`.

NOTE: These flags just skip the upfront or format time full-device BLKDISCARD/UNMAP. The discard mount option and periodic fstrim (if configured) still work normally afterward, so live space reclamation as files are deleted isn't touched at all. Usually mkfs gets triggered when new volume gets attached and mounted to any node, when most of the underlying disk is empty/unallocated. Even in case of static volume provisioning, i.e. attaching existing disks (with some allocated data present), next attach with mkfs having these flags will skip the space reclaimation at the start/format time, but get individually trimmed/reclaimed the first time it gets accessed/touched. Hence, it is safe to pass these flags for all filesystem mode PVC.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* WCP precheckin passed: https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1911/
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```
* VKS precheckin passed: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1455/
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```
* Verified fix on setup where the issue was seen previously and GetMetadataAllocated() did return only actual allocated blocks.
detailed testlog with fix: [test_8bf0-1.log](https://github.com/user-attachments/files/31207650/test_8bf0-1.log)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Pass argument to mkfs to avoid unmap operation at the startup, to avoid writes to disks that return incorrect CBT metadata
```
