### PR TITLE
Scope vSAN encryption check to the VSAN namespace to avoid false positives in ClusterSPI controller 

### DIFF
--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller.go
@@ -82,7 +82,7 @@ const (
 	workerThreadsEnvVar     = "WORKER_THREADS_CLUSTER_STORAGE_POLICY_INFO"
 	defaultMaxWorkerThreads = 4
 	vsanEncryptionPropID    = "dataAtRestEncryption"
-	vsanIopsLimitNs         = "VSAN"
+	vsanNs                  = "VSAN"
 	vsanIopsLimitPropID     = "iopsLimit"
 	vmEncryptionNs          = "vmwarevmcrypt"
 	vmEncryptionCapID       = "vmwarevmcrypt@ENCRYPTION"

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -1358,6 +1358,7 @@ func TestCheckVsanEncryption(t *testing.T) {
 						{
 							Rules: []cnsvsphere.SpbmPolicyRule{
 								{
+									Ns:     vsanNs,
 									PropID: "dataAtRestEncryption",
 									Value:  "true",
 								},
@@ -1367,6 +1368,26 @@ func TestCheckVsanEncryption(t *testing.T) {
 				},
 			},
 			expected: true,
+		},
+		{
+			name: "policy with dataAtRestEncryption PropID in wrong namespace",
+			policyContent: []cnsvsphere.SpbmPolicyContent{
+				{
+					ID: "test-policy",
+					Profiles: []cnsvsphere.SpbmPolicySubProfile{
+						{
+							Rules: []cnsvsphere.SpbmPolicyRule{
+								{
+									Ns:     "someOtherNamespace",
+									PropID: "dataAtRestEncryption",
+									Value:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
 		},
 		{
 			name: "policy without dataAtRestEncryption capability",
@@ -1409,6 +1430,7 @@ func TestCheckVsanEncryption(t *testing.T) {
 						{
 							Rules: []cnsvsphere.SpbmPolicyRule{
 								{
+									Ns:     vsanNs,
 									PropID: "dataAtRestEncryption",
 									Value:  "true",
 								},
@@ -1457,6 +1479,7 @@ func TestAnalyzeEncryptionCapabilities(t *testing.T) {
 						{
 							Rules: []cnsvsphere.SpbmPolicyRule{
 								{
+									Ns:     vsanNs,
 									PropID: "dataAtRestEncryption",
 									Value:  "true",
 								},
@@ -1518,6 +1541,7 @@ func TestAnalyzeEncryptionCapabilities(t *testing.T) {
 						{
 							Rules: []cnsvsphere.SpbmPolicyRule{
 								{
+									Ns:     vsanNs,
 									PropID: "dataAtRestEncryption",
 									Value:  "true",
 								},
@@ -1581,7 +1605,7 @@ func TestExtractIopsLimit(t *testing.T) {
 						{
 							Rules: []cnsvsphere.SpbmPolicyRule{
 								{
-									Ns:     vsanIopsLimitNs,
+									Ns:     vsanNs,
 									PropID: vsanIopsLimitPropID,
 									Value:  "100",
 								},
@@ -1602,7 +1626,7 @@ func TestExtractIopsLimit(t *testing.T) {
 						{
 							Rules: []cnsvsphere.SpbmPolicyRule{
 								{
-									Ns:     vsanIopsLimitNs,
+									Ns:     vsanNs,
 									PropID: vsanIopsLimitPropID,
 									Value:  "not-a-number",
 								},
@@ -1623,7 +1647,7 @@ func TestExtractIopsLimit(t *testing.T) {
 						{
 							Rules: []cnsvsphere.SpbmPolicyRule{
 								{
-									Ns:     vsanIopsLimitNs,
+									Ns:     vsanNs,
 									CapID:  "someOtherCap",
 									PropID: "someOtherProp",
 									Value:  "100",
@@ -1709,7 +1733,7 @@ func TestGetStorageTopologyTypeFromPolicy(t *testing.T) {
 		{
 			name: "policy without topology capability",
 			policyContent: policyWithRule(cnsvsphere.SpbmPolicyRule{
-				Ns:     vsanIopsLimitNs,
+				Ns:     vsanNs,
 				PropID: vsanIopsLimitPropID,
 				Value:  "100",
 			}),
@@ -1721,7 +1745,7 @@ func TestGetStorageTopologyTypeFromPolicy(t *testing.T) {
 				{
 					ID: "test-policy",
 					Profiles: []cnsvsphere.SpbmPolicySubProfile{
-						{Rules: []cnsvsphere.SpbmPolicyRule{{Ns: vsanIopsLimitNs, PropID: vsanIopsLimitPropID, Value: "100"}}},
+						{Rules: []cnsvsphere.SpbmPolicyRule{{Ns: vsanNs, PropID: vsanIopsLimitPropID, Value: "100"}}},
 						{Rules: []cnsvsphere.SpbmPolicyRule{topologyRule(pbmTopologyValueZonal)}},
 					},
 				},
@@ -1761,7 +1785,7 @@ func TestPopulatePerformanceCapabilities(t *testing.T) {
 						{
 							Rules: []cnsvsphere.SpbmPolicyRule{
 								{
-									Ns:     vsanIopsLimitNs,
+									Ns:     vsanNs,
 									PropID: vsanIopsLimitPropID,
 									Value:  "500",
 								},
@@ -1782,7 +1806,7 @@ func TestPopulatePerformanceCapabilities(t *testing.T) {
 						{
 							Rules: []cnsvsphere.SpbmPolicyRule{
 								{
-									Ns:     vsanIopsLimitNs,
+									Ns:     vsanNs,
 									PropID: vsanIopsLimitPropID,
 									Value:  "not-a-number",
 								},

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/helper.go
@@ -174,7 +174,7 @@ func checkVsanEncryption(policyContent []cnsvsphere.SpbmPolicyContent) bool {
 	for _, policy := range policyContent {
 		for _, subProfile := range policy.Profiles {
 			for _, rule := range subProfile.Rules {
-				if rule.PropID == vsanEncryptionPropID {
+				if rule.Ns == vsanNs && rule.PropID == vsanEncryptionPropID {
 					return true
 				}
 			}
@@ -256,7 +256,7 @@ func extractIopsLimit(policyContent []cnsvsphere.SpbmPolicyContent) (*int64, err
 	for _, policy := range policyContent {
 		for _, subProfile := range policy.Profiles {
 			for _, rule := range subProfile.Rules {
-				if rule.Ns == vsanIopsLimitNs && rule.PropID == vsanIopsLimitPropID {
+				if rule.Ns == vsanNs && rule.PropID == vsanIopsLimitPropID {
 					iops, err := strconv.ParseInt(rule.Value, 10, 64)
 					if err != nil {
 						return nil, fmt.Errorf("failed to parse IOPS limit value %q: %w", rule.Value, err)


### PR DESCRIPTION
checkVsanEncryption previously matched on PropID == "dataAtRestEncryption" alone, with no namespace check, so a rule with that PropID under any namespace would incorrectly report vSAN encryption as enabled. 
This closes a false-positive gap: since PropID values aren't guaranteed globally unique across namespaces in vSphere's policy model, a different capability provider reusing that same PropID string would cause ClusterStoragePolicyInfo to wrongly report vSAN encryption as enabled on a policy that doesn't actually have it. The fix addresses this issue.

Testing done:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1947/ - Passed
https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1492/ - Passed

Unit tests
```
go test ./pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/... \
  -run 'TestCheckVsanEncryption|TestAnalyzeEncryptionCapabilities|TestCheckVmEncryption' -v
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo   0.945s
```
All tests passed.
Added TestCheckVsanEncryption/policy_with_dataAtRestEncryption_PropID_in_wrong_namespace, which asserts checkVsanEncryption returns false when a rule has PropID == "dataAtRestEncryption" but Ns != "VSAN" — this is the false-positive case the fix closes and cannot be reproduced against a real vCenter, since it requires a capability provider that happens to reuse the same PropID string outside the VSAN namespace.

Live Supervisor cluster verification

(1) Verified the positive path is unaffected by the new namespace guard, using a storage policy with vSAN's "Encryption" storage rule enabled (new-vm-storage-policy):
```
kubectl apply -f - <<'EOF'
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: new-vm-storage-policy
provisioner: csi.vsphere.vmware.com
parameters:
  storagePolicyName: new-vm-storage-policy
EOF

kubectl get clusterstoragepolicyinfo new-vm-storage-policy -o yaml

apiVersion: cns.vmware.com/v1alpha1
kind: ClusterStoragePolicyInfo
metadata:
  creationTimestamp: "2026-08-26T08:57:48Z"
  generation: 1
  name: new-vm-storage-policy
  ownerReferences:
  - apiVersion: storage.k8s.io/v1
    blockOwnerDeletion: false
    controller: false
    kind: StorageClass
    name: new-vm-storage-policy
    uid: 4e4e29b4-87f4-4a16-a3f6-03f387e6afff
  resourceVersion: "924740"
  uid: b3aeaf58-6359-4456-ba24-9e474422bbf0
status:
  encryption:
    encryptionTypes:
    - vsan-encryption
    supportsEncryption: true
  performance:
    iopsLimit: 0
  storagePolicyDeleted: false
```
encryptionTypes correctly reports vsan-encryption, confirming vCenter reports this policy's dataAtRestEncryption rule under the VSAN namespace — matching the vsanNs constant — so the new rule.Ns == vsanNs guard in checkVsanEncryption does not regress real vSAN-encrypted policies.

Also confirmed a VM-encryption-only policy (management-storage-policy-encryption) correctly reports only vm-encryption (not vsan-encryption), showing the two encryption types remain correctly distinguished:
```
kubectl get clusterstoragepolicyinfo management-storage-policy-encryption -o jsonpath='{.status.encryption}' | jq

{
  "encryptionTypes": [
    "vm-encryption"
  ],
  "supportsEncryption": true
}
```

(2) vSAN IOPS-limit policy: 
Created StorageClass vsan-iops-limit-test-policy against a vSAN policy with an IOPS limit of 1000 set, no encryption:
```
kubectl apply -f - <<'EOF'
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: vsan-iops-limit-test-policy
provisioner: csi.vsphere.vmware.com
parameters:
  storagePolicyName: vsan-iops-limit-test-policy
EOF

kubectl get clusterstoragepolicyinfo vsan-iops-limit-test-policy -o yaml
```
Output:
```
status:
  encryption:
    supportsEncryption: false
  performance:
    iopsLimit: 1000
  storagePolicyDeleted: false
```
Confirms extractIopsLimit, which also matches on rule.Ns == vsanNs, still correctly reports the IOPS limit after the constant rename. No regression on the IOPS-limit path.


