### PR TITLE
Split UpdateVolumeMetadata calls by entity type not just POD in full sync

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -1546,38 +1546,70 @@ func fullSyncGetVolumeSpecs(ctx context.Context, vCenterVersion string, pvList [
 			}
 
 			if volumeType == common.BlockVolumeType {
-				// For Block volume, CNS only allow one instances for one
-				// EntityMetadata type in UpdateVolumeMetadataSpec. If there are
-				// more than one pod instances in the UpdateVolumeMetadataSpec,
-				// need to invoke multiple UpdateVolumeMetadata call.
-				var metadataList []cnstypes.BaseCnsEntityMetadata
-				var podMetadataList []cnstypes.BaseCnsEntityMetadata
-				for _, metadata := range updateSpec.Metadata.EntityMetadata {
-					entityType := metadata.(*cnstypes.CnsKubernetesEntityMetadata).EntityType
-					if entityType == string(cnstypes.CnsKubernetesEntityTypePOD) {
-						podMetadataList = append(podMetadataList, metadata)
-					} else {
-						metadataList = append(metadataList, metadata)
+				// CNS only allows one instance of each EntityMetadata type
+				// (e.g. PERSISTENT_VOLUME, PERSISTENT_VOLUME_CLAIM, POD) per
+				// UpdateVolumeMetadataSpec call — this includes an add and a
+				// delete of the same type together, e.g. when a stale PV
+				// entity (Delete=true, detected above) coexists with a
+				// renamed/recreated PV entity (add) for the same volume,
+				// such as after a static PV/PVC is recreated over a
+				// previously pv_missing-labeled volume. A duplicate-type
+				// spec is rejected outright by CNS with "Duplicated entity
+				// for each entity type in one cluster is found".
+				//
+				// Bucket entities by type and round-robin them across
+				// calls so each call has at most one instance per type.
+				// Deletes are grouped and issued before adds/updates so
+				// the final call in the sequence always carries the
+				// desired end-state metadata, never a stale delete-only
+				// entity.
+				bucketByType := func(entities []cnstypes.BaseCnsEntityMetadata) []cnstypes.CnsVolumeMetadataUpdateSpec {
+					entityMetadataByType := make(map[string][]cnstypes.BaseCnsEntityMetadata)
+					var entityTypeOrder []string
+					for _, metadata := range entities {
+						entityType := metadata.(*cnstypes.CnsKubernetesEntityMetadata).EntityType
+						if _, seen := entityMetadataByType[entityType]; !seen {
+							entityTypeOrder = append(entityTypeOrder, entityType)
+						}
+						entityMetadataByType[entityType] = append(entityMetadataByType[entityType], metadata)
 					}
-				}
-				if len(podMetadataList) > 0 {
-					for _, podMetadata := range podMetadataList {
-						updateSpecNew := cnstypes.CnsVolumeMetadataUpdateSpec{
+					var specs []cnstypes.CnsVolumeMetadataUpdateSpec
+					for {
+						var batch []cnstypes.BaseCnsEntityMetadata
+						for _, entityType := range entityTypeOrder {
+							if len(entityMetadataByType[entityType]) > 0 {
+								batch = append(batch, entityMetadataByType[entityType][0])
+								entityMetadataByType[entityType] = entityMetadataByType[entityType][1:]
+							}
+						}
+						if len(batch) == 0 {
+							break
+						}
+						specs = append(specs, cnstypes.CnsVolumeMetadataUpdateSpec{
 							VolumeId: cnstypes.CnsVolumeId{
 								Id: volumeHandle,
 							},
 							Metadata: cnstypes.CnsVolumeMetadata{
 								ContainerCluster:      containerCluster,
 								ContainerClusterArray: []cnstypes.CnsContainerCluster{containerCluster},
-								// Update metadata in CNS with the new metadata present in K8S.
-								EntityMetadata: append(metadataList, podMetadata),
+								EntityMetadata:        batch,
 							},
-						}
-						log.Debugf("FullSync for VC %s: updateSpec %+v is added to updateSpecArray\n", vc, spew.Sdump(updateSpecNew))
-						updateSpecArray = append(updateSpecArray, updateSpecNew)
+						})
 					}
-				} else {
-					updateSpecArray = append(updateSpecArray, updateSpec)
+					return specs
+				}
+
+				var deleteEntities, addEntities []cnstypes.BaseCnsEntityMetadata
+				for _, metadata := range updateSpec.Metadata.EntityMetadata {
+					if metadata.(*cnstypes.CnsKubernetesEntityMetadata).Delete {
+						deleteEntities = append(deleteEntities, metadata)
+					} else {
+						addEntities = append(addEntities, metadata)
+					}
+				}
+				for _, updateSpecNew := range append(bucketByType(deleteEntities), bucketByType(addEntities)...) {
+					log.Debugf("FullSync for VC %s: updateSpec %+v is added to updateSpecArray\n", vc, spew.Sdump(updateSpecNew))
+					updateSpecArray = append(updateSpecArray, updateSpecNew)
 				}
 			} else {
 				updateSpecArray = append(updateSpecArray, updateSpec)
@@ -1763,17 +1795,29 @@ func buildPVMissingUpdateSpec(ctx context.Context, vol cnstypes.CnsVolume,
 			continue
 		}
 		foundInClusterPV = true
-		labels := cnsvsphere.GetLabelsMapFromKeyValue(k8sEm.Labels)
-		if labels == nil {
-			labels = make(map[string]string)
-		}
-		if labels[prometheus.PrometheusPVMissingLabelKey] == prometheus.PrometheusPVMissingLabelValue {
-			// Already labeled in CNS; nothing to do for this entity.
+		existingLabels := cnsvsphere.GetLabelsMapFromKeyValue(k8sEm.Labels)
+		if len(existingLabels) == 1 &&
+			existingLabels[prometheus.PrometheusPVMissingLabelKey] == prometheus.PrometheusPVMissingLabelValue {
+			// Already labeled in CNS with nothing else to clean up.
 			log.Infof("FullSync for VC %s: buildPVMissingUpdateSpec: volume %q PV entity %q"+
 				" already has pv_missing=true label, skipping", vc, vol.VolumeId.Id, k8sEm.EntityName)
 			continue
 		}
-		labels[prometheus.PrometheusPVMissingLabelKey] = prometheus.PrometheusPVMissingLabelValue
+		// The volume is confirmed orphaned: its K8s PV object is gone, so any
+		// other labels mirrored onto this entity (e.g. CnsRegisterVolume/
+		// VKSRegisterVolume provenance labels such as cnsregistervolume-name,
+		// cnsregistervolume-namespace, created-by) describe a K8s object that
+		// no longer exists and can never be reconciled again. Reset the label
+		// set to just pv_missing=true instead of merging into the stale
+		// labels, so they don't survive forever. This also self-heals volumes
+		// that were already labeled pv_missing under the older merge
+		// behavior — the length check above lets a genuinely clean pv_missing
+		// entity skip re-issuing every cycle, while an entity with leftover
+		// stale labels gets reissued once to strip them. The entity's
+		// EntityName (last-known PV name) is left untouched.
+		labels := map[string]string{
+			prometheus.PrometheusPVMissingLabelKey: prometheus.PrometheusPVMissingLabelValue,
+		}
 		entityMetadata = append(entityMetadata,
 			cnsvsphere.GetCnsKubernetesEntityMetaData(k8sEm.EntityName, labels, false,
 				k8sEm.EntityType, k8sEm.Namespace, k8sEm.ClusterID, k8sEm.ReferredEntity))

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -2421,10 +2421,14 @@ func TestGetMissingPVVolumeUpdateSpecs_PVExists(t *testing.T) {
 		"volume with present PV should not be in grace tracker")
 }
 
-// TestGetMissingPVVolumeUpdateSpecs_PreservesExistingLabels verifies that the
-// pv_missing label is appended on top of any pre-existing labels on the PV-
-// type entity, rather than replacing them.
-func TestGetMissingPVVolumeUpdateSpecs_PreservesExistingLabels(t *testing.T) {
+// TestGetMissingPVVolumeUpdateSpecs_StripsExistingLabels verifies that once a
+// volume is confirmed orphaned, pv_missing=true replaces any pre-existing
+// labels on the PV-type entity rather than being merged alongside them. Those
+// labels (e.g. CnsRegisterVolume/VKSRegisterVolume provenance labels such as
+// cnsregistervolume-name, cnsregistervolume-namespace, created-by) describe a
+// K8s object that no longer exists and can never be reconciled again, so they
+// must not survive forever on the orphaned entity.
+func TestGetMissingPVVolumeUpdateSpecs_StripsExistingLabels(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	vc := "test-vc"
@@ -2461,8 +2465,7 @@ func TestGetMissingPVVolumeUpdateSpecs_PreservesExistingLabels(t *testing.T) {
 		}
 	}
 	assert.Equal(t, "true", labels["pv_missing"], "pv_missing label must be set")
-	assert.Equal(t, "nginx", labels["app"], "pre-existing app label must be preserved")
-	assert.Equal(t, "frontend", labels["tier"], "pre-existing tier label must be preserved")
+	assert.Len(t, labels, 1, "stale pre-existing labels must be stripped, leaving only pv_missing")
 }
 
 // TestGetMissingPVVolumeUpdateSpecs_AlreadyLabeled verifies idempotency: a


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Generalizes the entity-metadata splitting logic in `fullSyncGetVolumeSpecs` (pkg/syncer/fullsync.go) so full sync buckets `UpdateVolumeMetadata` entities by `EntityType` and issues one call per bucket-round, instead of only splitting `POD` entities out of an otherwise single combined call.

`fullSyncGetVolumeSpecs` now buckets the block-volume update spec's `EntityMetadata` by `EntityType` and round-robins across calls, taking at most one entity of each type per call. This:
- Fixes the reported scenario — the stale PV delete and new PV add now go out as two separate calls instead of one rejected call.
- Preserves single-call behavior for the common case (≤1 entity per type).
- Preserves (and generalizes) the existing multi-pod splitting behavior, and is slightly more efficient — it no longer redundantly re-sends PV/PVC metadata in every per-pod call.

**Testing done**:
```
1. Create initial PVC
2. Wait for PVC to bind
3. Extract PV Name & backing Volume Handle
4. Patch PV ReclaimPolicy to Retain
5. Delete K8s objects (PVC and PV)

=================================================================
INITIAL VOLUME PROVISIONED & DELETED:
PV Name:       pvc-db285118-48e1-4952-bd13-277a35721d91
CNS Volume ID: db285118-48e1-4952-bd13-277a35721d91
Waiting 3 minutes for FullSync orphan tagging (pv_missing=true)...
=================================================================
root@420a695b41e8f29740bd96aac71dc411 [ ~ ]# echo "=== 1. Confirm Syncer Tagged Orphan ==="
kubectl logs -n vmware-system-csi deployment/vsphere-csi-controller -c vsphere-syncer --tail=200 | grep -iE "Adding pv_missing|$VOL_HANDLE"

echo "=== 2. Confirm 'pv_missing=true' in CNS Database ==="
govc volume.ls -json $VOL_HANDLE | jq '.volume[]? | {volumeId: .volumeId.id, health: .healthStatus, labels: .metadata.entityMetadata[]?.labels}'

echo "=== 3. Confirm Prometheus Gauge Hits 1 ==="
kubectl exec -it -n vmware-system-csi deployment/vsphere-csi-controller -c vsphere-syncer -- curl -s http://localhost:2113/metrics | grep vsphere_cns_volume_pv_missing
=== 1. Confirm Syncer Tagged Orphan ===
{"level":"info","time":"2026-08-17T09:22:09.931999198Z","caller":"syncer/fullsync.go:1688","msg":"FullSync for VC lvn-dvm-10-161-193-11.dvm.lvn.broadcom.net: Volume \"db285118-48e1-4952-bd13-277a35721d91\" has no matching K8s PV; deferring pv_missing label to next cycle (grace period)","TraceId":"99f1591c-2de6-413d-b554-1090d351e3f1"}
=== 2. Confirm 'pv_missing=true' in CNS Database ===
{
  "volumeId": "db285118-48e1-4952-bd13-277a35721d91",
  "health": "green",
  "labels": null
}
{
  "volumeId": "db285118-48e1-4952-bd13-277a35721d91",
  "health": "green",
  "labels": null
}
=== 3. Confirm Prometheus Gauge Hits 1 ===
# HELP vsphere_cns_volume_pv_missing Number of CNS volumes whose corresponding Kubernetes PV was not found during the last full sync, per vCenter.
# TYPE vsphere_cns_volume_pv_missing gauge


1. Apply static PV
2. Apply static PVC
3. Wait for PVC to bind

echo "=== 2. Check if 'pv_missing' Label is Cleared ==="
govc volume.ls -json $VOL_HANDLE | jq '.volume[]?.metadata.entityMetadata[]?.labels'

echo "=== 3. Confirm Prometheus Gauge Resets to 0 ==="
kubectl exec -it -n vmware-system-csi deployment/vsphere-csi-controller -c vsphere-syncer -- curl -s http://localhost:2113/metrics | grep vsphere_cns_volume_pv_missing
=== 1. Check CNS Database Entity Metadata Count (FIX VERIFICATION) ===
[
  {
    "entityName": "pvc-recovery-static",
    "labels": null,
    "delete": false,
    "clusterID": "vSphereSupervisorID-1b0cc186-14c2-47fb-90e3-364e3dd27be3",
    "entityType": "PERSISTENT_VOLUME_CLAIM",
    "namespace": "test-ns",
    "referredEntity": [
      {
        "entityType": "PERSISTENT_VOLUME",
        "entityName": "static-pv-recovery",
        "namespace": "",
        "clusterID": "vSphereSupervisorID-1b0cc186-14c2-47fb-90e3-364e3dd27be3"
      }
    ]
  },
  {
    "entityName": "static-pv-recovery",
    "labels": null,
    "delete": false,
    "clusterID": "vSphereSupervisorID-1b0cc186-14c2-47fb-90e3-364e3dd27be3",
    "entityType": "PERSISTENT_VOLUME",
    "namespace": "",
    "referredEntity": null
  }
]
=== 2. Check if 'pv_missing' Label is Cleared ===
null
null
=== 3. Confirm Prometheus Gauge Resets to 0 ===
# HELP vsphere_cns_volume_pv_missing Number of CNS volumes whose corresponding Kubernetes PV was not found during the last full sync, per vCenter.
# TYPE vsphere_cns_volume_pv_missing gauge
vsphere_cns_volume_pv_missing{vc="lvn-dvm-10-161-193-11.dvm.lvn.broadcom.net"} 0
root@420a695b41e8f29740bd96aac71dc411 [ ~ ]#
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Split UpdateVolumeMetadata calls by entity type not just POD in full sync
```
