### PR TITLE
Vgl 68299 error message standardization

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -507,7 +507,7 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context,
 		storagePolicyID, err = vCenter.GetStoragePolicyIDByName(ctx, volumeSpec.StoragePolicyName)
 		if err != nil {
 			return "", false, logger.LogNewErrorf(log,
-				"Error occurred while getting stroage policy ID from storage policy name: %q, err: %+v",
+				"Error occurred while getting storage policy ID from storage policy name: %q, err: %+v",
 				volumeSpec.StoragePolicyName, err)
 		}
 		log.Debugf("Obtained storage policy ID: %q for storage policy name: %q",

--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -419,7 +419,7 @@ func (m *defaultManager) UnregisterNode(ctx context.Context, nodeName string) er
 	log := logger.GetLogger(ctx)
 	nodeUUID, found := m.nodeNameToUUID.Load(nodeName)
 	if !found {
-		log.Errorf("Node wasn't found, failed to unregister node: %q  err: %v", nodeName)
+		log.Errorf("failed to unregister node: %q not found", nodeName)
 		return ErrNodeNotFound
 	}
 	m.nodeNameToUUID.Delete(nodeName)

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -1494,7 +1494,7 @@ func (m *defaultManager) deleteVolume(ctx context.Context, volumeID string, dele
 			log.Infof("VolumeID: %q, not found, thus returning success", volumeID)
 			return "", nil
 		}
-		log.Errorf("CNS DeleteVolume failed from the  vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+		log.Errorf("CNS DeleteVolume failed from the vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 		return faultType, err
 	}
 	// Get the taskInfo.
@@ -1633,7 +1633,7 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 				}
 				return "", nil
 			}
-			log.Errorf("CNS DeleteVolume failed from the  vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			log.Errorf("CNS DeleteVolume failed from the vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 			volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 				nil, metav1.Now(), "", "", "", taskInvocationStatusError, err.Error(), "")
 			err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
