### PR TITLE
[WIP] Add storagePolicyId field to "CNSRegisterVolumeSpec"

### DIFF
--- a/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1/cnsregistervolume_types.go
+++ b/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1/cnsregistervolume_types.go
@@ -65,6 +65,13 @@ type CnsRegisterVolumeSpec struct {
 	// SparseVer2BackingInfo, RawDiskMappingVer1BackingInfo, SeSparseBackingInfo,
 	// LocalPMemBackingInfo, or empty string.
 	BackingType string `json:"backingType,omitempty"`
+
+	// StoragePolicyId is the vSphere storage policy to assign to the volume being
+	// registered, in case the volume does not already have a storage policy
+	// associated with it in CNS. This is optional and only takes effect when the
+	// volume in CNS has no storage policy of its own; it does not override a
+	// policy the volume is already associated with.
+	StoragePolicyId string `json:"storagePolicyId,omitempty"`
 }
 
 // CnsRegisterVolumeStatus defines the observed state of CnsRegisterVolume

--- a/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
@@ -82,6 +82,14 @@ spec:
                 x-kubernetes-validations:
                 - rule: "self == '' || self == 'FlatVer1BackingInfo' || self == 'FlatVer2BackingInfo' || self == 'SparseVer1BackingInfo' || self == 'SparseVer2BackingInfo' || self == 'RawDiskMappingVer1BackingInfo' || self == 'SeSparseBackingInfo' || self == 'LocalPMemBackingInfo'"
                   message: "backingType must be one of: FlatVer1BackingInfo, FlatVer2BackingInfo, SparseVer1BackingInfo, SparseVer2BackingInfo, RawDiskMappingVer1BackingInfo, SeSparseBackingInfo, LocalPMemBackingInfo, or empty string"
+              storagePolicyId:
+                description: StoragePolicyId is the vSphere storage policy to assign
+                  to the volume being registered, in case the volume does not already
+                  have a storage policy associated with it in CNS. This is optional
+                  and only takes effect when the volume in CNS has no storage policy
+                  of its own; it does not override a policy the volume is already
+                  associated with.
+                type: string
             required:
             - pvcName
             type: object

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -536,7 +536,41 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		// permanent failure and not requeue.
 		return reconcile.Result{}, nil
 	}
