### PR TITLE
Wire up late-enablement watcher for VSphereDPLPModernApp capability

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -93,8 +93,9 @@ var (
 	isMultipleClustersPerVsphereZoneEnabled bool
 	isSharedDiskEnabled                     bool
 	// isVSphereDPLPModernAppEnabled caches the VSphereDPLPModernApp
-	// WCP capability at controller startup. Set once in Add(); late enablement triggers
-	// a pod restart which re-evaluates this value.
+	// WCP capability at controller startup. Set once in Add(). The syncer's
+	// InitMetadataSyncer starts the late-enablement watcher for this capability, which
+	// exits the container on enablement so this value gets re-evaluated on restart.
 	isVSphereDPLPModernAppEnabled bool
 )
 

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -408,6 +408,10 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
 				clusterFlavor, common.SharedDiskFss, "", "")
 		}
+		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VSphereDPLPModernApp) {
+			go commonco.ContainerOrchestratorUtility.HandleLateEnablementOfCapability(ctx,
+				clusterFlavor, common.VSphereDPLPModernApp, "", "")
+		}
 		IsVsanFileVolumeServiceEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.VsanFileVolumeService)
 		if !IsVsanFileVolumeServiceEnabled {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PR add the late-enablement support for capability supports_vsphere_dp_lp_modern_app

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
late-enablement support for capability supports_vsphere_dp_lp_modern_app
```
