### PR TITLE
Stop unconditionally spew.Sdump-ing fullsync log arguments

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/sts"
@@ -293,17 +292,16 @@ func GetLabelsMapFromKeyValue(labels []types.KeyValue) map[string]string {
 func CompareKubernetesMetadata(ctx context.Context, k8sMetaData *cnstypes.CnsKubernetesEntityMetadata,
 	cnsMetaData *cnstypes.CnsKubernetesEntityMetadata) bool {
 	log := logger.GetLogger(ctx)
-	log.Debugf("CompareKubernetesMetadata called with k8spvMetaData: %+v\n and cnsMetaData: %+v\n",
-		spew.Sdump(k8sMetaData), spew.Sdump(cnsMetaData))
+	log.Debugw("CompareKubernetesMetadata called", "k8sMetaData", k8sMetaData, "cnsMetaData", cnsMetaData)
 	if (k8sMetaData.EntityName != cnsMetaData.EntityName) || (k8sMetaData.Delete != cnsMetaData.Delete) ||
 		(k8sMetaData.Namespace != cnsMetaData.Namespace) {
 		return false
 	}
-	labelsMatch := reflect.DeepEqual(GetLabelsMapFromKeyValue(k8sMetaData.Labels),
-		GetLabelsMapFromKeyValue(cnsMetaData.Labels))
-	log.Debugf("CompareKubernetesMetadata - labelsMatch returned: %v for k8spvMetaData: %+v\n and cnsMetaData: %+v\n",
-		labelsMatch, spew.Sdump(GetLabelsMapFromKeyValue(k8sMetaData.Labels)),
-		spew.Sdump(GetLabelsMapFromKeyValue(cnsMetaData.Labels)))
+	k8sLabels := GetLabelsMapFromKeyValue(k8sMetaData.Labels)
+	cnsLabels := GetLabelsMapFromKeyValue(cnsMetaData.Labels)
+	labelsMatch := reflect.DeepEqual(k8sLabels, cnsLabels)
+	log.Debugw("CompareKubernetesMetadata labels comparison", "labelsMatch", labelsMatch,
+		"k8sLabels", k8sLabels, "cnsLabels", cnsLabels)
 	return labelsMatch
 }
 

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -420,8 +420,8 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 						metadataSyncer.configInfo.Cfg.Global.SupervisorID)
 				}
 				for _, updateSpec := range updateMetadataSpecArray {
-					log.Debugf("Calling UpdateVolumeMetadata for volume %s with updateSpec: %+v",
-						updateSpec.VolumeId.Id, spew.Sdump(updateSpec))
+					log.Debugw("Calling UpdateVolumeMetadata", "volumeId", updateSpec.VolumeId.Id,
+						"updateSpec", updateSpec)
 					if err := volManager.UpdateVolumeMetadata(ctx, &updateSpec); err != nil {
 						log.Warnf("FullSync for VC %s: UpdateVolumeMetadata failed while replacing clusterID "+
 							"with supervisorID. Error: %+v", vc, err)
@@ -473,8 +473,9 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 		log.Errorf("FullSync for VC %s: fullSyncGetEntityMetadata failed with err %+v", vc, err)
 		return err
 	}
-	log.Debugf("FullSync for VC %s: pvToCnsEntityMetadataMap %+v \n pvToK8sEntityMetadataMap: %+v \n",
-		vc, spew.Sdump(volumeToCnsEntityMetadataMap), spew.Sdump(volumeToK8sEntityMetadataMap))
+	log.Debugw("FullSync: entity metadata maps built", "vc", vc,
+		"pvToCnsEntityMetadataMap", volumeToCnsEntityMetadataMap,
+		"pvToK8sEntityMetadataMap", volumeToK8sEntityMetadataMap)
 	log.Debugf("FullSync for VC %s: volumes where clusterDistribution is set: %+v", vc, volumeClusterDistributionMap)
 
 	containerCluster := cnsvsphere.GetContainerCluster(clusterIDforVolumeMetadata,
@@ -1167,8 +1168,7 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 			continue
 		}
 		if pv, existsInK8s := currentK8sPVMap[volumeID]; existsInK8s {
-			log.Debugf("FullSync for VC %s: Calling CreateVolume for volume id: %q with createSpec %+v",
-				vc, volumeID, spew.Sdump(createSpec))
+			log.Debugw("FullSync: Calling CreateVolume", "vc", vc, "volumeId", volumeID, "createSpec", createSpec)
 			_, _, err := volManager.CreateVolume(ctx, &createSpec, nil)
 			if err != nil {
 				log.Warnf("FullSync for VC %s: Failed to create volume with the spec: %+v. "+
@@ -1207,8 +1207,8 @@ func fullSyncUpdateVolumes(ctx context.Context, updateSpecArray []cnstypes.CnsVo
 	defer wg.Done()
 	log := logger.GetLogger(ctx)
 	for _, updateSpec := range updateSpecArray {
-		log.Debugf("FullSync for VC %s: Calling UpdateVolumeMetadata for volume %s with updateSpec: %+v",
-			vc, updateSpec.VolumeId.Id, spew.Sdump(updateSpec))
+		log.Debugw("FullSync: Calling UpdateVolumeMetadata", "vc", vc, "volumeId", updateSpec.VolumeId.Id,
+			"updateSpec", updateSpec)
 		if err := volManager.UpdateVolumeMetadata(ctx, &updateSpec); err != nil {
 			log.Warnf("FullSync for VC %s: UpdateVolumeMetadata failed with err %v", vc, err)
 		}
@@ -1247,7 +1247,7 @@ func buildCnsMetadataList(ctx context.Context, pv *v1.PersistentVolume, pvToPVCM
 			}
 		}
 	}
-	log.Debugf("FullSync for VC %s: buildMetadataList=%+v \n", vc, spew.Sdump(metadataList))
+	log.Debugw("FullSync: buildMetadataList", "vc", vc, "metadataList", metadataList)
 	return metadataList
 }
 
@@ -1608,7 +1608,7 @@ func fullSyncGetVolumeSpecs(ctx context.Context, vCenterVersion string, pvList [
 					}
 				}
 				for _, updateSpecNew := range append(bucketByType(deleteEntities), bucketByType(addEntities)...) {
-					log.Debugf("FullSync for VC %s: updateSpec %+v is added to updateSpecArray\n", vc, spew.Sdump(updateSpecNew))
+					log.Debugw("FullSync: updateSpec added to updateSpecArray", "vc", vc, "updateSpec", updateSpecNew)
 					updateSpecArray = append(updateSpecArray, updateSpecNew)
 				}
 			} else {
@@ -2027,8 +2027,8 @@ func buildPVCMapPodMap(ctx context.Context, pvList []*v1.PersistentVolume,
 func isUpdateRequired(ctx context.Context, vCenterVersion string, k8sMetadataList []cnstypes.BaseCnsEntityMetadata,
 	cnsMetadataList []cnstypes.BaseCnsEntityMetadata, volumeClusterDistributionSet bool, vc string) bool {
 	log := logger.GetLogger(ctx)
-	log.Debugf("FullSync for VC %s: isUpdateRequired called with k8sMetadataList: %+v \n", vc, spew.Sdump(k8sMetadataList))
-	log.Debugf("FullSync for VC %s: isUpdateRequired called with cnsMetadataList: %+v \n", vc, spew.Sdump(cnsMetadataList))
+	log.Debugw("FullSync: isUpdateRequired called", "vc", vc, "k8sMetadataList", k8sMetadataList,
+		"cnsMetadataList", cnsMetadataList)
 	if vCenterVersion != cns.ReleaseVSAN67u3 && vCenterVersion != cns.ReleaseVSAN70 &&
 		vCenterVersion != cns.ReleaseVSAN70u1 {
 		// Update is required if cluster distribution is not set on volume on
@@ -2050,7 +2050,7 @@ func isUpdateRequired(ctx context.Context, vCenterVersion string, k8sMetadataLis
 			key := metadata.EntityType + ":" + metadata.EntityName + ":" + metadata.Namespace
 			cnsEntityTypeMetadataMap[key] = metadata
 		}
-		log.Debugf("cnsEntityTypeMetadataMap :%+v", spew.Sdump(cnsEntityTypeMetadataMap))
+		log.Debugw("cnsEntityTypeMetadataMap built", "cnsEntityTypeMetadataMap", cnsEntityTypeMetadataMap)
 		for _, k8sMetadata := range k8sMetadataList {
 			metadata := k8sMetadata.(*cnstypes.CnsKubernetesEntityMetadata)
 			key := metadata.EntityType + ":" + metadata.EntityName + ":" + metadata.Namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes heavy memory allocation churn caused by the eager evaluation of `spew.Sdump()` in debug logs.

* **The Problem:** Go evaluates function arguments before passing them to `Debugf`. At scale (120k volumes), `spew.Sdump` was deep-reflecting massive metadata maps on every full sync pass, regardless of the log level. 
* **The Fix:** Swapped `Debugf` + `spew.Sdump` for `Debugw` + raw values. Zap's `SugaredLogger` checks the log level before encoding fields, allowing us to drop the heavy computations and explicit `if` checks entirely.
* **The Impact:** Significantly reduces Garbage Collection (GC) CPU pressure and transient RSS spikes during full sync passes.

*(Note: `Warnf`/`Errorf` call sites were intentionally left as-is, as those always surface and only dump single volume specs. This PR targets the worst offender; the remaining ~20 minor `spew.Sdump` calls codebase-wide will be addressed in a follow-up).*

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

* Verified code compiles successfully.
* Validated log outputs locally to ensure structured fields print correctly when Debug logging is enabled.
* Confirmed via Go memory profiling (`pprof`) that passing raw objects to `Debugw` eliminates the eager allocations when Debug logging is disabled.

**Special notes for your reviewer**:
This PR intentionally isolates the largest source of memory churn (`pvToCnsEntityMetadataMap` / `pvToK8sEntityMetadataMap`). I am keeping this scoped to the most critical bottlenecks; the remaining ~20 scattered `spew.Sdump` call sites will be cleaned up in a subsequent PR.

**Release note**:

```release-note
Improved system performance and reduced memory garbage collection overhead during volume full sync passes by optimizing debug log allocations.

```