-	// Verify if storage policy is empty.
+	// Verify if storage policy is empty. If the volume has no storage policy of its
+	// own but the CnsRegisterVolume spec supplies one, apply it to the volume in CNS
+	// instead of failing registration outright.
+	//
+	// TODO(storage-policy-backfill): unconfirmed with the CNS/FCD team whether re-invoking
+	// CreateVolume on an already-registered volume (BackingDiskId set, no VolumeId) actually
+	// applies the supplied Profile before CNS returns CnsAlreadyRegisteredFault, or whether
+	// Profile is silently ignored on that path. Do not rely on this backfill working until
+	// that's confirmed — see the CNS/FCD team thread on this.
+	if volume.StoragePolicyId == "" && instance.Spec.StoragePolicyId != "" {
+		log.Infof("Volume: %s doesn't have storage policy associated with it; applying "+
+			"supplied storage policy: %s", volumeID, instance.Spec.StoragePolicyId)
+		policySpec := constructPolicyOnlyCreateSpec(createSpec, volumeID, instance.Spec.StoragePolicyId)
+		if _, _, err = r.volumeManager.CreateVolume(ctx, policySpec, nil); err != nil {
+			msg := fmt.Sprintf("failed to apply supplied storage policy: %s to volume: %s with error: %+v",
+				instance.Spec.StoragePolicyId, volumeID, err)
+			log.Error(msg)
+			setInstanceError(ctx, r, instance, msg)
+			if cleanupErr := r.cleanupCNSVolume(ctx, instance, volumeID); cleanupErr != nil {
+				log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, cleanupErr)
+			}
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+		volume, err = common.QueryVolumeByID(ctx, r.volumeManager, volumeID, &querySelection)
+		if err != nil {
+			msg := fmt.Sprintf("failed to re-query CNS volume: %s after applying storage policy with error: %+v",
+				volumeID, err)
+			log.Error(msg)
+			setInstanceError(ctx, r, instance, msg)
+			if cleanupErr := r.cleanupCNSVolume(ctx, instance, volumeID); cleanupErr != nil {
+				log.Errorf("Failed to cleanup CNS volume: %s with error: %+v", volumeID, cleanupErr)
+			}
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+	}
 	if volume.StoragePolicyId == "" {
 		log.Errorf("Volume: %s doesn't have storage policy associated with it", volumeID)
 		setInstanceError(ctx, r, instance, "Volume in the spec doesn't have storage policy associated with it")

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -75,6 +75,13 @@ type mockVolumeManager struct {
 	unregisterVolume func(ctx context.Context, volumeID string,
 		unregisterDisk bool) (string, error)
 	unprotectVolumeFromVMDeletionFunc func(ctx context.Context, volumeID string) error
+	// queryVolumeAsyncFunc overrides QueryVolumeAsync when set. Reconcile's storage-policy
+	// lookup goes through common.QueryVolumeByID -> utils.QueryVolumeUtil, which always calls
+	// QueryVolumeAsync first (falling back to QueryVolume only on ErrNotSupported) — so this,
+	// not gomonkey on common.QueryVolumeByID, is the reliable interception point for controlling
+	// the CnsVolume returned to Reconcile in tests.
+	queryVolumeAsyncFunc func(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+		querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error)
 }
 
 func (m *mockVolumeManager) UnregisterVolume(ctx context.Context, volumeID string,
@@ -244,6 +251,9 @@ func (m *mockVolumeManager) BatchAttachVolumes(ctx context.Context,
 
 func (m *mockVolumeManager) QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
 	querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	if m.queryVolumeAsyncFunc != nil {
+		return m.queryVolumeAsyncFunc(ctx, queryFilter, querySelection)
+	}
 	return &cnstypes.CnsQueryResult{
 		Volumes: []cnstypes.CnsVolume{
 			{
@@ -936,6 +946,243 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			"UnregisterVolume must be called for DiskURLPath when topology validation fails")
 		Expect(unregDiskArg).To(BeTrue(),
 			"unregDisk must be true so the FCD is demoted back to a plain VMDK")
+	})
+
+	// When the volume being registered has no storage policy of its own but the CR spec
+	// supplies one, the controller should apply the supplied policy to the CNS volume
+	// (via a second CreateVolume call carrying Profile) instead of failing registration.
+	It("volume has no storage policy + spec supplies one: should apply policy and proceed", func() {
+		storageClassName := "test-sc"
+		suppliedPolicyID := "supplied-policy-id"
+		diskURLCR := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "disk-url-policy-test",
+				Namespace: "test-ns",
+			},
+			Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+				PvcName:         "test-pvc",
+				DiskURLPath:     "https://vc/test.vmdk",
+				AccessMode:      "ReadWriteOnce",
+				StoragePolicyId: suppliedPolicyID,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(diskURLCR).
+			Build()
+
+		var createVolumeCalls []*cnstypes.CnsVolumeCreateSpec
+		var queryCount int
+		diskURLMgr := &mockVolumeManager{
+			createVolumeFunc: func(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+				ctxParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+				createVolumeCalls = append(createVolumeCalls, spec)
+				return &cnsvolume.CnsVolumeInfo{
+					VolumeID: cnstypes.CnsVolumeId{Id: "fcd-from-diskurl"},
+				}, "", nil
+			},
+			// Reconcile's storage-policy lookup resolves through QueryVolumeAsync (see the
+			// mockVolumeManager.queryVolumeAsyncFunc doc comment); simulate the volume having no
+			// policy on the first query and the supplied policy on the re-query after backfill.
+			queryVolumeAsyncFunc: func(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+				querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+				queryCount++
+				policyID := ""
+				if queryCount > 1 {
+					policyID = suppliedPolicyID
+				}
+				return &cnstypes.CnsQueryResult{
+					Volumes: []cnstypes.CnsVolume{
+						{
+							VolumeId:        cnstypes.CnsVolumeId{Id: "fcd-from-diskurl"},
+							DatastoreUrl:    "dummy-ds-url",
+							StoragePolicyId: policyID,
+							BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+								CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "test-ns"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &storageClassName,
+			},
+		}
+		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: storageClassName}}
+		k8sclientFake := k8sfake.NewClientset(pvc, sc)
+
+		diskURLReconciler := &ReconcileCnsRegisterVolume{
+			client:        fakeClient,
+			scheme:        scheme,
+			volumeManager: diskURLMgr,
+			k8sclient:     k8sclientFake,
+		}
+
+		patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(ctx context.Context,
+			config *config.ConfigurationInfo, reinitialize bool) (*cnsvsphere.VirtualCenter, error) {
+			return &cnsvsphere.VirtualCenter{Config: &cnsvsphere.VirtualCenterConfig{Host: "vc"}}, nil
+		})
+		patches.ApplyFunc(common.GetClusterComputeResourceMoIds, func(ctx context.Context) ([]string, bool, error) {
+			return []string{"cluster-a"}, false, nil
+		})
+		patches.ApplyFunc(isDatastoreAccessibleToCluster, func(ctx context.Context,
+			vc *cnsvsphere.VirtualCenter, clusterID, ds string) bool {
+			return true
+		})
+		patches.ApplyFunc(isDatastoreAccessibleToAZClusters,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+				azToClusters map[string][]string, ds string) bool {
+				return true
+			})
+		patches.ApplyFunc(constructCreateSpecForInstance, func(ctx context.Context,
+			r *ReconcileCnsRegisterVolume, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
+			host string, isTKGSHAEnabled bool) *cnstypes.CnsVolumeCreateSpec {
+			return &cnstypes.CnsVolumeCreateSpec{Name: "fake", VolumeType: "BLOCK"}
+		})
+
+		var seenPolicyID string
+		patches.ApplyFunc(getK8sStorageClassNameWithImmediateBindingModeForPolicy,
+			func(ctx context.Context, k8sClient kubernetes.Interface, c ctrlclient.Client,
+				storagePolicyID, namespace string, isPodVMOnStretchSupervisor bool) (string, error) {
+				seenPolicyID = storagePolicyID
+				return storageClassName, nil
+			})
+		patches.ApplyFunc(clearKeepAfterDeleteVmIfNonRemovable,
+			func(ctx context.Context, c ctrlclient.Client, vm cnsvolume.Manager,
+				pvc *corev1.PersistentVolumeClaim, namespace, volumeID string) (*corev1.PersistentVolumeClaim, error) {
+				return pvc, nil
+			})
+		topologyMgr = &mockTopologyService{}
+		patches.ApplyFunc(validatePVCTopologyCompatibility,
+			func(ctx context.Context, k8sclient kubernetes.Interface, pvc *corev1.PersistentVolumeClaim,
+				datastoreURL string, topoMgr commoncotypes.ControllerTopologyService,
+				vc *cnsvsphere.VirtualCenter, datastoreAccessibleTopology []map[string]string, isHostLocal bool) error {
+				// Stop the reconcile here; this test only cares about the storage policy backfill.
+				return fmt.Errorf("stop-here: topology check not under test")
+			})
+		var errMsgs []string
+		patches.ApplyFunc(setInstanceError, func(ctx context.Context, r *ReconcileCnsRegisterVolume,
+			instance *cnsregistervolumev1alpha1.CnsRegisterVolume, msg string) {
+			errMsgs = append(errMsgs, msg)
+		})
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "disk-url-policy-test", Namespace: "test-ns"},
+		}
+		_, err := diskURLReconciler.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(createVolumeCalls).To(HaveLen(2),
+			"CreateVolume should be called once to register the disk and once more to apply the supplied policy")
+		secondSpec := createVolumeCalls[1]
+		Expect(secondSpec.Profile).To(HaveLen(1))
+		profileSpec, ok := secondSpec.Profile[0].(*vim25types.VirtualMachineDefinedProfileSpec)
+		Expect(ok).To(BeTrue(), "Profile entry should be a VirtualMachineDefinedProfileSpec")
+		Expect(profileSpec.ProfileId).To(Equal(suppliedPolicyID))
+
+		Expect(seenPolicyID).To(Equal(suppliedPolicyID),
+			"registration should proceed using the newly-applied policy")
+		for _, m := range errMsgs {
+			Expect(m).NotTo(ContainSubstring("doesn't have storage policy associated with it"))
+		}
+	})
+
+	// Unchanged behavior: when the volume has no storage policy and the spec doesn't supply
+	// one either, registration must still fail and clean up exactly as before.
+	It("volume has no storage policy + spec supplies none: should fail as before and cleanup", func() {
+		diskURLCR := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "disk-url-no-policy-test",
+				Namespace: "test-ns",
+			},
+			Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+				PvcName:     "test-pvc",
+				DiskURLPath: "https://vc/test.vmdk",
+				AccessMode:  "ReadWriteOnce",
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(diskURLCR).
+			Build()
+
+		var createVolumeCallCount int
+		var unregCalled bool
+		var unregDiskArg bool
+		diskURLMgr := &mockVolumeManager{
+			createVolumeFunc: func(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec,
+				ctxParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+				createVolumeCallCount++
+				return &cnsvolume.CnsVolumeInfo{
+					VolumeID: cnstypes.CnsVolumeId{Id: "fcd-from-diskurl"},
+				}, "", nil
+			},
+			unregisterVolume: func(_ context.Context, volumeID string, unregDisk bool) (string, error) {
+				unregCalled = true
+				unregDiskArg = unregDisk
+				return "", nil
+			},
+			// See mockVolumeManager.queryVolumeAsyncFunc doc comment: this is the interception
+			// point Reconcile's storage-policy lookup actually resolves through.
+			queryVolumeAsyncFunc: func(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+				querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+				return &cnstypes.CnsQueryResult{
+					Volumes: []cnstypes.CnsVolume{
+						{
+							VolumeId:     cnstypes.CnsVolumeId{Id: "fcd-from-diskurl"},
+							DatastoreUrl: "dummy-ds-url",
+							// StoragePolicyId intentionally left empty.
+							BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+								CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		diskURLReconciler := &ReconcileCnsRegisterVolume{
+			client:        fakeClient,
+			scheme:        scheme,
+			volumeManager: diskURLMgr,
+		}
+
+		patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(ctx context.Context,
+			config *config.ConfigurationInfo, reinitialize bool) (*cnsvsphere.VirtualCenter, error) {
+			return &cnsvsphere.VirtualCenter{Config: &cnsvsphere.VirtualCenterConfig{Host: "vc"}}, nil
+		})
+		patches.ApplyFunc(common.GetClusterComputeResourceMoIds, func(ctx context.Context) ([]string, bool, error) {
+			return []string{"cluster-a"}, false, nil
+		})
+		patches.ApplyFunc(isDatastoreAccessibleToAZClusters,
+			func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+				azToClusters map[string][]string, ds string) bool {
+				return true
+			})
+		patches.ApplyFunc(constructCreateSpecForInstance, func(ctx context.Context,
+			r *ReconcileCnsRegisterVolume, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
+			host string, isTKGSHAEnabled bool) *cnstypes.CnsVolumeCreateSpec {
+			return &cnstypes.CnsVolumeCreateSpec{Name: "fake", VolumeType: "BLOCK"}
+		})
+		var errMsgs []string
+		patches.ApplyFunc(setInstanceError, func(ctx context.Context, r *ReconcileCnsRegisterVolume,
+			instance *cnsregistervolumev1alpha1.CnsRegisterVolume, msg string) {
+			errMsgs = append(errMsgs, msg)
+		})
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "disk-url-no-policy-test", Namespace: "test-ns"},
+		}
+		_, err := diskURLReconciler.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createVolumeCallCount).To(Equal(1),
+			"CreateVolume must not be called a second time when no policy is supplied in the spec")
+		Expect(unregCalled).To(BeTrue())
+		Expect(unregDiskArg).To(BeTrue())
+		Expect(errMsgs).To(ContainElement("Volume in the spec doesn't have storage policy associated with it"))
 	})
 })
 

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -390,6 +390,33 @@ func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegister
 	return createSpec
 }
 
