### PR TITLE
Misc changes to support pvCSI CBT API with deployment via addon config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 	sigs.k8s.io/cluster-api v1.13.3
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -118,7 +119,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 // k8s.io/kubernetes declares staging module deps as v0.0.0 with local

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -44,20 +45,18 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
@@ -99,20 +98,32 @@ var (
 	}
 )
 
-// snapshotMetadataServiceCRName is the cluster-scoped name of the
-// SnapshotMetadataService CR that advertises the Supervisor's Snapshot
-// Metadata Service endpoint. By convention the CR is named after the CSI
-// driver, so we reuse csitypes.Name as the source of truth.
-const snapshotMetadataServiceCRName = csitypes.Name
+const (
+	// supervisorCBTConfigDir is the directory where the Secret carrying the
+	// Supervisor Snapshot Metadata Service connection details (address,
+	// audience, caCert) is mounted into the guest pvCSI controller pod.
+	supervisorCBTConfigDir = "/etc/cloud/supervisor-cbt-config"
 
-// snapshotMetadataTokenExpirationSeconds is the requested lifetime for
-// the audience-bound ServiceAccount token minted via TokenRequest before
-// each Snapshot Metadata Service RPC. We use the Kubernetes default of
-// one hour, which matches `kubectl create token`, kubelet's projected
-// ServiceAccount token rotation, and the value used by most upstream
-// CSI sidecars. The Supervisor API server may further cap this via
-// --service-account-max-token-expiration.
-const snapshotMetadataTokenExpirationSeconds int64 = 3600
+	// supervisorCBTConfigKey is the Secret data key (and therefore the file
+	// name kubelet projects under supervisorCBTConfigDir) holding the
+	// YAML-encoded connection details.
+	supervisorCBTConfigKey = "config"
+)
+
+// supervisorCBTConfigPath is the full path of the Secret-backed file read by
+// getSnapshotMetadataClient.
+var supervisorCBTConfigPath = filepath.Join(supervisorCBTConfigDir, supervisorCBTConfigKey)
+
+// supervisorCBTConfig is the schema of the YAML blob stored under
+// supervisorCBTConfigKey in the Supervisor CBT config Secret.
+type supervisorCBTConfig struct {
+	// sigs.k8s.io/yaml converts YAML to JSON and unmarshals via encoding/json, which keys
+	// off json tags (falling back to case-insensitive field-name matching only when a tag
+	// is absent). The json tags below make that explicit rather than relying on the fallback.
+	Address  string `json:"address" yaml:"address"`
+	Audience string `json:"audience" yaml:"audience"`
+	CACert   string `json:"caCert" yaml:"caCert"`
+}
 
 // dialSnapshotMetadata builds the gRPC client connection to the Supervisor
 // Snapshot Metadata Service. It is intentionally a package-level function
@@ -2542,160 +2553,47 @@ func (c *controller) waitForSupervisorPVCModifyVolume(
 	}
 }
 
-// mintSnapshotMetadataToken mints a fresh, audience-bound ServiceAccount
-// token for the Supervisor pvcsi-provider ServiceAccount via the
-// Kubernetes TokenRequest API. The returned token's "aud" claim equals
-// the SnapshotMetadataService CR's spec.audience, which is exactly what
-// the Supervisor csi-snapshot-metadata sidecar validates via TokenReview
-// before serving snapshot metadata RPCs.
-//
-// The function is a package-level variable so unit tests can substitute
-// a fixed token without reaching the API server. The default
-// implementation is defaultMintSnapshotMetadataToken.
-var mintSnapshotMetadataToken = defaultMintSnapshotMetadataToken
-
-// defaultMintSnapshotMetadataToken is the production implementation of
-// mintSnapshotMetadataToken. It first identifies the bootstrap
-// ServiceAccount the guest pvCSI is authenticated as on the Supervisor
-// (by inspecting the JWT "sub" claim of the bearer token loaded into
-// the Supervisor REST client config), and then asks the Supervisor API
-// server to mint a fresh, short-lived token bound to the requested
-// audience for that same ServiceAccount.
-func defaultMintSnapshotMetadataToken(
-	ctx context.Context,
-	supervisorClient clientset.Interface,
-	bootstrapToken string,
-	audience string,
-) (string, error) {
-	saNs, saName, err := parseServiceAccountFromJWT(bootstrapToken)
-	if err != nil {
-		return "", fmt.Errorf("identifying Supervisor ServiceAccount from "+
-			"pvcsi-provider bearer token: %w", err)
-	}
-	expSec := snapshotMetadataTokenExpirationSeconds
-	tr, err := supervisorClient.CoreV1().ServiceAccounts(saNs).CreateToken(
-		ctx, saName,
-		&authv1.TokenRequest{
-			Spec: authv1.TokenRequestSpec{
-				Audiences:         []string{audience},
-				ExpirationSeconds: &expSec,
-			},
-		},
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		return "", fmt.Errorf("TokenRequest for ServiceAccount %s/%s with "+
-			"audience %q: %w", saNs, saName, audience, err)
-	}
-	return tr.Status.Token, nil
-}
-
-// parseServiceAccountFromJWT decodes the payload of a Kubernetes
-// ServiceAccount JWT and returns its (namespace, name). The signature is
-// intentionally not verified — we only consult the token to learn our
-// own identity (the Supervisor pvcsi-provider SA) so we can target a
-// subsequent TokenRequest at it. The token itself was placed in our pod
-// by Supervisor (via the pvcsi-provider-creds Secret), not received over
-// the wire, so it is already trusted by construction.
-//
-// Both modern projected SA tokens (which encode identity in the JWT
-// "sub" claim) and legacy SA secret tokens (which use the
-// "kubernetes.io/serviceaccount/{namespace,service-account.name}" claims)
-// are supported.
-func parseServiceAccountFromJWT(token string) (namespace, name string, err error) {
-	parts := strings.Split(strings.TrimSpace(token), ".")
-	if len(parts) != 3 {
-		return "", "", fmt.Errorf("token is not a JWT (got %d segments, want 3)", len(parts))
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		// Some environments emit base64 with padding; tolerate that too.
-		payload, err = base64.StdEncoding.DecodeString(parts[1])
-		if err != nil {
-			return "", "", fmt.Errorf("decoding JWT payload: %w", err)
-		}
-	}
-	var claims struct {
-		Sub             string `json:"sub"`
-		LegacyNamespace string `json:"kubernetes.io/serviceaccount/namespace"`
-		LegacySAName    string `json:"kubernetes.io/serviceaccount/service-account.name"`
-	}
-	if err := json.Unmarshal(payload, &claims); err != nil {
-		return "", "", fmt.Errorf("unmarshal JWT claims: %w", err)
-	}
-	if claims.LegacyNamespace != "" && claims.LegacySAName != "" {
-		return claims.LegacyNamespace, claims.LegacySAName, nil
-	}
-	const prefix = "system:serviceaccount:"
-	if strings.HasPrefix(claims.Sub, prefix) {
-		rest := strings.TrimPrefix(claims.Sub, prefix)
-		if i := strings.Index(rest, ":"); i > 0 && i < len(rest)-1 {
-			return rest[:i], rest[i+1:], nil
-		}
-	}
-	return "", "", fmt.Errorf("token does not identify a ServiceAccount (sub=%q)", claims.Sub)
-}
-
 // getSnapshotMetadataClient returns a gRPC client connected to the
 // Supervisor's Snapshot Metadata Service.
 //
