### PR TITLE
Fix double-create volume issue by adding idempotency check

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -1054,20 +1054,26 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 					log.Errorf("failed to create volume with VolumeID: %q, faultType: %q, err: %v",
 						spec.VolumeId.Id, faultType, err)
 					if IsCnsVolumeAlreadyExistsFault(ctx, faultType) {
-						// CSI Transaction Support derives VolumeId deterministically from the
-						// PVC UID (see ExtractVolumeIDFromPVName) so a CreateVolume retry after
-						// a lost response, timeout, or CSI restart is idempotent instead of
-						// producing a duplicate FCD. But a retry can carry different placement
-						// candidates than the original attempt (e.g. the scheduler picked a
-						// different host, or the set of compatible datastores/clusters changed
-						// between attempts), so the volume CNS already created under this
-						// VolumeId may no longer satisfy the current request's placement scope.
-						// CNS reports that mismatch as CnsVolumeAlreadyExistsFault rather than
-						// silently reusing the volume. Delete it and recreate: VolumeId is
-						// unique to this PVC, so deleting it cannot affect any other volume,
-						// and the recreate lands the volume within the scope this request
-						// actually asked for.
-						log.Infof("Observed volume with Id: %q is already Exists. Deleting Volume.", spec.VolumeId.Id)
+						// CSI Transaction Support derives VolumeId deterministically from the PVC
+						// UID, so a retry can hit a volume CNS already created under this VolumeId
+						// but placed outside the current request's scope (e.g. datastore/zone
+						// candidates changed between attempts). VolumeId is unique to this PVC, so
+						// deleting it cannot affect any other volume. But if the existing volume
+						// already satisfies the current request, deleting and recreating it is
+						// unnecessary and would discard state such as a concurrent
+						// ControllerExpandVolume's growth — so check compatibility first.
+						compatible, queryErr := isExistingVolumeCompatible(ctx, m, spec)
+						if queryErr != nil {
+							log.Errorf("failed to check compatibility of existing volume: %q, err: %v. "+
+								"Proceeding to delete and recreate.", spec.VolumeId.Id, queryErr)
+							compatible = false
+						}
+						if compatible {
+							log.Infof("Existing volume %q is compatible with requested spec, treating as success",
+								spec.VolumeId.Id)
+							return &CnsVolumeInfo{VolumeID: cnstypes.CnsVolumeId{Id: spec.VolumeId.Id}}, "", nil
+						}
+						log.Infof("Existing volume %q is not compatible with requested spec, deleting", spec.VolumeId.Id)
 						deleteFaultType, deleteError := m.deleteVolume(ctx, spec.VolumeId.Id, true)
 						if deleteError != nil {
 							log.Errorf("failed to delete volume: %q to handle CnsVolumeAlreadyExistsFault , err :%v", spec.VolumeId.Id, err)
@@ -1099,6 +1105,107 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 	}
 
 	return resp, faultType, err
+}
+
+// isExistingVolumeCompatible checks whether the volume referenced by spec.VolumeId satisfies the
+// incoming CnsVolumeCreateSpec (zone, VolumeType, storage policy, capacity). Capacity is checked
+// as >=, not ==, so a volume already grown by a concurrent ControllerExpandVolume isn't mistaken
+// for incompatible.
+func isExistingVolumeCompatible(ctx context.Context, m *defaultManager,
+	spec *cnstypes.CnsVolumeCreateSpec) (bool, error) {
+	log := logger.GetLogger(ctx).With("volumeId", spec.VolumeId.Id)
+	queryFilter := cnstypes.CnsQueryFilter{
+		VolumeIds: []cnstypes.CnsVolumeId{{Id: spec.VolumeId.Id}},
+	}
+	queryResult, err := m.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		return false, logger.LogNewErrorf(log, "failed to query volume: %v", err)
+	}
+	if queryResult == nil || len(queryResult.Volumes) == 0 {
+		log.Infof("volume not found by QueryVolume, treating as incompatible")
+		return false, nil
+	}
+	return isQueriedVolumeCompatible(ctx, m, queryResult.Volumes[0], spec)
+}
+
+// isQueriedVolumeCompatible checks zone, then delegates the rest of the compatibility checks to
+// isVolumeSpecCompatible. Split out from isExistingVolumeCompatible so it can be unit tested with
+// a fake existing volume instead of a live QueryVolume call.
+func isQueriedVolumeCompatible(ctx context.Context, m *defaultManager, existing cnstypes.CnsVolume,
+	spec *cnstypes.CnsVolumeCreateSpec) (bool, error) {
+	log := logger.GetLogger(ctx).With("volumeId", spec.VolumeId.Id)
+	if len(spec.Datastores) > 0 {
+		inZone, err := isDatastoreAmongCandidates(ctx, m, existing.DatastoreUrl, spec.Datastores)
+		if err != nil {
+			return false, err
+		}
+		if !inZone {
+			log.Infof("existing volume is on datastore %q, outside the requested zone", existing.DatastoreUrl)
+			return false, nil
+		}
+	}
+
+	return isVolumeSpecCompatible(ctx, existing, spec)
+}
+
+// isDatastoreAmongCandidates checks whether datastoreURL matches one of the candidate datastores.
+func isDatastoreAmongCandidates(ctx context.Context, m *defaultManager, datastoreURL string,
+	candidates []vim25types.ManagedObjectReference) (bool, error) {
+	log := logger.GetLogger(ctx)
+	for _, candidate := range candidates {
+		url, err := GetDatastoreURLHook(ctx, m.virtualCenter, candidate)
+		if err != nil {
+			return false, logger.LogNewErrorf(log, "failed to get URL for candidate datastore %v: %v", candidate, err)
+		}
+		if url == datastoreURL {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// GetDatastoreURLHook resolves a candidate datastore moref to its URL; unit tests may replace it.
+var GetDatastoreURLHook = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+	ref vim25types.ManagedObjectReference) (string, error) {
+	ds := &cnsvsphere.Datastore{Datastore: object.NewDatastore(vc.Client.Client, ref)}
+	url, _, err := ds.GetDatastoreURLAndType(ctx)
+	return url, err
+}
+
+// isVolumeSpecCompatible compares an existing CNS volume against a requested CnsVolumeCreateSpec.
+// Split out so the comparison logic can be unit tested without a live CNS connection.
+func isVolumeSpecCompatible(ctx context.Context, existing cnstypes.CnsVolume,
+	spec *cnstypes.CnsVolumeCreateSpec) (bool, error) {
+	log := logger.GetLogger(ctx).With("volumeId", spec.VolumeId.Id)
+
+	if existing.VolumeType != spec.VolumeType {
+		log.Infof("VolumeType mismatch, existing %q requested %q", existing.VolumeType, spec.VolumeType)
+		return false, nil
+	}
+
+	if len(spec.Profile) > 0 {
+		if requestedProfile, ok := spec.Profile[0].(*vim25types.VirtualMachineDefinedProfileSpec); ok {
+			if existing.StoragePolicyId != requestedProfile.ProfileId {
+				log.Infof("StoragePolicyId mismatch, existing %q requested %q",
+					existing.StoragePolicyId, requestedProfile.ProfileId)
+				return false, nil
+			}
+		}
+	}
+
+	requestedBacking, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+	if !ok {
+		return false, logger.LogNewErrorf(log, "unable to retrieve requested capacity")
+	}
+	existingBacking, ok := existing.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+	if !ok {
+		return false, logger.LogNewErrorf(log, "unable to retrieve existing capacity")
+	}
+	if existingBacking.CapacityInMb < requestedBacking.CapacityInMb {
+		log.Infof("capacity %dMb less than requested %dMb", existingBacking.CapacityInMb, requestedBacking.CapacityInMb)
+		return false, nil
+	}
+	return true, nil
 }
 
 // ensureOperationContextHasATimeout checks if the passed context has a timeout associated with it.

--- a/pkg/common/cns-lib/volume/manager_test.go
+++ b/pkg/common/cns-lib/volume/manager_test.go
@@ -973,3 +973,284 @@ func TestDefaultVslmHooksDisconnectedVC(t *testing.T) {
 	_, err = defaultRetrieveSnapshotDetailsHook(ctx, &cnsvsphere.VirtualCenter{}, vim25types.ID{}, vim25types.ID{})
 	assert.Error(t, err)
 }
+
+// blockSpec builds a CnsVolumeCreateSpec for isVolumeSpecCompatible tests. profileID == "" omits
+// the Profile slice entirely, exercising the "no policy requested" branch.
+func blockSpec(volumeID string, capacityMb int64, profileID string) *cnstypes.CnsVolumeCreateSpec {
+	spec := &cnstypes.CnsVolumeCreateSpec{
+		VolumeId:   &cnstypes.CnsVolumeId{Id: volumeID},
+		VolumeType: string(cnstypes.CnsVolumeTypeBlock),
+		BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+			CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: capacityMb},
+		},
+	}
+	if profileID != "" {
+		spec.Profile = []vim25types.BaseVirtualMachineProfileSpec{
+			&vim25types.VirtualMachineDefinedProfileSpec{ProfileId: profileID},
+		}
+	}
+	return spec
+}
+
+func datastoreMoRef(value string) vim25types.ManagedObjectReference {
+	return vim25types.ManagedObjectReference{Type: "Datastore", Value: value}
+}
+
+// blockVolume builds a CnsVolume (as returned by QueryVolume) for isVolumeSpecCompatible tests.
+func blockVolume(volumeType string, capacityMb int64, storagePolicyID string) cnstypes.CnsVolume {
+	return cnstypes.CnsVolume{
+		VolumeType:      volumeType,
+		StoragePolicyId: storagePolicyID,
+		BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+			CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: capacityMb},
+		},
+	}
+}
+
+// TestIsVolumeSpecCompatible covers the compatibility decision used when CNS reports
+// CnsVolumeAlreadyExistsFault: an existing volume must be treated as an idempotent success when
+// it satisfies the requested spec, and as incompatible (falling back to delete+recreate)
+// otherwise.
+func TestIsVolumeSpecCompatible(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	const volID = "78be0f2f-b27d-49fe-8ffe-8107965361f7"
+	const policyID = "789e6ee7-280b-4b5e-81f5-59739df0d392"
+
+	tests := []struct {
+		name       string
+		existing   cnstypes.CnsVolume
+		spec       *cnstypes.CnsVolumeCreateSpec
+		wantCompat bool
+		wantErr    bool
+	}{
+		{
+			name:       "exact match is compatible",
+			existing:   blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1024, policyID),
+			spec:       blockSpec(volID, 1024, policyID),
+			wantCompat: true,
+		},
+		{
+			name:       "existing volume larger than requested (post-resize race) is compatible",
+			existing:   blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1025, policyID),
+			spec:       blockSpec(volID, 1024, policyID),
+			wantCompat: true,
+		},
+		{
+			name:       "existing volume smaller than requested is not compatible",
+			existing:   blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1000, policyID),
+			spec:       blockSpec(volID, 1024, policyID),
+			wantCompat: false,
+		},
+		{
+			name:       "VolumeType mismatch is not compatible",
+			existing:   blockVolume(string(cnstypes.CnsVolumeTypeFile), 1024, policyID),
+			spec:       blockSpec(volID, 1024, policyID),
+			wantCompat: false,
+		},
+		{
+			name:       "StoragePolicyId mismatch is not compatible",
+			existing:   blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1024, "other-policy-id"),
+			spec:       blockSpec(volID, 1024, policyID),
+			wantCompat: false,
+		},
+		{
+			name:       "no profile requested skips the policy check",
+			existing:   blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1024, "any-policy-id"),
+			spec:       blockSpec(volID, 1024, ""),
+			wantCompat: true,
+		},
+		{
+			name:     "unrecognised requested backing details type errors",
+			existing: blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1024, policyID),
+			spec: func() *cnstypes.CnsVolumeCreateSpec {
+				s := blockSpec(volID, 1024, policyID)
+				s.BackingObjectDetails = &cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024}
+				return s
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "unrecognised existing backing details type errors",
+			existing: cnstypes.CnsVolume{
+				VolumeType:           string(cnstypes.CnsVolumeTypeBlock),
+				StoragePolicyId:      policyID,
+				BackingObjectDetails: &cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
+			},
+			spec:    blockSpec(volID, 1024, policyID),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compatible, err := isVolumeSpecCompatible(ctx, tt.existing, tt.spec)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantCompat, compatible)
+		})
+	}
+}
+
+// TestIsExistingVolumeCompatible covers the QueryVolume-calling wrapper's own error/empty-result
+// handling, distinct from the pure comparison logic covered by TestIsVolumeSpecCompatible.
+func TestIsExistingVolumeCompatible(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	spec := blockSpec("78be0f2f-b27d-49fe-8ffe-8107965361f7", 1024, "")
+
+	// No virtualCenter means QueryVolume fails validateManager before touching the network,
+	// so this exercises the error-propagation path without a live CNS connection.
+	m := &defaultManager{virtualCenter: nil}
+	compatible, err := isExistingVolumeCompatible(ctx, m, spec)
+	assert.Error(t, err)
+	assert.False(t, compatible)
+}
+
+// TestIsDatastoreAmongCandidates covers isDatastoreAmongCandidates via GetDatastoreURLHook, so it
+// doesn't need a live vCenter to resolve candidate datastore morefs to URLs.
+func TestIsDatastoreAmongCandidates(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	origHook := GetDatastoreURLHook
+	defer func() { GetDatastoreURLHook = origHook }()
+
+	urlByMoRef := map[string]string{
+		"ds-1": "ds:///vmfs/volumes/ds-1/",
+		"ds-2": "ds:///vmfs/volumes/ds-2/",
+	}
+	GetDatastoreURLHook = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+		ref vim25types.ManagedObjectReference) (string, error) {
+		if ref.Value == "ds-error" {
+			return "", fmt.Errorf("failed to resolve datastore %s", ref.Value)
+		}
+		return urlByMoRef[ref.Value], nil
+	}
+
+	m := &defaultManager{virtualCenter: &cnsvsphere.VirtualCenter{}}
+
+	tests := []struct {
+		name         string
+		datastoreURL string
+		candidates   []vim25types.ManagedObjectReference
+		want         bool
+		wantErr      bool
+	}{
+		{
+			name:         "match on only candidate",
+			datastoreURL: urlByMoRef["ds-1"],
+			candidates:   []vim25types.ManagedObjectReference{datastoreMoRef("ds-1")},
+			want:         true,
+		},
+		{
+			name:         "match on later candidate",
+			datastoreURL: urlByMoRef["ds-2"],
+			candidates:   []vim25types.ManagedObjectReference{datastoreMoRef("ds-1"), datastoreMoRef("ds-2")},
+			want:         true,
+		},
+		{
+			name:         "no candidate matches",
+			datastoreURL: "ds:///vmfs/volumes/ds-3/",
+			candidates:   []vim25types.ManagedObjectReference{datastoreMoRef("ds-1"), datastoreMoRef("ds-2")},
+			want:         false,
+		},
+		{
+			name:         "empty candidate list",
+			datastoreURL: urlByMoRef["ds-1"],
+			candidates:   nil,
+			want:         false,
+		},
+		{
+			name:         "candidate resolution error propagates",
+			datastoreURL: urlByMoRef["ds-1"],
+			candidates:   []vim25types.ManagedObjectReference{datastoreMoRef("ds-error")},
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isDatastoreAmongCandidates(ctx, m, tt.datastoreURL, tt.candidates)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestIsQueriedVolumeCompatible covers the zone check added on top of isVolumeSpecCompatible,
+// using a fake existing CnsVolume instead of a live QueryVolume call.
+func TestIsQueriedVolumeCompatible(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	origHook := GetDatastoreURLHook
+	defer func() { GetDatastoreURLHook = origHook }()
+
+	const volID = "78be0f2f-b27d-49fe-8ffe-8107965361f7"
+	const requestedZoneURL = "ds:///vmfs/volumes/in-zone/"
+	const otherZoneURL = "ds:///vmfs/volumes/out-of-zone/"
+
+	GetDatastoreURLHook = func(ctx context.Context, vc *cnsvsphere.VirtualCenter,
+		ref vim25types.ManagedObjectReference) (string, error) {
+		if ref.Value == "ds-error" {
+			return "", fmt.Errorf("failed to resolve datastore %s", ref.Value)
+		}
+		return requestedZoneURL, nil
+	}
+
+	m := &defaultManager{virtualCenter: &cnsvsphere.VirtualCenter{}}
+
+	tests := []struct {
+		name       string
+		existing   cnstypes.CnsVolume
+		datastores []vim25types.ManagedObjectReference
+		wantCompat bool
+		wantErr    bool
+	}{
+		{
+			name:       "no candidate datastores skips zone check",
+			existing:   withDatastoreURL(blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1024, ""), otherZoneURL),
+			datastores: nil,
+			wantCompat: true,
+		},
+		{
+			name:       "existing volume in requested zone is compatible",
+			existing:   withDatastoreURL(blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1024, ""), requestedZoneURL),
+			datastores: []vim25types.ManagedObjectReference{datastoreMoRef("ds-in-zone")},
+			wantCompat: true,
+		},
+		{
+			name:       "existing volume outside requested zone is not compatible",
+			existing:   withDatastoreURL(blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1024, ""), otherZoneURL),
+			datastores: []vim25types.ManagedObjectReference{datastoreMoRef("ds-in-zone")},
+			wantCompat: false,
+		},
+		{
+			name:       "candidate resolution error propagates",
+			existing:   withDatastoreURL(blockVolume(string(cnstypes.CnsVolumeTypeBlock), 1024, ""), requestedZoneURL),
+			datastores: []vim25types.ManagedObjectReference{datastoreMoRef("ds-error")},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := blockSpec(volID, 1024, "")
+			spec.Datastores = tt.datastores
+			compatible, err := isQueriedVolumeCompatible(ctx, m, tt.existing, spec)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantCompat, compatible)
+		})
+	}
+}
+
+func withDatastoreURL(vol cnstypes.CnsVolume, url string) cnstypes.CnsVolume {
+	vol.DatastoreUrl = url
+	return vol
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add compatibility checking for existing volumes when handling CnsVolumeAlreadyExistsFault. Per CSI CreateVolume spec, a pre-existing volume satisfying the requested spec (zone, VolumeType, storage policy, capacity) should be treated as an idempotent success. This prevents legitimate volumes expanded via concurrent ControllerExpandVolume, or placed via topology-aware zone selection, from being deleted and recreated incorrectly.

- Query existing volume and check zone, VolumeType, storage policy, and capacity
- Only delete if existing volume is incompatible with requested spec
- Add unit tests covering the compatibility and zone-matching logic

**Testing done**:
Added unit tests covering the new compatibility logic:
- `TestIsVolumeSpecCompatible`: VolumeType, storage policy, and capacity matching (exact match, post-resize race, mismatch cases)
- `TestIsQueriedVolumeCompatible`: zone/datastore compatibility check
- `TestIsDatastoreAmongCandidates`: candidate datastore URL resolution (match, no-match, error propagation)
- `TestIsExistingVolumeCompatible`: error propagation when the compatibility query itself fails

All existing and new unit tests pass (`go test ./pkg/common/cns-lib/volume/...`). Full repo build verified (`go build ./...`).

**Special notes for your reviewer**:
This changes the CreateVolume idempotency handling for `CnsVolumeAlreadyExistsFault`: instead of unconditionally deleting and recreating the existing volume, we now check whether it already satisfies the requested spec (zone, VolumeType, storage policy, and capacity — using `>=` for capacity so a volume already grown by a concurrent `ControllerExpandVolume` isn't mistaken for incompatible). If compatible, CreateVolume returns success without touching the volume. If the compatibility check itself fails (e.g. query error), we fall back to the previous delete-and-recreate behavior.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix a race where a CreateVolume retry could delete and recreate a volume that was already correctly provisioned, discarding a concurrent volume expansion or moving it out of its assigned zone.
```