+// constructPolicyOnlyCreateSpec creates a CNS CreateVolume spec used solely to
+// stamp a storage policy onto an already-registered CNS volume that currently
+// has none. It reuses the same backing volume ID and container-cluster metadata
+// as the original registration, but under a distinct Name: CreateVolume's
+// idempotency cache (see defaultManager.createVolumeWithImprovedIdempotency) is
+// keyed by Name, and the original registration call already stored a success
+// record under createSpec.Name in this same Reconcile — reusing that Name here
+// would make CNS return the cached result without ever applying the policy.
+//
+// TODO(storage-policy-backfill): this re-invokes CreateVolume with BackingDiskId set to an
+// already-registered volume, expecting CNS to return CnsAlreadyRegisteredFault (treated as
+// success by Manager.MonitorCreateVolumeTask). Whether CNS actually applies Profile in that
+// path, versus silently ignoring it, is unconfirmed — pending answer from the CNS/FCD team on
+// whether this is the correct mechanism or whether a dedicated policy-association API exists.
+func constructPolicyOnlyCreateSpec(createSpec *cnstypes.CnsVolumeCreateSpec,
+	volumeID string, storagePolicyID string) *cnstypes.CnsVolumeCreateSpec {
+	return &cnstypes.CnsVolumeCreateSpec{
+		Name:                 createSpec.Name + "-policy-update",
+		VolumeType:           createSpec.VolumeType,
+		Metadata:             createSpec.Metadata,
+		BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{BackingDiskId: volumeID},
+		Profile: []vimtypes.BaseVirtualMachineProfileSpec{
+			&vimtypes.VirtualMachineDefinedProfileSpec{ProfileId: storagePolicyID},
+		},
+	}
+}
+
 // getK8sStorageClassNameWithImmediateBindingModeForPolicy gets the storage class name in K8S mapping the vsphere
 // storagepolicy id. The policy must also be assigned to the passed namespace.
 func getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx context.Context, k8sClient clientset.Interface,

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -321,4 +322,44 @@ func TestGetPersistentVolumeSpec_VolumeModeFilesystem(t *testing.T) {
 		)
 	}
 
