### PR TITLE
Initialize snapshotmetadataservice controller under DP operator always, irrespective of CBTconfig CRD present

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -433,19 +433,6 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 						cleanupSessions(ctx, r)
 					}
 				}()
-				if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-					// The CSI_Backup_API feature relies on the Data Protection Operator service for CbtConfig CRD definition.
-					installed, err := commonco.ContainerOrchestratorUtility.IsDPOServiceInstalled(ctx)
-					if err != nil {
-						log.Errorf("Error checking Data Protection Operator service installation. Error: %+v", err)
-						utils.LogoutAllvCenterSessions(ctx)
-						os.Exit(1)
-					}
-					if !installed {
-						commonco.ContainerOrchestratorUtility.HandleLateInstallationOfDPOService(ctx)
-						return
-					}
-				}
 				if err := startDpOperator(ctx, configInfo, clusterFlavor); err != nil {
 					log.Errorf("Error initializing Data Protection(DP) operator. Error: %+v", err)
 					utils.LogoutAllvCenterSessions(ctx)

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -55,6 +55,17 @@ type FakeK8SOrchestrator struct {
 	// NodeNameToHostMoID is the node name -> ESXi host MoID map returned by
 	// GetNodeNameToHostMoIDMap in tests. Nil returns an empty map.
 	NodeNameToHostMoID map[string]string
+	// dpoServiceInstalled / dpoServiceInstalledErr control IsDPOServiceInstalled's return value.
+	// dpoServiceInstalled defaults to true (see GetFakeContainerOrchestratorInterface) to
+	// preserve historical behavior for callers that don't configure it; use
+	// SetDPOServiceInstalled to override in a specific test.
+	dpoServiceInstalled    bool
+	dpoServiceInstalledErr error
+	// dpoLateInstallCalledOnce/dpoLateInstallCalled track HandleLateInstallationOfDPOService
+	// invocations so tests can synchronize on the call instead of racing/sleeping; see
+	// WaitForLateInstallationOfDPOServiceCall.
+	dpoLateInstallCalledOnce sync.Once
+	dpoLateInstallCalled     chan struct{}
 }
 
 // volumeMigration holds mocked migrated volume information

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -82,8 +82,10 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 		}
 
 		fakeCO := &FakeK8SOrchestrator{
-			featureStatesLock: &sync.RWMutex{},
-			featureStates:     defaultFSS,
+			featureStatesLock:    &sync.RWMutex{},
+			featureStates:        defaultFSS,
+			dpoServiceInstalled:  true,
+			dpoLateInstallCalled: make(chan struct{}),
 		}
 		return fakeCO, nil
 	}
