### PR TITLE
Return vSAN file store in CreateVolume response and guard its PVC label

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -177,6 +177,12 @@ const (
 	// Nfsv4ExportPathAnnotationKey specifies the NFSv4.1 export path annotation key on PVC
 	Nfsv4ExportPathAnnotationKey = "csi.vsphere.exportpath.nfs41"
 
+	// FileStoreLabelKey is the label key set by the FVS controller on a FileVolume CR to identify the
+	// backing vSAN file store. The same key is returned in the CreateVolume response VolumeContext so
+	// external-provisioner can publish it as a label on the PVC. Users are not allowed to set this
+	// label themselves on a dynamically provisioned PVC; that is enforced by a supervisor webhook.
+	FileStoreLabelKey = "fvs.vcf.broadcom.com/file-store"
+
 	// Nfsv4AccessPoint is the access point of file volume.
 	Nfsv4AccessPoint = "Nfsv4AccessPoint"
 

--- a/pkg/csi/service/wcp/fvs_filevolume.go
+++ b/pkg/csi/service/wcp/fvs_filevolume.go
@@ -486,7 +486,7 @@ func (c *controller) createFileVolumeViaFVS(ctx context.Context, req *csi.Create
 	}
 
 	fv := &fvv1alpha1.FileVolume{}
-	var exportPath, endpoint string
+	var exportPath, endpoint, fileStore string
 	err = wait.PollUntilContextTimeout(ctx, fvsWaitStep, fvsWaitMax, true, func(ctx context.Context) (bool, error) {
 		if err := c.fileVolumeClient.Get(ctx, ctrlclient.ObjectKey{Namespace: instanceNS, Name: fvName}, fv); err != nil {
 			return false, err
@@ -504,12 +504,22 @@ func (c *controller) createFileVolumeViaFVS(ctx context.Context, req *csi.Create
 		}
 		exportPath = fv.Status.ExportPath
 		endpoint = fv.Status.Endpoint
-		return exportPath != "" && endpoint != "", nil
+		// The FVS controller labels the FileVolume CR with the backing file store name once the volume
+		// is fully provisioned. We surface it in the CreateVolume response so that external-provisioner
+		// can publish it as a label on the PVC, so treat it as part of the readiness condition.
+		fileStore = fv.Labels[common.FileStoreLabelKey]
+		if exportPath == "" || endpoint == "" || fileStore == "" {
+			log.Warnf("FileVolume %s/%s is Ready but still incomplete (exportPath set: %t, endpoint set: %t, "+
+				"%q label set: %t); continuing to wait",
+				instanceNS, fvName, exportPath != "", endpoint != "", common.FileStoreLabelKey, fileStore != "")
+			return false, nil
+		}
+		return true, nil
 	})
 	if err != nil {
 		return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.DeadlineExceeded,
-			"timeout or error waiting for FileVolume %s/%s to become Ready with export path and endpoint: %v",
-			instanceNS, fvName, err)
+			"timeout or error waiting for FileVolume %s/%s to become Ready with export path, endpoint and "+
+				"%q label: %v", instanceNS, fvName, common.FileStoreLabelKey, err)
 	}
 
 	volumeID := fmt.Sprintf("%s%s:%s", common.FVSVolumeIDPrefix, instanceNS, fvName)
