### PR TITLE
Fix shared informer cache corruption in setFileShareAnnotationsOnPVC

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -818,6 +818,13 @@ func setFileShareAnnotationsOnPVC(ctx context.Context, k8sClient clientset.Inter
 		return err
 	}
 	vSANFileBackingDetails := volume.BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails)
+	// pvc is served from the shared PVC informer cache (a pointer into the informer's own
+	// store, not a copy) — DeepCopy before mutating so we don't corrupt it for every other
+	// reader of that cache.
+	pvc = pvc.DeepCopy()
+	if pvc.Annotations == nil {
+		pvc.Annotations = make(map[string]string)
+	}
 	accessPoints := make(map[string]string)
 	for _, kv := range vSANFileBackingDetails.AccessPoints {
 		if kv.Key == common.Nfsv3AccessPointKey {

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -1124,8 +1124,12 @@ func TestSetFileShareAnnotationsOnPVC_Success(t *testing.T) {
 	err := setFileShareAnnotationsOnPVC(ctx, k8sClient, nil, pvc)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "192.168.1.100:/nfs/v3/path", pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
-	assert.Equal(t, "192.168.1.100:/nfs/v4/path", pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+	// setFileShareAnnotationsOnPVC DeepCopy()s before mutating (pvc may be a shared informer
+	// cache object), so the caller's pvc pointer is untouched — verify via the fake client.
+	updated, getErr := k8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, "192.168.1.100:/nfs/v3/path", updated.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Equal(t, "192.168.1.100:/nfs/v4/path", updated.Annotations[common.Nfsv4ExportPathAnnotationKey])
 }
 
 func TestSetFileShareAnnotationsOnPVC_PVNotFound(t *testing.T) {
@@ -1220,8 +1224,10 @@ func TestSetFileShareAnnotationsOnPVC_PVCUpdateError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "update failed")
-	assert.Equal(t, "192.168.1.100:/nfs/v3/path", pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
-	assert.Equal(t, "192.168.1.100:/nfs/v4/path", pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+	// setFileShareAnnotationsOnPVC mutates a DeepCopy, so a failed Update leaves the
+	// caller's original pvc (a stand-in for a shared informer cache object) untouched.
+	assert.Empty(t, pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Empty(t, pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
 }
 
 func TestSetFileShareAnnotationsOnPVC_OnlyNFSv4AccessPoint(t *testing.T) {
@@ -1256,8 +1262,10 @@ func TestSetFileShareAnnotationsOnPVC_OnlyNFSv4AccessPoint(t *testing.T) {
 	err := setFileShareAnnotationsOnPVC(ctx, k8sClient, nil, pvc)
 
 	assert.NoError(t, err)
-	assert.Empty(t, pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
-	assert.Equal(t, "192.168.1.100:/nfs/v4/path", pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+	updated, getErr := k8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Empty(t, updated.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Equal(t, "192.168.1.100:/nfs/v4/path", updated.Annotations[common.Nfsv4ExportPathAnnotationKey])
 }
 
 func TestSetFileShareAnnotationsOnPVC_EmptyAccessPoints(t *testing.T) {
@@ -1329,8 +1337,11 @@ func TestSetFileShareAnnotationsOnPVC_ExistingAnnotations(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "existing-value", pvc.Annotations["existing-annotation"])
-	assert.Equal(t, "192.168.1.100:/nfs/v3/path", pvc.Annotations[common.Nfsv3ExportPathAnnotationKey])
-	assert.Empty(t, pvc.Annotations[common.Nfsv4ExportPathAnnotationKey])
+	updated, getErr := k8sClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, "existing-value", updated.Annotations["existing-annotation"])
+	assert.Equal(t, "192.168.1.100:/nfs/v3/path", updated.Annotations[common.Nfsv3ExportPathAnnotationKey])
+	assert.Empty(t, updated.Annotations[common.Nfsv4ExportPathAnnotationKey])
 }
 
 // fakeVolumeManager is a test-only mock of volumes.Manager. It embeds


### PR DESCRIPTION
Here is the completed and condensed PR template based on your provided text.

**What this PR does / why we need it**:
Fixes a shared informer cache corruption bug in `setFileShareAnnotationsOnPVC`.

* **The Problem:** `setFileShareAnnotationsOnPVC` was mutating PVC annotations in-place. Because the caller retrieves this PVC directly from `metadataSyncer.pvcLister` (the shared informer cache), it receives a pointer to the cache's internal store. Mutating this pointer directly corrupted the cache for all other readers/informers.
* **The Fix:** Added a `.DeepCopy()` immediately before the mutation to safely modify a clone, matching the existing safe pattern in `patchVolumeAccessibleTopologyToPVC`.
* **Test Updates:** Fixed 4 tests that were previously validating the bug by asserting on the mutated local pointer. They now correctly assert against the persisted state in the fake clientset. Notably, `TestSetFileShareAnnotationsOnPVC_PVCUpdateError` now correctly verifies that if the API server update fails, the local PVC remains untouched.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

* Updated 4 existing unit tests to assert against the fake clientset rather than local pointers.
* Verified tests pass and correctly simulate API server interactions (including update failures).

**Special notes for your reviewer**:
Pay special attention to the test changes. The tests previously asserted that the local pointer was updated even when the simulated API server update failed (which was asserting the bug's side effect). They now properly verify that the persisted state is updated on success, and the caller's PVC is left untouched on failure.

**Release note**:

```release-note
Fixed an issue where file share PVC annotations were mutating objects directly in the shared informer cache, preventing potential inconsistencies across components reading from the same cache.

```