### PR TITLE
Clean up linked clone if label can't be added

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1267,6 +1267,21 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		volumeSnapshotUID, err := commonco.ContainerOrchestratorUtility.GetLinkedCloneVolumeSnapshotSourceUUID(ctx,
 			pvcName, pvcNamespace)
 		if err != nil {
+			// The provisioned volume cannot be labeled as a linked clone, so it would be
+			// unreachable by the linked-clone-exists safety check on snapshot deletion. Clean it up.
+			log.Errorf("failed to get linked clone name: %s on namespace: %s source volumesnapshot. "+
+				"Cleaning up volume %q. Error: %+v", pvcName, pvcNamespace, volumeInfo.VolumeID.Id, err)
+			deleteOpReqError := operationStore.DeleteRequestDetails(ctx, req.Name)
+			if deleteOpReqError != nil {
+				log.Warnf("failed to cleanup CnsVolumeOperationRequest instance before erroring "+
+					"out. Error received: %+v", deleteOpReqError)
+			} else {
+				if _, deleteVolumeError := common.DeleteVolumeUtil(ctx, c.manager.VolumeManager,
+					volumeInfo.VolumeID.Id, true); deleteVolumeError != nil {
+					log.Warnf("failed to delete volume: %q while cleaning up after CreateVolume failure. "+
+						"Error: %+v", volumeInfo.VolumeID.Id, deleteVolumeError)
+				}
+			}
 			msg := fmt.Sprintf("failed to get linked clone name: %s on namespace: %s source volumesnapshot. "+
 				"Error: %+v", pvcName, pvcNamespace, err)
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal, msg)

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -1561,6 +1561,7 @@ type fakeCOOverrides struct {
 	err                error
 	fssOverrides       map[string]bool
 	nodeNameToHostMoID map[string]string
+	linkedCloneUUIDErr error
 }
 
 func (f *fakeCOOverrides) GetNodeNameToHostMoIDMap(ctx context.Context) map[string]string {
@@ -1580,6 +1581,14 @@ func (f *fakeCOOverrides) IsFSSEnabled(ctx context.Context, featureName string) 
 		return enabled
 	}
 	return f.COCommonInterface.IsFSSEnabled(ctx, featureName)
+}
+
+func (f *fakeCOOverrides) GetLinkedCloneVolumeSnapshotSourceUUID(ctx context.Context, pvcName string,
+	pvcNamespace string) (string, error) {
+	if f.linkedCloneUUIDErr != nil {
+		return "", f.linkedCloneUUIDErr
+	}
+	return f.COCommonInterface.GetLinkedCloneVolumeSnapshotSourceUUID(ctx, pvcName, pvcNamespace)
 }
 
 // TestGetAccessibleClustersForSnapshot verifies which vSphere clusters are handed to CNS as
@@ -1878,6 +1887,153 @@ func TestLinkedCloneOnHostExclusiveDatastoreRequiresHostLocalPolicy(t *testing.T
 			t.Fatalf("the guard must not fire when supports_host_local_storage is disabled: %v", err)
 		}
 	})