-// Authentication uses an audience-bound ServiceAccount token minted
-// fresh on every call via the Kubernetes TokenRequest API. The audience
-// is taken from the SnapshotMetadataService CR's spec.audience and must
-// match what the Supervisor csi-snapshot-metadata sidecar validates with
-// TokenReview. The returned token is also handed back to callers so
-// they can populate the per-request `security_token` field — the SMS
-// proto requires the same audience-bound token in both the gRPC bearer
-// header and the request body.
+// Authentication reuses the bootstrap pvcsi-provider token as-is (loaded into
+// c.restClientConfig.BearerToken from the pvcsi-provider-creds Secret by
+// k8s.GetRestClientConfigForSupervisor) — the Supervisor mints this token
+// already bound to this CSI driver's own audience (cfg.Audience), so no
+// per-call TokenRequest is needed. The token is also handed back to callers
+// so they can populate the per-request `security_token` field — the SMS
+// proto requires the same token in both the gRPC bearer header and the
+// request body.
 func (c *controller) getSnapshotMetadataClient(
 	ctx context.Context) (snapshotmetadataapi.SnapshotMetadataClient, *grpc.ClientConn, string, error) {
 	log := logger.GetLogger(ctx)
 
-	// Fetch the SnapshotMetadataService CR using the dynamic client. The CR
-	// name is the same as the CSI driver name (see snapshotMetadataServiceCRName).
-	smsGVK := schema.GroupVersionKind{
-		Group:   "cbt.storage.k8s.io",
-		Version: "v1beta1",
-		Kind:    "SnapshotMetadataService",
-	}
-
-	smsCR := &unstructured.Unstructured{}
-	smsCR.SetGroupVersionKind(smsGVK)
-
-	err := c.cnsOperatorClient.Get(ctx, client.ObjectKey{Name: snapshotMetadataServiceCRName}, smsCR)
+	data, err := os.ReadFile(supervisorCBTConfigPath)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("failed to get SnapshotMetadataService CR: %v", err)
+		return nil, nil, "", fmt.Errorf("failed to read Supervisor CBT config from %q: %w", supervisorCBTConfigPath, err)
+	}
+	cfg := &supervisorCBTConfig{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, nil, "", fmt.Errorf("failed to parse Supervisor CBT config: %w", err)
 	}
 
