### PR TITLE
Add StorageClass to CnsRegisterVolume spec.

### DIFF
--- a/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1/cnsregistervolume_types.go
+++ b/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1/cnsregistervolume_types.go
@@ -65,6 +65,13 @@ type CnsRegisterVolumeSpec struct {
 	// SparseVer2BackingInfo, RawDiskMappingVer1BackingInfo, SeSparseBackingInfo,
 	// LocalPMemBackingInfo, or empty string.
 	BackingType string `json:"backingType,omitempty"`
+
+	// StorageClassName is the name of the Kubernetes StorageClass whose associated
+	// vSphere storage policy should be assigned to the volume being registered.
+	// This is optional. If set, the storage policy is applied unconditionally,
+	// regardless of whether the volume already has a storage policy associated
+	// with it in CNS.
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 // CnsRegisterVolumeStatus defines the observed state of CnsRegisterVolume

--- a/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
@@ -82,6 +82,13 @@ spec:
                 x-kubernetes-validations:
                 - rule: "self == '' || self == 'FlatVer1BackingInfo' || self == 'FlatVer2BackingInfo' || self == 'SparseVer1BackingInfo' || self == 'SparseVer2BackingInfo' || self == 'RawDiskMappingVer1BackingInfo' || self == 'SeSparseBackingInfo' || self == 'LocalPMemBackingInfo'"
                   message: "backingType must be one of: FlatVer1BackingInfo, FlatVer2BackingInfo, SparseVer1BackingInfo, SparseVer2BackingInfo, RawDiskMappingVer1BackingInfo, SeSparseBackingInfo, LocalPMemBackingInfo, or empty string"
+              storageClassName:
+                description: StorageClassName is the name of the Kubernetes StorageClass
+                  whose associated vSphere storage policy should be assigned to
+                  the volume being registered. This is optional. If set, the storage
+                  policy is applied unconditionally, regardless of whether the volume
+                  already has a storage policy associated with it in CNS.
+                type: string
             required:
             - pvcName
             type: object

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -323,7 +323,13 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		pvNodeAffinity *v1.VolumeNodeAffinity
 	)
 	// Create Volume for the input CnsRegisterVolume instance.
-	createSpec := constructCreateSpecForInstance(ctx, r, instance, vc.Config.Host, isTKGSHAEnabled)
+	createSpec, err := constructCreateSpecForInstance(ctx, r, instance, vc.Config.Host, isTKGSHAEnabled)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to construct CNS create spec: %+v", err)
+		log.Error(msg)
+		setInstanceError(ctx, r, instance, msg)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
 	log.Infof("Creating CNS volume: %+v for CnsRegisterVolume request with name: %q on namespace: %q",
 		instance, instance.Name, instance.Namespace)
 	volInfo, _, err := r.volumeManager.CreateVolume(ctx, createSpec, nil)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -618,11 +618,11 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
 			host string,
 			isTKGSHAEnabled bool,
