### PR TITLE
Remove pv_retained flag for orphaned pvs

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -1715,7 +1715,17 @@ func getMissingPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstypes
 		// started (e.g. syncer restart), in which case pvMissingLabeledMap
 		// would not know about it yet. Detect that from the live query so we
 		// don't keep re-deriving an update spec for it every cycle.
-		if isPVEntityLabeled(vol, prometheus.PrometheusPVMissingLabelKey, prometheus.PrometheusPVMissingLabelValue) {
+		//
+		// This deliberately requires pv_missing to be the *only* label on the
+		// PV entity. A volume carrying pv_missing alongside other labels is
+		// still in a state that needs reconciling: those labels describe a
+		// K8s PV that no longer exists (e.g. a stale pv_retained from when
+		// the PV was still present-but-unconsumed, or CnsRegisterVolume
+		// provenance labels), and buildPVMissingUpdateSpec below is what
+		// strips them. Skipping on a mere pv_missing match would leave such
+		// volumes stale forever, since nothing else revisits an orphan.
+		if isPVEntityLabeledExclusively(vol, prometheus.PrometheusPVMissingLabelKey,
+			prometheus.PrometheusPVMissingLabelValue) {
 			pvMissingLabeledMap[vc][vol.VolumeId.Id] = true
 			continue
 		}
@@ -1736,28 +1746,43 @@ func getMissingPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstypes
 	return updateSpecArray, len(updateSpecArray), nil
 }
 