@@ -3661,7 +3661,7 @@ func (m *defaultManager) ProtectVolumeFromVMDeletion(ctx context.Context, volume
 		err = globalObjectManager.SetControlFlags(ctx, vim25types.ID{Id: volumeID}, []string{
 			string(vim25types.VslmVStorageObjectControlFlagKeepAfterDeleteVm)})
 		if err != nil {
-			log.Errorf("failed to set control flag keepAfterDeleteVm  for volumeID %q with err: %v", volumeID, err)
+			log.Errorf("failed to set control flag keepAfterDeleteVm for volumeID %q with err: %v", volumeID, err)
 			return err
 		}
 		log.Infof("Successfully set keepAfterDeleteVm control flag for volumeID: %q", volumeID)
@@ -4222,7 +4222,8 @@ func (m *defaultManager) unregisterVolume(ctx context.Context, volumeID string, 
 
 	err := m.virtualCenter.ConnectCns(ctx)
 	if err != nil {
-		return ExtractFaultTypeFromErr(ctx, err), errors.New("connecting to CNS failed")
+		log.Errorf("connecting to CNS failed with err: %v", err)
+		return ExtractFaultTypeFromErr(ctx, err), fmt.Errorf("connecting to CNS failed: %w", err)
 	}
 
 	targetVolumeType := "FCD"

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -4223,7 +4223,8 @@ func (m *defaultManager) unregisterVolume(ctx context.Context, volumeID string, 
 	err := m.virtualCenter.ConnectCns(ctx)
 	if err != nil {
 		log.Errorf("connecting to CNS failed with err: %v", err)
-		return ExtractFaultTypeFromErr(ctx, err), fmt.Errorf("connecting to CNS failed: %w", err)
+		return ExtractFaultTypeFromErr(ctx, err), fmt.Errorf(
+			"connecting to CNS failed: %w. Check vCenter connectivity and credentials in the vSphere config secret", err)
 	}
 
 	targetVolumeType := "FCD"

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -119,7 +119,7 @@ func IsDiskAttached(ctx context.Context, vm *cnsvsphere.VirtualMachine, volumeID
 							if backing, ok := virtualDevice.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
 								uuid, err := getNvmeUUID(ctx, backing.Uuid)
 								if err != nil {
-									log.Errorf("failed to convert uuid to  NvmeV13UUID for the vm: %s", vm.InventoryPath)
+									log.Errorf("failed to convert uuid to NvmeV13UUID for the vm: %s", vm.InventoryPath)
 									return "", err
 								}
 								log.Debugf("Successfully converted diskUUID %s to NvmeV13UUID %s for volume %s on vm %+v",

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -299,7 +299,7 @@ func GenerateFSEnabledClustersToDsMap(ctx context.Context,
 	// Initialize vsan client.
 	err = vc.ConnectVsan(ctx)
 	if err != nil {
-		log.Errorf("error occurred while connecting to VSAN from vCenter %q, err: %+v", vc.Config.Host, err)
+		log.Errorf("Error occurred while connecting to VSAN from vCenter %q, err: %+v", vc.Config.Host, err)
 		return nil, err
 	}
 

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -127,15 +127,18 @@ func CheckAPI(ctx context.Context,
 	log := logger.GetLogger(ctx)
 	items := strings.Split(versionToCheck, ".")
 	if len(items) < 2 {
-		return fmt.Errorf("invalid API Version format")
+		return fmt.Errorf("invalid API Version format %q: expected a dotted version string "+
+			"such as major.minor.patch. Check the vCenter version reported in the CSI config secret", versionToCheck)
 	}
 	major, err := strconv.Atoi(items[0])
 	if err != nil {
-		return fmt.Errorf("invalid Major Version value")
+		return fmt.Errorf("invalid Major Version value %q in API version %q: %v. Check the vCenter "+
+			"version reported by the vCenter About info", items[0], versionToCheck, err)
 	}
 	minor, err := strconv.Atoi(items[1])
 	if err != nil {
-		return fmt.Errorf("invalid Minor Version value")
+		return fmt.Errorf("invalid Minor Version value %q in API version %q: %v. Check the vCenter "+
+			"version reported by the vCenter About info", items[1], versionToCheck, err)
 	}
 
 	if major < minSupportedVCenterMajor || (major == minSupportedVCenterMajor && minor < minSupportedVCenterMinor) {
@@ -147,7 +150,8 @@ func CheckAPI(ctx context.Context,
 		if len(items) >= 3 {
 			patch, err := strconv.Atoi(items[2])
 			if err != nil {
-				return fmt.Errorf("invalid patch version value")
+				return fmt.Errorf("invalid patch version value %q in API version %q: %v. Check the vCenter "+
+					"version reported by the vCenter About info", items[2], versionToCheck, err)
 			}
 			if patch < minSupportedVCenterPatch {
 				return fmt.Errorf("the minimum supported vCenter is %d.%d.%d",

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1400,7 +1400,7 @@ func checkCapabilitiesCR(ctx context.Context, clusterFlavor cnstypes.CnsClusterF
 			Name: common.WCPCapabilitiesCRName},
 			wcpCapabilities)
 		if err != nil {
-			log.Errorf("failed to fetch Capabilities CR instance  with name %q Error: %+v",
+			log.Errorf("failed to fetch Capabilities CR instance with name %q Error: %+v",
 				common.WCPCapabilitiesCRName, err)
 			return err
 		}
@@ -1554,7 +1554,7 @@ func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) 
 		if isPVCSIFSSEnabled {
 			// Skip SV FSS check for Windows Support since there is no dependency on supervisor
 			if featureName == common.CSIWindowsSupport {
-				log.Info("CSI Windows Suppport is set to true in pvcsi fss configmap. Skipping SV FSS check")
+				log.Info("CSI Windows Support is set to true in pvcsi fss configmap. Skipping SV FSS check")
 				return true
 			}
 

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -858,7 +858,7 @@ func addResourceVersion(patchBytes []byte, resourceVersion string) ([]byte, erro
 	u := unstructured.Unstructured{Object: patchMap}
 	a, err := apiMeta.Accessor(&u)
 	if err != nil {
-		return nil, fmt.Errorf("error creating accessor with  %v", err)
+		return nil, fmt.Errorf("error creating accessor with %v", err)
 	}
 	a.SetResourceVersion(resourceVersion)
 	versionBytes, err := json.Marshal(patchMap)
@@ -1794,7 +1794,7 @@ func (c *K8sOrchestrator) GetActiveClustersForNamespaceInRequestedZones(ctx cont
 		activeClusters = append(activeClusters, clusters...)
 	}
 	if len(activeClusters) == 0 {
-		return nil, logger.LogNewErrorf(log, "could not find active cluster for the namespace  %q "+
+		return nil, logger.LogNewErrorf(log, "could not find active cluster for the namespace %q "+
 			"in requested zones: %v", targetNS, requestedZones)
 	}
 	log.Infof("active clusters: %v for namespace: %q in requested zones: %v", activeClusters, targetNS, requestedZones)

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -158,7 +158,7 @@ func CreateBlockVolumeUtil(
 		if opts.FilterSuspendedDatastores {
 			sharedDatastores, err = vsphere.FilterSuspendedDatastores(ctx, sharedDatastores)
 			if err != nil {
-				log.Errorf("Error occurred while filter suspended datastores, err: %+v", err)
+				log.Errorf("Error occurred while filtering suspended datastores, err: %+v", err)
 				return nil, csifault.CSIInternalFault, err
 			}
 		}
@@ -620,7 +620,7 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 		if filterSuspendedDatastores {
 			datastores, err = vsphere.FilterSuspendedDatastores(ctx, datastores)
 			if err != nil {
-				log.Errorf("Error occurred while filter suspended datastores, err: %+v", err)
+				log.Errorf("Error occurred while filtering suspended datastores, err: %+v", err)
 				return nil, csifault.CSIInternalFault, err
 			}
 		}

--- a/pkg/csi/service/mounter/mounter_windows.go
+++ b/pkg/csi/service/mounter/mounter_windows.go
@@ -481,7 +481,7 @@ func (mounter *csiProxyMounter) Rescan(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 	log.Infof("Calling CSI Proxy's rescan API")
 	if _, err := mounter.DiskClient.Rescan(ctx, &disk.RescanRequest{}); err != nil {
-		log.Errorf("failed to rescan stroage cache. err: %v", err)
+		log.Errorf("failed to rescan storage cache. err: %v", err)
 		return err
 	}
 	return nil

--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -820,7 +820,7 @@ func (osUtils *OsUtils) PublishFileVol(
 // an error if it doesn't exist or is not a block device.
 func (osUtils *OsUtils) GetDevice(ctx context.Context, path string) (*Device, error) {
 	log := logger.GetLogger(ctx)
-	log.Infof("check path exits %s", path)
+	log.Infof("check if path exists %s", path)
 	fi, err := os.Lstat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -831,10 +831,10 @@ func (osUtils *OsUtils) GetDevice(ctx context.Context, path string) (*Device, er
 				log.Debugf("Potential stale file handle detected: %s", path)
 				return nil, syscall.ESTALE
 			}
-			log.Infof("path: %v does not exists", err)
+			log.Infof("path: %s does not exist: %v", path, err)
 			return nil, nil
 		} else if mount.IsCorruptedMnt(err) {
-			log.Infof("mount is currupted %v", err)
+			log.Infof("mount is corrupted %v", err)
 			return nil, err
 		}
 		log.Infof("error checking path %v", err)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -740,7 +740,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			}
 			if isLinkedCloneRequest && !linkedCloneSupportEnabled {
 				return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCodef(log, codes.Unimplemented,
-					"linked clone volumes is not supported. Request: %+v", req)
+					"linked clone volumes are not supported. Request: %+v", req)
 			}
 		case common.AttributeHostLocalPolicy:
 			isHostLocalRequest = strings.EqualFold(req.Parameters[paramName], "true")
@@ -1887,7 +1887,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 			}
 			if isLinkedCloneRequest && !linkedCloneSupportEnabled {
 				return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCodef(log, codes.Unimplemented,
-					"linked clone volumes is not supported. Request: %+v", req)
+					"linked clone volumes are not supported. Request: %+v", req)
 			}
 		}
 	}
@@ -2007,7 +2007,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 			// Fail the request since we do not support this configuration.
 
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Unimplemented,
-				"support for topology requirement with hostname labels is not yet implemented ")
+				"support for topology requirement with hostname labels is not yet implemented")
 		} else {
 			// no label present in the topologyRequirement meaning
 			// it's non-host local volume provisioning on a non-stretched/single-zone supervisor cluster.
@@ -2887,7 +2887,8 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 				c.manager.CnsConfig.Global.SupervisorID, querySelection)
 			if err != nil {
 				log.Errorf("Error while querying volumes from CNS %v", err)
-				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, "Error while querying volumes from CNS")
+				return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal,
+					"Error while querying volumes from CNS: %v", err)
 			}
 
 			cnsVolumeIDs = nil
@@ -2898,7 +2899,8 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 			vmMoidToHostMoid, volumeIDToVMMap, err = c.GetVolumeToHostMapping(ctx, clusterMoIds)
 			if err != nil {
 				log.Errorf("failed to get VM MoID to Host MoID map, err:%v", err)
-				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, "failed to get VM MoID to Host MoID map")
+				return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal,
+					"failed to get VM MoID to Host MoID map: %v", err)
 			}
 		}
 
@@ -2935,7 +2937,8 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 		response, err := getVolumeIDToVMMap(ctx, volumeIDs, vmMoidToHostMoid, volumeIDToVMMap)
 		if err != nil {
 			log.Errorf("Error while generating ListVolume response, err:%v", err)
-			return nil, csifault.CSIInternalFault, status.Error(codes.Internal, "Error while generating ListVolume response")
+			return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal,
+				"Error while generating ListVolume response: %v", err)
 		}
 
 		// Correctly set response nextToken value for the paginated response

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -2869,8 +2869,10 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 			startingIdx, err = strconv.Atoi(req.StartingToken)
 			if err != nil {
 				log.Errorf("Unable to convert startingToken from string to int err=%v", err)
-				return nil, csifault.CSIInvalidArgumentFault, status.Error(codes.InvalidArgument,
-					"startingToken not a valid integer")
+				return nil, csifault.CSIInvalidArgumentFault, status.Errorf(codes.InvalidArgument,
+					"startingToken %q is not a valid integer: %v. Ensure the ListVolumes request uses the "+
+						"unmodified starting_token value returned by a previous ListVolumes response.",
+					req.StartingToken, err)
 			}
 		}
 

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -2888,7 +2888,8 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 			if err != nil {
 				log.Errorf("Error while querying volumes from CNS %v", err)
 				return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal,
-					"Error while querying volumes from CNS: %v", err)
+					"Error while querying volumes from CNS: %v. Check vCenter connectivity and "+
+						"credentials in the CSI config secret, and verify the CNS service is reachable.", err)
 			}
 
 			cnsVolumeIDs = nil
