### PR TITLE
Check storagePolicyId associated to the storage class is assigned to the namespace

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -298,6 +298,35 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		setInstanceError(ctx, r, instance, err.Error())
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
+
+	// If a StorageClassName is specified, verify up front that its storage policy is assigned
+	// to this instance's namespace, before any CNS volume is created or modified. Without this,
+	// a namespace could get a volume registered with a storage policy it isn't entitled to.
+	if instance.Spec.StorageClassName != "" {
+		policyID, err := getStoragePolicyIDForStorageClass(ctx, r.k8sclient, instance.Spec.StorageClassName)
+		if err != nil {
+			log.Error(err.Error())
+			setInstanceError(ctx, r, instance, err.Error())
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+		assigned, err := isStoragePolicyAssignedToNamespace(ctx, r.k8sclient, r.client, policyID,
+			instance.Spec.StorageClassName, instance.Namespace, syncer.IsPodVMOnStretchSupervisorFSSEnabled)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to verify StorageClass %q is assigned to namespace %q: %+v",
+				instance.Spec.StorageClassName, instance.Namespace, err)
+			log.Error(msg)
+			setInstanceError(ctx, r, instance, msg)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+		if !assigned {
+			msg := fmt.Sprintf("StorageClass %q's storage policy is not assigned to namespace %q",
+				instance.Spec.StorageClassName, instance.Namespace)
+			log.Error(msg)
+			setInstanceError(ctx, r, instance, msg)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+	}
+
 	// Verify if CnsRegisterVolume request is for block volume registration
 	// Currently file volume registration is not supported.
 	ok := isBlockVolumeRegisterRequest(ctx, instance)
@@ -555,18 +584,25 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	// Use cached K8s client for registration operations.
 	k8sclient := r.k8sclient
 
-	// Get K8S storageclass name mapping the storagepolicy id with Immediate volume binding mode
-	storageClassName, err := getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx, k8sclient, r.client,
-		volume.StoragePolicyId, request.Namespace, syncer.IsPodVMOnStretchSupervisorFSSEnabled)
-	if err != nil {
-		msg := fmt.Sprintf("Failed to find K8S Storageclass mapping storagepolicyId: %s and assigned to namespace: %s",
-			volume.StoragePolicyId, request.Namespace)
-		log.Error(msg)
-		setInstanceError(ctx, r, instance, msg)
-		return reconcile.Result{RequeueAfter: timeout}, nil
+	var storageClassName string
+	if instance.Spec.StorageClassName != "" {
+		// Already resolved and verified as assigned to this namespace before the CNS volume was
+		// created; no need to re-derive or re-validate it here.
+		storageClassName = instance.Spec.StorageClassName
+	} else {
+		// Get K8S storageclass name mapping the storagepolicy id with Immediate volume binding mode
+		storageClassName, err = getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx, k8sclient, r.client,
+			volume.StoragePolicyId, request.Namespace, syncer.IsPodVMOnStretchSupervisorFSSEnabled)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to find K8S Storageclass mapping storagepolicyId: %s and assigned to namespace: %s",
+				volume.StoragePolicyId, request.Namespace)
+			log.Error(msg)
+			setInstanceError(ctx, r, instance, msg)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+		log.Infof("Volume with storagepolicyId: %s is mapping to K8S storage class: %s and assigned to namespace: %s",
+			volume.StoragePolicyId, storageClassName, request.Namespace)
 	}
