### PR TITLE
Only clean up linked clone volume when the PVC is gone

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -19,6 +19,7 @@ package wcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -1267,19 +1268,28 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		volumeSnapshotUID, err := commonco.ContainerOrchestratorUtility.GetLinkedCloneVolumeSnapshotSourceUUID(ctx,
 			pvcName, pvcNamespace)
 		if err != nil {
-			// The provisioned volume cannot be labeled as a linked clone, so it would be
-			// unreachable by the linked-clone-exists safety check on snapshot deletion. Clean it up.
-			log.Errorf("failed to get linked clone name: %s on namespace: %s source volumesnapshot. "+
-				"Cleaning up volume %q. Error: %+v", pvcName, pvcNamespace, volumeInfo.VolumeID.Id, err)
-			deleteOpReqError := operationStore.DeleteRequestDetails(ctx, req.Name)
-			if deleteOpReqError != nil {
-				log.Warnf("failed to cleanup CnsVolumeOperationRequest instance before erroring "+
-					"out. Error received: %+v", deleteOpReqError)
-			} else {
-				if _, deleteVolumeError := common.DeleteVolumeUtil(ctx, c.manager.VolumeManager,
-					volumeInfo.VolumeID.Id, true); deleteVolumeError != nil {
-					log.Warnf("failed to delete volume: %q while cleaning up after CreateVolume failure. "+
-						"Error: %+v", volumeInfo.VolumeID.Id, deleteVolumeError)
+			// Only a NotFound error is terminal: the PVC is already gone from etcd, so
+			// csi-provisioner will never retry this claim and no PV will ever be created for the
+			// volume above. Nothing downstream can reclaim it (full sync only labels such volumes
+			// pv_missing), and it would stay a live linked clone that blocks deletion of its source
+			// snapshot, so delete it here.
+			//
+			// For any other error the PVC may still exist and the request is retryable. Leave the
+			// volume and the CnsVolumeOperationRequest in place so the idempotency feature retries
+			// with the same volume, per the convention used elsewhere in this function.
+			if errors.Is(err, common.ErrNotFound) {
+				log.Errorf("linked clone PVC %s/%s no longer exists; cleaning up volume %q. Error: %+v",
+					pvcNamespace, pvcName, volumeInfo.VolumeID.Id, err)
+				deleteOpReqError := operationStore.DeleteRequestDetails(ctx, req.Name)
+				if deleteOpReqError != nil {
+					log.Warnf("failed to cleanup CnsVolumeOperationRequest instance before erroring "+
+						"out. Error received: %+v", deleteOpReqError)
+				} else {
+					if _, deleteVolumeError := common.DeleteVolumeUtil(ctx, c.manager.VolumeManager,
+						volumeInfo.VolumeID.Id, true); deleteVolumeError != nil {
+						log.Warnf("failed to delete volume: %q while cleaning up after CreateVolume failure. "+
+							"Error: %+v", volumeInfo.VolumeID.Id, deleteVolumeError)
+					}
 				}
 			}
 			msg := fmt.Sprintf("failed to get linked clone name: %s on namespace: %s source volumesnapshot. "+

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -2010,7 +2010,8 @@ func TestCreateVolumeCleansUpVolumeWhenLinkedCloneUUIDLookupFails(t *testing.T) 
 
 	_, _, err = ct.controller.createBlockVolume(ctx, linkedCloneReq, true, clusterComputeResourceMoIds)
 	if err == nil {
-		t.Fatal("expected CreateVolume to fail when the linked clone source UUID lookup fails")
+		t.Fatal("expected createBlockVolume to fail when the linked clone source UUID lookup " +
+			"returns NotFound")
 	}
 	statusErr, ok := status.FromError(err)
 	if !ok {
@@ -2033,6 +2034,153 @@ func TestCreateVolumeCleansUpVolumeWhenLinkedCloneUUIDLookupFails(t *testing.T) 
 	if len(queryResult.Volumes) != 0 {
 		t.Fatalf("expected the volume created for %q to be cleaned up after the linked-clone-name "+
 			"lookup failure, but it still exists: %+v", linkedCloneVolName, queryResult.Volumes)
+	}
+}
+
+// TestCreateVolumeKeepsVolumeWhenLinkedCloneUUIDLookupFailsTransiently is the counterpart to
+// TestCreateVolumeCleansUpVolumeWhenLinkedCloneUUIDLookupFails: for a NON-NotFound (retryable)
+// error the volume must be LEFT IN PLACE.
+//
+// Only a NotFound error is terminal - it means the PVC is gone, so csi-provisioner will never
+// retry and the volume can never be reclaimed. Any other error (API server 5xx, throttling,
+// timeout) may well be transient with the PVC still present, and csi-provisioner will retry;
+// deleting the volume there would throw away a volume the idempotency feature would otherwise
+// reuse, and turn a self-healing retry into a destroy/recreate cycle - or, if the delete itself
+// fails after the CnsVolumeOperationRequest was already removed, into a permanent orphan with no
+// record anywhere. This matches the convention stated elsewhere in createBlockVolume: "do not
+// delete volume created as idempotency feature will ensure we retry with the same volume".
+func TestCreateVolumeKeepsVolumeWhenLinkedCloneUUIDLookupFailsTransiently(t *testing.T) {
+	ct := getControllerTest(t)
+
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	respCreate, err := ct.controller.CreateVolume(ctx, &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         map[string]string{},
+		VolumeCapabilities: capabilities,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcVolID := respCreate.Volume.VolumeId
+	defer func() {
+		if _, err := ct.controller.DeleteVolume(ctx, &csi.DeleteVolumeRequest{VolumeId: srcVolID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	respCreateSnapshot, err := ct.controller.CreateSnapshot(ctx, &csi.CreateSnapshotRequest{
+		SourceVolumeId: srcVolID,
+		Name:           "snapshot-" + uuid.New().String(),
+		Parameters: map[string]string{
+			common.VolumeSnapshotNamespaceKey: "default",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapID := respCreateSnapshot.Snapshot.SnapshotId
+	defer func() {
+		if _, err := ct.controller.DeleteSnapshot(ctx, &csi.DeleteSnapshotRequest{SnapshotId: snapID}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	fakeOpStore, err := unittestcommon.InitFakeVolumeOperationRequestInterface()
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalOperationStore := operationStore
+	operationStore = fakeOpStore
+	t.Cleanup(func() { operationStore = originalOperationStore })
+
+	pc, err := pbm.NewClient(ctx, ct.vcenter.Client.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profileID, err := pc.ProfileIDByName(ctx, "vSAN Default Storage Policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalCO := commonco.ContainerOrchestratorUtility
+	originalMultiCluster := IsMultipleClustersPerVsphereZoneFSSEnabled
+	t.Cleanup(func() {
+		commonco.ContainerOrchestratorUtility = originalCO
+		IsMultipleClustersPerVsphereZoneFSSEnabled = originalMultiCluster
+	})
+	IsMultipleClustersPerVsphereZoneFSSEnabled = true
+	// A retryable error, deliberately NOT common.ErrNotFound.
+	transientErr := fmt.Errorf("the server was unable to return a response in the time allotted")
+	commonco.ContainerOrchestratorUtility = &fakeCOOverrides{
+		COCommonInterface:  originalCO,
+		clusters:           []string{"domain-c8"},
+		fssOverrides:       map[string]bool{common.LinkedCloneSupport: true},
+		linkedCloneUUIDErr: transientErr,
+	}
+
+	linkedCloneVolName := testVolumeName + "-" + uuid.New().String()
+	linkedCloneReq := &csi.CreateVolumeRequest{
+		Name: linkedCloneVolName,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters: map[string]string{
+			common.AttributePvcName:             "audit-pvc",
+			common.AttributePvcNamespace:        "default",
+			common.AttributeIsLinkedCloneKey:    "true",
+			common.AttributeStoragePolicyID:     profileID,
+			common.AttributeStorageTopologyType: "zonal",
+		},
+		VolumeCapabilities: capabilities,
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Preferred: []*csi.Topology{
+				{Segments: map[string]string{v1.LabelTopologyZone: "zone-1"}},
+			},
+			Requisite: []*csi.Topology{
+				{Segments: map[string]string{v1.LabelTopologyZone: "zone-1"}},
+			},
+		},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: snapID},
+			},
+		},
+	}
+
+	_, _, err = ct.controller.createBlockVolume(ctx, linkedCloneReq, true, clusterComputeResourceMoIds)
+	if err == nil {
+		t.Fatal("expected createBlockVolume to fail when the linked clone source UUID lookup " +
+			"fails with a retryable error")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("expected %s, got %s: %v", codes.Internal, status.Code(err), err)
+	}
+
+	// The volume must survive so the provisioner's retry can reuse it via the idempotency record.
+	queryResult, err := ct.vcenter.CnsClient.QueryVolume(ctx, &cnstypes.CnsQueryFilter{
+		Names: []string{linkedCloneVolName},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(queryResult.Volumes) != 1 {
+		t.Fatalf("expected the volume created for %q to be retained after a retryable "+
+			"linked-clone-name lookup failure, but found %d matching volume(s)",
+			linkedCloneVolName, len(queryResult.Volumes))
+	}
+	// Clean up the intentionally-retained volume.
+	if _, err := common.DeleteVolumeUtil(ctx, ct.controller.manager.VolumeManager,
+		queryResult.Volumes[0].VolumeId.Id, true); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
PR #4233 deletes the just-created volume whenever
GetLinkedCloneVolumeSnapshotSourceUUID fails. That call can also fail for
retryable reasons (API server 5xx, throttling, timeout), and in those cases the
PVC still exists and csi-provisioner will retry. Deleting the volume there
throws away a volume the idempotency feature would have reused, and if the
delete itself fails after the CnsVolumeOperationRequest was already removed the
volume becomes a permanent orphan with no record anywhere - worse than the leak
the fix targets.

This matches the convention already stated twice in createBlockVolume: "do not
delete volume created as idempotency feature will ensure we retry with the same
volume."

Gate the cleanup on common.ErrNotFound, which is returned only when the PVC is
absent from etcd. That is the one terminal case: csi-provisioner will never
retry the claim, no PV will ever be created, full sync only labels such volumes
pv_missing rather than reclaiming them, and the volume stays a live linked clone
that blocks deletion of its source snapshot.

Add a test asserting a retryable error leaves the volume in place, alongside the
existing test that a NotFound error cleans it up.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1937/ (passed)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1470/  (VKS pre-check pipeline still has issues; my PR does not affect VKS side components)

[Manual Testing](https://gist.github.com/xing-yang/7abe4a97341da3d94bea59aabe58a672#file-followup-cleanup-linkedclone-md)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Only clean up linked clone volume when the PVC is gone.
```
