### PR TITLE
Add READY/AGE printer columns to CnsFileAccessConfig and CnsNodeVMBatchAttachment CRDs so kubectl get shows object health

### DIFF
--- a/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1/cnsfileaccessconfig_types.go
+++ b/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1/cnsfileaccessconfig_types.go
@@ -59,6 +59,8 @@ type CnsFileAccessConfigStatus struct {
 // CnsFileAccessConfig is the Schema for the CnsFileAccessConfig API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready",type="boolean",JSONPath=".status.done"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type CnsFileAccessConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
+++ b/pkg/apis/cnsoperator/cnsnodevmbatchattachment/v1alpha1/cnsnodebatchvmattachment_types.go
@@ -161,6 +161,8 @@ type PersistentVolumeClaimStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=batchattach
 // +kubebuilder:printcolumn:name="InstanceUUID",type="string",JSONPath=".spec.instanceUUID"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // CnsNodeVMBatchAttachment is the Schema for the cnsnodevmbatchattachments API
 type CnsNodeVMBatchAttachment struct {

--- a/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmbatchattachments.yaml
@@ -20,6 +20,12 @@ spec:
     - jsonPath: .spec.instanceUUID
       name: InstanceUUID
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
@@ -16,7 +16,14 @@ spec:
     singular: cnsfileaccessconfig
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.done
+      name: Ready
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CnsFileAccessConfig is the Schema for the CnsFileAccessConfig


### PR DESCRIPTION
**What this PR does / why we need it**:

Both CRDs already track health in .status, but neither surfaced it via `kubectl get`
- CnsFileAccessConfig had just NAME/AGE
- CnsNodeVMBatchAttachment had NAME/InstanceUUID 

As observed on a scale test environment, this is forcing a `kubectl describe` per object to spot failures.

This change adds +kubebuilder:printcolumn markers to both Go types and mirrors them into the corresponding CRD YAMLs.
- CnsFileAccessConfig: READY (.status.done).
- CnsNodeVMBatchAttachment: READY (from the Ready condition), AGE.

This is purely a CRD schema change. Both CRD YAMLs are go:embed'd and re-applied via Get+Update on every syncer startup, so a syncer upgrade alone rolls out the new columns. No changes in manifest, RBAC, or CRD version bump are needed.

Note: READY renders blank (not false) for CnsFileAccessConfig instances that never succeeded, since setInstanceError in controller never sets status.done which is existing behavior.

**Which issue this PR fixes** : fixes 3787587

**Testing done**:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1489/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1945/ - Passed

Verified end-to-end on a live Supervisor testbed that CnsFileAccessConfig and CnsNodeVMBatchAttachment (batchattach) now expose a READY column via additionalPrinterColumns, matching the behavior of volumeattachments.storage.k8s.io requested in this issue.

1. Deployed a syncer build with the change and confirmed both CRDs were updated in place
```
$ kubectl get pods -n vmware-system-csi
NAME                                    READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-984d979c-txk5k   7/7     Running   0          3m35s

$ kubectl logs -n vmware-system-csi vsphere-csi-controller-984d979c-txk5k -c vsphere-syncer | grep -i "CRD"
{"level":"info", ...,"msg":"\"cnsnodevmbatchattachments.cns.vmware.com\" CRD updated successfully", ...}
{"level":"info", ...,"msg":"\"cnsfileaccessconfigs.cns.vmware.com\" CRD updated successfully", ...}

$ kubectl get crd cnsfileaccessconfigs.cns.vmware.com -o jsonpath='{.metadata.uid}'
426ac840-4070-40f6-a4f3-c82ec3504c63
```
uid was identical before and after the syncer restart, confirming the CRD schema was updated in-place (Update), not deleted and recreated. So, no impact to existing objects/finalizers.

2. Confirmed the new additionalPrinterColumns on both CRDs
```
$ kubectl get crd cnsfileaccessconfigs.cns.vmware.com -o jsonpath='{.spec.versions[0].additionalPrinterColumns}' | jq .
[
  { "jsonPath": ".status.done", "name": "Ready", "type": "boolean" },
  { "jsonPath": ".metadata.creationTimestamp", "name": "Age", "type": "date" }
]

$ kubectl get crd cnsnodevmbatchattachments.cns.vmware.com -o jsonpath='{.spec.versions[0].additionalPrinterColumns}' | jq .
[
  { "jsonPath": ".spec.instanceUUID", "name": "InstanceUUID", "type": "string" },
  { "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status", "name": "Ready", "type": "string" },
  { "jsonPath": ".metadata.creationTimestamp", "name": "Age", "type": "date" }
]
```
3. batchattach: Verified READY renders correctly against live objects.
```
$ kubectl get batchattach -A
NAMESPACE             NAME                                                    INSTANCEUUID                           READY   AGE
test-gc-e2e-demo-ns   test-cluster-e2e-script-bh55r-4mszt                     10612fa0-1966-4f0c-bb7b-a5ccffcf5ab8   True    151m
test-gc-e2e-demo-ns   test-cluster-e2e-script-bh55r-5pgnd                     688d058f-656a-46f6-b268-cd1919ca43c1   True    160m
test-gc-e2e-demo-ns   test-cluster-e2e-script-bh55r-sfm7r                     0514b2ae-986a-4ddb-81da-1d1241cd3e30   True    155m
test-gc-e2e-demo-ns   test-cluster-e2e-script-node-pool-1-gxsnh-nmhbg-fcmfl   d9b6e573-34e2-459e-9d8f-06c343187171   True    156m
test-gc-e2e-demo-ns   test-cluster-e2e-script-node-pool-1-gxsnh-nmhbg-htd5p   828ae0d6-93fc-4ab5-b6a0-41e1612b6249   True    156m
test-gc-e2e-demo-ns   test-cluster-e2e-script-node-pool-1-gxsnh-nmhbg-svqh6   0f575a1c-5a9b-4663-bc62-792f38a7630c   True    156m
```
READY renders True for all 6 live attach objects. This matches the ATTACHED column behavior of volumeattachments.storage.k8s.io referenced in the original ask.

4. batchattach: Verified READY renders correctly for a failing object Created a CnsNodeVMBatchAttachment referencing an existing VM's instanceUUID but a nonexistent PVC, to exercise the error path:
```
$ cat <<YAML | kubectl apply -f -
apiVersion: cns.vmware.com/v1alpha1
kind: CnsNodeVMBatchAttachment
metadata:
  name: test-bad-batchattach
  namespace: test-gc-e2e-demo-ns
spec:
  instanceUUID: 10612fa0-1966-4f0c-bb7b-a5ccffcf5ab8
  volumes:
    - name: bad-vol
      persistentVolumeClaim:
        claimName: does-not-exist-pvc
        diskMode: persistent
        sharingMode: sharingNone
        controllerKey: 1000
        unitNumber: 5
YAML
cnsnodevmbatchattachment.cns.vmware.com/test-bad-batchattach created

$ kubectl get cnsnodevmbatchattachment -n test-gc-e2e-demo-ns test-bad-batchattach
NAME                   INSTANCEUUID                           READY   AGE
test-bad-batchattach   10612fa0-1966-4f0c-bb7b-a5ccffcf5ab8   False   19s
```
READY=False renders correctly for the failing attach, confirming the column reflects both the success and failure paths of the existing Ready condition

5. CnsFileAccessConfig: verified READY/ERROR against a live failure case
```
The testbed had no CnsFileAccessConfig objects and no ReadWriteMany PVCs, so a failing instance was reproduced directly: a CnsFileAccessConfig referencing an existing PVC and a TKG guest-cluster VM, which the controller's existing validation correctly rejects.

$ cat <<YAML | kubectl apply -f -
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-throwaway-pvc
  namespace: test-gc-e2e-demo-ns
spec:
  accessModes: [ReadWriteOnce]
  resources:
    requests:
      storage: 1Gi
  storageClassName: gc-storage-profile
YAML
persistentvolumeclaim/test-throwaway-pvc created

$ cat <<YAML | kubectl apply -f -
apiVersion: cns.vmware.com/v1alpha1
kind: CnsFileAccessConfig
metadata:
  name: test-bad-fileaccessconfig
  namespace: test-gc-e2e-demo-ns
spec:
  pvcName: test-throwaway-pvc
  vmName: test-cluster-e2e-script-bh55r-4mszt
YAML
cnsfileaccessconfig.cns.vmware.com/test-bad-fileaccessconfig created

$ kubectl get cnsfileaccessconfigs.cns.vmware.com -n test-gc-e2e-demo-ns test-bad-fileaccessconfig
cnsfileaccessconfigs.cns.vmware.com -n test-gc-e2e-demo-ns test-bad-fileaccessconfig
NAME                        READY   AGE
test-bad-fileaccessconfig           7s
```

READY rendered blank rather than false for this object. This is existing controller behavior.