@@ -517,6 +527,7 @@ func (c *controller) createFileVolumeViaFVS(ctx context.Context, req *csi.Create
 	attributes := map[string]string{
 		common.AttributeDiskType:            common.DiskTypeFileVolume,
 		common.Nfsv4ExportPathAnnotationKey: nfsv41Export,
+		common.FileStoreLabelKey:            fileStore,
 	}
 
 	resp := &csi.CreateVolumeResponse{

--- a/pkg/csi/service/wcp/fvs_filevolume_test.go
+++ b/pkg/csi/service/wcp/fvs_filevolume_test.go
@@ -1565,6 +1565,162 @@ func TestCreateFileVolumeViaFVS_ErrorPhasePropagatesCondition(t *testing.T) {
 	require.Contains(t, err.Error(), "vdfs grpc dial")
 }
 
+// newFileStoreTestController builds the FVS fixture shared by the file-store label tests: a consumer
+// namespace and an instance namespace on the same VPC and zone, plus a pre-seeded FileVolume (the
+// Phase 1 reuse path, so no healthy FileVolumeService CR is needed). It returns the controller and the
+// CreateVolume request to drive it with.
+func newFileStoreTestController(t *testing.T, pvcUID string,
+	existing *fvv1alpha1.FileVolume) (*controller, *csi.CreateVolumeRequest) {
+	t.Helper()
+	consumerAnn := "pvc-ns-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	instAnn := "inst-ns-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	sameVPCPath := "/orgs/default/projects/default/vpcs/same-vpc"
+
+	k8s := k8sfake.NewClientset(
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "pvc-ns",
+				Annotations: map[string]string{AnnotationVPCNetworkConfig: consumerAnn},
+			},
+		},
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "inst-ns",
+				Labels:      map[string]string{NamespaceLabelFVSInstance: "true"},
+				Annotations: map[string]string{AnnotationVPCNetworkConfig: instAnn},
+			},
+		},
+	)
+	dyn := newTestDynamicClient(t,
+		testVPCNetworkConfigurationCR(consumerAnn, sameVPCPath),
+		testVPCNetworkConfigurationCR(instAnn, sameVPCPath),
+	)
+
+	origZones := fvsZonesForNamespace
+	t.Cleanup(func() { fvsZonesForNamespace = origZones })
+	fvsZonesForNamespace = func(ns string) map[string]struct{} {
+		if ns == "pvc-ns" || ns == "inst-ns" {
+			return map[string]struct{}{"zone-a": {}}
+		}
+		return nil
+	}
+
+	fvClient := ctrlfake.NewClientBuilder().
+		WithScheme(newFileVolumeSchemeForTest(t)).
+		WithObjects(existing).
+		Build()
+
+	c := &controller{
+		k8sClient:        k8s,
+		dynamicClient:    dyn,
+		namespaceLister:  testNamespaceLister(t, k8s),
+		fileVolumeClient: fvClient,
+	}
+	req := &csi.CreateVolumeRequest{
+		Name: "pvc-" + pvcUID,
+		Parameters: map[string]string{
+			common.AttributePvcNamespace: "pvc-ns",
+			common.AttributePvcName:      "my-pvc",
+		},
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Preferred: []*csi.Topology{{Segments: map[string]string{v1.LabelTopologyZone: "zone-a"}}},
+		},
+	}
+	return c, req
+}
+
+// TestCreateFileVolumeViaFVS_HappyPathReturnsFileStore verifies that once the FileVolume CR is Ready
+// with an export path, an endpoint and the FVS file-store label, createFileVolumeViaFVS returns the
+// file store name in the CreateVolume response volume context. external-provisioner reads it from
+// there to publish the same label on the PVC.
+func TestCreateFileVolumeViaFVS_HappyPathReturnsFileStore(t *testing.T) {
+	ctx := context.Background()
+	withFastFVSWait(t)
+	pvcUID := "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+	existing := &fvv1alpha1.FileVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcUID,
+			Namespace: "inst-ns",
+			Labels:    map[string]string{common.FileStoreLabelKey: "my-file-store"},
+		},
+		Status: fvv1alpha1.FileVolumeStatus{
+			Phase:      fvv1alpha1.FileVolumePhaseReady,
+			ExportPath: "/vsanfs/fs-1",
+			Endpoint:   "10.0.0.10",
+		},
+	}
+	c, req := newFileStoreTestController(t, pvcUID, existing)
+
+	resp, fault, err := c.createFileVolumeViaFVS(ctx, req)
+	require.NoError(t, err)
+	require.Empty(t, fault)
+	require.NotNil(t, resp)
+	require.Equal(t, common.FVSVolumeIDPrefix+"inst-ns:"+pvcUID, resp.Volume.VolumeId)
+	require.Equal(t, common.DiskTypeFileVolume, resp.Volume.VolumeContext[common.AttributeDiskType])
+	require.Equal(t, "10.0.0.10:/vsanfs/fs-1", resp.Volume.VolumeContext[common.Nfsv4ExportPathAnnotationKey])
+	require.Equal(t, "my-file-store", resp.Volume.VolumeContext[common.FileStoreLabelKey])
+}
+
+// TestCreateFileVolumeViaFVS_IncompleteReadyTimesOut verifies that a Ready FileVolume that is missing
+// any of the export path, the endpoint or the file-store label is not treated as provisioned: the poll
+// keeps waiting and CreateVolume ultimately fails with DeadlineExceeded rather than returning a volume
+// with no file store to publish on the PVC.
+func TestCreateFileVolumeViaFVS_IncompleteReadyTimesOut(t *testing.T) {
+	pvcUID := "cccccccc-cccc-cccc-cccc-cccccccccccc"
+	cases := []struct {
+		name       string
+		labels     map[string]string
+		exportPath string
+		endpoint   string
+	}{
+		{
+			name:       "file store label absent",
+			exportPath: "/vsanfs/fs-1",
+			endpoint:   "10.0.0.10",
+		},
+		{
+			name:       "file store label present but empty",
+			labels:     map[string]string{common.FileStoreLabelKey: ""},
+			exportPath: "/vsanfs/fs-1",
+			endpoint:   "10.0.0.10",
+		},
+		{
+			// Regression guard: the file store label is an additional condition, not a replacement for
+			// the existing export path and endpoint checks.
+			name:       "file store label present but endpoint missing",
+			labels:     map[string]string{common.FileStoreLabelKey: "my-file-store"},
+			exportPath: "/vsanfs/fs-1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			withFastFVSWait(t)
+			existing := &fvv1alpha1.FileVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcUID,
+					Namespace: "inst-ns",
+					Labels:    tc.labels,
+				},
+				Status: fvv1alpha1.FileVolumeStatus{
+					Phase:      fvv1alpha1.FileVolumePhaseReady,
+					ExportPath: tc.exportPath,
+					Endpoint:   tc.endpoint,
+				},
+			}
+			c, req := newFileStoreTestController(t, pvcUID, existing)
+
+			resp, fault, err := c.createFileVolumeViaFVS(ctx, req)
+			require.Nil(t, resp)
+			require.Error(t, err)
+			require.Equal(t, csifault.CSIInternalFault, fault)
+			require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+			require.Contains(t, err.Error(), common.FileStoreLabelKey)
+		})
+	}
+}
+
 // TestReservedFVSStorageClassGuard documents the invariant the new CreateVolume guard relies on:
 // the reserved vSAN file-service storage classes are recognised by isVsanFileServicePolicyStorageClass,
 // and when the FVS FSS is disabled, shouldProvisionVsanFileVolumeViaFVS returns useFVS=false. The

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -64,6 +64,7 @@ var (
 	featureIsSharedDiskEnabled             bool
 	featureIsLinkedCloneSupportEnabled     bool
 	featureIsVACPolicyMutabilityEnabled    bool
+	featureIsVsanFileVolumeServiceEnabled  bool
 )
 
 // initWorkloadFSSFlag sets the given flag from the current state of the given Workload (Supervisor)