-// isPVEntityLabeled reports whether the volume's PV-type CNS entity
-// metadata, scoped to the current cluster, already carries the given label.
-func isPVEntityLabeled(vol cnstypes.CnsVolume, labelKey, labelValue string) bool {
+// isPVEntityLabeledExclusively reports whether every PV-type CNS entity
+// metadata on the volume, scoped to the current cluster, already carries the
+// given label and nothing else.
+//
+// It returns false if any such entity carries additional labels beyond the
+// given one (that entity still needs its stale labels stripped), and false if
+// the volume has no in-cluster PV-type entity at all (a synthetic entity
+// still needs to be created to host the label).
+func isPVEntityLabeledExclusively(vol cnstypes.CnsVolume, labelKey, labelValue string) bool {
+	foundInClusterPV := false
 	for _, em := range vol.Metadata.EntityMetadata {
 		k8sEm, ok := em.(*cnstypes.CnsKubernetesEntityMetadata)
 		if !ok || k8sEm.ClusterID != clusterIDforVolumeMetadata ||
 			k8sEm.EntityType != string(cnstypes.CnsKubernetesEntityTypePV) {
 			continue
 		}
-		if cnsvsphere.GetLabelsMapFromKeyValue(k8sEm.Labels)[labelKey] == labelValue {
-			return true
+		foundInClusterPV = true
+		labels := cnsvsphere.GetLabelsMapFromKeyValue(k8sEm.Labels)
+		if len(labels) != 1 || labels[labelKey] != labelValue {
+			return false
 		}
 	}
-	return false
+	return foundInClusterPV
 }
 
-// buildPVMissingUpdateSpec returns an UpdateSpec that sets pv_missing=true on
-// the CNS volume's PV-type CnsKubernetesEntityMetadata, preserving any
-// pre-existing labels on those entries.
+// buildPVMissingUpdateSpec returns an UpdateSpec that sets pv_missing=true as
+// the sole label on the CNS volume's PV-type CnsKubernetesEntityMetadata.
 //
 // If the volume has one or more in-cluster PV-type entities, each is reissued
-// with the pv_missing label appended.
+// with its label set reduced to just pv_missing=true. Pre-existing labels are
+// intentionally dropped rather than merged: the volume's K8s PV object is gone,
+// so any other label on the entity (a stale pv_retained from when the PV was
+// present-but-unconsumed, CnsRegisterVolume/VKSRegisterVolume provenance
+// labels, user labels mirrored from the PV) describes an object that no longer
+// exists and can never be reconciled again. The entity's EntityName — the
+// last-known PV name, which VI Admins rely on to identify the orphan — is
+// preserved.
 //
 // If no in-cluster PV-type entity is present (legacy volumes, or volumes
 // whose CNS metadata never carried a PV entity), a synthetic PV-type entity

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -2503,6 +2503,100 @@ func TestGetMissingPVVolumeUpdateSpecs_AlreadyLabeled(t *testing.T) {
 		"volume found already labeled via live CNS metadata should be recorded in pvMissingLabeledMap")
 }
 
+// TestGetMissingPVVolumeUpdateSpecs_StripsStalePVRetained covers the lifecycle
+// where a Retain-policy PV is first labeled pv_retained=true while it still
+// exists but is unconsumed (Released), and is then force-deleted so the volume
+// becomes a true orphan. Once the PV is gone, pv_retained is stale and the
+// volume must end up carrying pv_missing=true alone.
+func TestGetMissingPVVolumeUpdateSpecs_StripsStalePVRetained(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vc := "test-vc"
+	clusterID := "test-cluster"
+	ms := pvMissingTestSetup(t, vc, clusterID)
+
+	vol := makeCNSVolume("vol-1", "pv-orphan", clusterID,
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+				EntityName: "pv-orphan",
+				ClusterID:  clusterID,
+				Labels: []types.KeyValue{
+					{Key: "pv_retained", Value: "true"},
+				},
+			},
+			EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		})
+	cc := cnstypes.CnsContainerCluster{ClusterId: clusterID}
+
+	// Pre-seed grace tracker so we skip straight to the labeling decision.
+	cnsDeletionMap[vc]["vol-1"] = true
+
+	specs, _, err := getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		map[string]string{}, ms, false, cc, vc)
+	assert.NoError(t, err)
+	assert.Len(t, specs, 1)
+
+	labels := map[string]string{}
+	for _, baseEm := range specs[0].Metadata.EntityMetadata {
+		em := baseEm.(*cnstypes.CnsKubernetesEntityMetadata)
+		for _, kv := range em.Labels {
+			labels[kv.Key] = kv.Value
+		}
+	}
+	assert.Equal(t, "true", labels["pv_missing"], "pv_missing label must be set")
+	assert.NotContains(t, labels, "pv_retained",
+		"stale pv_retained must be stripped once the PV no longer exists")
+	assert.Len(t, labels, 1, "orphan volume must carry pv_missing alone")
+}
+
+// TestGetMissingPVVolumeUpdateSpecs_ReconcilesCoexistingLabels covers the
+// already-broken state observed in the field: a volume that full sync labeled
+// pv_missing=true under the older merge behavior, leaving an earlier
+// pv_retained=true alongside it. Such a volume must not be treated as "already
+// labeled, nothing to do" — it needs one more update to strip the stale label,
+// otherwise both labels show up in the vCenter UI forever.
+func TestGetMissingPVVolumeUpdateSpecs_ReconcilesCoexistingLabels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vc := "test-vc"
+	clusterID := "test-cluster"
+	ms := pvMissingTestSetup(t, vc, clusterID)
+
+	vol := makeCNSVolume("vol-1", "pv-orphan", clusterID,
+		&cnstypes.CnsKubernetesEntityMetadata{
+			CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+				EntityName: "pv-orphan",
+				ClusterID:  clusterID,
+				Labels: []types.KeyValue{
+					{Key: "pv_retained", Value: "true"},
+					{Key: "pv_missing", Value: "true"},
+				},
+			},
+			EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+		})
+	cc := cnstypes.CnsContainerCluster{ClusterId: clusterID}
+
+	// Pre-seed grace tracker so we skip straight to the labeling decision.
+	cnsDeletionMap[vc]["vol-1"] = true
+
+	specs, count, err := getMissingPVVolumeUpdateSpecs(ctx, []cnstypes.CnsVolume{vol},
+		map[string]string{}, ms, false, cc, vc)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count,
+		"a volume with pv_missing plus stale labels must still be reconciled")
+	assert.Len(t, specs, 1)
+
+	labels := map[string]string{}
+	for _, baseEm := range specs[0].Metadata.EntityMetadata {
+		em := baseEm.(*cnstypes.CnsKubernetesEntityMetadata)
+		for _, kv := range em.Labels {
+			labels[kv.Key] = kv.Value
+		}
+	}
+	assert.Equal(t, "true", labels["pv_missing"], "pv_missing label must remain set")
+	assert.Len(t, labels, 1, "stale pv_retained must be stripped, leaving pv_missing alone")
+}
+
 // TestGetMissingPVVolumeUpdateSpecs_SkipsOnceLocallyLabeled verifies that
 // once pvMissingLabeledMap records a volume as labeled, subsequent calls
 // short-circuit and never re-issue an update spec for it — even if the CNS


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Replaced isPVEntityLabeled with isPVEntityLabeledExclusively, skips only when the PV entity's label map is exactly pv_missing = true. Anything extra means the entity still needs reconciling. Returns false when there's no in-cluster PV entity, preserving the synthetic-entity path.


**Testing done**:
e2e pipelines - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1943/

```
1. Dynamically provision a PVC/PV on wcp-vmfs-policy.

2. Patch the PV reclaim policy to Retain: kubectl patch pv <pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'.

3. Delete the PVC, transitioning the PV to Status: Released.

4. Remove the PV finalizer and delete the PV resource from Kubernetes API: kubectl delete pv <pv-name> --force.

5. Wait for vsphere-syncer to complete a FullSync cycle.

6. Inspect the volume in vCenter UI 

```
<img width="1861" height="797" alt="Screenshot 2026-08-26 at 2 05 31 PM" src="https://github.com/user-attachments/assets/dcb03282-62b5-436a-9720-a3df6392f8f6" />


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove pv_retained flag for orphaned pvs
```