@@ -332,10 +334,34 @@ func (c *FakeK8SOrchestrator) HandleLateEnablementOfCapability(
 }
 
 func (c *FakeK8SOrchestrator) IsDPOServiceInstalled(ctx context.Context) (bool, error) {
-	return true, nil
+	if c.dpoServiceInstalledErr != nil {
+		return false, c.dpoServiceInstalledErr
+	}
+	return c.dpoServiceInstalled, nil
 }
 
 func (c *FakeK8SOrchestrator) HandleLateInstallationOfDPOService(ctx context.Context) {
+	if c.dpoLateInstallCalled != nil {
+		c.dpoLateInstallCalledOnce.Do(func() { close(c.dpoLateInstallCalled) })
+	}
+}
+
+// SetDPOServiceInstalled configures the value (and optional error) IsDPOServiceInstalled
+// returns. Tests should call this before exercising code that calls IsDPOServiceInstalled.
+func (c *FakeK8SOrchestrator) SetDPOServiceInstalled(installed bool, err error) {
+	c.dpoServiceInstalled = installed
+	c.dpoServiceInstalledErr = err
+}
+
+// WaitForLateInstallationOfDPOServiceCall blocks until HandleLateInstallationOfDPOService has
+// been invoked, or ctx is done, returning whether the call was observed.
+func (c *FakeK8SOrchestrator) WaitForLateInstallationOfDPOServiceCall(ctx context.Context) bool {
+	select {
+	case <-c.dpoLateInstallCalled:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // GetNodeTopologyLabels fetches the topology information of a node from the CSINodeTopology CR.

--- a/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller.go
+++ b/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer"
@@ -72,6 +73,18 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 
 	if clusterFlavor != cnstypes.CnsClusterFlavorWorkload {
 		log.Debug("Not initializing the CBTConfig Controller as its a non-WCP CSI deployment")
+		return nil
+	}
+
+	// Check if CBTConfig CRD is installed and available before proceeding further.
+	installed, err := commonco.ContainerOrchestratorUtility.IsDPOServiceInstalled(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check Data Protection Operator service installation: %w", err)
+	}
+	if !installed {
+		log.Info("Data Protection Operator service is not yet installed; deferring CBTConfig " +
+			"Controller initialization")
+		go commonco.ContainerOrchestratorUtility.HandleLateInstallationOfDPOService(ctx)
 		return nil
 	}
 

--- a/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller_test.go
+++ b/pkg/syncer/dpoperator/controller/cbtconfig/cbtconfig_controller_test.go
@@ -42,7 +42,9 @@ import (
 
 	cbtconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cbtconfig/v1alpha1"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer"
 )
@@ -471,5 +473,54 @@ func TestReconcile(t *testing.T) {
 		assert.Equal(t, reconcile.Result{}, res, "per-volume set failure is best-effort; no requeue expected")
 		eventuallyEqual(t, vm.setCallsCopy, []string{"vol-1"},
 			"background goroutine should still attempt the per-volume Set even on failure")
+	})
+}
+
+// installFakeCOForTest points commonco.ContainerOrchestratorUtility at a fresh fake CO for the
+// duration of the test, restoring the original value via t.Cleanup, and returns the concrete
+// fake so the test can drive its DPO-related test hooks (SetDPOServiceInstalled,
+// WaitForLateInstallationOfDPOServiceCall).
+func installFakeCOForTest(t *testing.T) *unittestcommon.FakeK8SOrchestrator {
+	t.Helper()
+	co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	require.NoError(t, err)
+	fakeCO := co.(*unittestcommon.FakeK8SOrchestrator)
+
+	orig := commonco.ContainerOrchestratorUtility
+	commonco.ContainerOrchestratorUtility = fakeCO
+	t.Cleanup(func() { commonco.ContainerOrchestratorUtility = orig })
+	return fakeCO
+}
+
+func TestAdd(t *testing.T) {
+	t.Run("non-Workload flavor is a no-op", func(t *testing.T) {
+		// Guest never registers CBTConfig; Add must return before touching commonco, mgr, or
+		// configInfo, so passing nil for the latter two is safe here.
+		err := Add(nil, cnstypes.CnsClusterFlavorGuest, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("IsDPOServiceInstalled error is propagated", func(t *testing.T) {
+		fakeCO := installFakeCOForTest(t)
+		fakeCO.SetDPOServiceInstalled(false, errors.New("apiserver unreachable"))
+
+		err := Add(nil, cnstypes.CnsClusterFlavorWorkload, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check Data Protection Operator service installation")
+	})
+
+	t.Run("DPO not installed defers initialization without failing Add", func(t *testing.T) {
+		fakeCO := installFakeCOForTest(t)
+		fakeCO.SetDPOServiceInstalled(false, nil)
+
+		err := Add(nil, cnstypes.CnsClusterFlavorWorkload, nil)
+		require.NoError(t, err)
+
+		waitCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		require.True(t, fakeCO.WaitForLateInstallationOfDPOServiceCall(waitCtx),
+			"Add should start HandleLateInstallationOfDPOService in the background instead of "+
+				"failing outright, so sibling DP operator controllers (e.g. "+
+				"SnapshotMetadataService) still get registered")
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently for refreshing CA cert in SnapshotMetadataService CR in supervisor cluster, we start snapshotmetadataservice controller under DP operator added for CBT functionality. However, DP operator currently start on WCP only if underlying dependency of CbtConfig CRD is satisfied as required by other cbtconfig_controller under same operator. Even though the functionality of  snapshotmetadataservice controller does not require the CRD, code does not initialize the controller and that does not refresh the CAcert if CRD is not installed. 
This PR removes this dependency to start DP operator always, but start the underlying controller with required dependency if any.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
* WCP precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1953/
```
Ran 15 of 2362 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2347 Skipped | 0 Flaked
```
* VKS precheckin passed - https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1503/
```
Ran 6 of 2362 Specs
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2356 Skipped | 0 Flaked
```
* Tested the change manually on setup with CRD not present 
```
root@4206aafdfaf811c236b1ef88e2e89746 [ ~ ]# k get crd -A | grep cbtconfigs.cnsdp.vmware.com
root@4206aafdfaf811c236b1ef88e2e89746 [ ~ ]#

* Patch SMS CR with some invalid cert val and see if it gets refreshed to actual cert

root@4206aafdfaf811c236b1ef88e2e89746 [ ~ ]# kubectl patch snapshotmetadataservice csi.vsphere.vmware.com   --type=merge   -p '{"spec":{"caCert":"bm8tY2VydC1kYXRhCg=="}}' --kubeconfig /etc/kubernetes/admin.conf
snapshotmetadataservice.cbt.storage.k8s.io/csi.vsphere.vmware.com patched
root@4206aafdfaf811c236b1ef88e2e89746 [ ~ ]#
root@4206aafdfaf811c236b1ef88e2e89746 [ ~ ]# k get snapshotmetadataservices.cbt.storage.k8s.io -o yaml
...
  spec:
    address: 192.168.130.1:8100
    audience: csi.vsphere.vmware.com
    caCert: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVRE1XOVdnblNYRi81bmYvUndRVTVvRUNSTVlNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0FEQWVGdzB5TmpBNE1qVXdOelEzTURoYUZ3MHlOakV4TWpNd056UTNNRGhhTUFBd2dnRWlNQTBHQ1NxRwpTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEU2UzNEx4cmtoaVcwTGZkSmh5akRNRnMvTVFFRkVwZnNSCjRzMHF4OElQUUdKTnhpSVBHeVI0Uk52Mm13Uk9lLy8vOURMekNESnczaW5ObGFiNmVTamh4OXVpK1dnSEsyWWcKTC9Ba3ltdlRsSjVveE8yK3B4UEQ4czM0UUh0eDkzZjlaRUdUeFZDZjJlNS9HMmY3Y051WEc2c1J5aXNENFI5bQpoSHVhRkZMZlBhWGZ2OHgvNldMZmxYYURSM051ekJTT1lkSWlwQmIrWjFBMndqRk5yaEdpWXpXWk5JcGROU2ozCnVienVJQmYzdWtOS0RNNy8rdTdaTmV3L0VseVR3N0tuTjBacys4N0lEQkFGcjgvdllUMndBZzNQUm1zYWRROEoKNndPUlpWeDZsbFBoTnpCMU5laFU4cjUzQ0RaZCswUW96WW5qOEpieFkybGllZlBFaG4rL0FnTUJBQUdqZ2RFdwpnYzR3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQXBwCmY5d2cwMzF2aU9ZM21GZ2VYZXo1OWVETE1JR0xCZ05WSFJFQkFmOEVnWUF3Zm9JelkzTnBMWE51WVhCemFHOTAKTFcxbGRHRmtZWFJoTFhObGNuWnBZMlV1ZG0xM1lYSmxMWE41YzNSbGJTMWpjMmt1YzNaamdrRmpjMmt0YzI1aApjSE5vYjNRdGJXVjBZV1JoZEdFdGMyVnlkbWxqWlM1MmJYZGhjbVV0YzNsemRHVnRMV056YVM1emRtTXVZMngxCmMzUmxjaTVzYjJOaGJJY0V3S2lDQVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXpCOFM3RmpucFByeFNoKzcKRDBCRm1LTnhrQ0NSYTJnOGV4ZGFodnhHWDJpSzR6VFMxejVxVXhVVDJGalBTS1ZwU2NPNDdPbVpqZlNPQzUzZwo3NStVb1BiZ25hSXhpVVBuWDFzMVo4Z083aCs2NWFSSmlzUXVDbHpSODJKd3haUjUyR3EveExMQUZHRUY3Z0QzCktMTzE3ZFdRVXJaMjlQL2VENFVwOUNmbUxtdklrR1VJcVFCR3lxUG02N2hkWHNISGs2UWs2UjU1L0JEeUZVRlYKa3NGY1pDUXh6YWM4cDhVZnRuTEJrTjJnZGMxYWZLaFhnMVVGY0hBLzJkbGpBNm1iNGRuS2x4enYwcHlSMEE4ZQpRemJub0xhTWRySHhSSC8vblg1SWFEVnQ0Z0JCRSs1QjFqd2g4SWovOVFIbHJENlRHV0pGRUFwaldDTEJWS0huClZPdkQxUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
root@4206aafdfaf811c236b1ef88e2e89746 [ ~ ]#
```

syncer logs:
```
{"level":"info","time":"2026-08-27T11:04:48.138662043Z","caller":"snapshotmetadataservice/snapshotmetadataservice_controller.go:299","msg":"Received Reconcile for request: \"/csi.vsphere.vmware.com\"","TraceId":"045d63d2-75f4-4b03-a548-1348d3b55fe8"}
{"level":"info","time":"2026-08-27T11:04:48.138786655Z","caller":"snapshotmetadataservice/snapshotmetadataservice_controller.go:300","msg":"Started Reconcile for SnapshotMetadataService request: \"/csi.vsphere.vmware.com\"","TraceId":"045d63d2-75f4-4b03-a548-1348d3b55fe8"}
{"level":"info","time":"2026-08-27T11:04:48.140442672Z","caller":"snapshotmetadataservice/snapshotmetadataservice_controller.go:442","msg":"Updating SnapshotMetadataService csi.vsphere.vmware.com (caCert changed=true, address changed=false; address=\"192.168.130.1:8100\")","TraceId":"045d63d2-75f4-4b03-a548-1348d3b55fe8"}
{"level":"info","time":"2026-08-27T11:04:48.148450102Z","caller":"snapshotmetadataservice/snapshotmetadataservice_controller.go:582","msg":"Successfully synced SnapshotMetadataService csi.vsphere.vmware.com (caCert, address=\"192.168.130.1:8100\")","TraceId":"045d63d2-75f4-4b03-a548-1348d3b55fe8"}
{"level":"info","time":"2026-08-27T11:04:48.148528797Z","caller":"snapshotmetadataservice/snapshotmetadataservice_controller.go:466","msg":"Finished Reconcile for SnapshotMetadataService request: \"/csi.vsphere.vmware.com\"","TraceId":"045d63d2-75f4-4b03-a548-1348d3b55fe8"}
{"level":"info","time":"2026-08-27T11:04:48.148743273Z","caller":"snapshotmetadataservice/snapshotmetadataservice_controller.go:299","msg":"Received Reconcile for request: \"/csi.vsphere.vmware.com\"","TraceId":"3d6240db-29e6-4789-98f1-be8e0c77eab2"}
{"level":"info","time":"2026-08-27T11:04:48.148752036Z","caller":"snapshotmetadataservice/snapshotmetadataservice_controller.go:300","msg":"Started Reconcile for SnapshotMetadataService request: \"/csi.vsphere.vmware.com\"","TraceId":"3d6240db-29e6-4789-98f1-be8e0c77eab2"}
{"level":"info","time":"2026-08-27T11:04:48.148955887Z","caller":"snapshotmetadataservice/snapshotmetadataservice_controller.go:458","msg":"SnapshotMetadataService csi.vsphere.vmware.com already up-to-date, no action needed","TraceId":"3d6240db-29e6-4789-98f1-be8e0c77eab2"}
{"level":"info","time":"2026-08-27T11:04:48.14896977Z","caller":"snapshotmetadataservice/snapshotmetadataservice_controller.go:466","msg":"Finished Reconcile for SnapshotMetadataService request: \"/csi.vsphere.vmware.com\"","TraceId":"3d6240db-29e6-4789-98f1-be8e0c77eab2"}
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Initialize snapshotmetadataservice controller under DP operator always, irrespective of CBTconfig CRD present
```