@@ -2900,7 +2901,8 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 			if err != nil {
 				log.Errorf("failed to get VM MoID to Host MoID map, err:%v", err)
 				return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal,
-					"failed to get VM MoID to Host MoID map: %v", err)
+					"failed to get VM MoID to Host MoID map: %v. Verify vCenter connectivity and that "+
+						"the ClusterComputeResource MoIDs in the config are correct.", err)
 			}
 		}
 
@@ -2938,7 +2940,8 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 		if err != nil {
 			log.Errorf("Error while generating ListVolume response, err:%v", err)
 			return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal,
-				"Error while generating ListVolume response: %v", err)
+				"Error while generating ListVolume response: %v. Retry after vCenter connectivity is "+
+					"restored; if the error persists, check CNS query logs for the affected volume IDs.", err)
 		}
 
 		// Correctly set response nextToken value for the paginated response

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -980,7 +980,8 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) {
 				// Feature is disabled on the cluster
 				return nil, csifault.CSIInternalFault,
-					status.Error(codes.InvalidArgument, "File volume not supported.")
+					status.Error(codes.InvalidArgument,
+						"File volume is not supported because the File Volume feature is disabled on this cluster")
 			}
 			return controllerPublishForFileVolume(ctx, req, c)
 		}
@@ -1448,7 +1449,8 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				return controllerUnpublishForFileVolume(ctx, req, c)
 			}
 			// Feature is disabled on the cluster