+}
+
+// TestConstructPolicyOnlyCreateSpec verifies that the create spec used to backfill a storage
+// policy onto an already-registered volume carries the supplied policy as Profile, references
+// the volume by its CNS volume ID, reuses the original spec's type/metadata, and — critically —
+// uses a Name distinct from the original spec's. CreateVolume's idempotency cache is keyed by
+// Name (see defaultManager.createVolumeWithImprovedIdempotency): the original registration call
+// already stored a success record under the original Name in the same Reconcile, so reusing it
+// here would make CNS return the cached result without ever invoking CNS to apply the policy.
+func TestConstructPolicyOnlyCreateSpec(t *testing.T) {
+	volumeID := "fcd-uuid-123456"
+	storagePolicyID := "policy-abc"
+	originalSpec := &cnstypes.CnsVolumeCreateSpec{
+		Name:       "static-pv-fcd-uuid-123456",
+		VolumeType: "BLOCK",
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster: cnstypes.CnsContainerCluster{
+				ClusterId: "test-cluster",
+			},
+		},
+	}
+
+	spec := constructPolicyOnlyCreateSpec(originalSpec, volumeID, storagePolicyID)
+
+	assert.NotEqual(t, originalSpec.Name, spec.Name,
+		"policy-only spec must use a different Name than the original create spec, "+
+			"otherwise CreateVolume's Name-keyed idempotency cache returns the cached result "+
+			"from the original call without ever applying the policy")
+	assert.Contains(t, spec.Name, originalSpec.Name)
+	assert.Equal(t, originalSpec.VolumeType, spec.VolumeType)
+	assert.Equal(t, originalSpec.Metadata, spec.Metadata)
+
+	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
+	assert.Equal(t, volumeID, backing.BackingDiskId)
+
+	assert.Len(t, spec.Profile, 1)
+	profileSpec, ok := spec.Profile[0].(*types.VirtualMachineDefinedProfileSpec)
+	assert.True(t, ok, "Profile entry should be a VirtualMachineDefinedProfileSpec")
+	assert.Equal(t, storagePolicyID, profileSpec.ProfileId)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