+}
+
+// TestCreateVolumeCleansUpVolumeWhenLinkedCloneUUIDLookupFails verifies that CreateVolume does not
+// leak the CNS volume it just created when a later step - resolving the linked clone's source
+// VolumeSnapshot UID from the requesting PVC, so it can be labeled on the resulting PV - fails.
+//
+// This happens in practice when the requesting PVC is deleted between volume creation and this
+// lookup (e.g. a caller rapidly deleting/recreating a PVC under the same name to audit a snapshot
+// repeatedly). Before this fix, CreateVolume returned an Internal error without deleting the
+// already-created volume: no PV was ever created in Kubernetes, so nothing ever asked the driver to
+// clean it up, permanently orphaning the underlying FCD.
+func TestCreateVolumeCleansUpVolumeWhenLinkedCloneUUIDLookupFails(t *testing.T) {
+	ct := getControllerTest(t)
+
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         map[string]string{},
+		VolumeCapabilities: capabilities,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcVolID := respCreate.Volume.VolumeId
+	defer func() {
+		if _, err := ct.controller.DeleteVolume(ctx, &csi.DeleteVolumeRequest{VolumeId: srcVolID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	respCreateSnapshot, err := ct.controller.CreateSnapshot(ctx, &csi.CreateSnapshotRequest{
+		SourceVolumeId: srcVolID,
+		Name:           "snapshot-" + uuid.New().String(),
+		Parameters: map[string]string{
+			common.VolumeSnapshotNamespaceKey: "default",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapID := respCreateSnapshot.Snapshot.SnapshotId
+	defer func() {
+		if _, err := ct.controller.DeleteSnapshot(ctx, &csi.DeleteSnapshotRequest{SnapshotId: snapID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// The cleanup path under test calls the package-level operationStore, which getControllerTest
+	// never initializes since no other existing test exercises it. Give it a fake instance here.
+	fakeOpStore, err := unittestcommon.InitFakeVolumeOperationRequestInterface()
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalOperationStore := operationStore
+	operationStore = fakeOpStore
+	t.Cleanup(func() { operationStore = originalOperationStore })
+
+	// A real, PBM-resolvable storage policy is required for CreateBlockVolumeUtil to actually
+	// succeed in creating the linked-clone volume below - the failure under test happens in the
+	// step *after* volume creation, so creation itself must succeed.
+	pc, err := pbm.NewClient(ctx, ct.vcenter.Client.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profileID, err := pc.ProfileIDByName(ctx, "vSAN Default Storage Policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalCO := commonco.ContainerOrchestratorUtility
+	originalMultiCluster := IsMultipleClustersPerVsphereZoneFSSEnabled
+	t.Cleanup(func() {
+		commonco.ContainerOrchestratorUtility = originalCO
+		IsMultipleClustersPerVsphereZoneFSSEnabled = originalMultiCluster
+	})
+	IsMultipleClustersPerVsphereZoneFSSEnabled = true
+	commonco.ContainerOrchestratorUtility = &fakeCOOverrides{
+		COCommonInterface:  originalCO,
+		clusters:           []string{"domain-c8"},
+		fssOverrides:       map[string]bool{common.LinkedCloneSupport: true},
+		linkedCloneUUIDErr: common.ErrNotFound,
+	}
+
+	linkedCloneVolName := testVolumeName + "-" + uuid.New().String()
+	linkedCloneReq := &csi.CreateVolumeRequest{
+		Name: linkedCloneVolName,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters: map[string]string{
+			common.AttributePvcName:             "audit-pvc",
+			common.AttributePvcNamespace:        "default",
+			common.AttributeIsLinkedCloneKey:    "true",
+			common.AttributeStoragePolicyID:     profileID,
+			common.AttributeStorageTopologyType: "zonal",
+		},
+		VolumeCapabilities: capabilities,
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Preferred: []*csi.Topology{
+				{Segments: map[string]string{v1.LabelTopologyZone: "zone-1"}},
+			},
+			Requisite: []*csi.Topology{
+				{Segments: map[string]string{v1.LabelTopologyZone: "zone-1"}},
+			},
+		},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: snapID},
+			},
+		},
+	}
+
+	_, _, err = ct.controller.createBlockVolume(ctx, linkedCloneReq, true, clusterComputeResourceMoIds)
+	if err == nil {
+		t.Fatal("expected CreateVolume to fail when the linked clone source UUID lookup fails")
+	}
+	statusErr, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("unable to convert the error: %+v into a grpc status error type", err)
+	}
+	if statusErr.Code() != codes.Internal {
+		t.Fatalf("expected %s, got %s: %v", codes.Internal, statusErr.Code(), err)
+	}
+	if !strings.Contains(err.Error(), "failed to get linked clone name") {
+		t.Fatalf("expected the linked-clone-name lookup failure to be reported, got: %v", err)
+	}
+
+	// The volume CreateBlockVolumeUtil created before the failed lookup must not be leaked.
+	queryResult, err := ct.vcenter.CnsClient.QueryVolume(ctx, &cnstypes.CnsQueryFilter{
+		Names: []string{linkedCloneVolName},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(queryResult.Volumes) != 0 {
+		t.Fatalf("expected the volume created for %q to be cleaned up after the linked-clone-name "+
+			"lookup failure, but it still exists: %+v", linkedCloneVolName, queryResult.Volumes)
+	}
 }
 
 // TestRestoreFromHostLocalSnapshotPinsPlacementToSourceHost covers the placement constraints a


### PR DESCRIPTION
**What this PR does / why we need it**:

Problem: 
When creating a linked-clone volume, CreateVolume (pkg/csi/service/wcp/controller.go) first creates the real CNS/FCD volume via CreateBlockVolumeUtil. Afterward, for linked-clone requests, it performs a secondary step: it re-fetches the linked-clone PVC itself in order to read that PVC's spec.dataSource and resolve the UID of the VolumeSnapshot it was cloned from. This UID is then stamped onto the resulting PV as a linked-clone-source-uid label.

If the linked-clone PVC has already been deleted by the time this second lookup runs — which happens when a caller rapidly deletes and recreates a PVC under the same name (e.g., to repeatedly audit/verify a snapshot via short-lived linked clones) — the re-fetch fails with NotFound (GetLinkedCloneVolumeSnapshotSourceUUID). CreateVolume then returns an Internal error without deleting the volume it already created.

Because CreateVolume returned an error, no PV is ever created in Kubernetes for that volume, so nothing in the normal PVC/PV lifecycle ever asks the driver to clean it up — the underlying CNS/FCD volume becomes a permanent, invisible-to-Kubernetes orphan.

1. CreateBlockVolumeUtil succeeds → CNS/FCD volume is created.
2. Because isLinkedCloneRequest, the code then does a live Get on the PVC, to read its spec.dataSource and look up the source VolumeSnapshot's UID.
3. That Get returns apierrors.IsNotFound — the PVC object no longer exists at that instant.
4. The function returns common.ErrNotFound ("not found"), CreateVolume returns Internal to csi-provisioner, and the already-created volume is never cleaned up (unlike the sibling host-local-topology failure path a few lines down, which does call DeleteVolumeUtil).

This happens when a test program deletes and recreates the PVC under the same name faster than provisioning completes. By the time step 2 runs for this particular UID's CreateVolume call, the test program has already deleted that PVC to start its next cycle. So the trigger is the test program's PVC churn rate outpacing provisioning latency, and the bug is the driver's missing cleanup-on-failure in that specific branch.

Fix: 
In that error branch, delete the volume (and its CnsVolumeOperationRequest record) before returning the error, mirroring the existing cleanup pattern already used a few lines below for a different CreateVolume failure mode (host-local topology resolution). Now a failed CreateVolume for this reason no longer leaves storage behind.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1915/ (passed)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1459/ (passed)

[Manual Testing](https://gist.github.com/xing-yang/c07efb95fcf34ac4b426ebd5cd4ab1e9#file-cleanup-linkedclone-volume-md)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Clean up linked clone volume if label can't be added.
```
