### PR TITLE
Fix ':=' shadowing bug that discards FULL_SYNC_WAIT_TIME in e2e/csi_static_provisioning_basic.go:132

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -129,7 +129,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		}
 
 		if os.Getenv(envFullSyncWaitTime) != "" {
-			fullSyncWaitTime, err := strconv.Atoi(os.Getenv(envFullSyncWaitTime))
+			fullSyncWaitTime, err = strconv.Atoi(os.Getenv(envFullSyncWaitTime))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if fullSyncWaitTime <= 0 || fullSyncWaitTime > defaultFullSyncWaitTime {
 				framework.Failf("The FullSync Wait time %v is not set correctly", fullSyncWaitTime)


### PR DESCRIPTION
tests/e2e/csi_static_provisioning_basic.go:132 used ':=' inside an if-block to parse FULL_SYNC_WAIT_TIME, which declares a new fullSyncWaitTime scoped to that block instead of assigning the Describe-scoped variable declared at line 80. Go's short-variable-declaration redeclaration rule only looks at the current block, and an if-statement's braces are their own block, so neither fullSyncWaitTime nor err qualified for reuse there.

The outer fullSyncWaitTime is read later by "Verify static provisioning workflow using same PV name twice" (line 569) to sleep before checking that full-sync has cleared the pv_missing label on a reappeared PV. Whenever FULL_SYNC_WAIT_TIME is set, the parsed value never reaches that variable, so the sleep is always 0 seconds and the spec fails the pv_missing assertion before a real full-sync cycle can run. The bug is invisible when FULL_SYNC_WAIT_TIME is unset, since the else branch assigns the default correctly.

tests/e2e/fullsync_pv_missing.go already has the correct '=' pattern for the same variable and env var.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixes a failing e2e test

**Which issue this PR fixes** 
fixes #4226 

**Testing done**:
Targeted e2e test of effected test

**Special notes for your reviewer**:

**Release note**:
```release-note
```
