### PR TITLE
Rename supervisor CBT service name

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -114,14 +114,6 @@ const snapshotMetadataServiceCRName = csitypes.Name
 // --service-account-max-token-expiration.
 const snapshotMetadataTokenExpirationSeconds int64 = 3600
 
-// snapMetadataSrvName is the canonical in-cluster DNS name
-// used as the TLS ServerName when dialing the Supervisor Snapshot Metadata
-// Service. Supplying an explicit DNS name (rather than deriving it from the
-// dial address, which is a LoadBalancer IP) means the service certificate
-// only needs DNS SANs — no IP SAN is required, so the cert stays valid
-// regardless of which LoadBalancer IP is allocated.
-const snapMetadataSrvName = "vmware-system-csi-snapshot-metadata-service.vmware-system-csi.svc.cluster.local"
-
 // dialSnapshotMetadata builds the gRPC client connection to the Supervisor
 // Snapshot Metadata Service. It is intentionally a package-level function
 // variable so unit tests can override it to dial an in-process mock with
@@ -2711,7 +2703,7 @@ func (c *controller) getSnapshotMetadataClient(
 			return nil, nil, "", fmt.Errorf("failed to append caCert to pool after base64 decode")
 		}
 	}
-	transportCreds := credentials.NewClientTLSFromCert(certPool, snapMetadataSrvName)
+	transportCreds := credentials.NewClientTLSFromCert(certPool, "")
 
 	// Mint a fresh audience-bound token via TokenRequest on every call.
 	// We pass the bootstrap pvcsi-provider bearer token (loaded by

--- a/pkg/csi/service/wcpguest/controller_cbt_test.go
+++ b/pkg/csi/service/wcpguest/controller_cbt_test.go
@@ -348,10 +348,7 @@ func testLocalhostTLSCert(t *testing.T) (caPEM []byte, serverCert tls.Certificat
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
-		// Include the production TLS ServerName so tests that use the real TLS
-		// dial path (withProductionTLSDialForSubtest) pass the same DNS-SAN
-		// check that production clients perform.
-		DNSNames: []string{"localhost", snapMetadataSrvName},
+		DNSNames:     []string{"localhost"},
 	}
 	servDER, err := x509.CreateCertificate(rand.Reader, servTmpl, caTmpl, &servKey.PublicKey, caKey)
 	require.NoError(t, err)

--- a/pkg/syncer/dpoperator/controller/snapshotmetadataservice/snapshotmetadataservice_controller.go
+++ b/pkg/syncer/dpoperator/controller/snapshotmetadataservice/snapshotmetadataservice_controller.go
@@ -60,7 +60,7 @@ const (
 	// self-signed serving certificate for the Snapshot Metadata gRPC endpoint.
 	// In the self-signed single-CA model, the Secret's ca.crt IS this served
 	// certificate, so the certificate must itself carry the LB IP in its IP SANs.
-	targetCertificateName = "vmware-system-csi-snapshot-metadata-service-cert"
+	targetCertificateName = "csi-snapshot-metadata-service-cert"
 
 	// targetSMSName is the (cluster-scoped) SnapshotMetadataService CR that
 	// this controller owns. It is the primary reconciled object: the controller
@@ -75,7 +75,7 @@ const (
 	// Metadata gRPC port. Its external ingress IP is the address advertised in
 	// the SnapshotMetadataService CR and the IP that must appear in the served
 	// certificate's IP SANs.
-	targetServiceName = "vmware-system-csi-snapshot-metadata-service"
+	targetServiceName = "csi-snapshot-metadata-service"
 )
 
 // backOffDuration is a map of SnapshotMetadataService CR name's to the time

--- a/pkg/syncer/dpoperator/controller/snapshotmetadataservice/snapshotmetadataservice_controller_test.go
+++ b/pkg/syncer/dpoperator/controller/snapshotmetadataservice/snapshotmetadataservice_controller_test.go
@@ -161,7 +161,7 @@ func generateSelfSignedCertPEM(t *testing.T, ips ...net.IP) []byte {
 
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "vsphere-csi-snapshot-metadata-service"},
+		Subject:      pkix.Name{CommonName: "csi-snapshot-metadata-service"},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
 		IPAddresses:  ips,

--- a/pkg/syncer/dpoperator/controller/snapshotmetadataservicegc/snapshotmetadataservicegc_controller_test.go
+++ b/pkg/syncer/dpoperator/controller/snapshotmetadataservicegc/snapshotmetadataservicegc_controller_test.go
@@ -64,7 +64,7 @@ func makeSMSCR(caCert []byte) *snapshotmetadatav1beta1.SnapshotMetadataService {
 		ObjectMeta: metav1.ObjectMeta{Name: targetSMSName},
 		Spec: snapshotmetadatav1beta1.SnapshotMetadataServiceSpec{
 			CACert:   caCert,
-			Address:  "vmware-system-csi-snapshot-metadata-service.vmware-system-csi.svc.cluster.local:8100",
+			Address:  "csi-snapshot-metadata-service.vmware-system-csi.svc.cluster.local:8100",
 			Audience: "csi.vsphere.vmware.com",
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses earlier review comment https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/4179#issuecomment-5059935330
Also removed change (added in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/4071) to use supervisor CBT service DNSname for cert verification in pvCSI as supervisor CBT server cert now trusts LB IP associated, does not need DNSname for verification specifically.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* Setup deployment passed - https://jenkins-vcf-tkgservice.devops.broadcom.net/job/create-testbed/34189/
*VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1450/
```
Ran 6 of 2361 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2355 Skipped | 0 Flaked
```
*WCP precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1902/
```
Ran 15 of 2361 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2346 Skipped | 0 Flaked
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Rename supervisor CBT service name
```
