### PR TITLE
Normalize vCenter host and thumbprint casing (VGL-66658)

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -182,10 +182,10 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 	vcThumbprint := cfg.Global.Thumbprint
 
 	vcConfig := &VirtualCenterConfig{
-		Host:                        host,
+		Host:                        strings.ToLower(host),
 		Port:                        port,
 		CAFile:                      vcCAFile,
-		Thumbprint:                  vcThumbprint,
+		Thumbprint:                  strings.ToUpper(vcThumbprint),
 		Username:                    cfg.VirtualCenter[host].User,
 		Password:                    cfg.VirtualCenter[host].Password,
 		Insecure:                    cfg.VirtualCenter[host].InsecureFlag,
@@ -235,10 +235,13 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 		}
 
 		vcConfig := &VirtualCenterConfig{
-			Host:                        vCenterIP,
+			// vCenter FQDN/IP is a protocol-compliant case-insensitive identifier
+			// (used as a map key and in equality checks throughout the driver),
+			// so it is normalized to lowercase at this single entry point.
+			Host:                        strings.ToLower(vCenterIP),
 			Port:                        port,
 			CAFile:                      cfg.VirtualCenter[vCenterIP].CAFile,
-			Thumbprint:                  cfg.VirtualCenter[vCenterIP].Thumbprint,
+			Thumbprint:                  strings.ToUpper(cfg.VirtualCenter[vCenterIP].Thumbprint),
 			Username:                    cfg.VirtualCenter[vCenterIP].User,
 			Password:                    cfg.VirtualCenter[vCenterIP].Password,
 			Insecure:                    cfg.VirtualCenter[vCenterIP].InsecureFlag,
@@ -253,7 +256,9 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			vcConfig.CAFile = cfg.Global.CAFile
 		}
 		if vcConfig.Thumbprint == "" {
-			vcConfig.Thumbprint = cfg.Global.Thumbprint
+			// Thumbprints are compared uppercase (govmomi's soap.ThumbprintSHA1/256
+			// always generate uppercase hex), so normalize this fallback too.
+			vcConfig.Thumbprint = strings.ToUpper(cfg.Global.Thumbprint)
 		}
 		log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
 		if strings.TrimSpace(cfg.VirtualCenter[vCenterIP].Datacenters) != "" {

--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -9,7 +9,74 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 )
+
+// vCenter host and thumbprint are protocol-compliant case-insensitive identifiers, so
+// GetVirtualCenterConfigs must normalize them (host -> lowercase, thumbprint -> uppercase)
+// regardless of the casing an operator used in vsphere.conf, to avoid case-mismatch failures
+// in the map lookups and equality checks performed downstream on VirtualCenterConfig.Host.
+func TestGetVirtualCenterConfigsNormalizesHostAndThumbprint(t *testing.T) {
+	ctx := context.Background()
+
+	mixedCaseHost := "VC.Example.COM"
+	mixedCaseThumbprint := "aa:bb:cc:dd:11:22:33:44:55:66:77:88:99:00:aa:bb:cc:dd:ee:ff"
+
+	cfg := &config.Config{}
+	cfg.Global.QueryLimit = 100
+	cfg.Global.ListVolumeThreshold = 100
+	cfg.VirtualCenter = map[string]*config.VirtualCenterConfig{
+		mixedCaseHost: {
+			User:         "administrator@vsphere.local",
+			Password:     "password",
+			VCenterPort:  "443",
+			InsecureFlag: true,
+			Thumbprint:   mixedCaseThumbprint,
+		},
+	}
+
+	vcConfigs, err := GetVirtualCenterConfigs(ctx, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vcConfigs) != 1 {
+		t.Fatalf("expected 1 VirtualCenterConfig, got %d", len(vcConfigs))
+	}
+
+	assert.Equal(t, "vc.example.com", vcConfigs[0].Host,
+		"vCenter host should be normalized to lowercase")
+	assert.Equal(t, "AA:BB:CC:DD:11:22:33:44:55:66:77:88:99:00:AA:BB:CC:DD:EE:FF", vcConfigs[0].Thumbprint,
+		"thumbprint should be normalized to uppercase to match govmomi's SHA1/SHA256 format")
+}
+
+// The Global.Thumbprint fallback path must be normalized the same way as the
+// per-VirtualCenter thumbprint.
+func TestGetVirtualCenterConfigsNormalizesGlobalThumbprintFallback(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := &config.Config{}
+	cfg.Global.QueryLimit = 100
+	cfg.Global.ListVolumeThreshold = 100
+	cfg.Global.Thumbprint = "aa:bb:cc:dd:11:22:33:44:55:66:77:88:99:00:aa:bb:cc:dd:ee:ff"
+	cfg.VirtualCenter = map[string]*config.VirtualCenterConfig{
+		"vc.example.com": {
+			User:         "administrator@vsphere.local",
+			Password:     "password",
+			VCenterPort:  "443",
+			InsecureFlag: true,
+		},
+	}
+
+	vcConfigs, err := GetVirtualCenterConfigs(ctx, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vcConfigs) != 1 {
+		t.Fatalf("expected 1 VirtualCenterConfig, got %d", len(vcConfigs))
+	}
+
+	assert.Equal(t, "AA:BB:CC:DD:11:22:33:44:55:66:77:88:99:00:AA:BB:CC:DD:EE:FF", vcConfigs[0].Thumbprint)
+}
 
 func TestFilterSuspendedDatastoresWhenDatastoreIsSuspended(t *testing.T) {
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -217,7 +217,10 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 
 	// Globals.
 	if v := os.Getenv("VSPHERE_VCENTER"); v != "" {
-		cfg.Global.VCenterIP = v
+		// vCenter FQDN/IP is a protocol-compliant case-insensitive identifier that is
+		// later used as an exact-match map key against VirtualCenterConfig.Host, which
+		// is normalized to lowercase, so normalize this copy the same way.
+		cfg.Global.VCenterIP = strings.ToLower(v)
 	}
 	if v := os.Getenv("VSPHERE_PORT"); v != "" {
 		cfg.Global.VCenterPort = v
@@ -422,7 +425,9 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 			vcConfig.InsecureFlag = cfg.Global.InsecureFlag
 		}
 		if setCfgGlobalvCenter && cfg.Global.VCenterIP == "" {
-			cfg.Global.VCenterIP = vcServer
+			// Normalize to lowercase to match VirtualCenterConfig.Host, which downstream
+			// code looks up by exact-match against this value.
+			cfg.Global.VCenterIP = strings.ToLower(vcServer)
 		}
 		// Print out the config.
 		log.Debugf("vc server %s config: %+v", vcServer, vcConfig)

--- a/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
+++ b/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
@@ -166,7 +166,11 @@ func (volumeInfo *volumeInfo) GetvCenterForVolumeID(ctx context.Context, volumeI
 		return "", logger.LogNewErrorf(log, "failed to parse cnsvolumeinfo object: %v, err: %v", info, err)
 	}
 	log.Infof("Volume ID %q is associated with VC %q", volumeID, cnsvolumeinfo.Spec.VCenterServer)
-	return cnsvolumeinfo.Spec.VCenterServer, nil
+	// Normalize to lowercase: this value is used as an exact-match key against
+	// VirtualCenterConfig.Host-keyed maps (e.g. VolumeManagers), which are always
+	// lowercase. CRs persisted before host normalization was introduced may still
+	// carry their original casing.
+	return strings.ToLower(cnsvolumeinfo.Spec.VCenterServer), nil
 }
 
 // CreateVolumeInfo creates VolumeInfo CR to persist VolumeID to vCenter mapping

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -1003,7 +1003,9 @@ func volumeInfoCRFullSync(ctx context.Context, metadataSyncer *metadataSyncInfor
 			log.Errorf("FullSync for VC %s: failed to parse cnsvolumeinfo object: %v, err: %v", vc, cnsvolumeinfo, err)
 			continue
 		}