@@ -168,6 +169,8 @@ func StartWebhookServer(ctx context.Context, enableWebhookClientCertVerification
 			&featureIsSharedDiskEnabled)
 		initWorkloadFSSFlag(ctx, containerOrchestratorUtility, common.VMPVCStoragePolicyMutability,
 			&featureIsVACPolicyMutabilityEnabled)
+		initWorkloadFSSFlag(ctx, containerOrchestratorUtility, common.VsanFileVolumeService,
+			&featureIsVsanFileVolumeServiceEnabled)
 		if err := startCNSCSIWebhookManager(ctx, enableWebhookClientCertVerification,
 			containerOrchestratorUtility); err != nil {
 			return fmt.Errorf("unable to run the webhook manager: %w", err)

--- a/pkg/syncer/admissionhandler/admissionhandler_test.go
+++ b/pkg/syncer/admissionhandler/admissionhandler_test.go
@@ -67,6 +67,20 @@ func TestInitWorkloadFSSFlag(t *testing.T) {
 			expectFlag:           false,
 			expectLateEnablement: true,
 		},
+		{
+			name:                 "vSAN file volume service enabled",
+			capability:           common.VsanFileVolumeService,
+			fssEnabled:           true,
+			expectFlag:           true,
+			expectLateEnablement: false,
+		},
+		{
+			name:                 "vSAN file volume service disabled starts late-enablement watcher",
+			capability:           common.VsanFileVolumeService,
+			fssEnabled:           false,
+			expectFlag:           false,
+			expectLateEnablement: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -233,6 +233,12 @@ func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request
 		if !resp.Allowed {
 			return
 		}
+		if featureIsVsanFileVolumeServiceEnabled {
+			resp = validatePVCLabelForFileStore(ctx, req)
+			if !resp.Allowed {
+				return
+			}
+		}
 		if featureGateBlockVolumeSnapshotEnabled {
 			admissionResp := validatePVC(ctx, &req.AdmissionRequest)
 			resp.AdmissionResponse = *admissionResp.DeepCopy()

--- a/pkg/syncer/admissionhandler/validatepvclabelforfilestore.go
+++ b/pkg/syncer/admissionhandler/validatepvclabelforfilestore.go
@@ -1,0 +1,88 @@
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+const (
+	NonCreatablePVCLabel = "PVC Label %s cannot be created by user %s"
+	NonUpdatablePVCLabel = "PVC Label %s is not mutable by user %s"
+)
+
+// validatePVCLabelForFileStore disallows non cns-csi service account users from setting or editing the
+// file store label on a PVC. The label is published by the CSI provisioning flow once the backing
+// FileVolume CR is Ready, so a user supplied value would misrepresent which file store actually backs
+// the volume.
+//
+// On CREATE the label is rejected only for dynamically provisioned PVCs. A statically provisioned PVC
+// (one that names an existing PV through spec.volumeName) is bound to a volume that CSI did not create
+// here, so its labels are the user's to set.
+//
+// On UPDATE the label is immutable: it may not be added, changed or removed. The CSI service account is
+// exempt from both checks, since external-provisioner is what stamps the label in the first place.
+func validatePVCLabelForFileStore(ctx context.Context, request admission.Request) admission.Response {
+	log := logger.GetLogger(ctx)
+	username := request.UserInfo.Username
+	log.Debugf("validatePVCLabelForFileStore called with the request %v by user: %v", request, username)
+	if request.Operation == admissionv1.Delete {
+		// File store label validation is not required for delete PVC calls.
+		return admission.Allowed("")
+	}
+	if validateCSIServiceAccount(username) {
+		// The CSI service account owns this label.
+		return admission.Allowed("")
+	}
+
+	newPVC := corev1.PersistentVolumeClaim{}
+	if err := json.Unmarshal(request.Object.Raw, &newPVC); err != nil {
+		log.Errorf("error unmarshalling pvc: %v", err)
+		reason := "skipped validation when failed to deserialize PVC from new request object"
+		log.Warn(reason)
+		return admission.Allowed(reason)
+	}
+	newFileStore, newOk := newPVC.Labels[common.FileStoreLabelKey]
+
+	if request.Operation == admissionv1.Create {
+		if newOk && isDynamicallyProvisionedPVC(&newPVC) {
+			return admission.Denied(fmt.Sprintf(NonCreatablePVCLabel, common.FileStoreLabelKey, username))
+		}
+	} else if request.Operation == admissionv1.Update {
+		oldPVC := corev1.PersistentVolumeClaim{}
+		if err := json.Unmarshal(request.OldObject.Raw, &oldPVC); err != nil {
+			log.Errorf("error unmarshalling pvc: %v", err)
+			reason := "skipped validation when failed to deserialize PVC from old request object"
+			log.Warn(reason)
+			return admission.Allowed(reason)
+		}
+
+		oldFileStore, oldOk := oldPVC.Labels[common.FileStoreLabelKey]
+		// We only need to prevent updates to the file store label. Other PVC edit requests should go through.
+		if oldOk && newOk {
+			// Disallow changing the value of the file store label on an existing PVC.
+			if oldFileStore != newFileStore {
+				return admission.Denied(fmt.Sprintf(NonUpdatablePVCLabel, common.FileStoreLabelKey, username))
+			}
+		} else if oldOk || newOk {
+			// Disallow adding/removing the file store label on an existing PVC.
+			return admission.Denied(fmt.Sprintf(NonUpdatablePVCLabel, common.FileStoreLabelKey, username))
+		}
+	}
+
+	log.Debugf("validatePVCLabelForFileStore completed for the request %v", request)
+	return admission.Allowed("")
+}
+
+// isDynamicallyProvisionedPVC reports whether the PVC, as submitted on CREATE, will be dynamically
+// provisioned: it names a storage class and does not pre-bind itself to an existing PV.
+func isDynamicallyProvisionedPVC(pvc *corev1.PersistentVolumeClaim) bool {
+	return pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" && pvc.Spec.VolumeName == ""
+}

--- a/pkg/syncer/admissionhandler/validatepvclabelforfilestore_test.go
+++ b/pkg/syncer/admissionhandler/validatepvclabelforfilestore_test.go
@@ -1,0 +1,346 @@
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+)
+
+const testFileStoreName = "my-file-store"
+
+// fileStorePVCOption customises the PVC built by fileStorePVCRaw.
+type fileStorePVCOption func(*corev1.PersistentVolumeClaim)
+
+// withFileStoreLabel sets the reserved file store label to the given value.
+func withFileStoreLabel(value string) fileStorePVCOption {
+	return func(pvc *corev1.PersistentVolumeClaim) {
+		if pvc.Labels == nil {
+			pvc.Labels = map[string]string{}
+		}
+		pvc.Labels[common.FileStoreLabelKey] = value
+	}
+}
+
+// withVolumeName pre-binds the PVC to an existing PV, making it statically provisioned.
+func withVolumeName(name string) fileStorePVCOption {
+	return func(pvc *corev1.PersistentVolumeClaim) { pvc.Spec.VolumeName = name }
+}
+
+// withoutStorageClass clears the storage class, so the PVC is not dynamically provisioned.
+func withoutStorageClass() fileStorePVCOption {
+	return func(pvc *corev1.PersistentVolumeClaim) { pvc.Spec.StorageClassName = nil }
+}
+
+// withUserLabel adds an unrelated user label, to confirm other labels are never considered.
+func withUserLabel(key, value string) fileStorePVCOption {
+	return func(pvc *corev1.PersistentVolumeClaim) {
+		if pvc.Labels == nil {
+			pvc.Labels = map[string]string{}
+		}
+		pvc.Labels[key] = value
+	}
+}
+
+// fileStorePVCRaw builds a dynamically provisioned PVC (storage class set, no volumeName) with the
+// given modifications applied, and returns its JSON encoding for the admission request payload.
+func fileStorePVCRaw(t *testing.T, opts ...fileStorePVCOption) []byte {
+	t.Helper()
+	sc := common.StorageClassVsanFileServicePolicy
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: "pvc-ns"},
+		Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &sc},
+	}
+	for _, opt := range opts {
+		opt(pvc)
+	}
+	raw, err := json.Marshal(pvc)
+	if err != nil {
+		t.Fatalf("failed to marshal PVC %v: %v", pvc, err)
+	}
+	return raw
+}
+
+func TestValidatePVCLabelForFileStore(t *testing.T) {
+	deniedOnCreate := admission.Denied(fmt.Sprintf(NonCreatablePVCLabel,
+		common.FileStoreLabelKey, nonCSIServiceAccountExample))
+	deniedOnUpdate := admission.Denied(fmt.Sprintf(NonUpdatablePVCLabel,
+		common.FileStoreLabelKey, nonCSIServiceAccountExample))
+
+	tests := []struct {
+		name             string
+		admissionReview  admission.Request
+		expectedResponse admission.Response
+	}{
+		{
+			name: "TestCreateDynamicPVCWithFileStoreLabelByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName)),
+					},
+				},
+			},
+			expectedResponse: deniedOnCreate,
+		},
+		{
+			// Even an empty value is a squat on the reserved key.
+			name: "TestCreateDynamicPVCWithEmptyFileStoreLabelByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: fileStorePVCRaw(t, withFileStoreLabel(""))},
+				},
+			},
+			expectedResponse: deniedOnCreate,
+		},
+		{
+			name: "TestCreateDynamicPVCWithoutFileStoreLabelByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: fileStorePVCRaw(t, withUserLabel("app", "web"))},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			// A statically provisioned PVC names an existing PV, so its labels are the user's to set.
+			name: "TestCreateStaticPVCWithFileStoreLabelByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName), withVolumeName("pv-1")),
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			name: "TestCreatePVCWithoutStorageClassAndWithFileStoreLabelByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName), withoutStorageClass()),
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			name: "TestCreateDynamicPVCWithFileStoreLabelByCSIServiceAccount",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: csiServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName)),
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			name: "TestAddFileStoreLabelOnUpdateByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{Raw: fileStorePVCRaw(t)},
+					Object: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName)),
+					},
+				},
+			},
+			expectedResponse: deniedOnUpdate,
+		},
+		{
+			name: "TestChangeFileStoreLabelOnUpdateByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName)),
+					},
+					Object: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel("other-file-store")),
+					},
+				},
+			},
+			expectedResponse: deniedOnUpdate,
+		},
+		{
+			name: "TestRemoveFileStoreLabelOnUpdateByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName)),
+					},
+					Object: runtime.RawExtension{Raw: fileStorePVCRaw(t)},
+				},
+			},
+			expectedResponse: deniedOnUpdate,
+		},
+		{
+			// Editing anything else on a PVC that carries the label must still go through.
+			name: "TestUpdateOtherLabelsKeepingFileStoreLabelByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName)),
+					},
+					Object: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName), withUserLabel("app", "web")),
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			// This is external-provisioner publishing the label after CreateVolume returns.
+			name: "TestAddFileStoreLabelOnUpdateByCSIServiceAccount",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: csiServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{Raw: fileStorePVCRaw(t)},
+					Object: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName)),
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			name: "TestDeletePVCWithFileStoreLabelByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName)),
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			name: "TestCreatePVCWithMalformedObject",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: []byte("not-json")},
+				},
+			},
+			expectedResponse: admission.Allowed(
+				"skipped validation when failed to deserialize PVC from new request object"),
+		},
+		{
+			name: "TestUpdatePVCWithMalformedOldObject",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{Raw: []byte("not-json")},
+					Object: runtime.RawExtension{
+						Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName)),
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(
+				"skipped validation when failed to deserialize PVC from old request object"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validatePVCLabelForFileStore(context.Background(), tt.admissionReview)
+			if !reflect.DeepEqual(got, tt.expectedResponse) {
+				t.Errorf("validatePVCLabelForFileStore() = %v, want %v", got, tt.expectedResponse)
+			}
+		})
+	}
+}
+
+// TestCSISupervisorWebhookFileStoreLabelGatedByFSS verifies the file store label validation only runs
+// when the vSAN file service capability is enabled, so clusters on the legacy vSAN file service are
+// unaffected.
+func TestCSISupervisorWebhookFileStoreLabelGatedByFSS(t *testing.T) {
+	origVsanFileService := featureIsVsanFileVolumeServiceEnabled
+	origSnapshot := featureGateBlockVolumeSnapshotEnabled
+	origTKGSHa := featureGateTKGSHaEnabled
+	origByok := featureGateByokEnabled
+	defer func() {
+		featureIsVsanFileVolumeServiceEnabled = origVsanFileService
+		featureGateBlockVolumeSnapshotEnabled = origSnapshot
+		featureGateTKGSHaEnabled = origTKGSHa
+		featureGateByokEnabled = origByok
+	}()
+	// Keep every other PVC validator out of the way so the result is attributable to this one.
+	featureGateBlockVolumeSnapshotEnabled = false
+	featureGateTKGSHaEnabled = false
+	featureGateByokEnabled = false
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UserInfo:  authv1.UserInfo{Username: nonCSIServiceAccountExample},
+			Kind:      metav1.GroupVersionKind{Kind: "PersistentVolumeClaim"},
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: fileStorePVCRaw(t, withFileStoreLabel(testFileStoreName))},
+		},
+	}
+	webhook := &CSISupervisorWebhook{}
+
+	featureIsVsanFileVolumeServiceEnabled = false
+	if resp := webhook.Handle(context.Background(), req); !resp.Allowed {
+		t.Errorf("with the vSAN file service capability disabled the request must be admitted, got %v", resp)
+	}
+
+	featureIsVsanFileVolumeServiceEnabled = true
+	resp := webhook.Handle(context.Background(), req)
+	if resp.Allowed {
+		t.Errorf("with the vSAN file service capability enabled the request must be denied, got %v", resp)
+	}
+	want := fmt.Sprintf(NonCreatablePVCLabel, common.FileStoreLabelKey, nonCSIServiceAccountExample)
+	if resp.Result == nil || resp.Result.Message != want {
+		t.Errorf("unexpected denial message: got %v, want %q", resp.Result, want)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
With the new vSAN file service architecture, a PVC on the reserved vsan-file-service-policy storage classes is provisioned by creating a FileVolume CR and waiting for it to become Ready. The FVS controller labels that CR with fvs.vcf.broadcom.com/file-store, naming the file store backing the volume, but the CR lives in an FVS instance namespace the DevOps user cannot see, so the file store was not discoverable from the PVC.

createFileVolumeViaFVS now reads that label off the FileVolume CR and treats it as part of the readiness condition, alongside status.exportPath and status.endpoint: a CR reporting Ready without the label is not yet usable, so the poll keeps waiting (logging which field is missing) and CreateVolume fails on the existing fvsWaitMax timeout rather than returning a volume with no file store to publish. The file store is returned in the CreateVolume response VolumeContext under the same key, where external-provisioner picks it up and publishes it on the PVC.

Since the label is now driver-owned data, add a supervisor validating webhook that stops a user from forging it. On CREATE it is rejected on a dynamically provisioned PVC (storage class set, no spec.volumeName); a statically provisioned PVC names a PV the driver did not create here, so its labels remain the user's to set. On UPDATE it is immutable - no add, change or remove. The CSI service account is exempt from both, since external-provisioner is what stamps the label; this reuses the existing validateCSIServiceAccount identity check that the volume health annotation webhook already relies on.

Everything is gated on the supports_vsan_fileservice capability, so clusters on the legacy vSAN file service are unaffected: the legacy CNS file volume path is untouched and never returns the key, and the validator is registered only on the supervisor webhook, which does not run in the vanilla flavor. No manifest change is needed - PVC CREATE and UPDATE are already covered by the existing ValidatingWebhookConfiguration.

Unit tests cover the FVS create path (happy path asserting all three volume context keys, plus Ready-without-label, empty label and missing-endpoint timeouts) and the webhook (CREATE/UPDATE/DELETE across dynamic, static and CSI-service-account requests, plus the capability gate).



**Testing done**:
wcp pre-checkin - https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/1966/ :white_check_mark:

```
Ran 15 of 2362 Specs
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2347 Skipped | 0 Flaked
```

Manual testing result


PVC with filevolume having file-store label. `fvs.vcf.broadcom.com/file-store` label is propagated on PVC.

```
# kubectl describe pvc example-file-pvc  -n test-ns
Name:          example-file-pvc
Namespace:     test-ns
StorageClass:  vsan-file-service-policy
Status:        Bound
Volume:        pvc-4af6feec-4c0b-497a-b83c-ca6e943a4b8b
Labels:        fvs.vcf.broadcom.com/file-store=my-file-store
Annotations:   csi.vsphere.exportpath.nfs41: 172.18.0.36:/export/3cabad6a-87ea-33a0-5633-02007753b8c8
               csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"zone1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Gi
Access Modes:  RWX
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                 Age                    From                                                                                          Message
  ----     ------                 ----                   ----                                                                                          -------
  Normal   ExternalProvisioning   5m5s (x43 over 15m)    persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal   Provisioning           4m39s (x3 over 14m)    csi.vsphere.vmware.com_422441c2b8c0be553bcb1cd24dd641ab_15e6d69b-cb00-4505-8a3b-ebda8fd14149  External provisioner is provisioning volume for claim "test-ns/example-file-pvc"
  Normal   ProvisioningSucceeded  37s                    csi.vsphere.vmware.com_422441c2b8c0be553bcb1cd24dd641ab_15e6d69b-cb00-4505-8a3b-ebda8fd14149  Successfully provisioned volume pvc-4af6feec-4c0b-497a-b83c-ca6e943a4b8b
```


PVC with filevolume having no file-store label 

```
# kubectl describe  pvc example-file-pvc-2   -n test-ns
Name:          example-file-pvc-2
Namespace:     test-ns
StorageClass:  vsan-file-service-policy
Status:        Bound
Volume:        pvc-a69d29f4-f882-4af1-a06e-8d54800638d6
Labels:        <none>
Annotations:   csi.vsphere.exportpath.nfs41: 172.18.0.36:/export/7bb3ad6a-9092-7686-22db-02007753b8c8
               csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"zone1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Gi
Access Modes:  RWX
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                   From                                                                                          Message
  ----    ------                 ----                  ----                                                                                          -------
  Normal  Provisioning           4m8s                  csi.vsphere.vmware.com_4224229dcbd8cb25e68ba7eb76f8c156_1795bdd7-e910-4032-b0cb-8e010202a214  External provisioner is provisioning volume for claim "test-ns/example-file-pvc-2"
  Normal  ExternalProvisioning   4m2s (x5 over 4m28s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  4m2s                  csi.vsphere.vmware.com_4224229dcbd8cb25e68ba7eb76f8c156_1795bdd7-e910-4032-b0cb-8e010202a214  Successfully provisioned volume pvc-a69d29f4-f882-4af1-a06e-8d54800638d6
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Return vSAN file store in CreateVolume response and guard its PVC label
```