-	log.Infof("Volume with storagepolicyId: %s is mapping to K8S storage class: %s and assigned to namespace: %s",
-		volume.StoragePolicyId, storageClassName, request.Namespace)
 
 	sc, err := k8sclient.StorageV1().StorageClasses().Get(ctx, storageClassName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -57,6 +57,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
+	cnsstoragepolicyquotasv1alpha3 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha3"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -2166,6 +2167,298 @@ func TestConstructCreateSpecForInstanceWithStorageClassMissingPolicyIDParam(t *t
 	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
 	assert.Error(t, err)
 	assert.Nil(t, spec)
+}
+
+// TestIsStoragePolicyAssignedToNamespaceViaResourceQuota covers the non-stretched-supervisor path,
+// where namespace assignment is expressed via a ResourceQuota entry named
+// "<storage-class-name>.storageclass.storage.k8s.io/requests.storage".
+func TestIsStoragePolicyAssignedToNamespaceViaResourceQuota(t *testing.T) {
+	scName := "sc-with-quota"
+	namespace := "test-ns"
+
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace + "-storagequota", Namespace: namespace},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceName(scName + scResourceNameSuffix): resource.MustParse("5Gi"),
+			},
+		},
+	}
+
+	t.Run("assigned when a matching ResourceQuota entry exists", func(t *testing.T) {
+		k8sclient := k8sfake.NewClientset(quota)
+		assigned, err := isStoragePolicyAssignedToNamespace(context.TODO(), k8sclient, nil,
+			"policy-1", scName, namespace, false)
+		assert.NoError(t, err)
+		assert.True(t, assigned)
+	})
+
+	t.Run("not assigned when no ResourceQuota matches the storage class", func(t *testing.T) {
+		k8sclient := k8sfake.NewClientset(quota)
+		assigned, err := isStoragePolicyAssignedToNamespace(context.TODO(), k8sclient, nil,
+			"policy-1", "other-sc", namespace, false)
+		assert.NoError(t, err)
+		assert.False(t, assigned)
+	})
+
+	t.Run("not assigned when the storage class name is empty", func(t *testing.T) {
+		k8sclient := k8sfake.NewClientset(quota)
+		assigned, err := isStoragePolicyAssignedToNamespace(context.TODO(), k8sclient, nil,
+			"policy-1", "", namespace, false)
+		assert.NoError(t, err)
+		assert.False(t, assigned)
+	})
+}
+
+// TestIsStoragePolicyAssignedToNamespaceViaStoragePolicyQuotaCR covers the Pod VM on stretched
+// supervisor path, where namespace assignment is expressed via a StoragePolicyQuota CR whose
+// SCLevelQuotaStatuses names the storage class.
+func TestIsStoragePolicyAssignedToNamespaceViaStoragePolicyQuotaCR(t *testing.T) {
+	namespace := "test-ns"
+	scName := "sc-with-spq"
+	storagePolicyID := "policy-1"
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = cnsstoragepolicyquotasv1alpha3.AddToScheme(scheme)
+
+	spq := &cnsstoragepolicyquotasv1alpha3.StoragePolicyQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "spq-1", Namespace: namespace},
+		Spec:       cnsstoragepolicyquotasv1alpha3.StoragePolicyQuotaSpec{StoragePolicyId: storagePolicyID},
+		Status: cnsstoragepolicyquotasv1alpha3.StoragePolicyQuotaStatus{
+			SCLevelQuotaStatuses: []cnsstoragepolicyquotasv1alpha3.SCLevelQuotaStatus{
+				{StorageClassName: scName},
+			},
+		},
+	}
+
+	t.Run("assigned when a matching StoragePolicyQuota CR names the storage class", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spq).Build()
+		assigned, err := isStoragePolicyAssignedToNamespace(context.TODO(), nil, fakeClient,
+			storagePolicyID, scName, namespace, true)
+		assert.NoError(t, err)
+		assert.True(t, assigned)
+	})
+
+	t.Run("not assigned when the StoragePolicyQuota CR is for a different policy", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spq).Build()
+		assigned, err := isStoragePolicyAssignedToNamespace(context.TODO(), nil, fakeClient,
+			"other-policy", scName, namespace, true)
+		assert.NoError(t, err)
+		assert.False(t, assigned)
+	})
+
+	t.Run("not assigned when no StoragePolicyQuota CR exists in the namespace", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		assigned, err := isStoragePolicyAssignedToNamespace(context.TODO(), nil, fakeClient,
+			storagePolicyID, scName, namespace, true)
+		assert.NoError(t, err)
+		assert.False(t, assigned)
+	})
+}
+
+// TestReconcileRejectsUnassignedStorageClassPolicy verifies that when Spec.StorageClassName's storage
+// policy is not assigned to the instance's namespace, Reconcile fails fast — before ever contacting
+// vCenter or constructing a CNS create spec — rather than discovering the mismatch only after a CNS
+// volume has already been created with the unauthorized policy.
+func TestReconcileRejectsUnassignedStorageClassPolicy(t *testing.T) {
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	scheme.AddKnownTypes(schema.GroupVersion{Group: "cnsoperator.vmware.com", Version: "v1alpha1"},
+		&cnsregistervolumev1alpha1.CnsRegisterVolume{}, &cnsregistervolumev1alpha1.CnsRegisterVolumeList{})
+
+	crv := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-volume", Namespace: "test-ns"},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:          "test-pvc",
+			VolumeID:         "dummy-volume-id",
+			AccessMode:       "ReadWriteOnce",
+			StorageClassName: "unauthorized-sc",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(crv).Build()
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "unauthorized-sc"},
+		Parameters: map[string]string{"storagePolicyID": "policy-x"},
+	}
+	// No ResourceQuota exists in the namespace granting access to "unauthorized-sc".
+	k8sclientFake := k8sfake.NewClientset(sc)
+
+	commonco.ContainerOrchestratorUtility = &mockCOCommon{}
+
+	origStretch := syncer.IsPodVMOnStretchSupervisorFSSEnabled
+	syncer.IsPodVMOnStretchSupervisorFSSEnabled = false
+	defer func() { syncer.IsPodVMOnStretchSupervisorFSSEnabled = origStretch }()
+
+	r := &ReconcileCnsRegisterVolume{
+		client:     fakeClient,
+		scheme:     scheme,
+		k8sclient:  k8sclientFake,
+		configInfo: &config.ConfigurationInfo{Cfg: &config.Config{}},
+	}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	vcCalled := false
+	patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(_ context.Context,
+		_ *config.ConfigurationInfo, _ bool) (*cnsvsphere.VirtualCenter, error) {
+		vcCalled = true
+		return newFakeVCWithClient(), nil
+	})
+
+	createSpecCalled := false
+	patches.ApplyFunc(constructCreateSpecForInstance, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ string, _ bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+		createSpecCalled = true
+		return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}, nil
+	})
+
+	setErrCalled := false
+	var capturedMsg string
+	patches.ApplyFunc(setInstanceError, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, msg string) {
+		setErrCalled = true
+		capturedMsg = msg
+	})
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-volume", Namespace: "test-ns"}}
+	result, err := r.Reconcile(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{RequeueAfter: time.Second}, result)
+	assert.True(t, setErrCalled,
+		"setInstanceError should be called when the StorageClass's policy isn't assigned to the namespace")
+	assert.Contains(t, capturedMsg, "unauthorized-sc")
+	assert.False(t, vcCalled, "Reconcile should reject before ever contacting vCenter")
+	assert.False(t, createSpecCalled, "Reconcile should reject before constructing the CNS create spec")
+}
+
+// TestReconcileReusesSpecifiedStorageClassNameWithoutLateDiscovery verifies that once Spec.StorageClassName
+// has been validated up front (see TestReconcileRejectsUnassignedStorageClassPolicy), Reconcile reuses it
+// directly for the resulting PV's storage class rather than re-deriving/re-validating it via
+// getK8sStorageClassNameWithImmediateBindingModeForPolicy after the CNS volume is created.
+func TestReconcileReusesSpecifiedStorageClassNameWithoutLateDiscovery(t *testing.T) {
+	backOffDuration = make(map[types.NamespacedName]time.Duration)
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	scheme.AddKnownTypes(schema.GroupVersion{Group: "cnsoperator.vmware.com", Version: "v1alpha1"},
+		&cnsregistervolumev1alpha1.CnsRegisterVolume{}, &cnsregistervolumev1alpha1.CnsRegisterVolumeList{})
+
+	scName := "authorized-sc"
+	crv := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-volume", Namespace: "test-ns"},
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
+			PvcName:          "test-pvc",
+			VolumeID:         "dummy-volume-id",
+			AccessMode:       "ReadWriteOnce",
+			StorageClassName: scName,
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(crv).Build()
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: scName},
+		Parameters: map[string]string{"storagePolicyID": "policy-1"},
+	}
+	// ResourceQuota grants the namespace access to scName, so the early guard passes.
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns-storagequota", Namespace: "test-ns"},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceName(scName + scResourceNameSuffix): resource.MustParse("5Gi"),
+			},
+		},
+	}
+	k8sclientFake := k8sfake.NewClientset(sc, quota)
+
+	commonco.ContainerOrchestratorUtility = &mockCOCommon{}
+
+	origStretch := syncer.IsPodVMOnStretchSupervisorFSSEnabled
+	syncer.IsPodVMOnStretchSupervisorFSSEnabled = false
+	defer func() { syncer.IsPodVMOnStretchSupervisorFSSEnabled = origStretch }()
+
+	r := &ReconcileCnsRegisterVolume{
+		client:    fakeClient,
+		scheme:    scheme,
+		k8sclient: k8sclientFake,
+		configInfo: &config.ConfigurationInfo{Cfg: &config.Config{
+			VirtualCenter: map[string]*config.VirtualCenterConfig{"vc": {User: "test-user"}},
+		}},
+		volumeManager: &mockVolumeManager{
+			createVolumeFunc: func(_ context.Context, _ *cnstypes.CnsVolumeCreateSpec,
+				_ interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
+				return &cnsvolume.CnsVolumeInfo{VolumeID: cnstypes.CnsVolumeId{Id: "dummy-volume-id"}}, "", nil
+			},
+		},
+	}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(_ context.Context,
+		_ *config.ConfigurationInfo, _ bool) (*cnsvsphere.VirtualCenter, error) {
+		return newFakeVCWithClient(), nil
+	})
+	patches.ApplyFunc(constructCreateSpecForInstance, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ string, _ bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+		return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}, nil
+	})
+	patches.ApplyFunc(common.QueryVolumeByID, func(_ context.Context, _ cnsvolume.Manager,
+		volumeID string, _ *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
+		return &cnstypes.CnsVolume{
+			VolumeId:        cnstypes.CnsVolumeId{Id: volumeID},
+			DatastoreUrl:    "dummy-ds-url",
+			StoragePolicyId: "policy-1",
+			BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+				CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
+			},
+		}, nil
+	})
+	patches.ApplyFunc(isDatastoreAccessibleToCluster, func(_ context.Context,
+		_ *cnsvsphere.VirtualCenter, _ string, _ string) bool {
+		return true
+	})
+
+	lateDiscoveryCalled := false
+	patches.ApplyFunc(getK8sStorageClassNameWithImmediateBindingModeForPolicy,
+		func(_ context.Context, _ kubernetes.Interface, _ ctrlclient.Client,
+			_, _ string, _ bool) (string, error) {
+			lateDiscoveryCalled = true
+			return "should-not-be-used", nil
+		})
+
+	// Stop the reconcile right after the StorageClass has been resolved and fetched (line 607),
+	// so a successful call here proves storageClassName resolved to scName without error.
+	reachedPVCCheck := false
+	patches.ApplyFunc(checkExistingPVCDataSourceRef, func(_ context.Context, _ kubernetes.Interface,
+		_ string, _ string) (*corev1.PersistentVolumeClaim, error) {
+		reachedPVCCheck = true
+		return nil, fmt.Errorf("stop reconcile here for the test")
+	})
+
+	setErrCalled := false
+	var capturedMsg string
+	patches.ApplyFunc(setInstanceError, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, msg string) {
+		setErrCalled = true
+		capturedMsg = msg
+	})
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-volume", Namespace: "test-ns"}}
+	_, err := r.Reconcile(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.False(t, lateDiscoveryCalled,
+		"the late storage-class discovery must be skipped when StorageClassName was explicitly specified")
+	assert.True(t, reachedPVCCheck,
+		"reconcile should fetch the specified StorageClass successfully and proceed past it")
+	assert.True(t, setErrCalled)
+	assert.Contains(t, capturedMsg, "stop reconcile here for the test")
 }
 
 func TestIsBlockVolumeRegisterRequestWithSharedBlockVolume(t *testing.T) {

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -342,6 +342,21 @@ func clearKeepAfterDeleteVmIfNonRemovable(ctx context.Context, c ctrlruntimeclie
 // policy name requiring PBM resolution, which is the vanilla/guest-cluster convention).
 const scParamStoragePolicyID = "storagePolicyID"
 
+// getStoragePolicyIDForStorageClass fetches the named StorageClass and returns the vSphere
+// storage policy ID carried in its storagePolicyID parameter.
+func getStoragePolicyIDForStorageClass(ctx context.Context, k8sClient clientset.Interface,
+	scName string) (string, error) {
+	sc, err := k8sClient.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch StorageClass %q: %w", scName, err)
+	}
+	policyID := sc.Parameters[scParamStoragePolicyID]
+	if policyID == "" {
+		return "", fmt.Errorf("StorageClass %q has no %s parameter", scName, scParamStoragePolicyID)
+	}
+	return policyID, nil
+}
+
 // constructCreateSpecForInstance creates CNS CreateVolume spec.
 func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegisterVolume,
 	instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
@@ -393,14 +408,9 @@ func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegister
 	createSpec.VolumeType = common.BlockVolumeType
 
 	if instance.Spec.StorageClassName != "" {
-		sc, err := r.k8sclient.StorageV1().StorageClasses().Get(ctx, instance.Spec.StorageClassName, metav1.GetOptions{})
+		policyID, err := getStoragePolicyIDForStorageClass(ctx, r.k8sclient, instance.Spec.StorageClassName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch StorageClass %q: %w", instance.Spec.StorageClassName, err)
-		}
-		policyID := sc.Parameters[scParamStoragePolicyID]
-		if policyID == "" {
-			return nil, fmt.Errorf("StorageClass %q has no %s parameter",
-				instance.Spec.StorageClassName, scParamStoragePolicyID)
+			return nil, err
 		}
 		createSpec.Profile = []vimtypes.BaseVirtualMachineProfileSpec{
 			&vimtypes.VirtualMachineDefinedProfileSpec{ProfileId: policyID},
@@ -408,6 +418,70 @@ func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegister
 	}
 
 	return createSpec, nil
+}
+
+// isStoragePolicyAssignedToNamespace checks whether the storage policy identified by storagePolicyID,
+// as consumed through the k8s StorageClass scName, has quota assigned in namespace: via a ResourceQuota
+// entry for vanilla/non-stretched supervisors, or a StoragePolicyQuota CR when Pod VM on stretched
+// supervisor is enabled.
+func isStoragePolicyAssignedToNamespace(ctx context.Context, k8sClient clientset.Interface,
+	client ctrlruntimeclient.Client, storagePolicyID, scName, namespace string,
+	isPodVMOnStretchedSupervisorEnabled bool) (bool, error) {
+	log := logger.GetLogger(ctx)
+	if scName == "" {
+		return false, nil
+	}
+
+	if !isPodVMOnStretchedSupervisorEnabled {
+		/*
+			Resource Quotas
+				Name:                                                                   <namespace>-storagequota
+				Resource                                                                Used  Hard
+				--------                                                                ---   ---
+				<storage-class-name>.storageclass.storage.k8s.io/requests.storage  		0     5Gi
+		*/
+		quotaList, err := k8sClient.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, logger.LogNewErrorf(log, "Failed to get resource quotas on the namespace: %s", namespace)
+		}
+		for _, quota := range quotaList.Items {
+			// Looping over each named resource in the storage quota to check if
+			// it matches the storage class.
+			for resource := range quota.Spec.Hard {
+				if scName+scResourceNameSuffix == resource.String() {
+					log.Debugf("Found k8s storage class: %s with storagePolicyId: %s and "+
+						"the policy is assigned to namespace: %s", scName, storagePolicyID, namespace)
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}
+
+	storagePolicyQuotaList := &cnsstoragepolicyquotasv1alpha3.StoragePolicyQuotaList{}
+	if err := client.List(ctx, storagePolicyQuotaList, &ctrlruntimeclient.ListOptions{
+		Namespace: namespace,
+	}); err != nil {
+		return false, logger.LogNewErrorf(log, "Failed to list StoragePolicyQuota CR on the namespace: %s", namespace)
+	}
+	log.Debugf("Fetch storagePolicyQuotaList: %+v  in namespace %s", storagePolicyQuotaList, namespace)
+	for _, storagePolicyQuota := range storagePolicyQuotaList.Items {
+		if storagePolicyQuota.Spec.StoragePolicyId != storagePolicyID {
+			continue
+		}
+		log.Debugf("Found storagePlicyQuota CR with matching storagePolicyId:%s in namespaces:%s",
+			storagePolicyID, namespace)
+		// NOTE: Below code expects StoragePolicyQuota CR status will be populated with all fields with zero values from the
+		// start (to be taken care by quota controller), otherwise this code will always return error.
+		for _, quota := range storagePolicyQuota.Status.SCLevelQuotaStatuses {
+			if quota.StorageClassName == scName {
+				log.Debugf("Found k8s storage class: %s with storagePolicyId: %s and "+
+					"the policy is assigned to namespace: %s", scName, storagePolicyID, namespace)
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // getK8sStorageClassNameWithImmediateBindingModeForPolicy gets the storage class name in K8S mapping the vsphere
@@ -434,73 +508,17 @@ func getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx context.Context
 		}
 	}
 
-	if !isPodVMOnStretchedSupervisorEnabled {
-		/*
-			Resource Quotas
-				Name:                                                                   <namespace>-storagequota
-				Resource                                                                Used  Hard
-				--------                                                                ---   ---
-				<storage-class-name>.storageclass.storage.k8s.io/requests.storage  		0     5Gi
-		*/
-		quotaList, err := k8sClient.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return "", logger.LogNewErrorf(log, "Failed to get resource quotas on the namespace: %s", namespace)
-		}
-
-		if scName != "" && len(quotaList.Items) > 0 {
-			for _, quota := range quotaList.Items {
-				// Looping over each named resource in the storage quota to check if
-				// it matches the storage class.
-				for resource := range quota.Spec.Hard {
-					if scName+scResourceNameSuffix == resource.String() {
-						log.Debugf("Found k8s storage class: %s with storagePolicyId: %s and "+
-							"the policy is assigned to namespace: %s", scName, storagePolicyID, namespace)
-						return scName, nil
-					}
-				}
-			}
-		}
-		return "", logger.LogNewErrorf(log, "Failed to find matching K8s Storageclass. "+
-			"Either storagepolicyId: %s doesn't match any storage class, or the policy is not assigned to namespace: %s",
-			storagePolicyID, namespace)
-	} else {
-		storagePolicyQuotaList := &cnsstoragepolicyquotasv1alpha3.StoragePolicyQuotaList{}
-		err := client.List(ctx, storagePolicyQuotaList, &ctrlruntimeclient.ListOptions{
-			Namespace: namespace,
-		})
-		if err != nil {
-			return "", logger.LogNewErrorf(log, "Failed to list StoragePolicyQuota CR on the namespace: %s", namespace)
-		}
-		log.Debugf("Found scName %s which has matching storagePolicyId %s", scName, storagePolicyID)
-		log.Debugf("Fetch storagePolicyQuotaList: %+v  in namespace %s", storagePolicyQuotaList, namespace)
-		foundMatchStoragePolicyQuotaCR := false
-		matchedStoragePolicyQuotaCR := cnsstoragepolicyquotasv1alpha3.StoragePolicyQuota{}
-		if scName != "" && len(storagePolicyQuotaList.Items) > 0 {
-			for _, storagePolicyQuota := range storagePolicyQuotaList.Items {
-				if storagePolicyQuota.Spec.StoragePolicyId == storagePolicyID {
-					log.Debugf("Found storagePlicyQuota CR with matching storagePolicyId:%s in namespaces:%s",
-						storagePolicyID, namespace)
-					foundMatchStoragePolicyQuotaCR = true
-					matchedStoragePolicyQuotaCR = storagePolicyQuota
-					break
-				}
-			}
-			// NOTE: Below code expects StoragePolicyQuota CR status will be populated with all fields with zero values from the
-			// start (to be taken care by quota controller), otherwise this code will always return error.
-			if foundMatchStoragePolicyQuotaCR && len(matchedStoragePolicyQuotaCR.Status.SCLevelQuotaStatuses) > 0 {
-				for _, quota := range matchedStoragePolicyQuotaCR.Status.SCLevelQuotaStatuses {
-					if quota.StorageClassName == scName {
-						log.Debugf("Found k8s storage class: %s with storagePolicyId: %s and "+
-							"the policy is assigned to namespace: %s", scName, storagePolicyID, namespace)
-						return scName, nil
-					}
-				}
-			}
-		}
-		return "", logger.LogNewErrorf(log, "Failed to find matching K8s Storageclass. "+
-			"Either storagepolicyId: %s doesn't match any storage class, or the policy is not assigned to namespace: %s",
-			storagePolicyID, namespace)
+	assigned, err := isStoragePolicyAssignedToNamespace(ctx, k8sClient, client, storagePolicyID, scName,
+		namespace, isPodVMOnStretchedSupervisorEnabled)
+	if err != nil {
+		return "", err
 	}
+	if assigned {
+		return scName, nil
+	}
+	return "", logger.LogNewErrorf(log, "Failed to find matching K8s Storageclass. "+
+		"Either storagepolicyId: %s doesn't match any storage class, or the policy is not assigned to namespace: %s",
+		storagePolicyID, namespace)
 }
 
 // getPersistentVolumeSpec creates a PV spec for the given params. Caller supplies capacity


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds an optional `storageClassName` field to `CnsRegisterVolumeSpec`. When set, the registration request resolves the vSphere storage policy from the named Kubernetes StorageClass's `storagePolicyID` parameter and assigns it to the volume being registered (unconditionally, regardless of whatever policy the volume already has in CNS). This lets callers such as SnapService register a volume with an explicit storage policy instead of relying on whatever policy already happens to be set on the volume in CNS.

To prevent a namespace from registering a volume with a storage policy it isn't entitled to, the storage policy behind `storageClassName` is validated against the namespace's assigned quota (a `ResourceQuota` entry or a `StoragePolicyQuota` CR, depending on configuration) up front, before any CNS volume is created or modified. If `storageClassName` was not specified, the pre-existing behavior (deriving and validating the storage class from the volume's existing policy after registration) is unchanged.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Unit tests added and passing (`go test ./pkg/syncer/cnsoperator/controller/cnsregistervolume/...`), including:
- `constructCreateSpecForInstance` with/without `storageClassName`, missing StorageClass, and StorageClass missing the `storagePolicyID` parameter.
- `isStoragePolicyAssignedToNamespace` for both the `ResourceQuota` and `StoragePolicyQuota` CR paths.
- Full `Reconcile` behavior: rejects an unauthorized `storageClassName` before contacting vCenter or creating a CNS volume, and reuses an already-validated `storageClassName` directly without re-deriving it after volume creation.

`go build ./...` and `go vet` are clean. E2E / precheckin (jtest) results pending — will update and remove [WIP] once available.

pre-checkin pipeline:

https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1487/
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1942/

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added an optional `storageClassName` field to CnsRegisterVolume to let a registration request explicitly assign a vSphere storage policy to the volume being registered, subject to the policy being assigned to the request's namespace.
```
