### PR TITLE
Call GetSVMotionPlan directly rather than via a network call

### DIFF
--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -295,36 +295,6 @@ func newClientTransportCredentials() (credentials.TransportCredentials, error) {
 	}), nil
 }
 
-// GetsvMotionPlanFromK8sCloudOperatorService gets storage vMotion plan from
-// K8sCloudOperator gRPC service.
-func GetsvMotionPlanFromK8sCloudOperatorService(ctx context.Context,
-	storagePoolName string, maintenanceMode string) (map[string]string, error) {
-	log := logger.GetLogger(ctx)
-	conn, err := getK8sCloudOperatorClientConnection(ctx)
-	if err != nil {
-		log.Errorf("Failed to establish the connection to k8s cloud operator service "+
-			"when getting svMotion plan for SP: %s. Error: %+v", storagePoolName, err)
-		return nil, err
-	}
-	defer conn.Close()
-	// Create a client stub for k8s cloud operator gRPC service.
-	client := k8scloudoperator.NewK8SCloudOperatorClient(conn)
-
-	res, err := client.GetStorageVMotionPlan(ctx,
-		&k8scloudoperator.StorageVMotionRequest{
-			StoragePoolName: storagePoolName,
-			MaintenanceMode: maintenanceMode,
-		})
-	if err != nil {
-		msg := fmt.Sprintf("Failed to get storage vMotion plan from the k8s cloud operator service. Error: %+v", err)
-		log.Error(msg)
-		return nil, err
-	}
-
-	log.Infof("Got storage vMotion plan: %v from K8sCloudOperator gRPC service", res.SvMotionPlan)
-	return res.SvMotionPlan, nil
-}
-
 // getHostMOIDFromK8sCloudOperatorService gets the host-moid from
 // K8sCloudOperator gRPC service.
 func getHostMOIDFromK8sCloudOperatorService(ctx context.Context, nodeName string) (string, error) {

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
@@ -218,7 +217,19 @@ func (w *DiskDecommController) DecommissionDisk(ctx context.Context, storagePool
 			return
 		}
 
-		svMotionPlan, err := wcp.GetsvMotionPlanFromK8sCloudOperatorService(ctx, storagePoolName, maintenanceMode)
+		// DiskDecommController runs inside vsphere-syncer,
+		// so the mTLS hop authenticates the process to itself and adds nothing.
+		// Hence, calling GetSVMotionPlan directly rather than over the
+		// K8sCloudOperator gRPC service.
+		k8sClient, err := k8s.NewClient(ctx)
+		if err != nil {
+			msg := fmt.Sprintf("Creating Kubernetes client failed. Err: %v", err)
+			if err := updateDrainStatus(ctx, storagePoolName, drainFailStatus, msg); err != nil {
+				log.Errorf("Failed to update drain status to %v. Error: %v", drainFailStatus, err)
+			}
+			return
+		}
+		svMotionPlan, err := k8scloudoperator.GetSVMotionPlan(ctx, k8sClient, storagePoolName, maintenanceMode)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to decommission disk. Error: %+v", err)
 			err := updateDrainStatus(ctx, storagePoolName, drainFailStatus, msg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

DiskDecommController runs inside the vsphere-syncer container and calls GetsvMotionPlanFromK8sCloudOperatorService dials the gRPC server at its own loopback address - the syncer is client and server at once for this one RPC. 

Due to this the grpc call is failing due to both client and server certs being the same.
This is the error obtained on disk decomm:

```
{"reason":"Failed to decommission disk. Error: rpc error: code = Unavailable desc = write tcp 127.0.0.1:36380->127.0.0.1:29000: write: connection reset by peer","status":"fail"}
```

In order to fix this, we don't need a network hop since both the client and the server are the same.


**Testing done**:

Disk decommission is successful:

```
{"level":"info","time":"2026-08-31T15:07:38.470701259Z","caller":"storagepool/[diskDecommissionController.go:431](http://diskdecommissioncontroller.go:431/)","msg":"Got enter disk decommission request for StoragePool storagepool-vsand-10.162.186.215-mpx.vmhba0-c0-t4-l0 with MM ensureAccessibility","TraceId":"9c88d657-46c1-4ae0-a8dd-edde6f438863"}
{"level":"info","time":"2026-08-31T15:07:38.672318013Z","caller":"storagepool/[diskDecommissionController.go:244](http://diskdecommissioncontroller.go:244/)","msg":"Successfully decommission disk storagepool-vsand-10.162.186.215-mpx.vmhba0-c0-t4-l0","TraceId":"9c88d657-46c1-4ae0-a8dd-edde6f438863"}
```

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1960/
VKS precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1510/
