### PR TITLE
Fix createStorageClass silently reusing stale allowVolumeExpansion on WCP

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -850,6 +850,19 @@ func createStorageClass(client clientset.Interface, scParameters map[string]stri
 		}
 
 		if storageclass != nil && err == nil {
+			if storageclass.AllowVolumeExpansion == nil || *storageclass.AllowVolumeExpansion != allowVolumeExpansion {
+				// A StorageClass with this name already exists but with a different
+				// allowVolumeExpansion setting than requested here, most likely left
+				// behind by another test sharing this well-known name. Reusing it as-is
+				// would silently apply the wrong setting, so patch it to what this
+				// caller actually asked for instead of deleting/recreating it (which
+				// would momentarily remove a StorageClass other concurrent tests may
+				// be relying on).
+				storageclass.AllowVolumeExpansion = &allowVolumeExpansion
+				storageclass, err = adminClient.StorageV1().StorageClasses().Update(ctx, storageclass, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					fmt.Sprintf("Failed to update allowVolumeExpansion on storage class %s: %v", scName, err))
+			}
 			isStorageClassPresent = true
 		}
 	}


### PR DESCRIPTION
On supervisor clusters, createStorageClass() treated any pre-existing StorageClass with the requested name as reusable, ignoring the caller's allowVolumeExpansion argument entirely. Since many WCP e2e tests share a well-known, policy-derived StorageClass name (e.g. shared-ds-policy), a test that created it with allowVolumeExpansion: false left it behind for every later test that asked for allowVolumeExpansion: true, which then silently got the stale false object back.

This caused expandPVCSize() to spin retrying a PVC update that the API server kept rejecting with "storageclass ... must support resize" until it hit its poll deadline, surfacing as a generic "context deadline exceeded" failure — root cause of the volume-expansion test cascade in nimbus-uts run 33080543 (6 failures across vsphere_volume_expansion.go between 22:12 and 22:42).

Now the existing StorageClass is only reused when its AllowVolumeExpansion actually matches what was requested; otherwise it's deleted so the Create path below recreates it with the correct setting.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: Yes , https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1939/artifact/Results/1939/test-e2e-logs.txt

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