-			return nil, csifault.CSIInvalidArgumentFault, status.Error(codes.InvalidArgument, "File volume not supported.")
+			return nil, csifault.CSIInvalidArgumentFault, status.Error(codes.InvalidArgument,
+				"File volume is not supported because the File Volume feature is disabled on this cluster")
 		}
 		volumeType = prometheus.PrometheusBlockVolumeType
 		return controllerUnpublishForBlockVolume(ctx, req, c)

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -981,7 +981,9 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 				// Feature is disabled on the cluster
 				return nil, csifault.CSIInternalFault,
 					status.Error(codes.InvalidArgument,
-						"File volume is not supported because the File Volume feature is disabled on this cluster")
+						"File volume is not supported because the File Volume feature is disabled on this cluster. "+
+							"Check the File Volume feature state in the CSI feature-states ConfigMap and enable it "+
+							"if file volumes are required")
 			}
 			return controllerPublishForFileVolume(ctx, req, c)
 		}

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -402,14 +402,14 @@ func (h *CSISupervisorMutationWebhook) mutateNewCnsFileAccessConfig(ctx context.
 	// Obtain VM's UID
 	vmUID, err := getVmUID(ctx, newCnsFileAccessConfig.Spec.VMName, newCnsFileAccessConfig.Namespace)
 	if err != nil {
-		log.Errorf("faield to get VM UID for VM %s. Err: %s", newCnsFileAccessConfig.Spec.VMName, err)
+		log.Errorf("failed to get VM UID for VM %s. Err: %s", newCnsFileAccessConfig.Spec.VMName, err)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
 	// Obtain PVC's UID
 	pvcUID, err := getPVCUID(ctx, newCnsFileAccessConfig.Spec.PvcName, newCnsFileAccessConfig.Namespace)
 	if err != nil {
-		log.Errorf("faield to get PVC UID for PVC %s. Err: %s", newCnsFileAccessConfig.Spec.PvcName, err)
+		log.Errorf("failed to get PVC UID for PVC %s. Err: %s", newCnsFileAccessConfig.Spec.PvcName, err)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 

--- a/pkg/syncer/admissionhandler/validatepvc.go
+++ b/pkg/syncer/admissionhandler/validatepvc.go
@@ -33,7 +33,8 @@ var (
 )
 
 const (
-	ExpandVolumeWithSnapshotErrorMessage   = "Expanding volume with snapshots is not allowed"
+	ExpandVolumeWithSnapshotErrorMessage = "Expanding volume with snapshots is not allowed. " +
+		"Please delete the existing snapshots before expanding the volume"
 	ExpandLinkedCloneVolumeErrorMessage    = "Expanding linked clone volume is not allowed"
 	UpdateLinkedCloneVolumeAnnErrorMessage = "Cannot update linked clone volume annotations after creation"
 	DeleteVolumeWithSnapshotErrorMessage   = "Deleting volume with snapshots is not allowed"

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_controller.go
@@ -649,7 +649,9 @@ func (r *Reconciler) processBatchAttach(ctx context.Context, k8sClient kubernete
 			if res.finalizerErr != nil {
 				statusErr = res.finalizerErr
 				attachErr = errors.Join(attachErr,
-					fmt.Errorf("failure during attach of PVC %s", res.pvcName))
+					fmt.Errorf("failed to add finalizer on PVC %s after successful attach: %w. "+
+						"Verify API server connectivity and RBAC permissions to update PVC finalizers",
+						res.pvcName, res.finalizerErr))
 			}
 		}
 		// Update instance with attach result.

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmbatchattachment/cnsnodevmbatchattachment_helper.go
@@ -208,8 +208,9 @@ func getVolumesToDetachFromInstance(ctx context.Context,
 		// Get PVC object for the given PVC name.
 		pvcObj, err := commonco.ContainerOrchestratorUtility.GetPvcObjectByName(ctx, pvcName, pvcNs)
 		if err != nil {
-			msg := fmt.Sprintf("failed to find PVC obj for PVC name %s in namespace %s", pvcName, pvcNs)
-			return pvcsToDetach, errors.New(msg)
+			return pvcsToDetach, fmt.Errorf("failed to find PVC obj for PVC name %s in namespace %s: %w. "+
+				"Verify the PVC still exists and the CSI node informer cache is in sync",
+				pvcName, pvcNs, err)
 		}
 
 		addPVCToDetachList := false
@@ -643,7 +644,9 @@ func constructBatchAttachRequest(ctx context.Context,
 
 			pvcObj, err := commonco.ContainerOrchestratorUtility.GetPvcObjectByName(ctx, pvcName, instance.Namespace)
 			if err != nil {
-				err := fmt.Errorf("failed to find the PVC object")
+				err := fmt.Errorf("failed to find the PVC object %q in namespace %q: %w. "+
+					"Verify the PVC exists and the CnsNodeVMBatchAttachment spec references a valid PVC name",
+					pvcName, instance.Namespace, err)
 				log.With("pvc", pvcName).With("namespace", instance.Namespace).
 					Error(err)
 				return pvcsInSpec, volumeIdsInSpec, batchAttachRequest, err

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/util.go
@@ -19,6 +19,7 @@ package cnsunregistervolume
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	snapshotclient "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
@@ -200,7 +201,8 @@ func getPodsForPVC(ctx context.Context, pvcName string, pvcNamespace string,
 	if err != nil {
 		log.Warnf("Failed to list pods in namespace %q for PVC %q. Error: %q",
 			pvcNamespace, pvcName, err.Error())
-		return nil, false, errors.New("failed to list pods")
+		return nil, false, fmt.Errorf("failed to list pods in namespace %q for PVC %q: %w",
+			pvcNamespace, pvcName, err)
 	}
 
 	var pods []string
@@ -229,7 +231,8 @@ func getSnapshotsForPVC(ctx context.Context, pvcName string, pvcNamespace string
 	if err != nil {
 		log.Warnf("Failed to create snapshot client for PVC %q in namespace %q. Error: %q",
 			pvcName, pvcNamespace, err.Error())
-		return nil, false, errors.New("failed to create snapshot client")
+		return nil, false, fmt.Errorf("failed to create snapshot client for PVC %q in namespace %q: %w",
+			pvcName, pvcNamespace, err)
 	}
 
 	// TODO: check if we can use informer cache
@@ -237,7 +240,8 @@ func getSnapshotsForPVC(ctx context.Context, pvcName string, pvcNamespace string
 	if err != nil {
 		log.Warnf("Failed to list VolumeSnapshots in namespace %q for PVC %q. Error: %q",
 			pvcNamespace, pvcName, err.Error())
-		return nil, false, errors.New("failed to list VolumeSnapshots")
+		return nil, false, fmt.Errorf("failed to list VolumeSnapshots in namespace %q for PVC %q: %w",
+			pvcNamespace, pvcName, err)
 	}
 
 	var snapshots []string
@@ -275,7 +279,8 @@ func getGuestClustersForPVC(ctx context.Context, pvcName, pvcNamespace string,
 
 		log.Warnf("Failed to get CnsVolumeMetadata %q in namespace %q. Error: %q",
 			pvcName, pvcNamespace, err.Error())
-		return nil, false, errors.New("failed to get CnsVolumeMetadata")
+		return nil, false, fmt.Errorf("failed to get CnsVolumeMetadata %q in namespace %q: %w",
+			pvcName, pvcNamespace, err)
 	}
 
 	var gcs []string
@@ -292,15 +297,22 @@ func getGuestClustersForPVC(ctx context.Context, pvcName, pvcNamespace string,
 // getVMsForPVC returns a list of virtual machines that are using the specified PVC.
 func getVMsForPVC(ctx context.Context, pvcName string, pvcNamespace string,
 	cfg rest.Config) ([]string, bool, error) {
+	log := logger.GetLogger(ctx)
 	c, err := k8s.NewClientForGroup(ctx, &cfg, vmoperatortypes.GroupName)
 	if err != nil {
-		return nil, false, errors.New("failed to create client for virtual machine group")
+		log.Warnf("Failed to create client for virtual machine group for PVC %q in namespace %q. Error: %q",
+			pvcName, pvcNamespace, err.Error())
+		return nil, false, fmt.Errorf("failed to create client for virtual machine group for PVC %q in namespace %q: %w",
+			pvcName, pvcNamespace, err)
 	}
 
 	// TODO: check if we can use informer cache
 	list, err := utils.ListVirtualMachines(ctx, c, pvcNamespace)
 	if err != nil {
-		return nil, false, errors.New("failed to list virtual machines")
+		log.Warnf("Failed to list virtual machines in namespace %q for PVC %q. Error: %q",
+			pvcNamespace, pvcName, err.Error())
+		return nil, false, fmt.Errorf("failed to list virtual machines in namespace %q for PVC %q: %w",
+			pvcNamespace, pvcName, err)
 	}
 
 	var vms []string

--- a/pkg/syncer/cnsoperator/controller/cnsunregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsunregistervolume/util.go
@@ -201,7 +201,8 @@ func getPodsForPVC(ctx context.Context, pvcName string, pvcNamespace string,
 	if err != nil {
 		log.Warnf("Failed to list pods in namespace %q for PVC %q. Error: %q",
 			pvcNamespace, pvcName, err.Error())
-		return nil, false, fmt.Errorf("failed to list pods in namespace %q for PVC %q: %w",
+		return nil, false, fmt.Errorf("failed to list pods in namespace %q for PVC %q: %w. "+
+			"Verify API server connectivity and RBAC permissions to list pods in this namespace",
 			pvcNamespace, pvcName, err)
 	}
 
@@ -231,7 +232,8 @@ func getSnapshotsForPVC(ctx context.Context, pvcName string, pvcNamespace string
 	if err != nil {
 		log.Warnf("Failed to create snapshot client for PVC %q in namespace %q. Error: %q",
 			pvcName, pvcNamespace, err.Error())
-		return nil, false, fmt.Errorf("failed to create snapshot client for PVC %q in namespace %q: %w",
+		return nil, false, fmt.Errorf("failed to create snapshot client for PVC %q in namespace %q: %w. "+
+			"Verify the VolumeSnapshot CRDs/API group are installed and reachable",
 			pvcName, pvcNamespace, err)
 	}
 
@@ -240,7 +242,8 @@ func getSnapshotsForPVC(ctx context.Context, pvcName string, pvcNamespace string
 	if err != nil {
 		log.Warnf("Failed to list VolumeSnapshots in namespace %q for PVC %q. Error: %q",
 			pvcNamespace, pvcName, err.Error())
-		return nil, false, fmt.Errorf("failed to list VolumeSnapshots in namespace %q for PVC %q: %w",
+		return nil, false, fmt.Errorf("failed to list VolumeSnapshots in namespace %q for PVC %q: %w. "+
+			"Verify API server connectivity and RBAC permissions to list VolumeSnapshots",
 			pvcNamespace, pvcName, err)
 	}
 
@@ -279,7 +282,8 @@ func getGuestClustersForPVC(ctx context.Context, pvcName, pvcNamespace string,
 
 		log.Warnf("Failed to get CnsVolumeMetadata %q in namespace %q. Error: %q",
 			pvcName, pvcNamespace, err.Error())
-		return nil, false, fmt.Errorf("failed to get CnsVolumeMetadata %q in namespace %q: %w",
+		return nil, false, fmt.Errorf("failed to get CnsVolumeMetadata %q in namespace %q: %w. "+
+			"Verify the CNS operator CRDs are installed and the API server is reachable",
 			pvcName, pvcNamespace, err)
 	}
 
@@ -302,7 +306,8 @@ func getVMsForPVC(ctx context.Context, pvcName string, pvcNamespace string,
 	if err != nil {
 		log.Warnf("Failed to create client for virtual machine group for PVC %q in namespace %q. Error: %q",
 			pvcName, pvcNamespace, err.Error())
-		return nil, false, fmt.Errorf("failed to create client for virtual machine group for PVC %q in namespace %q: %w",
+		return nil, false, fmt.Errorf("failed to create client for virtual machine group for PVC %q in namespace %q: %w. "+
+			"Verify the VM Operator CRDs/API group are installed and reachable",
 			pvcName, pvcNamespace, err)
 	}
 
@@ -311,7 +316,8 @@ func getVMsForPVC(ctx context.Context, pvcName string, pvcNamespace string,
 	if err != nil {
 		log.Warnf("Failed to list virtual machines in namespace %q for PVC %q. Error: %q",
 			pvcNamespace, pvcName, err.Error())
-		return nil, false, fmt.Errorf("failed to list virtual machines in namespace %q for PVC %q: %w",
+		return nil, false, fmt.Errorf("failed to list virtual machines in namespace %q for PVC %q: %w. "+
+			"Verify API server connectivity and RBAC permissions to list VirtualMachines",
 			pvcNamespace, pvcName, err)
 	}
 

--- a/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
+++ b/pkg/syncer/cnsoperator/controller/virtualmachinesnapshot/virtualmachinesnapshot_controller.go
@@ -216,7 +216,7 @@ func (r *ReconcileVirtualMachineSnapshot) Reconcile(ctx context.Context,
 				request.Namespace, request.Name)
 			return reconcile.Result{}, nil
 		}
-		log.Errorf("error while fetch the virtualmachinesnapshot %s/%s. error: %v",
+		log.Errorf("error while fetching the virtualmachinesnapshot %s/%s. error: %v",
 			request.Namespace, request.Name, err)
 		// Error reading the object - return with err.
 		return reconcile.Result{}, err
@@ -262,8 +262,8 @@ func (r *ReconcileVirtualMachineSnapshot) reconcileNormal(ctx context.Context, l
 				SyncVolumeFinalizer, vmsnapshot.Namespace, vmsnapshot.Name)
 			err := r.vmSnapVMOperatorClient.Patch(ctx, vmsnapshot, vmSnapshotPatch)
 			if err != nil {
-				log.Errorf("reconcileNormal: error while add finalizer to "+
-					"virtualmachinesnapshot %s/%s. error: %v", vmsnapshot.Name, vmsnapshot.Name, err)
+				log.Errorf("reconcileNormal: error while adding finalizer to "+
+					"virtualmachinesnapshot %s/%s. error: %v", vmsnapshot.Namespace, vmsnapshot.Name, err)
 				return err
 			}
 			return nil
@@ -438,7 +438,7 @@ func (r *ReconcileVirtualMachineSnapshot) syncVolumesAndUpdateCNSVolumeInfo(ctx 
 	}
 	log.Info("syncVolumesAndUpdateCNSVolumeInfo: wait for syncvolume operation to be completed")
 	if err := syncgrp.Wait(); err != nil {
-		log.Errorf("syncVolumesAndUpdateCNSVolumeInfo: error while sync volume "+
+		log.Errorf("syncVolumesAndUpdateCNSVolumeInfo: error while syncing volume "+
 			"error: %v", err)
 		return err
 	}
@@ -525,7 +525,7 @@ func (r *ReconcileVirtualMachineSnapshot) invokeSyncVolume(ctx context.Context, 
 			syncVolumeSpecs[0])
 		syncVolumeFaultType, err := r.volumeManager.SyncVolume(ctx, syncVolumeSpecs)
 		if err != nil {
-			log.Errorf("invokeSyncVolume: error while sync volume %s "+
+			log.Errorf("invokeSyncVolume: error while syncing volume %s "+
 				"cnsfault %s. error: %v", syncVolumeSpecs[0], syncVolumeFaultType, err)
 			return err
 		}

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -1096,7 +1096,7 @@ func validateAndCorrectVolumeInfoSnapshotDetails(ctx context.Context,
 				}
 				patchBytes, err := json.Marshal(patch)
 				if err != nil {
-					log.Errorf("error while create VolumeInfo patch for volume %s. Error while marshaling: %+v. Continuing..",
+					log.Errorf("error while creating VolumeInfo patch for volume %s. Error while marshaling: %+v. Continuing..",
 						cnsvolumeinfo.Spec.VolumeID, err)
 					continue
 				}

--- a/pkg/syncer/k8scloudoperator/placement.go
+++ b/pkg/syncer/k8scloudoperator/placement.go
@@ -302,7 +302,9 @@ func GetSVMotionPlan(ctx context.Context, client kubernetes.Interface,
 
 	volumeInfoList, allPVCList, err := GetVolumesOnStoragePool(ctx, client, storagePoolName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the list of volumes to be migrated")
+		return nil, fmt.Errorf("failed to get the list of volumes to be migrated from StoragePool %s: %w. "+
+			"Verify API server connectivity and that the CNS-CSI volumes/PVCs referencing this "+
+			"StoragePool are in a consistent state", storagePoolName, err)
 	}
 	if len(volumeInfoList) == 0 {
 		log.Infof("No volume present in storagePool %v to migrate. ", storagePoolName)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -3716,7 +3716,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 					log.Errorf("PVUpdated: Failed to get VC host and volume manager for multi VC setup. "+
 						"Error occurred: %+v", err)
 					generateEventOnPv(ctx, oldPv, v1.EventTypeWarning,
-						staticVolumeProvisioningFailure, "Failed to identify VC for volume.")
+						staticVolumeProvisioningFailure,
+						fmt.Sprintf("Failed to identify VC for volume: %v", err))
 					return
 				}
 			} else {
@@ -3736,7 +3737,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 						// Failed to create static PV
 						log.Errorf("PVUpdated: Failed to create static file volume %q. Error: %+v", newPv.Name, err)
 						generateEventOnPv(ctx, oldPv, v1.EventTypeWarning,
-							staticVolumeProvisioningFailure, "Failed to create volume on any of the VCs")
+							staticVolumeProvisioningFailure,
+							fmt.Sprintf("Failed to create volume on any of the VCs: %v", err))
 						return
 					}
 					return
@@ -3751,7 +3753,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 				log.Errorf("PVUpdated: Failed to get VC host and volume manager for single VC setup. "+
 					"Error occoured: %+v", err)
 				generateEventOnPv(ctx, oldPv, v1.EventTypeWarning,
-					staticVolumeProvisioningFailure, "Failed to identify VC for volume")
+					staticVolumeProvisioningFailure,
+					fmt.Sprintf("Failed to identify VC for volume: %v", err))
 				return
 			}
 		}
@@ -3782,7 +3785,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 				// Call CreateVolume for Static Volume Provisioning.
 				err = createCnsVolume(ctx, oldPv, metadataSyncer, cnsVolumeMgr, volumeType, vcHost, metadataList, volumeHandle)
 				if err != nil {
-					errMsg := fmt.Sprintf("Failed to create volume on VC %s", vcHost)
+					errMsg := fmt.Sprintf("Failed to create volume on VC %s: %v", vcHost, err)
 					log.Errorf(errMsg)
 					generateEventOnPv(ctx, oldPv, v1.EventTypeWarning,
 						staticVolumeProvisioningFailure, errMsg)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -3717,7 +3717,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 						"Error occurred: %+v", err)
 					generateEventOnPv(ctx, oldPv, v1.EventTypeWarning,
 						staticVolumeProvisioningFailure,
-						fmt.Sprintf("Failed to identify VC for volume: %v", err))
+						fmt.Sprintf("Failed to identify VC for volume: %v. Check topology/nodeAffinity on "+
+							"the PV and vCenter connectivity for the configured VCs", err))
 					return
 				}
 			} else {
@@ -3738,7 +3739,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 						log.Errorf("PVUpdated: Failed to create static file volume %q. Error: %+v", newPv.Name, err)
 						generateEventOnPv(ctx, oldPv, v1.EventTypeWarning,
 							staticVolumeProvisioningFailure,
-							fmt.Sprintf("Failed to create volume on any of the VCs: %v", err))
+							fmt.Sprintf("Failed to create volume on any of the VCs: %v. Check vCenter "+
+								"connectivity/credentials for all configured VCs in the config secret", err))
 						return
 					}
 					return
@@ -3754,7 +3756,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 					"Error occoured: %+v", err)
 				generateEventOnPv(ctx, oldPv, v1.EventTypeWarning,
 					staticVolumeProvisioningFailure,
-					fmt.Sprintf("Failed to identify VC for volume: %v", err))
+					fmt.Sprintf("Failed to identify VC for volume: %v. Check topology/nodeAffinity on "+
+						"the PV and vCenter connectivity for the configured VC", err))
 				return
 			}
 		}
@@ -3785,7 +3788,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 				// Call CreateVolume for Static Volume Provisioning.
 				err = createCnsVolume(ctx, oldPv, metadataSyncer, cnsVolumeMgr, volumeType, vcHost, metadataList, volumeHandle)
 				if err != nil {
-					errMsg := fmt.Sprintf("Failed to create volume on VC %s: %v", vcHost, err)
+					errMsg := fmt.Sprintf("Failed to create volume on VC %s: %v. Check vCenter connectivity "+
+						"and credentials for VC %s in the config secret", vcHost, err, vcHost)
 					log.Errorf(errMsg)
 					generateEventOnPv(ctx, oldPv, v1.EventTypeWarning,
 						staticVolumeProvisioningFailure, errMsg)

--- a/pkg/syncer/resize_reconciler.go
+++ b/pkg/syncer/resize_reconciler.go
@@ -266,7 +266,7 @@ func (rc *resizeReconciler) syncPVC(ctx context.Context, key string) error {
 	if updatePVC {
 		svcUpdatedPVC, err := patchPVCStatus(ctx, svcPVC, svcPvcClone, rc.supervisorClient)
 		if err != nil {
-			log.Errorf("cannot update Supervisor Cluster PVC  [%s] in namespace [%s]: [%v]",
+			log.Errorf("cannot update Supervisor Cluster PVC [%s] in namespace [%s]: [%v]",
 				svcUpdatedPVC.Name, rc.supervisorNamespace, err)
 			return err
 		}


### PR DESCRIPTION
This change focuses on error message standardization and improvement across the vSphere CSI driver codebase. The changes involve 19 files with 103 insertions and 52 deletions, implementing a more comprehensive error reporting strategy.

Key Themes:
1. Enhanced Error Context & Remediation (Main Focus)

- Converting simple error messages to rich fmt.Errorf() calls with %w (error wrapping)
- Adding root-cause details to previously generic error messages
- Including actionable remediation steps in error messages to help operators debug issues

Example: "failed to list pods" → "failed to list pods in namespace %q for PVC %q: %w. Verify API server connectivity and RBAC permissions to list pods in this namespace"
2. Grammar & Spelling Fixes

- Fixed typos: "faield" → "failed", "currupted" → "corrupted", "Suppport" → "Support"
- Fixed double spaces in error messages
- Improved grammar: "check path exits" → "check if path exists", "error while fetch" → "error while fetching"

3. Improved Error Messages Structure

- Root cause information → Actionable remediation guidance
- Wrapped errors preserve original error details while adding context
- Log entries now include format specifiers with actual values
Apart from these some issues were find by the skill provided. This is the generated report:

https://lvn-dbc2425.lvn.broadcom.net/ab002488/public_html/VCF_Wide_Error_Messaging/vsphere-csi-9-1-2-error-message-audit-summary.html
https://lvn-dbc2425.lvn.broadcom.net/ab002488/public_html/VCF_Wide_Error_Messaging/vsphere-csi-9-1-2-error-message-audit.html

Testing Done: All precheckins are passed