-	address, found, err := unstructured.NestedString(smsCR.Object, "spec", "address")
-	if !found || err != nil || address == "" {
-		return nil, nil, "", fmt.Errorf("failed to get address from SnapshotMetadataService CR: %v", err)
+	if cfg.Address == "" {
+		return nil, nil, "", fmt.Errorf("address is empty in Supervisor CBT config")
 	}
 
-	// spec.audience is the audience that the Supervisor SMS sidecar passes
-	// to TokenReview when validating the SecurityToken on every RPC. It
-	// must therefore also be the audience embedded in the JWT we send. An
-	// empty audience would silently fall back to the API server default
-	// audience (a property of legacy non-bound tokens), which is exactly
-	// the fragile behaviour we are eliminating, so we reject it loudly.
-	audience, found, err := unstructured.NestedString(smsCR.Object, "spec", "audience")
-	if !found || err != nil || audience == "" {
-		return nil, nil, "", fmt.Errorf("failed to get audience from SnapshotMetadataService CR: %v", err)
+	if cfg.Audience == "" {
+		return nil, nil, "", fmt.Errorf("audience is empty in Supervisor CBT config")
 	}
 
-	caCert, found, err := unstructured.NestedString(smsCR.Object, "spec", "caCert")
-	if !found || err != nil {
-		return nil, nil, "", fmt.Errorf("failed to get caCert from SnapshotMetadataService CR: %v", err)
-	}
-
-	if caCert == "" {
-		return nil, nil, "", fmt.Errorf("caCert is empty in SnapshotMetadataService CR")
+	if cfg.CACert == "" {
+		return nil, nil, "", fmt.Errorf("caCert is empty in Supervisor CBT config")
 	}
 	certPool := x509.NewCertPool()
-	caBytes := []byte(caCert)
+	caBytes := []byte(cfg.CACert)
 	if !certPool.AppendCertsFromPEM(caBytes) {
-		// SnapshotMetadataService CRD uses OpenAPI "byte" (base64 on the wire); accept PEM or base64-of-PEM.
-		decoded, decErr := base64.StdEncoding.DecodeString(strings.TrimSpace(caCert))
+		// caCert mirrors the SnapshotMetadataService CR's OpenAPI "byte" encoding
+		// (base64-of-PEM); accept PEM or base64-of-PEM.
+		decoded, decErr := base64.StdEncoding.DecodeString(strings.TrimSpace(cfg.CACert))
 		if decErr != nil || !certPool.AppendCertsFromPEM(decoded) {
 			if decErr != nil {
 				return nil, nil, "", fmt.Errorf("failed to append caCert to pool: %w", decErr)
@@ -2705,25 +2603,19 @@ func (c *controller) getSnapshotMetadataClient(
 	}
 	transportCreds := credentials.NewClientTLSFromCert(certPool, "")
 
-	// Mint a fresh audience-bound token via TokenRequest on every call.
-	// We pass the bootstrap pvcsi-provider bearer token (loaded by
-	// k8s.GetRestClientConfigForSupervisor from the pvcsi-provider-creds
-	// Secret) only so the minter can recover the SA identity from its
-	// JWT "sub" claim — the bootstrap token itself is never sent to the
-	// SMS sidecar.
-	bootstrapToken := ""
-	if c.restClientConfig != nil {
-		bootstrapToken = c.restClientConfig.BearerToken
+	// Read c.restClientConfig exactly once: ReloadConfiguration can replace it (including with
+	// nil, on failure) concurrently from the fsnotify watcher goroutine, so checking and then
+	// re-reading the field separately would be a TOCTOU race that could panic on a nil pointer.
+	restClientConfig := c.restClientConfig
+	if restClientConfig == nil || restClientConfig.BearerToken == "" {
+		return nil, nil, "", fmt.Errorf("bootstrap Supervisor token is not available")
 	}
-	token, err := mintSnapshotMetadataToken(ctx, c.supervisorClient, bootstrapToken, audience)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("failed to mint audience-bound Supervisor token: %w", err)
-	}
+	token := restClientConfig.BearerToken
 
-	log.Infof("Dialing SnapshotMetadataService at %s (audience=%s)", address, audience)
-	conn, err := dialSnapshotMetadata(address, transportCreds, tokenAuth{token: token})
+	log.Infof("Dialing SnapshotMetadataService at %s (audience=%s)", cfg.Address, cfg.Audience)
+	conn, err := dialSnapshotMetadata(cfg.Address, transportCreds, tokenAuth{token: token})
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("failed to connect to Snapshot Metadata Service at %s: %v", address, err)
+		return nil, nil, "", fmt.Errorf("failed to connect to Snapshot Metadata Service at %s: %w", cfg.Address, err)
 	}
 
 	return snapshotmetadataapi.NewSnapshotMetadataClient(conn), conn, token, nil

--- a/pkg/csi/service/wcpguest/controller_cbt_test.go
+++ b/pkg/csi/service/wcpguest/controller_cbt_test.go
@@ -25,9 +25,13 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,11 +47,10 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	clientset "k8s.io/client-go/kubernetes"
-	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"k8s.io/client-go/rest"
 	snapshotterfake "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fakesnapshot"
+	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
@@ -97,13 +100,32 @@ type mockSupervisorSnapshotMetadataServer struct {
 	// afterSendsReturn is returned from the handler after all configured Sends (e.g. io.EOF for a
 	// normal end of stream, or a non-EOF status such as OutOfRange to simulate a Supervisor error).
 	afterSendsReturn error
+	// blockAfterSendsUntilCtxDoneMu guards blockAfterSendsUntilCtxDone: it's read by the handler
+	// goroutine (started internally by grpc.Server) and written by tests from a separate
+	// goroutine with no other synchronization between the two, which is a real data race under
+	// -race without this lock (the client observing the stream end does not imply the server-side
+	// handler goroutine's reads have completed).
+	blockAfterSendsUntilCtxDoneMu sync.Mutex
 	// blockAfterSendsUntilCtxDone: after sending all responses, block until server.Context() is done,
-	// then return afterSendsReturn (or Canceled).
+	// then return afterSendsReturn (or Canceled). Access only via setBlockAfterSendsUntilCtxDone /
+	// shouldBlockAfterSends.
 	blockAfterSendsUntilCtxDone bool
 	// lastAllocatedReq / lastDeltaReq capture the last request each handler received so tests can
 	// assert on the (namespace, snapshot_name) translation done by the driver.
 	lastAllocatedReq *snapshotmetadataapi.GetMetadataAllocatedRequest
 	lastDeltaReq     *snapshotmetadataapi.GetMetadataDeltaRequest
+}
+
+func (m *mockSupervisorSnapshotMetadataServer) setBlockAfterSendsUntilCtxDone(v bool) {
+	m.blockAfterSendsUntilCtxDoneMu.Lock()
+	defer m.blockAfterSendsUntilCtxDoneMu.Unlock()
+	m.blockAfterSendsUntilCtxDone = v
+}
+
+func (m *mockSupervisorSnapshotMetadataServer) shouldBlockAfterSends() bool {
+	m.blockAfterSendsUntilCtxDoneMu.Lock()
+	defer m.blockAfterSendsUntilCtxDoneMu.Unlock()
+	return m.blockAfterSendsUntilCtxDone
 }
 
 func (m *mockSupervisorSnapshotMetadataServer) GetMetadataAllocated(
@@ -122,7 +144,7 @@ func (m *mockSupervisorSnapshotMetadataServer) GetMetadataAllocated(
 			return err
 		}
 	}
-	if m.blockAfterSendsUntilCtxDone {
+	if m.shouldBlockAfterSends() {
 		<-server.Context().Done()
 		if m.afterSendsReturn != nil {
 			return m.afterSendsReturn
@@ -151,7 +173,7 @@ func (m *mockSupervisorSnapshotMetadataServer) GetMetadataDelta(
 			return err
 		}
 	}
-	if m.blockAfterSendsUntilCtxDone {
+	if m.shouldBlockAfterSends() {
 		<-server.Context().Done()
 		if m.afterSendsReturn != nil {
 			return m.afterSendsReturn
@@ -209,29 +231,42 @@ func setupMockSupervisorServer(t *testing.T) (*grpc.Server, *mockSupervisorSnaps
 	return setupMockSupervisorServerWithOptions(t, nil)
 }
 
-// installFakeTokenMinterForTest swaps the package-level
-// mintSnapshotMetadataToken function with one that returns the supplied
-// (token, err) on every invocation, ignoring its inputs. The original is
-// restored via t.Cleanup. Production replaces this seam with a call to
-// the Kubernetes TokenRequest API against the Supervisor — see
-// defaultMintSnapshotMetadataToken in controller.go. Tests use it to:
+// installBootstrapTokenForTest sets the controller's restClientConfig.BearerToken to token for
+// the duration of the test, standing in for the pvcsi-provider-creds bootstrap token that
+// getSnapshotMetadataClient now uses directly (production mints this once, on the Supervisor
+// side, already bound to the CBT audience — see getSnapshotMetadataClient in controller.go).
+// The original restClientConfig is restored via t.Cleanup. Tests use it to:
 //
 //   - return a constant "test-token" matching the value the in-process
 //     mock SMS server expects in the Authorization header;
-//   - return a different token to exercise the Unauthenticated path;
-//   - return an error to exercise the minter-failure path.
-func installFakeTokenMinterForTest(t *testing.T, token string, mintErr error) {
+//   - return a different token to exercise the Unauthenticated path.
+func installBootstrapTokenForTest(t *testing.T, c *controller, token string) {
 	t.Helper()
-	orig := mintSnapshotMetadataToken
-	mintSnapshotMetadataToken = func(
-		_ context.Context,
-		_ clientset.Interface,
-		_ string,
-		_ string,
-	) (string, error) {
-		return token, mintErr
+	orig := c.restClientConfig
+	c.restClientConfig = &rest.Config{BearerToken: token}
+	t.Cleanup(func() { c.restClientConfig = orig })
+}
+
+// installSupervisorCBTConfigForTest writes cfg as YAML to a temp file and
+// points the package-level supervisorCBTConfigPath at it for the duration of
+// the test, standing in for the real Secret-backed file. The original path
+// is restored via t.Cleanup. Passing a nil cfg points supervisorCBTConfigPath
+// at a path that does not exist, so getSnapshotMetadataClient's os.ReadFile
+// fails exactly like it would if the Secret were missing.
+func installSupervisorCBTConfigForTest(t *testing.T, cfg *supervisorCBTConfig) {
+	t.Helper()
+	orig := supervisorCBTConfigPath
+	t.Cleanup(func() { supervisorCBTConfigPath = orig })
+
+	if cfg == nil {
+		supervisorCBTConfigPath = filepath.Join(t.TempDir(), "does-not-exist")
+		return
 	}
-	t.Cleanup(func() { mintSnapshotMetadataToken = orig })
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	supervisorCBTConfigPath = path
 }
 
 // installInsecureDialForTest swaps the package-level dialSnapshotMetadata
@@ -377,30 +412,18 @@ func TestGetMetadataAllocated(t *testing.T) {
 	// is bypassed by installInsecureDialForTest below, which swaps
 	// dialSnapshotMetadata for an insecure dialer.
 	caPEM, _ := testLocalhostTLSCert(t)
-	smsCR := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "cbt.storage.k8s.io/v1beta1",
-			"kind":       "SnapshotMetadataService",
-			"metadata": map[string]interface{}{
-				"name": "csi.vsphere.vmware.com",
-			},
-			"spec": map[string]interface{}{
-				"address":  addr,
-				"caCert":   string(caPEM),
-				"audience": "test-audience",
-			},
-		},
-	}
+	installSupervisorCBTConfigForTest(t, &supervisorCBTConfig{
+		Address:  addr,
+		CACert:   string(caPEM),
+		Audience: "test-audience",
+	})
 
-	scheme := runtime.NewScheme()
-	ct.controller.cnsOperatorClient = ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(smsCR).Build()
-
-	// Install test-only seams: a fake token minter that returns the
+	// Install test-only seams: a bootstrap Supervisor token set to the
 	// constant "test-token" the mock SMS server checks for in the
 	// Authorization header, and an insecure dialer (the production
 	// binary always uses TLS — see dialSnapshotMetadata in
 	// controller.go).
-	installFakeTokenMinterForTest(t, "test-token", nil)
+	installBootstrapTokenForTest(t, ct.controller, "test-token")
 	installInsecureDialForTest(t)
 
 	// Enable CBT FSS
@@ -500,14 +523,13 @@ func TestGetMetadataAllocated(t *testing.T) {
 		assert.Equal(t, codes.NotFound, status.Code(err))
 	})
 
-	t.Run("minted token rejected by supervisor", func(t *testing.T) {
-		// Mint a token whose value differs from the one the mock SMS
-		// server expects in the Authorization header. This exercises
-		// the path where the audience-bound TokenRequest succeeds but
-		// the supervisor rejects the call (e.g. audience mismatch on
-		// the wire).
+	t.Run("bootstrap token rejected by supervisor", func(t *testing.T) {
+		// Use a bootstrap token whose value differs from the one the mock
+		// SMS server expects in the Authorization header. This exercises
+		// the path where the Supervisor rejects the call (e.g. an
+		// unexpected/stale bootstrap token).
 		mockServer.errToReturn = nil
-		installFakeTokenMinterForTest(t, "wrong-token", nil)
+		installBootstrapTokenForTest(t, ct.controller, "wrong-token")
 
 		req := &csi.GetMetadataAllocatedRequest{
 			SnapshotId:     "snap-1",
@@ -524,30 +546,6 @@ func TestGetMetadataAllocated(t *testing.T) {
 		assert.Equal(t, codes.Unauthenticated, status.Code(err))
 	})
 
-	t.Run("token mint failure", func(t *testing.T) {
-		// Simulate the Supervisor TokenRequest API rejecting our mint
-		// (e.g. RBAC missing on the pvcsi-provider SA, or the API
-		// being unreachable). The driver must surface this as an
-		// Internal error rather than papering it over.
-		mockServer.errToReturn = nil
-		installFakeTokenMinterForTest(t, "", fmt.Errorf("simulated TokenRequest failure"))
-
-		req := &csi.GetMetadataAllocatedRequest{
-			SnapshotId:     "snap-1",
-			StartingOffset: 0,
-			MaxResults:     10,
-		}
-
-		mockStream := &mockAllocatedStreamServer{
-			ctx: ctx,
-		}
-
-		err := ct.controller.GetMetadataAllocated(req, mockStream)
-		assert.Error(t, err)
-		assert.Equal(t, codes.Internal, status.Code(err))
-		assert.Contains(t, err.Error(), "audience-bound Supervisor token")
-	})
-
 	t.Run("nil request", func(t *testing.T) {
 		mockStream := &mockAllocatedStreamServer{ctx: ctx}
 		err := ct.controller.GetMetadataAllocated(nil, mockStream)
@@ -559,7 +557,7 @@ func TestGetMetadataAllocated(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.allocatedResponses = nil
 		mockServer.afterSendsReturn = nil
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 
 		req := &csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1", StartingOffset: 0, MaxResults: 10}
 		mockStream := &mockAllocatedStreamServer{ctx: ctx}
@@ -569,27 +567,15 @@ func TestGetMetadataAllocated(t *testing.T) {
 	})
 
 	t.Run("supervisor GetMetadataAllocated RPC not implemented", func(t *testing.T) {
-		prevClient := ct.controller.cnsOperatorClient
-		defer func() { ct.controller.cnsOperatorClient = prevClient }()
-
 		bareSrv, addr := setupBareGRPCServer(t)
 		defer bareSrv.Stop()
 
 		bareCAPEM, _ := testLocalhostTLSCert(t)
-		smsCR := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec": map[string]interface{}{
-					"address":  addr,
-					"caCert":   string(bareCAPEM),
-					"audience": "test-audience",
-				},
-			},
-		}
-		ct.controller.cnsOperatorClient = ctrlclientfake.NewClientBuilder().
-			WithScheme(runtime.NewScheme()).WithObjects(smsCR).Build()
+		installSupervisorCBTConfigForTest(t, &supervisorCBTConfig{
+			Address:  addr,
+			CACert:   string(bareCAPEM),
+			Audience: "test-audience",
+		})
 
 		req := &csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1", StartingOffset: 0, MaxResults: 10}
 		mockStream := &mockAllocatedStreamServer{ctx: ctx}
@@ -602,7 +588,7 @@ func TestGetMetadataAllocated(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.allocatedResponses = []*snapshotmetadataapi.GetMetadataAllocatedResponse{{VolumeCapacityBytes: 100}}
 		mockServer.afterSendsReturn = status.Error(codes.OutOfRange, "startOffset is out of range")
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 
 		req := &csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1",
 			StartingOffset: 123456789123456789, MaxResults: 10}
@@ -617,7 +603,7 @@ func TestGetMetadataAllocated(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.allocatedResponses = []*snapshotmetadataapi.GetMetadataAllocatedResponse{{VolumeCapacityBytes: 100}}
 		mockServer.afterSendsReturn = status.Error(codes.ResourceExhausted, "slow down")
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 
 		req := &csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1", StartingOffset: 0, MaxResults: 10}
 		mockStream := &mockAllocatedStreamServer{ctx: ctx}
@@ -630,7 +616,7 @@ func TestGetMetadataAllocated(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.allocatedResponses = []*snapshotmetadataapi.GetMetadataAllocatedResponse{{VolumeCapacityBytes: 100}}
 		mockServer.afterSendsReturn = status.Error(codes.DeadlineExceeded, "timeout")
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 
 		req := &csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1", StartingOffset: 0, MaxResults: 10}
 		mockStream := &mockAllocatedStreamServer{ctx: ctx}
@@ -658,7 +644,7 @@ func TestGetMetadataAllocated(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.afterSendsReturn = nil
 		mockServer.allocatedResponses = []*snapshotmetadataapi.GetMetadataAllocatedResponse{{VolumeCapacityBytes: 100}}
-		mockServer.blockAfterSendsUntilCtxDone = true
+		mockServer.setBlockAfterSendsUntilCtxDone(true)
 
 		ctx2, cancel := context.WithCancel(ctx)
 		req := &csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1", StartingOffset: 0, MaxResults: 10}
@@ -674,12 +660,10 @@ func TestGetMetadataAllocated(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for GetMetadataAllocated")
 		}
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 	})
 
 	t.Run("tls caCert PEM to supervisor", func(t *testing.T) {
-		prevClient := ct.controller.cnsOperatorClient
-		defer func() { ct.controller.cnsOperatorClient = prevClient }()
 		withProductionTLSDialForSubtest(t)
 
 		caPEM, leaf := testLocalhostTLSCert(t)
@@ -687,20 +671,11 @@ func TestGetMetadataAllocated(t *testing.T) {
 		grpcServer, mockServer, addr := setupMockSupervisorServerWithOptions(t, tlsConf)
 		defer grpcServer.Stop()
 
-		smsCR := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec": map[string]interface{}{
-					"address":  addr,
-					"caCert":   string(caPEM),
-					"audience": "test-audience",
-				},
-			},
-		}
-		ct.controller.cnsOperatorClient = ctrlclientfake.NewClientBuilder().
-			WithScheme(runtime.NewScheme()).WithObjects(smsCR).Build()
+		installSupervisorCBTConfigForTest(t, &supervisorCBTConfig{
+			Address:  addr,
+			CACert:   string(caPEM),
+			Audience: "test-audience",
+		})
 
 		mockServer.errToReturn = nil
 		mockServer.allocatedResponses = []*snapshotmetadataapi.GetMetadataAllocatedResponse{{VolumeCapacityBytes: 500}}
@@ -713,8 +688,6 @@ func TestGetMetadataAllocated(t *testing.T) {
 	})
 
 	t.Run("tls caCert base64-encoded PEM", func(t *testing.T) {
-		prevClient := ct.controller.cnsOperatorClient
-		defer func() { ct.controller.cnsOperatorClient = prevClient }()
 		withProductionTLSDialForSubtest(t)
 
 		caPEM, leaf := testLocalhostTLSCert(t)
@@ -722,20 +695,11 @@ func TestGetMetadataAllocated(t *testing.T) {
 		grpcServer, mockServer, addr := setupMockSupervisorServerWithOptions(t, tlsConf)
 		defer grpcServer.Stop()
 
-		smsCR := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec": map[string]interface{}{
-					"address":  addr,
-					"caCert":   base64.StdEncoding.EncodeToString(caPEM),
-					"audience": "test-audience",
-				},
-			},
-		}
-		ct.controller.cnsOperatorClient = ctrlclientfake.NewClientBuilder().
-			WithScheme(runtime.NewScheme()).WithObjects(smsCR).Build()
+		installSupervisorCBTConfigForTest(t, &supervisorCBTConfig{
+			Address:  addr,
+			CACert:   base64.StdEncoding.EncodeToString(caPEM),
+			Audience: "test-audience",
+		})
 
 		mockServer.errToReturn = nil
 		mockServer.allocatedResponses = []*snapshotmetadataapi.GetMetadataAllocatedResponse{{VolumeCapacityBytes: 500}}
@@ -764,30 +728,18 @@ func TestGetMetadataDelta(t *testing.T) {
 	// is bypassed by installInsecureDialForTest below, which swaps
 	// dialSnapshotMetadata for an insecure dialer.
 	caPEM, _ := testLocalhostTLSCert(t)
-	smsCR := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "cbt.storage.k8s.io/v1beta1",
-			"kind":       "SnapshotMetadataService",
-			"metadata": map[string]interface{}{
-				"name": "csi.vsphere.vmware.com",
-			},
-			"spec": map[string]interface{}{
-				"address":  addr,
-				"caCert":   string(caPEM),
-				"audience": "test-audience",
-			},
-		},
-	}
+	installSupervisorCBTConfigForTest(t, &supervisorCBTConfig{
+		Address:  addr,
+		CACert:   string(caPEM),
+		Audience: "test-audience",
+	})
 
-	scheme := runtime.NewScheme()
-	ct.controller.cnsOperatorClient = ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(smsCR).Build()
-
-	// Install test-only seams: a fake token minter that returns the
+	// Install test-only seams: a bootstrap Supervisor token set to the
 	// constant "test-token" the mock SMS server checks for in the
 	// Authorization header, and an insecure dialer (the production
 	// binary always uses TLS — see dialSnapshotMetadata in
 	// controller.go).
-	installFakeTokenMinterForTest(t, "test-token", nil)
+	installBootstrapTokenForTest(t, ct.controller, "test-token")
 	installInsecureDialForTest(t)
 
 	// Enable CBT FSS
@@ -962,9 +914,9 @@ func TestGetMetadataDelta(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid format")
 	})
 
-	t.Run("minted token rejected by supervisor", func(t *testing.T) {
+	t.Run("bootstrap token rejected by supervisor", func(t *testing.T) {
 		mockServer.errToReturn = nil
-		installFakeTokenMinterForTest(t, "wrong-token", nil)
+		installBootstrapTokenForTest(t, ct.controller, "wrong-token")
 
 		req := &csi.GetMetadataDeltaRequest{
 			BaseSnapshotId:   testValidChangeID,
@@ -982,27 +934,6 @@ func TestGetMetadataDelta(t *testing.T) {
 		assert.Equal(t, codes.Unauthenticated, status.Code(err))
 	})
 
-	t.Run("token mint failure", func(t *testing.T) {
-		mockServer.errToReturn = nil
-		installFakeTokenMinterForTest(t, "", fmt.Errorf("simulated TokenRequest failure"))
-
-		req := &csi.GetMetadataDeltaRequest{
-			BaseSnapshotId:   testValidChangeID,
-			TargetSnapshotId: "snap-2",
-			StartingOffset:   0,
-			MaxResults:       10,
-		}
-
-		mockStream := &mockDeltaStreamServer{
-			ctx: ctx,
-		}
-
-		err := ct.controller.GetMetadataDelta(req, mockStream)
-		assert.Error(t, err)
-		assert.Equal(t, codes.Internal, status.Code(err))
-		assert.Contains(t, err.Error(), "audience-bound Supervisor token")
-	})
-
 	t.Run("nil request", func(t *testing.T) {
 		mockStream := &mockDeltaStreamServer{ctx: ctx}
 		err := ct.controller.GetMetadataDelta(nil, mockStream)
@@ -1014,7 +945,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.deltaResponses = nil
 		mockServer.afterSendsReturn = nil
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 
 		req := &csi.GetMetadataDeltaRequest{
 			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
@@ -1026,27 +957,15 @@ func TestGetMetadataDelta(t *testing.T) {
 	})
 
 	t.Run("supervisor GetMetadataDelta RPC not implemented", func(t *testing.T) {
-		prevClient := ct.controller.cnsOperatorClient
-		defer func() { ct.controller.cnsOperatorClient = prevClient }()
-
 		bareSrv, addr := setupBareGRPCServer(t)
 		defer bareSrv.Stop()
 
 		bareCAPEM, _ := testLocalhostTLSCert(t)
-		smsCR := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec": map[string]interface{}{
-					"address":  addr,
-					"caCert":   string(bareCAPEM),
-					"audience": "test-audience",
-				},
-			},
-		}
-		ct.controller.cnsOperatorClient = ctrlclientfake.NewClientBuilder().
-			WithScheme(runtime.NewScheme()).WithObjects(smsCR).Build()
+		installSupervisorCBTConfigForTest(t, &supervisorCBTConfig{
+			Address:  addr,
+			CACert:   string(bareCAPEM),
+			Audience: "test-audience",
+		})
 
 		req := &csi.GetMetadataDeltaRequest{
 			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
@@ -1061,7 +980,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.deltaResponses = []*snapshotmetadataapi.GetMetadataDeltaResponse{{VolumeCapacityBytes: 100}}
 		mockServer.afterSendsReturn = status.Error(codes.OutOfRange, "startOffset is out of range")
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 
 		req := &csi.GetMetadataDeltaRequest{
 			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2",
@@ -1078,7 +997,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.deltaResponses = []*snapshotmetadataapi.GetMetadataDeltaResponse{{VolumeCapacityBytes: 100}}
 		mockServer.afterSendsReturn = status.Error(codes.ResourceExhausted, "slow down")
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 
 		req := &csi.GetMetadataDeltaRequest{
 			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
@@ -1093,7 +1012,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.deltaResponses = []*snapshotmetadataapi.GetMetadataDeltaResponse{{VolumeCapacityBytes: 100}}
 		mockServer.afterSendsReturn = status.Error(codes.DeadlineExceeded, "timeout")
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 
 		req := &csi.GetMetadataDeltaRequest{
 			BaseSnapshotId: testValidChangeID, TargetSnapshotId: "snap-2", StartingOffset: 0, MaxResults: 10,
@@ -1125,7 +1044,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		mockServer.errToReturn = nil
 		mockServer.afterSendsReturn = nil
 		mockServer.deltaResponses = []*snapshotmetadataapi.GetMetadataDeltaResponse{{VolumeCapacityBytes: 100}}
-		mockServer.blockAfterSendsUntilCtxDone = true
+		mockServer.setBlockAfterSendsUntilCtxDone(true)
 
 		ctx2, cancel := context.WithCancel(ctx)
 		req := &csi.GetMetadataDeltaRequest{
@@ -1143,7 +1062,7 @@ func TestGetMetadataDelta(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatal("timeout waiting for GetMetadataDelta")
 		}
-		mockServer.blockAfterSendsUntilCtxDone = false
+		mockServer.setBlockAfterSendsUntilCtxDone(false)
 	})
 }
 
@@ -1185,168 +1104,118 @@ func TestGetSnapshotMetadataClient_Errors(t *testing.T) {
 	// lookup, so the lookup itself must succeed for "snap-1".
 	seedSupervisorVolumeSnapshots(t, ct.controller, "snap-1")
 
-	// Install a test-only token minter (the production binary always
-	// uses TokenRequest — see defaultMintSnapshotMetadataToken in
+	// Install a bootstrap Supervisor token (production reads this from
+	// c.restClientConfig.BearerToken — see getSnapshotMetadataClient in
 	// controller.go) and an insecure dialer for the whole function.
 	// Sub-tests that assert errors before the dial path is reached
 	// (invalid PEM, empty caCert, missing audience, etc.) never invoke
 	// these; the "grpc dial failure" sub-test relies on the dialer to
 	// hit 127.0.0.1:1 and return Unavailable.
-	installFakeTokenMinterForTest(t, "test-token", nil)
+	installBootstrapTokenForTest(t, ct.controller, "test-token")
 	installInsecureDialForTest(t)
 
-	runAllocated := func(sms *unstructured.Unstructured) error {
-		ct.controller.cnsOperatorClient = ctrlclientfake.NewClientBuilder().
-			WithScheme(runtime.NewScheme()).WithObjects(sms).Build()
+	runAllocated := func(cfg *supervisorCBTConfig) error {
+		installSupervisorCBTConfigForTest(t, cfg)
 		return ct.controller.GetMetadataAllocated(
 			&csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1", StartingOffset: 0, MaxResults: 10},
 			&mockAllocatedStreamServer{ctx: ctx},
 		)
 	}
 
-	t.Run("SnapshotMetadataService CR missing", func(t *testing.T) {
-		ct.controller.cnsOperatorClient = ctrlclientfake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+	t.Run("Supervisor CBT config unreadable", func(t *testing.T) {
+		err := runAllocated(nil)
+		require.Error(t, err)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.Contains(t, err.Error(), "failed to read Supervisor CBT config")
+	})
+
+	t.Run("Supervisor CBT config is malformed YAML", func(t *testing.T) {
+		origPath := supervisorCBTConfigPath
+		t.Cleanup(func() { supervisorCBTConfigPath = origPath })
+		path := filepath.Join(t.TempDir(), "config")
+		require.NoError(t, os.WriteFile(path, []byte("address: [this is not valid yaml"), 0o600))
+		supervisorCBTConfigPath = path
+
 		err := ct.controller.GetMetadataAllocated(
 			&csi.GetMetadataAllocatedRequest{SnapshotId: "snap-1", StartingOffset: 0, MaxResults: 10},
 			&mockAllocatedStreamServer{ctx: ctx},
 		)
 		require.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
-		assert.Contains(t, err.Error(), "failed to get SnapshotMetadataService CR")
+		assert.Contains(t, err.Error(), "failed to parse Supervisor CBT config")
 	})
 
-	t.Run("empty spec.address", func(t *testing.T) {
-		sms := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec":       map[string]interface{}{"address": "", "caCert": ""},
-			},
-		}
-		err := runAllocated(sms)
+	t.Run("empty address", func(t *testing.T) {
+		err := runAllocated(&supervisorCBTConfig{Address: "", CACert: ""})
 		require.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 		assert.Contains(t, err.Error(), "address")
 	})
 
-	t.Run("missing spec.audience", func(t *testing.T) {
-		// spec.audience is mandatory: the Supervisor SMS sidecar uses
-		// it to bind the TokenReview audience, so an empty audience
-		// would silently fall back to the API server default audience
-		// (the fragile pre-TokenRequest behaviour we deliberately
-		// replaced). The driver must reject this loudly.
-		sms := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec":       map[string]interface{}{"address": "127.0.0.1:9", "audience": ""},
-			},
-		}
-		err := runAllocated(sms)
+	t.Run("missing audience", func(t *testing.T) {
+		// audience is mandatory: it identifies which audience the bootstrap
+		// Supervisor token (c.restClientConfig.BearerToken) is expected to be
+		// bound to. An empty audience means the Supervisor CBT config is
+		// incomplete/misconfigured, and the driver must reject this loudly
+		// rather than dial with an unverified token.
+		err := runAllocated(&supervisorCBTConfig{Address: "127.0.0.1:9", Audience: ""})
 		require.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 		assert.Contains(t, err.Error(), "audience")
 	})
 
-	t.Run("missing spec.caCert", func(t *testing.T) {
-		sms := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec":       map[string]interface{}{"address": "127.0.0.1:9", "audience": "test-audience"},
-			},
-		}
-		err := runAllocated(sms)
-		require.Error(t, err)
-		assert.Equal(t, codes.Internal, status.Code(err))
-		assert.Contains(t, err.Error(), "caCert")
-	})
-
 	t.Run("invalid caCert PEM and base64", func(t *testing.T) {
-		sms := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec": map[string]interface{}{
-					"address":  "127.0.0.1:9",
-					"audience": "test-audience",
-					"caCert":   "not-valid-pem",
-				},
-			},
-		}
-		err := runAllocated(sms)
+		err := runAllocated(&supervisorCBTConfig{
+			Address:  "127.0.0.1:9",
+			Audience: "test-audience",
+			CACert:   "not-valid-pem",
+		})
 		require.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 		assert.Contains(t, err.Error(), "caCert")
 	})
 
 	t.Run("base64 decodes but PEM append still fails", func(t *testing.T) {
-		sms := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec": map[string]interface{}{
-					"address":  "127.0.0.1:9",
-					"audience": "test-audience",
-					"caCert":   base64.StdEncoding.EncodeToString([]byte("not a pem block")),
-				},
-			},
-		}
-		err := runAllocated(sms)
+		err := runAllocated(&supervisorCBTConfig{
+			Address:  "127.0.0.1:9",
+			Audience: "test-audience",
+			CACert:   base64.StdEncoding.EncodeToString([]byte("not a pem block")),
+		})
 		require.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 	})
 
 	t.Run("empty caCert is rejected", func(t *testing.T) {
-		// TLS is mandatory for the Supervisor dial — an empty spec.caCert
+		// TLS is mandatory for the Supervisor dial — an empty caCert
 		// must always be rejected (the production binary has no insecure
 		// fallback; see getSnapshotMetadataClient in controller.go).
-		sms := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec": map[string]interface{}{
-					"address":  "127.0.0.1:9",
-					"audience": "test-audience",
-					"caCert":   "",
-				},
-			},
-		}
-		err := runAllocated(sms)
+		err := runAllocated(&supervisorCBTConfig{
+			Address:  "127.0.0.1:9",
+			Audience: "test-audience",
+			CACert:   "",
+		})
 		require.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 		assert.Contains(t, err.Error(), "caCert is empty")
 	})
 
-	t.Run("token mint failure", func(t *testing.T) {
-		// Verify that a TokenRequest API failure (e.g. RBAC missing or
-		// API server unreachable) is surfaced as Internal. We override
-		// the minter just for this sub-test; t.Cleanup restores the
-		// happy-path minter installed at the top of the test function.
+	t.Run("bootstrap token unavailable", func(t *testing.T) {
+		// Verify that a missing bootstrap Supervisor token (e.g.
+		// restClientConfig failed to load, or the pvcsi-provider-creds
+		// Secret's token file was empty) is surfaced as Internal rather
+		// than dialing with an empty bearer token. We override just for
+		// this sub-test; t.Cleanup restores the happy-path bootstrap
+		// token installed at the top of the test function.
+		installBootstrapTokenForTest(t, ct.controller, "")
 		caPEM, _ := testLocalhostTLSCert(t)
-		installFakeTokenMinterForTest(t, "", fmt.Errorf("simulated TokenRequest failure"))
-		sms := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec": map[string]interface{}{
-					"address":  "127.0.0.1:1",
-					"audience": "test-audience",
-					"caCert":   string(caPEM),
-				},
-			},
-		}
-		err := runAllocated(sms)
+		err := runAllocated(&supervisorCBTConfig{
+			Address:  "127.0.0.1:1",
+			Audience: "test-audience",
+			CACert:   string(caPEM),
+		})
 		require.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
-		assert.Contains(t, err.Error(), "audience-bound Supervisor token")
+		assert.Contains(t, err.Error(), "bootstrap Supervisor token is not available")
 	})
 
 	t.Run("grpc dial failure", func(t *testing.T) {
@@ -1355,21 +1224,35 @@ func TestGetSnapshotMetadataClient_Errors(t *testing.T) {
 		// installed at the top of TestGetSnapshotMetadataClient_Errors and
 		// then fails because nothing is listening on 127.0.0.1:1.
 		caPEM, _ := testLocalhostTLSCert(t)
-		sms := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "cbt.storage.k8s.io/v1beta1",
-				"kind":       "SnapshotMetadataService",
-				"metadata":   map[string]interface{}{"name": "csi.vsphere.vmware.com"},
-				"spec": map[string]interface{}{
-					"address":  "127.0.0.1:1",
-					"audience": "test-audience",
-					"caCert":   string(caPEM),
-				},
-			},
-		}
-		err := runAllocated(sms)
+		err := runAllocated(&supervisorCBTConfig{
+			Address:  "127.0.0.1:1",
+			Audience: "test-audience",
+			CACert:   string(caPEM),
+		})
 		require.Error(t, err)
 		// gRPC surfaces connection refused as Unavailable when the client fails the RPC (lazy dial).
 		assert.Equal(t, codes.Unavailable, status.Code(err))
+	})
+
+	t.Run("dial setup itself fails", func(t *testing.T) {
+		// Distinct from "grpc dial failure" above: here dialSnapshotMetadata (grpc.NewClient)
+		// itself returns an error synchronously, exercising getSnapshotMetadataClient's own
+		// wrapping of that error rather than a later RPC-time failure on a lazy dial.
+		origDial := dialSnapshotMetadata
+		dialSnapshotMetadata = func(string, credentials.TransportCredentials, credentials.PerRPCCredentials,
+		) (*grpc.ClientConn, error) {
+			return nil, errors.New("dial setup failed")
+		}
+		t.Cleanup(func() { dialSnapshotMetadata = origDial })
+
+		caPEM, _ := testLocalhostTLSCert(t)
+		err := runAllocated(&supervisorCBTConfig{
+			Address:  "127.0.0.1:1",
+			Audience: "test-audience",
+			CACert:   string(caPEM),
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.Contains(t, err.Error(), "failed to connect to Snapshot Metadata Service")
 	})
 }

--- a/pkg/syncer/dpoperator/controller/snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go
+++ b/pkg/syncer/dpoperator/controller/snapshotmetadataservicegc/snapshotmetadataservicegc_controller.go
@@ -64,7 +64,7 @@ const (
 	// leaf certificate that secures the guest cluster's own csi-snapshot-metadata
 	// sidecar. Its ca.crt field is the CA that must be published in the guest
 	// SnapshotMetadataService CR's spec.caCert.
-	targetSecretName = "vmware-system-csi-snapshot-metadata-service-cert-gc"
+	targetSecretName = "csi-snapshot-metadata-service-cert-gc"
 
 	// targetNamespace is the namespace of targetSecretName in the guest cluster.
 	targetNamespace = "vmware-system-csi"


### PR DESCRIPTION
The PR includes following changes:
1. Use default SA token, instead of recreating new to connect to supervisor CBT service
2. rename guest cluster CBT cert secret name to watch for, while refreshing cert data
3. Read supervisor CBT service config from secret mounted, instead of reading the CR from supervisor directly

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* WCP precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1948/
```
Ran 15 of 2362 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2347 Skipped | 0 Flaked
```
* VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1498/
```
Ran 6 of 2362 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2356 Skipped | 0 Flaked
```
* Tested manual deployment in VKS cluster and tested CBT API in guest cluster, that worked fine. Detailed logs - 
[pvCSI-CBT-deployment-review-testlogs.txt](https://github.com/user-attachments/files/31449147/pvCSI-CBT-deployment-review-testlogs.txt)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Misc changes to support pvCSI CBT API with deployment via addon config
```
