### PR TITLE
Resolve mismatched printf style in logs

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -417,7 +417,7 @@ func (m *defaultManager) UnregisterNode(ctx context.Context, nodeName string) er
 	log := logger.GetLogger(ctx)
 	nodeUUID, found := m.nodeNameToUUID.Load(nodeName)
 	if !found {
-		log.Errorf("Node wasn't found, failed to unregister node: %q  err: %v", nodeName)
+		log.Errorf("Node wasn't found, failed to unregister node: %q", nodeName)
 		return ErrNodeNotFound
 	}
 	m.nodeNameToUUID.Delete(nodeName)

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -549,7 +549,7 @@ func patchSupervisorPVCAnnotation(ctx context.Context, client clientset.Interfac
 			supervisorNamespace, supervisorPVCName, patchErr)
 	}
 	log.Infof("Successfully patched guest-cluster annotation on supervisor PVC %s/%s with patch %s",
-		supervisorNamespace, supervisorPVCName)
+		supervisorNamespace, supervisorPVCName, string(patchBytes))
 	return nil
 }
 

--- a/pkg/internalapis/cnsoperator/cnsfilevolumeclient/cnsfilevolumeclient.go
+++ b/pkg/internalapis/cnsoperator/cnsfilevolumeclient/cnsfilevolumeclient.go
@@ -231,7 +231,7 @@ func (f *fileVolumeClient) AddClientVMToIPList(ctx context.Context,
 	log.Debugf("Updating cnsfilevolumeclient instance %s with spec: %+v", fileVolumeName, instance)
 	err = f.client.Update(ctx, instance)
 	if err != nil {
-		log.Errorf("failed to update cnsfilevolumeclient instance %s/%s with error: %+v", fileVolumeName, err)
+		log.Errorf("failed to update cnsfilevolumeclient instance %s with error: %+v", fileVolumeName, err)
 	}
 	return err
 }

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1262,7 +1262,7 @@ func syncStorageQuotaReserved(ctx context.Context,
 		log.Errorf("syncStorageQuotaReserved: failed to fetch storage policy quota instances, Error: %+v", err)
 		return
 	}
-	log.Debugf("syncStorageQuotaReserved: Retrieved StoragePolicyQuota instances for syncing", "Count: %d",
+	log.Debugf("syncStorageQuotaReserved: Retrieved StoragePolicyQuota instances for syncing, Count: %d",
 		len(spqList.Items))
 	namespaces := make(map[string]string)
 	// create namespace map to be able to calculate reserved namespace wise


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Corrects four `log` calls where the number of printf-style verbs in the format string didn't match the number of arguments. Go doesn't fail to compile on this, so these calls were silently emitting garbled log output instead of the intended diagnostic information, which made the affected log lines useless for debugging.

**Which issue this PR fixes** 
NA

**Testing done**:
`make check` - passes, 0 issues
Logging only changes. No functional behavior changes

**Special notes for your reviewer**:
NA

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