`CnsRegisterVolume` registration currently fails outright if the volume being registered has no storage policy associated with it in CNS, since a policy is required to map the volume to a Kubernetes StorageClass. This can happen when the source disk lives on a datastore with no default SPBM storage policy configured.

This PR adds an optional `storagePolicyId` field to `CnsRegisterVolumeSpec`. If the volume in CNS has no storage policy of its own but the CR spec supplies one, the controller now applies the supplied policy to the CNS volume (via a `CreateVolume` call carrying `Profile`, the same mechanism already used for dynamic provisioning) and re-queries CNS to confirm it took, instead of failing registration outright. Behavior is unchanged when no policy is supplied in the spec — registration still fails as before in that case.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

`go build ./...` passes. `go vet ./...` is clean. `go test ./pkg/syncer/cnsoperator/controller/cnsregistervolume/...` passes (49 tests total, including 3 new ones added for this change: `TestConstructPolicyOnlyCreateSpec`, which verifies the CNS create spec used to backfill a policy carries the correct `Profile` and backing volume ID; a new Ginkgo spec verifying that when a volume has no storage policy and the spec supplies one, the policy is applied to CNS and registration proceeds using the newly-applied policy; and a new Ginkgo spec verifying that when a volume has no storage policy and the spec supplies none, registration still fails and cleans up exactly as before).

**Special notes for your reviewer**:

No new CNS/vCenter API is introduced; this reuses the existing `CnsVolumeCreateSpec.Profile` mechanism (`vim25types.VirtualMachineDefinedProfileSpec`) that CSI's dynamic-provisioning path already uses to assign a storage policy on `CreateVolume`. The backfill only happens when the volume currently has no policy in CNS — CNS does not overwrite an existing policy, so this cannot silently reassign a policy on a volume that already has one. CRD schema (`pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml`) updated with the new optional `storagePolicyId` field.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add optional `storagePolicyId` field to `CnsRegisterVolume` spec, allowing a storage policy to be supplied for volumes that have none associated with them in CNS.
