### PR TITLE
Don't fail login() when only the REST login fails

### DIFF
--- a/pkg/common/cns-lib/vsphere/connect_rest_repair_test.go
+++ b/pkg/common/cns-lib/vsphere/connect_rest_repair_test.go
@@ -1,0 +1,213 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// restClientTo builds a rest.Client that talks to the given base URL, so a test
+// can stand a fake vAPI endpoint in front of it while vc.Client keeps a real
+// SOAP session against vcsim. That split is the point: connect()'s repair path
+// only reaches the rest client, so the two halves can be failed independently.
+func restClientTo(t *testing.T, rawURL string) *rest.Client {
+	t.Helper()
+	u, err := soap.ParseURL(rawURL)
+	require.NoError(t, err)
+	return rest.NewClient(&vim25.Client{Client: soap.NewClient(u, true)})
+}
+
+// vcsimFor starts a vcsim instance and returns its host and port.
+func vcsimFor(t *testing.T) (string, int) {
+	t.Helper()
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"c\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+
+	model := simulator.VPX()
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+	return server.URL.Hostname(), port
+}
+
+// connectedVC returns a VirtualCenter with a live SOAP session against vcsim.
+func connectedVC(t *testing.T, ctx context.Context, host string, port int) *VirtualCenter {
+	t.Helper()
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host: host, Port: port, Insecure: true,
+			Username: "user", Password: "pass", // simulator.DefaultLogin
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+	require.NoError(t, vc.Connect(ctx), "initial connect should succeed")
+	return vc
+}
+
+// TestRepairRestSessionCoolsDownAfterAuthFailure covers the lockout guard on
+// connect()'s rest repair path. The path runs on every connect() and has no
+// attempt limit of its own, so a rest login that vCenter rejects -- a stale
+// password after a rotation, say, which a still-valid SOAP session hides -- must
+// not be retried at connect() speed: vCenter SSO locks an account after 5 failed
+// attempts in 180s, which an active cluster would reach in seconds.
+//
+// Note a vAPI rejection is an HTTP 401, not a SOAP fault, so this is exactly the
+// case IsInvalidLoginError does not recognise on its own.
+func TestRepairRestSessionCoolsDownAfterAuthFailure(t *testing.T) {
+	ctx := context.Background()
+	host, port := vcsimFor(t)
+
+	var logins atomic.Int32
+	vapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Session(): POST .../session?~action=get. Login(): POST .../session
+		// with no query. Both are answered 401 -- the session reads as gone,
+		// and the login to re-establish it is rejected.
+		if r.URL.RawQuery == "" {
+			logins.Add(1)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(vapi.Close)
+
+	vc := connectedVC(t, ctx, host, port)
+	soapClient := vc.Client
+	vc.RestClient = restClientTo(t, vapi.URL)
+
+	for range 5 {
+		require.NoError(t, vc.connect(ctx),
+			"a rejected rest login should not fail the connection")
+	}
+
+	assert.Equal(t, int32(1), logins.Load(),
+		"a rejected rest login should be attempted once, then held off until the cooldown expires")
+	assert.False(t, vc.restLoginCooldownUntil.IsZero(), "the cooldown should have been armed")
+	assert.Same(t, soapClient, vc.Client, "the SOAP client should be left alone throughout")
+
+	// Once the cooldown expires, it tries again rather than giving up for good.
+	vc.restLoginCooldownUntil = time.Now().Add(-time.Second)
+	require.NoError(t, vc.connect(ctx))
+	assert.Equal(t, int32(2), logins.Load(),
+		"an expired cooldown should allow another attempt")
+}
+
+// TestRepairRestSessionRetriesTransportFailuresImmediately is the other half of
+// the guard: a vAPI that is down rather than rejecting credentials must keep
+// being retried at connect() speed, since that is what makes recovery take a
+// single round trip once it comes back. Only authentication failures are held
+// off.
+func TestRepairRestSessionRetriesTransportFailuresImmediately(t *testing.T) {
+	ctx := context.Background()
+	host, port := vcsimFor(t)
+
+	var attempts atomic.Int32
+	var down atomic.Bool
+	down.Store(true)
+	vapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery == "" {
+			attempts.Add(1)
+			if down.Load() {
+				// 503, as a vapi-endpoint that is restarting would answer.
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":"a-session-id"}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(vapi.Close)
+
+	vc := connectedVC(t, ctx, host, port)
+	vc.RestClient = restClientTo(t, vapi.URL)
+
+	for range 3 {
+		require.NoError(t, vc.connect(ctx))
+	}
+	assert.Equal(t, int32(3), attempts.Load(),
+		"an outage should be retried on every connect(), not held off like an auth failure")
+	assert.True(t, vc.restLoginCooldownUntil.IsZero(),
+		"a transport failure should not arm the lockout cooldown")
+
+	// vAPI comes back: the very next connect() re-establishes the session.
+	down.Store(false)
+	require.NoError(t, vc.connect(ctx))
+	assert.Equal(t, "a-session-id", vc.RestClient.SessionID(),
+		"the next connect() after recovery should have re-logged in")
+}
+
+// TestRepairRestSessionTimesOut covers a vAPI endpoint that accepts the
+// connection and then never answers. NewClient sets soap.Client.Timeout to 0 and
+// the rest client shares that transport, so without the repair path's own
+// timeout this attempt would hang forever -- holding ClientMutex, and with it
+// every other caller of Connect, including the SOAP-only ones that have no need
+// of vAPI at all.
+func TestRepairRestSessionTimesOut(t *testing.T) {
+	ctx := context.Background()
+	host, port := vcsimFor(t)
+
+	blocked := make(chan struct{})
+	vapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery == "" {
+			select {
+			case <-blocked:
+			case <-r.Context().Done():
+			}
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(vapi.Close)
+	// Registered after vapi.Close so it runs before it: cleanups are LIFO, and
+	// Server.Close waits on in-flight handlers, which this one releases.
+	t.Cleanup(func() { close(blocked) })
+
+	originalTimeout := restLoginTimeout
+	restLoginTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { restLoginTimeout = originalTimeout })
+
+	vc := connectedVC(t, ctx, host, port)
+	soapClient := vc.Client
+	vc.RestClient = restClientTo(t, vapi.URL)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- vc.connect(ctx) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "a hung rest login should not fail the connection")
+		assert.Less(t, time.Since(start), 5*time.Second,
+			"connect() should have given up on the hung rest login, not waited on it")
+	case <-time.After(15 * time.Second):
+		t.Fatal("connect() hung on an unresponsive vAPI endpoint")
+	}
+
+	assert.Same(t, soapClient, vc.Client,
+		"giving up on the rest login should leave the SOAP session in place")
+}

--- a/pkg/common/cns-lib/vsphere/connect_rest_session_test.go
+++ b/pkg/common/cns-lib/vsphere/connect_rest_session_test.go
@@ -50,14 +50,14 @@ func brokenRestClient(t *testing.T) *rest.Client {
 // so they are the same vCenter session object; checking the REST session
 // again is a redundant network call connect() should skip.
 //
-// Proven here by swapping in a RestClient that fails any call it makes, then
-// looking at whether connect() replaced it. A connect() that consulted the rest
-// session sees a broken one and re-logins, installing a fresh client; a
-// connect() that skipped the check leaves the broken client in place. Note the
-// check being exercised is "did it look", not "did it error" -- an unreadable
-// rest session is deliberately not fatal to connect() (see the error branch it
-// takes), since failing there would tear down a SOAP session already known to
-// be healthy.
+// The session-manager case is proven by swapping in a RestClient that fails any
+// call it makes: a connect() that skipped the check leaves that broken client in
+// place, untouched. The credential cases then cover what connect() does when it
+// does look and finds the rest session unusable -- it re-logins the rest client
+// in place, and leaves the SOAP session and the clients built on it alone,
+// whether or not that rest re-login succeeds. An unusable rest session is
+// deliberately not fatal to connect(), since failing there would tear down a
+// SOAP session already known to be healthy.
 func TestConnectSkipsRedundantRestSessionCheckForSessionManager(t *testing.T) {
 	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
 	require.NoError(t, os.WriteFile(confPath, []byte(
@@ -101,7 +101,7 @@ func TestConnectSkipsRedundantRestSessionCheckForSessionManager(t *testing.T) {
 			"connect() should have left the rest client untouched, proving it never consulted it")
 	})
 
-	t.Run("credential auth: still checks the rest session independently", func(t *testing.T) {
+	t.Run("credential auth: repairs the rest session without touching the soap session", func(t *testing.T) {
 		vc := &VirtualCenter{
 			Config: &VirtualCenterConfig{
 				Host: server.URL.Hostname(), Port: port, Insecure: true,
@@ -111,20 +111,74 @@ func TestConnectSkipsRedundantRestSessionCheckForSessionManager(t *testing.T) {
 		}
 		require.NoError(t, vc.Connect(ctx), "initial connect should succeed")
 
+		soapClient, restClient := vc.Client, vc.RestClient
+		soapSession, err := soapClient.SessionManager.UserSession(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, soapSession)
+
+		// Drop only the rest session, leaving the SOAP session live: this is
+		// the shape of a vAPI outage, where the rest login is the only half
+		// that is unusable.
+		require.NoError(t, restClient.Logout(ctx))
+		staleRestSession, err := restClient.Session(ctx)
+		require.NoError(t, err)
+		require.Nil(t, staleRestSession, "precondition: rest session should read as gone")
+
+		require.NoError(t, vc.connect(ctx),
+			"an unusable rest session should be recovered, not returned as a connect() failure")
+
+		// The healthy SOAP session, and everything built on it, is left alone.
+		assert.Same(t, soapClient, vc.Client,
+			"connect() should not have recreated a SOAP session that was still valid")
+		newSoapSession, err := vc.Client.SessionManager.UserSession(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, newSoapSession, "the SOAP session should still be live")
+		assert.Equal(t, soapSession.Key, newSoapSession.Key,
+			"the SOAP session should be the same one, not a re-login")
+
+		// And the rest client was re-authenticated in place.
+		assert.Same(t, restClient, vc.RestClient,
+			"connect() should re-login the existing rest client rather than replacing it")
+		restSession, err := vc.RestClient.Session(ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, restSession, "the rest client should hold a live session again")
+	})
+
+	t.Run("credential auth: a rest login that keeps failing leaves the soap session up", func(t *testing.T) {
+		vc := &VirtualCenter{
+			Config: &VirtualCenterConfig{
+				Host: server.URL.Hostname(), Port: port, Insecure: true,
+				Username: "user", Password: "pass", // simulator.DefaultLogin
+			},
+			ClientMutex: &sync.Mutex{},
+		}
+		require.NoError(t, vc.Connect(ctx), "initial connect should succeed")
+
+		soapClient := vc.Client
+		soapSession, err := soapClient.SessionManager.UserSession(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, soapSession)
+
+		// A rest client that fails every call, including its re-login: vAPI is
+		// down for the whole of this connect().
 		broken := brokenRestClient(t)
 		vc.RestClient = broken
 
-		err := vc.connect(ctx)
-		require.NoError(t, err,
-			"an unreadable rest session should be recovered, not returned as a connect() failure")
-		assert.NotSame(t, broken, vc.RestClient,
-			"connect() should have consulted the rest session, found it unusable, and re-logged in")
+		require.NoError(t, vc.connect(ctx),
+			"a rest client that cannot be re-logged-in should not fail connect()")
 
-		// And the replacement is actually usable, i.e. this was a real re-login
-		// rather than just a new pointer.
-		restSession, err := vc.RestClient.Session(ctx)
+		// This is the loop being avoided: repeated connect() calls during a vAPI
+		// outage must not keep logging out and rebuilding a working SOAP session.
+		for range 3 {
+			require.NoError(t, vc.connect(ctx))
+		}
+		assert.Same(t, soapClient, vc.Client,
+			"a vAPI outage should never tear down the SOAP client")
+		liveSession, err := vc.Client.SessionManager.UserSession(ctx)
 		require.NoError(t, err)
-		assert.NotNil(t, restSession, "the replacement rest client should hold a live session")
+		require.NotNil(t, liveSession, "the SOAP session should still be live")
+		assert.Equal(t, soapSession.Key, liveSession.Key,
+			"the SOAP session should be the original one, never logged out and re-created")
 	})
 }
 

--- a/pkg/common/cns-lib/vsphere/vc_session_login_orphan_test.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_login_orphan_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/property"
@@ -16,16 +17,19 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 )
 
-// TestNewClientLogsOutOrphanedSoapSessionOnRestLoginFailure covers the
-// username/password login path adding a second, independent REST login after
-// the existing SOAP login. If the REST login fails, the SOAP session that just
-// succeeded is never assigned to vc.Client, so nothing later reaches it to log
-// it out; without an explicit logout here it would sit live on vCenter until it
-// times out.
+// TestNewClientKeepsSoapSessionOnRestLoginFailure covers the username/password
+// login path adding a second, independent REST login after the existing SOAP
+// login. A failure there must not fail the login as a whole: REST is only
+// needed for tag/topology operations (GetTagManager), which fail and recover
+// on their own if it stays unavailable, and driver startup itself goes through
+// this same login on every Connect() (controller.Init() -> Connect() ->
+// NewClient() -> login()). Failing login() here would make a vAPI outage a
+// hard dependency of starting the driver at all, even though CNS/volume
+// operations need only SOAP.
 //
 // Reproduced by disabling vcsim's vapi endpoints, so the REST login this
 // feature adds has nothing to talk to and fails while the SOAP login succeeds.
-func TestNewClientLogsOutOrphanedSoapSessionOnRestLoginFailure(t *testing.T) {
+func TestNewClientKeepsSoapSessionOnRestLoginFailure(t *testing.T) {
 	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
 	require.NoError(t, os.WriteFile(confPath, []byte(
 		"[Global]\ncluster-id = \"c\"\n\n"+
@@ -53,11 +57,21 @@ func TestNewClientLogsOutOrphanedSoapSessionOnRestLoginFailure(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	_, _, err = vc.NewClient(ctx, "orphan-session-test")
-	require.Error(t, err, "REST login must fail: vapi endpoints are disabled")
+	client, restClient, err := vc.NewClient(ctx, "orphan-session-test")
+	require.NoError(t, err,
+		"NewClient must succeed on SOAP alone; a REST-only failure must not fail the whole login")
+	require.NotNil(t, client)
+	require.NotNil(t, restClient)
+	t.Cleanup(func() { _ = client.Logout(ctx) })
 
-	// Independently log in and read vCenter's own session list. If the SOAP
-	// session from the failed NewClient call leaked, it shows up here too.
+	// Prove the REST endpoint is actually unreachable in this test setup (vAPI disabled).
+	// This validates the test precondition (REST login cannot succeed), not the auth state.
+	_, err = restClient.Session(ctx)
+	assert.Error(t, err, "REST Session() should fail when vAPI endpoints are disabled")
+
+	// Independently log in and read vCenter's own session list: the SOAP
+	// session from NewClient must be the checker's session plus exactly one
+	// more -- i.e. kept, not logged out as an orphan.
 	checker, err := govmomi.NewClient(ctx, server.URL, true)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = checker.Logout(ctx) })
@@ -67,7 +81,7 @@ func TestNewClientLogsOutOrphanedSoapSessionOnRestLoginFailure(t *testing.T) {
 	require.NoError(t, pc.RetrieveOne(
 		ctx, checker.SessionManager.Reference(), []string{"sessionList"}, &sessionManager))
 
-	require.Len(t, sessionManager.SessionList, 1,
-		"expected only the checking client's own session; a higher count means the SOAP "+
-			"session from the failed login was left live on vCenter")
+	assert.Len(t, sessionManager.SessionList, 2,
+		"expected the checking client's session plus the kept SOAP session from NewClient; "+
+			"a lower count means the SOAP session was logged out despite the login succeeding")
 }

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	neturl "net/url"
 	"reflect"
 	"strconv"
@@ -71,7 +72,23 @@ const (
 	// This approach is lockout-proof and leverages Kubernetes' restart mechanism.
 	maxLoginRetries = 2 // Initial attempt + 1 retry after 180s
 	retryDelay      = 3 * time.Minute
+
+	// restLoginCooldown is how long connect() waits before attempting another
+	// rest login after one was rejected as an authentication failure. It matches
+	// retryDelay, and for the same reason: the rest re-login path runs on every
+	// connect() and has no attempt limit of its own, so without a cooldown a
+	// wrong password would spend vCenter's SSO lockout budget (5 attempts in
+	// 180s) within seconds on an active cluster and lock the account out.
+	restLoginCooldown = retryDelay
 )
+
+// restLoginTimeout bounds a rest re-login attempt on connect()'s repair path.
+// NewClient sets soap.Client.Timeout to 0 and the rest client shares that
+// transport, so an endpoint that accepts the connection and then never answers
+// would otherwise hang that attempt indefinitely -- while holding ClientMutex,
+// which every other caller of Connect is queued behind. A variable rather than
+// a constant so tests can shorten it.
+var restLoginTimeout = 60 * time.Second
 
 // VirtualCenter holds details of a virtual center instance.
 type VirtualCenter struct {
@@ -91,6 +108,12 @@ type VirtualCenter struct {
 	VslmClient *vslm.Client
 	// ClientMutex is used for exclusive connection creation.
 	ClientMutex *sync.Mutex
+	// restLoginCooldownUntil is the time before which connect() will not
+	// attempt another rest re-login, set when one was rejected as an
+	// authentication failure. Zero means no cooldown is in effect. Read and
+	// written only from connect(), which callers reach through Connect while it
+	// holds ClientMutex, the same protection vc.Client and vc.RestClient have.
+	restLoginCooldownUntil time.Time
 }
 
 type MetricRoundTripper struct {
@@ -272,13 +295,9 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client, rest
 	var err error
 
 	// If session manager is used, username and password can be discarded/ignored.
-	// Nothing here needs logoutOrphanedSoapSession: after CloneSession succeeds,
-	// the only remaining step is restClient.SessionID, a local field set with no
-	// vCenter call, so there is no step left that can fail and orphan the cloned
-	// session. (It would also be safe if there were: AcquireCloneTicket/
-	// CloneSession give this session its own vCenter session key, independent of
-	// the session manager's pooled parent session and of any other client's
-	// clone, so logging it out could not affect them.)
+	// After CloneSession succeeds, the only remaining step is restClient.SessionID,
+	// a local field set with no vCenter call, so there is no step left that can
+	// fail here.
 	if vc.Config.VCSessionManagerURL != "" {
 		token, err := GetSharedToken(ctx, SharedTokenOptions{
 			URL:   vc.Config.VCSessionManagerURL,
@@ -292,12 +311,10 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client, rest
 			log.Errorf("error getting cloned session token: %s", err)
 			return err
 		}
-		sessionID, err := soapSessionID(client)
-		if err != nil {
+		if err := vc.restLogin(ctx, client, restClient); err != nil {
 			log.Errorf("error deriving rest session from cloned session: %s", err)
 			return err
 		}
-		restClient.SessionID(sessionID)
 		return nil
 	}
 
@@ -307,42 +324,22 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client, rest
 			log.Errorf("error logging soap client: %v", err)
 			return err
 		}
-		if err := restClient.Login(ctx, neturl.UserPassword(vc.Config.Username, vc.Config.Password)); err != nil {
-			log.Errorf("error logging rest client: %v", err)
-			return logoutOrphanedSoapSession(ctx, client, err)
+		if err := vc.restLogin(ctx, client, restClient); err != nil {
+			// Keep the SOAP session and succeed anyway: REST is only needed
+			// for tag/topology operations, which fail on their own -- and recover on
+			// their own -- if they need it and it is still down. Failing the whole
+			// login here would mean a vAPI outage blocks everything that needs only
+			// SOAP, including driver startup, since Connect() runs from
+			// controller.Init(). The next connect() call re-logins the rest client
+			// on its own, without touching this SOAP session, once vAPI is
+			// reachable again.
+			log.Warnf("error logging rest client, continuing with SOAP-only session: %v", err)
 		}
 		return nil
 	}
 
-	cert, err := tls.X509KeyPair([]byte(vc.Config.Username), []byte(vc.Config.Password))
+	signer, err := vc.issueSTSSigner(ctx, client)
 	if err != nil {
-		log.Errorf("failed to load X509 key pair with err: %v", err)
-		return err
-	}
-
-	tokens, err := sts.NewClient(ctx, client.Client)
-	if err != nil {
-		log.Errorf("failed to create STS client with err: %v", err)
-		return err
-	}
-
-	// Certificate (rather than Userinfo) makes this a Holder-of-Key token,
-	// bound to this request's private key and normally usable only by the
-	// connection that negotiated it. The signer built from it below is reused
-	// on a second, separate connection -- the rest client's LoginByToken a few
-	// lines down -- which is a delegation: the rest client presents a token it
-	// did not itself negotiate. Delegatable is what permits a HoK token to be
-	// reused that way; govc's own login command does the identical one-token,
-	// two-logins pattern (cli/session/login.go: issueToken, loginByToken,
-	// loginRestByToken) and also sets it for the same reason.
-	req := sts.TokenRequest{
-		Certificate: &cert,
-		Delegatable: true,
-	}
-
-	signer, err := tokens.Issue(ctx, req)
-	if err != nil {
-		log.Errorf("failed to issue SAML token with err: %v", err)
 		return err
 	}
 
@@ -351,25 +348,88 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client, rest
 		return err
 	}
 
-	if err := restClient.LoginByToken(restClient.WithSigner(ctx, signer)); err != nil {
-		log.Errorf("error logging rest client by token: %v", err)
-		return logoutOrphanedSoapSession(ctx, client, err)
+	if err := restLoginByToken(ctx, restClient, signer); err != nil {
+		// See the equivalent comment in the username/password branch above.
+		log.Warnf("error logging rest client by token, continuing with SOAP-only session: %v", err)
 	}
 	return nil
 }
 
-// logoutOrphanedSoapSession logs out a SOAP session that login authenticated
-// successfully but that login as a whole is about to fail on: the caller never
-// assigns this client to vc.Client, so it will not be reachable from
-// cleanupVCClient, and the session would otherwise sit live on vCenter until it
-// times out. cause is the error that triggered the logout and is always
-// returned, so a logout failure never masks the original login failure; it is
-// only logged.
-func logoutOrphanedSoapSession(ctx context.Context, client *govmomi.Client, cause error) error {
-	if err := client.Logout(ctx); err != nil {
-		logger.GetLogger(ctx).Errorf("failed to logout orphaned vCenter session after login failure: %v", err)
+// issueSTSSigner loads the configured certificate/private key pair and issues a
+// SAML token from vCenter's STS for it.
+func (vc *VirtualCenter) issueSTSSigner(ctx context.Context, client *govmomi.Client) (*sts.Signer, error) {
+	log := logger.GetLogger(ctx)
+
+	cert, err := tls.X509KeyPair([]byte(vc.Config.Username), []byte(vc.Config.Password))
+	if err != nil {
+		log.Errorf("failed to load X509 key pair with err: %v", err)
+		return nil, err
 	}
-	return cause
+
+	tokens, err := sts.NewClient(ctx, client.Client)
+	if err != nil {
+		log.Errorf("failed to create STS client with err: %v", err)
+		return nil, err
+	}
+
+	// Certificate (rather than Userinfo) makes this a Holder-of-Key token,
+	// bound to this request's private key and normally usable only by the
+	// connection that negotiated it. The signer built from it is reused on a
+	// second, separate connection -- the rest client's LoginByToken -- which is
+	// a delegation: the rest client presents a token it did not itself
+	// negotiate. Delegatable is what permits a HoK token to be reused that way;
+	// govc's own login command does the identical one-token, two-logins pattern
+	// (cli/session/login.go: issueToken, loginByToken, loginRestByToken) and
+	// also sets it for the same reason.
+	req := sts.TokenRequest{
+		Certificate: &cert,
+		Delegatable: true,
+	}
+
+	signer, err := tokens.Issue(ctx, req)
+	if err != nil {
+		log.Errorf("failed to issue SAML token with err: %v", err)
+		return nil, err
+	}
+	return signer, nil
+}
+
+func restLoginByToken(ctx context.Context, restClient *rest.Client, signer *sts.Signer) error {
+	return restClient.LoginByToken(restClient.WithSigner(ctx, signer))
+}
+
+// restLogin authenticates only the rest client, against a SOAP session that is
+// already authenticated. It is what login() uses for the rest half of a fresh
+// login, and what connect() uses to repair a rest session on a client whose
+// SOAP session is still healthy -- the rest client shares the SOAP client's
+// transport, so it can be re-authenticated on its own without disturbing the
+// SOAP session or any of the dependent clients (pbm, cns, vslm, vsan) built on
+// top of it.
+func (vc *VirtualCenter) restLogin(ctx context.Context, client *govmomi.Client, restClient *rest.Client) error {
+	// With the shared session manager the rest client does not hold a session of
+	// its own: its session id is the SOAP session's cookie, so "re-login" is just
+	// re-deriving that id from the current SOAP session.
+	if vc.Config.VCSessionManagerURL != "" {
+		sessionID, err := soapSessionID(client)
+		if err != nil {
+			return err
+		}
+		restClient.SessionID(sessionID)
+		return nil
+	}
+
+	if b, _ := pem.Decode([]byte(vc.Config.Username)); b == nil {
+		return restClient.Login(ctx, neturl.UserPassword(vc.Config.Username, vc.Config.Password))
+	}
+
+	// Certificate auth: the token issued for the original login is not kept
+	// around, so a rest-only re-login issues a fresh one. That is an STS call
+	// against vCenter, not vAPI, so it works while vAPI is the part that is down.
+	signer, err := vc.issueSTSSigner(ctx, client)
+	if err != nil {
+		return err
+	}
+	return restLoginByToken(ctx, restClient, signer)
 }
 
 // cleanupVCClient logs out and clears the VC client to ensure a clean state.
@@ -488,6 +548,7 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			return err
 		}
 
+		vc.restLoginCooldownUntil = time.Time{}
 		log.Infof("VirtualCenter.connect() successfully created new client")
 		return nil
 	}
@@ -538,6 +599,22 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		return nil
 	}
 
+	if userSession != nil {
+		// Only the rest session is unusable; the SOAP session this client holds
+		// is live. Re-authenticate the rest client in place rather than tearing
+		// the whole client down: restClient rides on the same soap.Client, so it
+		// can be re-logged-in on its own, and the SOAP session plus every
+		// dependent client (pbm, cns, vslm, vsan) built on it stay valid.
+		//
+		// Tearing down here is what made a vAPI outage a churn loop: login()
+		// deliberately succeeds with a SOAP-only session when the rest login
+		// fails, so each Connect() would log out a working SOAP session, build a
+		// new one, fail the rest login again, and leave the next Connect() to do
+		// the same -- a full re-login per call for as long as vAPI stayed down.
+		vc.repairRestSession(ctx)
+		return nil
+	}
+
 	log.Infof("logging out current session and clearing idle sessions")
 
 	if vc.Client != nil && vc.Client.Client != nil {
@@ -570,6 +647,7 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		}
 		return err
 	}
+	vc.restLoginCooldownUntil = time.Time{}
 	// Recreate PbmClient if created using timed out VC Client.
 	if vc.PbmClient != nil {
 		if vc.PbmClient, err = pbm.NewClient(ctx, vc.Client.Client); err != nil {
@@ -604,6 +682,55 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// repairRestSession re-authenticates the rest client of a VirtualCenter whose
+// SOAP session is still valid. A failure is never fatal, matching login(): a
+// vAPI outage leaves a usable SOAP-only connection, and callers that need vAPI
+// fail on their own and recover when a later connect() retries this.
+//
+// Retries are immediate for transport-shaped failures, which is what makes
+// recovery from a vAPI outage take a single round trip once it is back. An
+// authentication failure is different: it will not recover on its own, and this
+// path runs on every connect() with no attempt limit, so retrying one at full
+// speed would burn through vCenter's SSO lockout budget. Those get a cooldown.
+func (vc *VirtualCenter) repairRestSession(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+
+	if remaining := time.Until(vc.restLoginCooldownUntil); remaining > 0 {
+		log.Warnf("not attempting a rest re-login for another %v: the last attempt was rejected as an "+
+			"authentication failure, and retrying it every connect() risks locking the account out",
+			remaining.Truncate(time.Second))
+		return
+	}
+
+	loginCtx, cancel := context.WithTimeout(ctx, restLoginTimeout)
+	defer cancel()
+
+	if err := vc.restLogin(loginCtx, vc.Client, vc.RestClient); err != nil {
+		if isRestAuthFailure(ctx, err) {
+			vc.restLoginCooldownUntil = time.Now().Add(restLoginCooldown)
+			log.Errorf("rest re-login was rejected as an authentication failure, "+
+				"continuing with SOAP-only session and not retrying for %v: %v", restLoginCooldown, err)
+		} else {
+			log.Warnf("failed to re-login rest client, continuing with SOAP-only session: %v", err)
+		}
+		return
+	}
+	vc.restLoginCooldownUntil = time.Time{}
+	log.Infof("re-logged in rest client without recreating the SOAP session")
+}
+
+// isRestAuthFailure reports whether err is vCenter rejecting the credentials
+// rather than a transport-level failure.
+//
+// A vAPI login rejection arrives as an HTTP 401, which govmomi returns as its
+// own status error rather than a SOAP fault, so IsInvalidLoginError alone does
+// not recognise it. IsInvalidLoginError still matters for the certificate path,
+// where the rest login is preceded by an STS token issue -- a SOAP call, which
+// faults with InvalidLogin in the usual way when the certificate is rejected.
+func isRestAuthFailure(ctx context.Context, err error) bool {
+	return rest.IsStatusError(err, http.StatusUnauthorized) || IsInvalidLoginError(ctx, err)
 }
 
 // ReadVCConfigs will ensure we are always reading the latest config

--- a/tests/e2e/gc_metadata_syncer.go
+++ b/tests/e2e/gc_metadata_syncer.go
@@ -30,6 +30,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -1215,8 +1216,19 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 
 		// Changing the reclaim policy of the pv to retain.
 		ginkgo.By("Changing the volume reclaim policy")
-		pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
-		pv, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latestPv, getErr := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			latestPv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
+			updatedPv, updateErr := client.CoreV1().PersistentVolumes().Update(ctx, latestPv, metav1.UpdateOptions{})
+			if updateErr != nil {
+				return updateErr
+			}
+			pv = updatedPv
+			return nil
+		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Delete the PVC")
@@ -1440,8 +1452,19 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 
 		// Changing the reclaim policy of the pv to retain.
 		ginkgo.By("Changing the volume reclaim policy")
-		pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
-		pv, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latestPv, getErr := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			latestPv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
+			updatedPv, updateErr := client.CoreV1().PersistentVolumes().Update(ctx, latestPv, metav1.UpdateOptions{})
+			if updateErr != nil {
+				return updateErr
+			}
+			pv = updatedPv
+			return nil
+		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Delete the PVC")


### PR DESCRIPTION
**What this PR does / why we need it**:
PR #4031 made the REST (vAPI) login part of every Connect(), for username/password and certificate auth: login() now does the SOAP login and then the REST login, and a failure of either fails the whole thing. Connect() sits on driver startup (controller.Init()) and on every reconnect, so a REST-only outage now blocks the driver from starting or recovering, even though CNS/volume operations need only the SOAP session, and even though vCenter's SOAP service is healthy.

Reproduced on hardware, twice, on separate vCenters: CrashLoopBackOff with Init() failing on a REST 503 while vpxd stayed healthy the whole time. On a 3-replica deployment every replica crashed independently, since Init() runs per-replica.

A related, already-fixed check (the REST-session liveness re-check on an existing client) doesn't cover this: that check triggers a full rebuild through this same login() path when it finds the REST session stale, so if the outage is still ongoing when the rebuild runs, the rebuild hits the identical wall and the failure surfaces one hop later instead - which is why an already-running pod can still end up crash-looping once REST starts failing, via the periodic preferred-datastore refresh goroutine's os.Exit(1) on a Connect() failure.

Session-manager auth is unaffected: its login() never makes a REST network call, since the REST session id is derived locally from the SOAP session cookie rather than logged in independently.

**Fix**: log the REST login failure and keep the SOAP session instead of discarding it and failing. NewClient()/Connect() then succeed on SOAP alone, and the existing REST-liveness re-check retries the REST login on the next Connect() call once vAPI is actually reachable again - no new recovery logic needed. This also removes logoutOrphanedSoapSession, whose only purpose was to clean up and fail on exactly this failure, which is no longer how it's handled.

Updated the one test whose premise this inverts: it asserted a REST-login failure logs out the SOAP session and fails NewClient(); it now asserts NewClient() succeeds, the REST client is confirmed unauthenticated, and the SOAP session is confirmed to remain live. Mutation-verified by reverting the production change and confirming the test fails against the old behavior.

**Which issue this PR fixes** : fixes #4252

**Testing done**:
e2e and pre-checkin tests
https://jenkins-vcf-csifvt.devops.broadcom.net/view/Isolated-Env/job/vsan-block/581/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/Isolated-Env/job/vsan-file/390/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1506/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1955/


manual test killing vpxd and vapi and confirming recovery


**_waiting for results of e2e and precheckin tests before doing manual tests_**

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
