### PR TITLE
Fix - initialize VAC policy mutability flag for Supervisor

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -66,6 +66,18 @@ var (
 	featureIsVACPolicyMutabilityEnabled    bool
 )
 
+// initWorkloadFSSFlag sets the given flag from the current state of the given Workload (Supervisor)
+// capability, and starts a late-enablement watcher (which will restart the container) when the
+// capability is not yet active.
+func initWorkloadFSSFlag(ctx context.Context, containerOrchestratorUtility commonco.COCommonInterface,
+	capability string, flag *bool) {
+	*flag = containerOrchestratorUtility.IsFSSEnabled(ctx, capability)
+	if !*flag {
+		go containerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
+			capability, "", "")
+	}
+}
+
 // watchConfigChange watches on the webhook configuration directory for changes
 // like cert, key etc. This is required for certificate rotation.
 func watchConfigChange(enableWebhookClientCertVerification bool) {
@@ -148,18 +160,14 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 		featureGateTKGSHaEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		featureGateByokEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BYOKEncryption)
-		featureIsSharedDiskEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.SharedDiskFss)
 		featureFileVolumesWithVmServiceEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.FileVolumesWithVmService)
-		featureIsLinkedCloneSupportEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.LinkedCloneSupport)
-		if !featureIsLinkedCloneSupportEnabled {
-			go containerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
-				common.LinkedCloneSupport, "", "")
-		}
-		if !featureIsSharedDiskEnabled {
-			go containerOrchestratorUtility.HandleLateEnablementOfCapability(ctx, cnstypes.CnsClusterFlavorWorkload,
-				common.SharedDiskFss, "", "")
-		}
+		initWorkloadFSSFlag(ctx, containerOrchestratorUtility, common.LinkedCloneSupport,
+			&featureIsLinkedCloneSupportEnabled)
+		initWorkloadFSSFlag(ctx, containerOrchestratorUtility, common.SharedDiskFss,
+			&featureIsSharedDiskEnabled)
+		initWorkloadFSSFlag(ctx, containerOrchestratorUtility, common.VMPVCStoragePolicyMutability,
+			&featureIsVACPolicyMutabilityEnabled)
 		if err := startCNSCSIWebhookManager(ctx, enableWebhookClientCertVerification,
 			containerOrchestratorUtility); err != nil {
 			return fmt.Errorf("unable to run the webhook manager: %w", err)

--- a/pkg/syncer/admissionhandler/admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/admissionhandler_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionhandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+)
+
+// TestInitWorkloadFSSFlag covers initWorkloadFSSFlag, the helper StartWebhookServer uses to
+// initialize each Workload-flavor feature flag from the live capability/FSS state. Add a new
+// row here (rather than a bespoke test) when wiring up a new Workload capability.
+func TestInitWorkloadFSSFlag(t *testing.T) {
+	tests := []struct {
+		name                 string
+		capability           string
+		fssEnabled           bool
+		expectFlag           bool
+		expectLateEnablement bool
+	}{
+		{
+			name:                 "VAC policy mutability enabled",
+			capability:           common.VMPVCStoragePolicyMutability,
+			fssEnabled:           true,
+			expectFlag:           true,
+			expectLateEnablement: false,
+		},
+		{
+			name:                 "VAC policy mutability disabled starts late-enablement watcher",
+			capability:           common.VMPVCStoragePolicyMutability,
+			fssEnabled:           false,
+			expectFlag:           false,
+			expectLateEnablement: true,
+		},
+		{
+			name:                 "shared disk support enabled",
+			capability:           common.SharedDiskFss,
+			fssEnabled:           true,
+			expectFlag:           true,
+			expectLateEnablement: false,
+		},
+		{
+			name:                 "linked clone support disabled starts late-enablement watcher",
+			capability:           common.LinkedCloneSupport,
+			fssEnabled:           false,
+			expectFlag:           false,
+			expectLateEnablement: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Setup
+			ctx := context.Background()
+			mockCO := new(MockCOCommonInterface)
+			mockCO.On("IsFSSEnabled", ctx, test.capability).Return(test.fssEnabled)
+
+			lateEnablementCalled := make(chan struct{}, 1)
+			mockCO.On("HandleLateEnablementOfCapability", ctx, cnstypes.CnsClusterFlavorWorkload,
+				test.capability, "", "").Run(func(_ mock.Arguments) {
+				lateEnablementCalled <- struct{}{}
+			}).Return()
+
+			// Execute
+			var flag bool
+			initWorkloadFSSFlag(ctx, mockCO, test.capability, &flag)
+
+			// Assert
+			assert.Equal(t, test.expectFlag, flag)
+
+			select {
+			case <-lateEnablementCalled:
+				assert.True(t, test.expectLateEnablement,
+					"HandleLateEnablementOfCapability was called but not expected")
+			case <-time.After(200 * time.Millisecond):
+				assert.False(t, test.expectLateEnablement,
+					"HandleLateEnablementOfCapability was expected but not called")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- PR #4184 introduced a new variable `featureIsVACPolicyMutabilityEnabled` in `pkg/syncer/admissionhandler/admissionhandler.go` which was supposed to represent whether the VC FSS `VM_PVC_STORAGE_POLICY_MUTABILITY` and the WCP capability `supports_VM_PVC_storage_policy_mutability` are enabled. 
- The webhook relies on the above var to allow or to reject a VAC modification request. 
- But, the PR missed adding the needed logic in [StartWebhookServer](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/4184/changes#diff-03bebe47d4027df92d467a939bed295fd060d17ff6ecd7b7f9dbf5534cee0ba4R127)'s supervisor flow(`clusterFlavor == cnstypes.CnsClusterFlavorWorkload`) which resulted in the var to always be `false`.
- This resulted in the admission webhook rejecting **all** the VAC modification requests with a forbidden error even if the FSS and the capability are enabled - 
```shell
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \"validation.csi.vsphere.vmware.com\" denied the request: VolumeAttributesClass modification is not allowed: VM_PVC_STORAGE_POLICY_MUTABILITY feature is disabled","reason":"VolumeAttributesClass modification is not allowed: VM_PVC_STORAGE_POLICY_MUTABILITY feature is disabled","code":400}

# VC FSS
> feature-state-util -s VM_PVC_STORAGE_POLICY_MUTABILITY
enabled

# WCP capability

> kubectl get capabilities.iaas.vmware.com supervisor-capabilities -o jsonpath={'.status.supervisor.supports_VM_PVC_storage_policy_mutability'}
{"activated":true}%
```
- This PR addresses the issue by accurately setting the `featureIsVACPolicyMutabilityEnabled` to `true` if the FSS and the capability are enabled.

## Testing
### Issue reproduction
Ran the `vac-sv host-local` E2E suite (`script/test/supervisor/vac/test_vac_rejection.py`) against a Supervisor testbed with `VM_PVC_STORAGE_POLICY_MUTABILITY` enabled at the VC FSS level and `supports_VM_PVC_storage_policy_mutability` activated in the `supervisor-capabilities` Capabilities CR, using the pre-fix driver image.

All 3 tests failed, each expecting a `403` denial from the storage-quota-webhook (`validate-quota-on-update.k8s.io`) but instead getting no denial at all raised by the VAC patch call itself:
```
✘ CALL  FAILED   supervisor/vac/test_vac_rejection.py::test_non_host_local_to_host_local_vac_change_denied[vac-present]
✘ CALL  FAILED   supervisor/vac/test_vac_rejection.py::test_non_host_local_to_host_local_vac_change_denied[vac-absent]
✘ CALL  FAILED   supervisor/vac/test_vac_rejection.py::test_host_local_vac_change_denied
```

### Fix verification
Ran the targeted parametrized scenario against the Supervisor testbed with the fix deployed:
```
> ./test vac-sv -k test_non_host_local_to_host_local_vac_change_denied -v
✔ CALL  PASSED   supervisor/vac/test_vac_rejection.py::test_non_host_local_to_host_local_vac_change_denied[vac-present]
✔ CALL  PASSED   supervisor/vac/test_vac_rejection.py::test_non_host_local_to_host_local_vac_change_denied[vac-absent]
Client-side, each attempted VAC change to host-local was correctly denied with a 403 from the storage-quota-webhook, not the CSI driver's own admission handler:
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \"validate-quota-on-update.k8s.io\" denied the request: Operation denied, Error returned from extension service for resource PersistentVolumeClaim in namespace vac-annotation, err = VAC compatibility check failed: PVC vac-annotation/e2e-vac-non-host-local-106f102f \n","reason":"Forbidden","code":403}
-----

{"level":"info","time":"2026-08-19T09:10:41.009443324Z","caller":"admissionhandler/validatepvc.go:275","msg":"VAC change detected for PVC vac-annotation/e2e-vac-non-host-local-106f102f: \"wcpglobal-storage-profile\" -> \"host-local\""}
{"level":"info","time":"2026-08-19T09:10:49.415144638Z","caller":"admissionhandler/validatepvc.go:275","msg":"VAC change detected for PVC vac-annotation/e2e-vac-non-host-local-53ddb060: \"\" -> \"host-local\""}
```
### Precheckins
#### WCP - [Jenkins Build #1912](https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1912/)
```
Ran 15 of 2362 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2347 Skipped | 0 Flaked
```
#### VKS - [Jenkins Build #1456](https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1456/)
```
Ran 6 of 2362 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2356 Skipped | 0 Flaked
```
## Special notes for your reviewer
- Extracted the repeated FSS initialisation logic to `initWorkloadFSSFlag` func to keep the code clean and adaptable for future FSS additions.

**Release note**:
```release-note
NONE
```
