### PR TITLE
Redact clear-text vCenter credentials from logs

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -26,6 +26,7 @@ import (
 	neturl "net/url"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -124,9 +125,9 @@ type VirtualCenterConfig struct {
 	// Host represents the virtual center host address.
 	Host string
 	// Username represents the virtual center username.
-	Username string
+	Username string `sensitive:"true"`
 	// Password represents the virtual center password in clear text.
-	Password string
+	Password string `sensitive:"true"`
 	// Specifies the path to a CA certificate in PEM format. This has no effect
 	// if Insecure is enabled. Optional; if not configured, the system's CA
 	// certificates will be used.
@@ -166,7 +167,30 @@ type VirtualCenterConfig struct {
 	VCSessionManagerURL string
 	// VCSessionManagerToken is the token that should be passed to authenticate against the session manager
 	// If empty, the Pod service account will be used
-	VCSessionManagerToken string
+	VCSessionManagerToken string `sensitive:"true"`
+}
+
+// String returns a string representation of VirtualCenterConfig with sensitive fields redacted.
+func (vcc *VirtualCenterConfig) String() string {
+	if vcc == nil {
+		return "<nil>"
+	}
+	val := reflect.ValueOf(*vcc)
+	typ := val.Type()
+
+	var fields []string
+	for i := 0; i < val.NumField(); i++ {
+		field := typ.Field(i)
+		value := val.Field(i)
+
+		if field.Tag.Get("sensitive") == "true" {
+			fields = append(fields, fmt.Sprintf("%s:%s", field.Name, strings.Repeat("*", value.Len())))
+		} else {
+			fields = append(fields, fmt.Sprintf("%s:%v", field.Name, value.Interface()))
+		}
+	}
+
+	return fmt.Sprintf("{%s}", strings.Join(fields, " "))
 }
 
 // NewClient creates a new govmomi Client instance.

--- a/pkg/common/cns-lib/vsphere/virtualcenter_config_string_test.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter_config_string_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestVirtualCenterConfigStringRedactsSensitiveFields(t *testing.T) {
+	cfg := &VirtualCenterConfig{
+		Host:                  "vc.example.com",
+		Username:              "administrator@vsphere.local",
+		Password:              "S3cretPassw0rd!",
+		VCSessionManagerToken: "top-secret-token",
+	}
+
+	for _, out := range []string{cfg.String(), fmt.Sprintf("%v", cfg), fmt.Sprintf("%+v", cfg)} {
+		if strings.Contains(out, cfg.Password) {
+			t.Errorf("expected Password to be redacted, got: %s", out)
+		}
+		if strings.Contains(out, cfg.Username) {
+			t.Errorf("expected Username to be redacted, got: %s", out)
+		}
+		if strings.Contains(out, cfg.VCSessionManagerToken) {
+			t.Errorf("expected VCSessionManagerToken to be redacted, got: %s", out)
+		}
+		if !strings.Contains(out, cfg.Host) {
+			t.Errorf("expected non-sensitive Host field to be preserved, got: %s", out)
+		}
+	}
+}
+
+func TestVirtualCenterStringRedactsSensitiveFields(t *testing.T) {
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host:     "vc.example.com",
+			Username: "administrator@vsphere.local",
+			Password: "S3cretPassw0rd!",
+		},
+	}
+
+	out := fmt.Sprintf("%+v", vc)
+	if strings.Contains(out, vc.Config.Password) {
+		t.Errorf("expected Password to be redacted in VirtualCenter.String(), got: %s", out)
+	}
+}

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -1152,7 +1152,7 @@ func getDatastoreInfoObjList(ctx context.Context, vc *vsphere.VirtualCenter,
 		return datastoreInfos, nil
 	} else {
 		return nil, logger.LogNewErrorf(log,
-			"Unable to find datastore for datastore URL %s in VC %+v", datastoreURL, vc)
+			"Unable to find datastore for datastore URL %s in VC %s", datastoreURL, vc.Config.Host)
 	}
 }
 

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -69,6 +69,7 @@ const (
 	diskSizeLarge                              = "100Gi"
 	diskSizeInMb                               = int64(2048)
 	diskSizeInMinMb                            = int64(200)
+	e2eTestPassword                            = "E2E-test-password!23"
 	e2evSphereCSIDriverName                    = "csi.vsphere.vmware.com"
 	ensureAccessibilityMModeType               = "ensureObjectAccessibility"
 	envClusterFlavor                           = "CLUSTER_FLAVOR"
@@ -404,20 +405,13 @@ var (
 	envTestbedInfoJsonPath = "TESTBEDINFO_JSON"
 )
 
-// Config secret testuser credentials.
-// Passwords are sourced from the environment so no clear-text credential is
-// checked into source; the literal values below are only used as the
-// fallback default when the corresponding env var is not set.
+// Config secret testuser credentials
 var (
-	configSecretTestUser1Password = GetStringEnvVarOrDefault("CONFIG_SECRET_TEST_USER1_PASSWORD", "VMware!23")
-	configSecretTestUser2Password = GetStringEnvVarOrDefault("CONFIG_SECRET_TEST_USER2_PASSWORD", "VMware!234")
+	configSecretTestUser1Password = "VMware!23"
+	configSecretTestUser2Password = "VMware!234"
 	configSecretTestUser1         = "testuser1"
 	configSecretTestUser2         = "testuser2"
 )
-
-// e2eTestPassword is used as a placeholder password for negative/API test cases.
-// Sourced from the environment so no clear-text credential is checked into source.
-var e2eTestPassword = GetStringEnvVarOrDefault("E2E_TEST_PASSWORD", "E2E-test-password!23")
 
 // Nimbus generated passwords
 var (

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -69,7 +69,6 @@ const (
 	diskSizeLarge                              = "100Gi"
 	diskSizeInMb                               = int64(2048)
 	diskSizeInMinMb                            = int64(200)
-	e2eTestPassword                            = "E2E-test-password!23"
 	e2evSphereCSIDriverName                    = "csi.vsphere.vmware.com"
 	ensureAccessibilityMModeType               = "ensureObjectAccessibility"
 	envClusterFlavor                           = "CLUSTER_FLAVOR"
@@ -405,13 +404,20 @@ var (
 	envTestbedInfoJsonPath = "TESTBEDINFO_JSON"
 )
 
-// Config secret testuser credentials
+// Config secret testuser credentials.
+// Passwords are sourced from the environment so no clear-text credential is
+// checked into source; the literal values below are only used as the
+// fallback default when the corresponding env var is not set.
 var (
-	configSecretTestUser1Password = "VMware!23"
-	configSecretTestUser2Password = "VMware!234"
+	configSecretTestUser1Password = GetStringEnvVarOrDefault("CONFIG_SECRET_TEST_USER1_PASSWORD", "VMware!23")
+	configSecretTestUser2Password = GetStringEnvVarOrDefault("CONFIG_SECRET_TEST_USER2_PASSWORD", "VMware!234")
 	configSecretTestUser1         = "testuser1"
 	configSecretTestUser2         = "testuser2"
 )
+
+// e2eTestPassword is used as a placeholder password for negative/API test cases.
+// Sourced from the environment so no clear-text credential is checked into source.
+var e2eTestPassword = GetStringEnvVarOrDefault("E2E_TEST_PASSWORD", "E2E-test-password!23")
 
 // Nimbus generated passwords
 var (


### PR DESCRIPTION
Redact clear-text vCenter credentials from logs(VGL-68298)

VirtualCenterConfig had no redaction, so VirtualCenter.String() leaked the plaintext password whenever a *VirtualCenter was logged with %v/%+v, which happened in an actual error path in vsphereutil.go. Added sensitive-field tagging and a redacting String() method mirroring pkg/common/config, and fixed the leaking log call.

Jira: https://vmw-jira.broadcom.net/browse/CNAS-12355

Testing Done: Yes

https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1956/
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1509/