-		if cnsvolumeinfo.Spec.VCenterServer == vc {
+		// Use case-insensitive comparison: VCenterServer values persisted before
+		// vCenter host normalization was introduced may retain their original casing.
+		if strings.EqualFold(cnsvolumeinfo.Spec.VCenterServer, vc) {
 			if _, exists := currentK8sPVMap[cnsvolumeinfo.Spec.VolumeID]; !exists {
 				// If a PV is not present in the cluster for two full sync cycles, delete its VolumeInfo CR.
 				if _, existsInCrDeletionMap := volumeInfoCrDeletionMap[vc][cnsvolumeinfo.Spec.VolumeID]; existsInCrDeletionMap {


### PR DESCRIPTION
vCenter FQDN/IP and TLS thumbprint are protocol-compliant case-insensitive identifiers, but VirtualCenterConfig.Host and Thumbprint were used verbatim as map keys and in == comparisons throughout the driver, and govmomi's thumbprint comparison is uppercase-only. 

This change normalize Host to lowercase and Thumbprint to uppercase at the single entry point (GetVirtualCenterConfigs / GetVirtualCenterConfig), and compare persisted CNSVolumeInfo.VCenterServer values case-insensitively in fullsync to stay compatible with CRs created before this change.

Please refer to https://vmw-jira.broadcom.net/browse/VGL-66658 for more. information

Testing Done:
https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1949/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1496/

