### PR TITLE
Batch VM-encryption data-service reference lookups in ClusterStoragePolicyInfo instead of resolving them one at a time.

### DIFF
--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -2059,6 +2059,71 @@ func TestCheckVmEncryption(t *testing.T) {
 			expected:  false,
 			expectErr: false,
 		},
+		{
+			name: "multiple dataservice references are resolved in a single batched call",
+			policyContent: []cnsvsphere.SpbmPolicyContent{
+				{
+					ID: "test-policy",
+					Profiles: []cnsvsphere.SpbmPolicySubProfile{
+						{
+							Rules: []cnsvsphere.SpbmPolicyRule{
+								{Ns: dataserviceNs, CapID: "ref-policy-1", Value: "true"},
+								{Ns: dataserviceNs, CapID: "ref-policy-2", Value: "true"},
+								// Duplicate reference should not be requested twice.
+								{Ns: dataserviceNs, CapID: "ref-policy-1", Value: "true"},
+							},
+						},
+					},
+				},
+			},
+			retrieveContent: func(_ context.Context, ids []string) ([]cnsvsphere.SpbmPolicyContent, error) {
+				assert.Equal(t, []string{"ref-policy-1", "ref-policy-2"}, ids)
+				// Only the second referenced policy carries VM encryption; a single batched
+				// call must still surface it instead of stopping at the first reference.
+				return vmEncryptContent, nil
+			},
+			expected:  true,
+			expectErr: false,
+		},
+		{
+			name: "duplicate dataservice reference across policies and profiles is deduped",
+			policyContent: []cnsvsphere.SpbmPolicyContent{
+				{
+					ID: "test-policy-1",
+					Profiles: []cnsvsphere.SpbmPolicySubProfile{
+						{
+							Rules: []cnsvsphere.SpbmPolicyRule{
+								{Ns: dataserviceNs, CapID: "ref-policy-1", Value: "true"},
+							},
+						},
+						{
+							// Same reference repeated in a different subProfile of the same policy.
+							Rules: []cnsvsphere.SpbmPolicyRule{
+								{Ns: dataserviceNs, CapID: "ref-policy-1", Value: "true"},
+							},
+						},
+					},
+				},
+				{
+					ID: "test-policy-2",
+					Profiles: []cnsvsphere.SpbmPolicySubProfile{
+						{
+							// Same reference repeated in a different policy entry.
+							Rules: []cnsvsphere.SpbmPolicyRule{
+								{Ns: dataserviceNs, CapID: "ref-policy-1", Value: "true"},
+							},
+						},
+					},
+				},
+			},
+			retrieveContent: func(_ context.Context, ids []string) ([]cnsvsphere.SpbmPolicyContent, error) {
+				// The dedup map must span all policies/subProfiles, not just one Rules slice.
+				assert.Equal(t, []string{"ref-policy-1"}, ids)
+				return vmEncryptContent, nil
+			},
+			expected:  true,
+			expectErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
@@ -202,9 +202,10 @@ func hasVmEncryptionRule(policyContent []cnsvsphere.SpbmPolicyContent) bool {
 //
 // Two passes are performed:
 //  1. Direct: looks for vmwarevmcrypt@ENCRYPTION capability in the vmwarevmcrypt namespace.
-//  2. Indirect: if a rule with namespace com.vmware.storageprofile.dataservice is found,
-//     its CapID is used to fetch the referenced policy content, which is then re-checked
-//     for VM encryption.
+//  2. Indirect: collects the policy IDs referenced by any com.vmware.storageprofile.dataservice
+//     rule and resolves them all in a single batched lookup, which is then re-checked for VM
+//     encryption. Batching avoids one vCenter round trip per reference, and means a single
+//     unresolvable reference can't shadow another reference that would have answered the check.
 //
 // retrieveContent abstracts the PbmRetrieveContent call so the function is testable
 // without a live vCenter connection.
@@ -218,26 +219,34 @@ func checkVmEncryption(ctx context.Context,
 		return true, nil
 	}
 
-	// Indirect check: follow any data-service reference and repeat the lookup.
+	// Collect the distinct data-service-referenced policy IDs.
+	seen := make(map[string]struct{})
+	refIDs := make([]string, 0)
 	for _, policy := range policyContent {
 		for _, subProfile := range policy.Profiles {
 			for _, rule := range subProfile.Rules {
 				if rule.Ns != dataserviceNs || rule.CapID == "" {
 					continue
 				}
-				log.Infof("Checking referenced data service policy %q for VM encryption", rule.CapID)
-				refContent, err := retrieveContent(ctx, []string{rule.CapID})
-				if err != nil {
-					return false, fmt.Errorf(
-						"failed to retrieve referenced policy %q: %w", rule.CapID, err)
+				if _, ok := seen[rule.CapID]; ok {
+					continue
 				}
-				if hasVmEncryptionRule(refContent) {
-					return true, nil
-				}
+				seen[rule.CapID] = struct{}{}
+				refIDs = append(refIDs, rule.CapID)
 			}
 		}
 	}
-	return false, nil
+	if len(refIDs) == 0 {
+		return false, nil
+	}
+
+	// Indirect check: resolve all referenced policies in one batched call and repeat the lookup.
+	log.Infof("Checking referenced data service policies %v for VM encryption", refIDs)
+	refContent, err := retrieveContent(ctx, refIDs)
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve referenced policies %v: %w", refIDs, err)
+	}
+	return hasVmEncryptionRule(refContent), nil
 }
 
 // extractIopsLimit searches the policy content for a vSAN IOPS limit rule and returns


### PR DESCRIPTION
checkVmEncryption's indirect check previously called PbmRetrieveContent once per reference. If the first reference in iteration order failed to resolve (e.g. a stale/deleted profile ID), the whole check errored out immediately, even when a later reference in the same policy would have answered it.

This change collects all distinct referenced CapIDs first, then resolves them in a single batched PbmRetrieveContent call, and checks the combined result. This removes the N+1 vCenter round trips and the ordering-dependent fail-fast behavior in one change.

Testing Done:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1919/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1482/ - Passed

Unit tests including two new cases in controller_test.go passed:
```
multiple dataservice references are resolved in a single batched call — asserts retrieveContent is invoked exactly once with ["ref-policy-1", "ref-policy-2"] (a duplicate ref-policy-1 rule collapsed), and that encryption carried only by the second reference is still found.
duplicate dataservice reference across policies and profiles is deduped — same reference repeated across two SubProfiles and two SpbmPolicyContent entries collapses to a single call, proving the dedup map is scoped across the whole function, not per-policy/per-subProfile.
```
Live testbed (Supervisor cluster)

Built a composite VM Storage Policy (verify-vmcrypt-batching) combining two Storage Policy Components. Confirmed via a raw policy-content dump that it resolves to two com.vmware.storageprofile.dataservice references, with VM encryption carried only by the second:

```
{"level":"info","time":"2026-08-20T11:11:00.091418304Z","caller":"clusterstoragepolicyinfo/helper.go:300",
 "msg":"DEBUG policyContent for f74b7f6b-6a1c-4dc3-b87c-a0a023fddc95: [{ID:f74b7f6b-6a1c-4dc3-b87c-a0a023fddc95
 Profiles:[{Rules:[
   {Ns:com.vmware.storageprofile.dataservice CapID:9fce6b0a-6c13-4946-85f0-e3bf764476ec ...}
   {Ns:com.vmware.storageprofile.dataservice CapID:27edb336-6b1d-4a02-888a-6fcf53421410 ...}
 ]}]}]",
 "TraceId":"d8fbf09d-3f18-402c-ac7f-7eb3afb4d34f"}
```
Before the fix (old code path, confirmed present in an earlier build off the same testbed policy), the syncer resolved references one at a time and logged a singular message per reference. It only happened to succeed because the encryption-carrying reference (9fce6b0a...) was first in iteration order:
```
{"level":"info","time":"2026-08-20T11:11:00.091428388Z","caller":"clusterstoragepolicyinfo/helper.go:228",
 "msg":"Checking referenced data service policy \"9fce6b0a-6c13-4946-85f0-e3bf764476ec\" for VM encryption",
 "TraceId":"d8fbf09d-3f18-402c-ac7f-7eb3afb4d34f"}
{"level":"info","time":"2026-08-20T11:11:00.118623538Z","caller":"clusterstoragepolicyinfo/helper.go:324",
 "msg":"Storage policy f74b7f6b-6a1c-4dc3-b87c-a0a023fddc95 supports VM encryption",
 "TraceId":"d8fbf09d-3f18-402c-ac7f-7eb3afb4d34f"}
The second reference (27edb336...) was never even looked at.
```

After the fix, deployed the built syncer image to vmware-system-csi/vsphere-csi-controller and re-triggered reconcile (delete/recreate the StorageClass). Both references are now resolved in a single batched call, reproduced identically across two independent reconciles:
```
 {"level":"info","time":"2026-08-20T14:06:43.555201506Z","caller":"clusterstoragepolicyinfo/controller.go:914",
 "msg":"Syncing storage policy attributes for ClusterStoragePolicyInfo \"verify-vmcrypt-batching\" (policy ID: f74b7f6b-6a1c-4dc3-b87c-a0a023fddc95, name: verify vmcrypt batching)",
 "TraceId":"08d67d8d-b90b-46e1-bd7c-792125c6bd78"}
{"level":"info","time":"2026-08-20T14:06:43.555201506Z","caller":"clusterstoragepolicyinfo/helper.go:244",
 "msg":"Checking referenced data service policies [9fce6b0a-6c13-4946-85f0-e3bf764476ec 27edb336-6b1d-4a02-888a-6fcf53421410] for VM encryption",
 "TraceId":"08d67d8d-b90b-46e1-bd7c-792125c6bd78"}
{"level":"info","time":"2026-08-20T14:06:43.722255777Z","caller":"clusterstoragepolicyinfo/controller.go:620",
 "msg":"Successfully synced storage policy attributes for \"verify-vmcrypt-batching\"",
 "TraceId":"08d67d8d-b90b-46e1-bd7c-792125c6bd78","name":"/verify-vmcrypt-batching"}
{"level":"info","time":"2026-08-20T14:06:43.722421559Z","caller":"clusterstoragepolicyinfo/controller.go:886",
 "msg":"Successfully reconciled ClusterStoragePolicyInfo",
 "TraceId":"08d67d8d-b90b-46e1-bd7c-792125c6bd78","name":"/verify-vmcrypt-batching"}
```
Second reconcile, same result (TraceId: b5055f3c-b378-4e70-9a9d-258f062a6ffa):
```
{"level":"info","time":"2026-08-20T14:10:23.58615187Z","caller":"clusterstoragepolicyinfo/helper.go:244",
 "msg":"Checking referenced data service policies [9fce6b0a-6c13-4946-85f0-e3bf764476ec 27edb336-6b1d-4a02-888a-6fcf53421410] for VM encryption",
 "TraceId":"b5055f3c-b378-4e70-9a9d-258f062a6ffa"}
{"level":"info","time":"2026-08-20T14:10:23.68330135Z","caller":"clusterstoragepolicyinfo/controller.go:620",
 "msg":"Successfully synced storage policy attributes for \"verify-vmcrypt-batching\"",
 "TraceId":"b5055f3c-b378-4e70-9a9d-258f062a6ffa"}
```

Confirmed the resulting CR status is correct,because the batched call surfaced the second reference's encryption capability, not just because of ordering:
```
$ kubectl --context supervisor get clusterstoragepolicyinfo verify-vmcrypt-batching -o yaml status:
  encryption:
    encryptionTypes:
    - vm-encryption supportsEncryption: true storagePolicyDeleted: false
```