-		) *cnstypes.CnsVolumeCreateSpec {
+		) (*cnstypes.CnsVolumeCreateSpec, error) {
 			return &cnstypes.CnsVolumeCreateSpec{
 				Name:       "fake-volume",
 				VolumeType: "BLOCK",
-			}
+			}, nil
 		})
 
 		patches.ApplyFunc(
@@ -800,8 +800,8 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			})
 		patches.ApplyFunc(constructCreateSpecForInstance, func(ctx context.Context,
 			r *ReconcileCnsRegisterVolume, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
-			host string, isTKGSHAEnabled bool) *cnstypes.CnsVolumeCreateSpec {
-			return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}
+			host string, isTKGSHAEnabled bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+			return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}, nil
 		})
 		patches.ApplyFunc(setInstanceError, func(ctx context.Context, r *ReconcileCnsRegisterVolume,
 			instance *cnsregistervolumev1alpha1.CnsRegisterVolume, msg string) {
@@ -902,8 +902,8 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			})
 		patches.ApplyFunc(constructCreateSpecForInstance, func(ctx context.Context,
 			r *ReconcileCnsRegisterVolume, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
-			host string, isTKGSHAEnabled bool) *cnstypes.CnsVolumeCreateSpec {
-			return &cnstypes.CnsVolumeCreateSpec{Name: "fake", VolumeType: "BLOCK"}
+			host string, isTKGSHAEnabled bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+			return &cnstypes.CnsVolumeCreateSpec{Name: "fake", VolumeType: "BLOCK"}, nil
 		})
 		patches.ApplyFunc(getK8sStorageClassNameWithImmediateBindingModeForPolicy,
 			func(ctx context.Context, k8sClient kubernetes.Interface, c ctrlclient.Client,
@@ -1909,7 +1909,8 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityE
 	origCapability := isVSphereDPLPModernAppEnabled
 	t.Cleanup(func() { isVSphereDPLPModernAppEnabled = origCapability })
 	isVSphereDPLPModernAppEnabled = true
-	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	assert.NoError(t, err)
 	if assert.NotNil(t, spec.VolumeId, "VolumeId should be set") {
 		assert.Equal(t, volumeID, spec.VolumeId.Id, "VolumeId.Id should be VolumeID")
 	}
@@ -1952,7 +1953,8 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityD
 	origCapability := isVSphereDPLPModernAppEnabled
 	t.Cleanup(func() { isVSphereDPLPModernAppEnabled = origCapability })
 	isVSphereDPLPModernAppEnabled = false
-	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	assert.NoError(t, err)
 	assert.Nil(t, spec.VolumeId, "VolumeId should not be set on the legacy VolumeID-only path")
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
@@ -1985,7 +1987,8 @@ func TestConstructCreateSpecForInstanceWithVolumeIDOnly(t *testing.T) {
 		configInfo: &config.ConfigurationInfo{Cfg: cfg},
 	}
 
-	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	assert.NoError(t, err)
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
 	assert.Equal(t, volumeID, backing.BackingDiskId, "BackingDiskId should be VolumeID")
@@ -2016,11 +2019,153 @@ func TestConstructCreateSpecForInstanceWithDiskURLPathOnly(t *testing.T) {
 		configInfo: &config.ConfigurationInfo{Cfg: cfg},
 	}
 
-	spec := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	assert.NoError(t, err)
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
 	assert.Empty(t, backing.BackingDiskId, "BackingDiskId should be empty")
 	assert.Equal(t, diskURL, backing.BackingDiskUrlPath, "BackingDiskUrlPath should be DiskURLPath")
+}
+
+// TestConstructCreateSpecForInstanceWithoutStorageClassName verifies that Profile is left unset
+// when Spec.StorageClassName is not specified.
+func TestConstructCreateSpecForInstanceWithoutStorageClassName(t *testing.T) {
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:    "pvc-1",
+			VolumeID:   "fcd-uuid",
+			AccessMode: corev1.ReadWriteOnce,
+		},
+	}
+
+	cfg := &config.Config{
+		VirtualCenter: map[string]*config.VirtualCenterConfig{
+			"test-host": {User: "test-user"},
+		},
+	}
+	cfg.Global.ClusterID = "test-cluster"
+	r := &ReconcileCnsRegisterVolume{
+		configInfo: &config.ConfigurationInfo{Cfg: cfg},
+		k8sclient:  k8sfake.NewClientset(),
+	}
+
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	assert.NoError(t, err)
+	assert.Nil(t, spec.Profile, "Profile should not be set when StorageClassName is empty")
+}
+
+// TestConstructCreateSpecForInstanceWithStorageClassName verifies that Profile is populated with
+// the storage policy ID from the referenced StorageClass's storagePolicyID parameter.
+func TestConstructCreateSpecForInstanceWithStorageClassName(t *testing.T) {
+	scName := "test-sc"
+	policyID := "test-policy-id"
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:          "pvc-1",
+			VolumeID:         "fcd-uuid",
+			AccessMode:       corev1.ReadWriteOnce,
+			StorageClassName: scName,
+		},
+	}
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: scName},
+		Parameters: map[string]string{"storagePolicyID": policyID},
+	}
+
+	cfg := &config.Config{
+		VirtualCenter: map[string]*config.VirtualCenterConfig{
+			"test-host": {User: "test-user"},
+		},
+	}
+	cfg.Global.ClusterID = "test-cluster"
+	r := &ReconcileCnsRegisterVolume{
+		configInfo: &config.ConfigurationInfo{Cfg: cfg},
+		k8sclient:  k8sfake.NewClientset(sc),
+	}
+
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	assert.NoError(t, err)
+	if assert.Len(t, spec.Profile, 1, "Profile should contain a single entry") {
+		profile, ok := spec.Profile[0].(*vim25types.VirtualMachineDefinedProfileSpec)
+		assert.True(t, ok, "Profile entry should be *VirtualMachineDefinedProfileSpec")
+		assert.Equal(t, policyID, profile.ProfileId, "ProfileId should be the StorageClass's storagePolicyID")
+	}
+}
+
+// TestConstructCreateSpecForInstanceWithMissingStorageClass verifies that an error is returned when
+// the referenced StorageClass does not exist.
+func TestConstructCreateSpecForInstanceWithMissingStorageClass(t *testing.T) {
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:          "pvc-1",
+			VolumeID:         "fcd-uuid",
+			AccessMode:       corev1.ReadWriteOnce,
+			StorageClassName: "does-not-exist",
+		},
+	}
+
+	cfg := &config.Config{
+		VirtualCenter: map[string]*config.VirtualCenterConfig{
+			"test-host": {User: "test-user"},
+		},
+	}
+	cfg.Global.ClusterID = "test-cluster"
+	r := &ReconcileCnsRegisterVolume{
+		configInfo: &config.ConfigurationInfo{Cfg: cfg},
+		k8sclient:  k8sfake.NewClientset(),
+	}
+
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	assert.Error(t, err)
+	assert.Nil(t, spec)
+}
+
+// TestConstructCreateSpecForInstanceWithStorageClassMissingPolicyIDParam verifies that an error is
+// returned when the referenced StorageClass has no storagePolicyID parameter.
+func TestConstructCreateSpecForInstanceWithStorageClassMissingPolicyIDParam(t *testing.T) {
+	scName := "test-sc-no-policy"
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "register-vol",
+			Namespace: "test-ns",
+		},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:          "pvc-1",
+			VolumeID:         "fcd-uuid",
+			AccessMode:       corev1.ReadWriteOnce,
+			StorageClassName: scName,
+		},
+	}
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: scName},
+	}
+
+	cfg := &config.Config{
+		VirtualCenter: map[string]*config.VirtualCenterConfig{
+			"test-host": {User: "test-user"},
+		},
+	}
+	cfg.Global.ClusterID = "test-cluster"
+	r := &ReconcileCnsRegisterVolume{
+		configInfo: &config.ConfigurationInfo{Cfg: cfg},
+		k8sclient:  k8sfake.NewClientset(sc),
+	}
+
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	assert.Error(t, err)
+	assert.Nil(t, spec)
 }
 
 func TestIsBlockVolumeRegisterRequestWithSharedBlockVolume(t *testing.T) {
@@ -4387,8 +4532,8 @@ func newHostLocalReconcileFixture(patches *gomonkey.Patches, storageLocality str
 		return newFakeVCWithClient(), nil
 	})
 	patches.ApplyFunc(constructCreateSpecForInstance, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
-		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ string, _ bool) *cnstypes.CnsVolumeCreateSpec {
-		return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ string, _ bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+		return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}, nil
 	})
 	patches.ApplyFunc(common.QueryVolumeByID, func(_ context.Context, _ cnsvolume.Manager,
 		volumeID string, _ *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -337,10 +337,15 @@ func clearKeepAfterDeleteVmIfNonRemovable(ctx context.Context, c ctrlruntimeclie
 	return pvcCopy, nil
 }
 
+// scParamStoragePolicyID is the StorageClass parameter key under which Supervisor
+// storage classes carry the vSphere storage policy ID directly (as opposed to a
+// policy name requiring PBM resolution, which is the vanilla/guest-cluster convention).
+const scParamStoragePolicyID = "storagePolicyID"
+
 // constructCreateSpecForInstance creates CNS CreateVolume spec.
 func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegisterVolume,
 	instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
-	host string, useSupervisorId bool) *cnstypes.CnsVolumeCreateSpec {
+	host string, useSupervisorId bool) (*cnstypes.CnsVolumeCreateSpec, error) {
 	var volumeName string
 	if instance.Spec.VolumeID != "" {
 		volumeName = staticPvNamePrefix + instance.Spec.VolumeID
@@ -387,7 +392,22 @@ func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegister
 
 	createSpec.VolumeType = common.BlockVolumeType
 
-	return createSpec
+	if instance.Spec.StorageClassName != "" {
+		sc, err := r.k8sclient.StorageV1().StorageClasses().Get(ctx, instance.Spec.StorageClassName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch StorageClass %q: %w", instance.Spec.StorageClassName, err)
+		}
+		policyID := sc.Parameters[scParamStoragePolicyID]
+		if policyID == "" {
+			return nil, fmt.Errorf("StorageClass %q has no %s parameter",
+				instance.Spec.StorageClassName, scParamStoragePolicyID)
+		}
+		createSpec.Profile = []vimtypes.BaseVirtualMachineProfileSpec{
+			&vimtypes.VirtualMachineDefinedProfileSpec{ProfileId: policyID},
+		}
+	}
+
+	return createSpec, nil
 }
 
 // getK8sStorageClassNameWithImmediateBindingModeForPolicy gets the storage class name in K8S mapping the vsphere


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
SnapService stages backed-up disks in CNS without an associated storage policy. This PR adds support for `CnsRegisterVolume` to assign a storage policy at registration time so those disks end up with a policy instead of none.

Specifically:
- Adds a new optional `StorageClass` field to `CnsRegisterVolumeSpec` — the name of a Kubernetes StorageClass in the Supervisor cluster whose associated vSphere storage policy should be applied to the volume being registered.
- `constructCreateSpecForInstance` resolves `StorageClass` to the vSphere storage policy ID (read from the StorageClass's `storagePolicyID` parameter) and sets it on the CNS `CreateVolume` spec's `Profile` field, so CNS assigns the policy during registration.
- This only takes effect when the volume in CNS has no storage policy of its own — it does not override a policy the volume is already associated with.
- If the StorageClass can't be found, or is found but has no `storagePolicyID` parameter, the CR is marked with an error and requeued rather than silently registering the volume without a policy.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
— Unit tests updated and passing locally (`go test ./pkg/syncer/cnsoperator/controller/cnsregistervolume/...`), covering the existing `constructCreateSpecForInstance` cases plus the new StorageClass-resolution path. 
- pre-check pipeline passed:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1468/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1925/

**Special notes for your reviewer**:
Open question for the CSI team, called out as a TODO in `util.go`: should setting `StorageClass` be restricted to `CnsRegisterVolume` CRs created by SnapService specifically (e.g. via a creator label/annotation), or is it acceptable for any creator to set this field? Flagging for discussion before this is considered final.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add optional `storageClass` field to CnsRegisterVolume CRD, allowing a storage policy to be assigned to a volume being registered when it doesn't already have one in CNS.
```
