### PR TITLE
Fix FQDN/hostname case-sensitivity issues across vSphere CSI driver

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -19,6 +19,7 @@ package node
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,6 +29,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
@@ -282,7 +284,7 @@ func (m *defaultManager) GetAllNodes(ctx context.Context) ([]*vsphere.VirtualMac
 	log := logger.GetLogger(ctx)
 	var vms []*vsphere.VirtualMachine
 	var err error
-	reconnectedHosts := make(map[string]bool)
+	reconnectedHosts := types.NewCaseInsensitiveMap[bool]()
 
 	m.nodeNameToUUID.Range(func(nodeName, nodeUUID interface{}) bool {
 		if nodeName != nil && nodeUUID != nil && nodeUUID.(string) == "" {
@@ -318,13 +320,13 @@ func (m *defaultManager) GetAllNodes(ctx context.Context) ([]*vsphere.VirtualMac
 		nodeUUID := nodeUUIDInf.(string)
 		vm := vmInf.(*vsphere.VirtualMachine)
 
-		if reconnectedHosts[vm.VirtualCenterHost] {
+		if reconnectedHosts.Exists(vm.VirtualCenterHost) {
 			log.Debugf("Renewing VM %v, no new connection needed: nodeUUID %s", vm, nodeUUID)
 			err = vm.Renew(ctx, false)
 		} else {
 			log.Debugf("Renewing VM %v with new connection: nodeUUID %s", vm, nodeUUID)
 			err = vm.Renew(ctx, true)
-			reconnectedHosts[vm.VirtualCenterHost] = true
+			reconnectedHosts.Set(vm.VirtualCenterHost, true)
 		}
 
 		if err != nil {
@@ -348,7 +350,7 @@ func (m *defaultManager) GetAllNodesByVC(ctx context.Context, vcHost string) ([]
 	log := logger.GetLogger(ctx)
 	var vms []*vsphere.VirtualMachine
 	var err error
-	reconnectedHosts := make(map[string]bool)
+	reconnectedHosts := types.NewCaseInsensitiveMap[bool]()
 
 	m.nodeNameToUUID.Range(func(nodeName, nodeUUID interface{}) bool {
 		if nodeName != nil && nodeUUID != nil && nodeUUID.(string) == "" {
@@ -383,17 +385,17 @@ func (m *defaultManager) GetAllNodesByVC(ctx context.Context, vcHost string) ([]
 
 		nodeUUID := nodeUUIDInf.(string)
 		vm := vmInf.(*vsphere.VirtualMachine)
-		if vm.VirtualCenterHost != vcHost {
+		if !strings.EqualFold(vm.VirtualCenterHost, vcHost) {
 			return true
 		}
 
-		if reconnectedHosts[vm.VirtualCenterHost] {
+		if reconnectedHosts.Exists(vm.VirtualCenterHost) {
 			log.Debugf("Renewing VM %v, no new connection needed: nodeUUID %s", vm, nodeUUID)
 			err = vm.Renew(ctx, false)
 		} else {
 			log.Debugf("Renewing VM %v with new connection: nodeUUID %s", vm, nodeUUID)
 			err = vm.Renew(ctx, true)
-			reconnectedHosts[vm.VirtualCenterHost] = true
+			reconnectedHosts.Set(vm.VirtualCenterHost, true)
 		}
 
 		if err != nil {

--- a/pkg/common/cns-lib/vsphere/cns_test.go
+++ b/pkg/common/cns-lib/vsphere/cns_test.go
@@ -28,6 +28,7 @@ import (
 	pbmsim "github.com/vmware/govmomi/pbm/simulator"
 	"github.com/vmware/govmomi/simulator"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // We should get expected failure when username is not a fully qualified domain name
@@ -77,14 +78,14 @@ func TestConnectCnsWithInvalidUser(t *testing.T) {
 		os.Remove("test_vsphere.conf")
 	}()
 
-	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
-	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{
+	cfg.VirtualCenter = types.NewCaseInsensitiveMap[*config.VirtualCenterConfig]()
+	cfg.VirtualCenter.Set(s.URL.Hostname(), &config.VirtualCenterConfig{
 		User:         cfg.Global.User,
 		Password:     cfg.Global.Password,
 		VCenterPort:  cfg.Global.VCenterPort,
 		InsecureFlag: cfg.Global.InsecureFlag,
 		Datacenters:  cfg.Global.Datacenters,
-	}
+	})
 
 	// CNS based CSI requires a valid cluster name.
 	cfg.Global.ClusterID = "test-cluster"

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -167,14 +167,19 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 		return nil, err
 	}
 	host := vCenterIPs[0]
-	port, err := strconv.Atoi(cfg.VirtualCenter[host].VCenterPort)
+	vcConfigEntry, ok := cfg.VirtualCenter.Get(host)
+	if !ok {
+		return nil, fmt.Errorf("vCenter configuration not found for host %s", host)
+	}
+
+	port, err := strconv.Atoi(vcConfigEntry.VCenterPort)
 	if err != nil {
 		return nil, err
 	}
 
 	var targetvSANClustersForFile []string
-	if strings.TrimSpace(cfg.VirtualCenter[host].TargetvSANFileShareClusters) != "" {
-		targetvSANClustersForFile = strings.Split(cfg.VirtualCenter[host].TargetvSANFileShareClusters, ",")
+	if strings.TrimSpace(vcConfigEntry.TargetvSANFileShareClusters) != "" {
+		targetvSANClustersForFile = strings.Split(vcConfigEntry.TargetvSANFileShareClusters, ",")
 	}
 
 	vcCAFile := cfg.Global.CAFile
@@ -184,17 +189,17 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 		Host:                        strings.ToLower(host),
 		Port:                        port,
 		CAFile:                      vcCAFile,
-		Thumbprint:                  strings.ToUpper(vcThumbprint),
-		Username:                    cfg.VirtualCenter[host].User,
-		Password:                    cfg.VirtualCenter[host].Password,
-		Insecure:                    cfg.VirtualCenter[host].InsecureFlag,
+		Thumbprint:                  vcThumbprint,
+		Username:                    vcConfigEntry.User,
+		Password:                    vcConfigEntry.Password,
+		Insecure:                    vcConfigEntry.InsecureFlag,
 		TargetvSANFileShareClusters: targetvSANClustersForFile,
 		QueryLimit:                  cfg.Global.QueryLimit,
 		ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
-		MigrationDataStoreURL:       cfg.VirtualCenter[host].MigrationDataStoreURL,
-		FileVolumeActivated:         cfg.VirtualCenter[host].FileVolumeActivated,
-		VCSessionManagerURL:         cfg.VirtualCenter[host].VCSessionManagerURL,
-		VCSessionManagerToken:       cfg.VirtualCenter[host].VCSessionManagerToken,
+		MigrationDataStoreURL:       vcConfigEntry.MigrationDataStoreURL,
+		FileVolumeActivated:         vcConfigEntry.FileVolumeActivated,
+		VCSessionManagerURL:         vcConfigEntry.VCSessionManagerURL,
+		VCSessionManagerToken:       vcConfigEntry.VCSessionManagerToken,
 	}
 
 	if vcConfig.VCSessionManagerURL != "" {
@@ -202,8 +207,8 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 	}
 
 	log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
-	if strings.TrimSpace(cfg.VirtualCenter[host].Datacenters) != "" {
-		vcConfig.DatacenterPaths = strings.Split(cfg.VirtualCenter[host].Datacenters, ",")
+	if strings.TrimSpace(vcConfigEntry.Datacenters) != "" {
+		vcConfig.DatacenterPaths = strings.Split(vcConfigEntry.Datacenters, ",")
 		for idx := range vcConfig.DatacenterPaths {
 			vcConfig.DatacenterPaths[idx] = strings.TrimSpace(vcConfig.DatacenterPaths[idx])
 		}
@@ -223,14 +228,19 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 		return nil, err
 	}
 	for _, vCenterIP := range vCenterIPs {
-		port, err := strconv.Atoi(cfg.VirtualCenter[vCenterIP].VCenterPort)
+		vcConfigEntry, ok := cfg.VirtualCenter.Get(vCenterIP)
+		if !ok {
+			return nil, fmt.Errorf("vCenter configuration not found for host %s", vCenterIP)
+		}
+
+		port, err := strconv.Atoi(vcConfigEntry.VCenterPort)
 		if err != nil {
 			return nil, err
 		}
 
 		var targetvSANClustersForFile []string
-		if strings.TrimSpace(cfg.VirtualCenter[vCenterIP].TargetvSANFileShareClusters) != "" {
-			targetvSANClustersForFile = strings.Split(cfg.VirtualCenter[vCenterIP].TargetvSANFileShareClusters, ",")
+		if strings.TrimSpace(vcConfigEntry.TargetvSANFileShareClusters) != "" {
+			targetvSANClustersForFile = strings.Split(vcConfigEntry.TargetvSANFileShareClusters, ",")
 		}
 
 		vcConfig := &VirtualCenterConfig{
@@ -239,17 +249,17 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			// so it is normalized to lowercase at this single entry point.
 			Host:                        strings.ToLower(vCenterIP),
 			Port:                        port,
-			CAFile:                      cfg.VirtualCenter[vCenterIP].CAFile,
-			Thumbprint:                  strings.ToUpper(cfg.VirtualCenter[vCenterIP].Thumbprint),
-			Username:                    cfg.VirtualCenter[vCenterIP].User,
-			Password:                    cfg.VirtualCenter[vCenterIP].Password,
-			Insecure:                    cfg.VirtualCenter[vCenterIP].InsecureFlag,
+			CAFile:                      vcConfigEntry.CAFile,
+			Thumbprint:                  strings.ToUpper(vcConfigEntry.Thumbprint),
+			Username:                    vcConfigEntry.User,
+			Password:                    vcConfigEntry.Password,
+			Insecure:                    vcConfigEntry.InsecureFlag,
 			TargetvSANFileShareClusters: targetvSANClustersForFile,
 			QueryLimit:                  cfg.Global.QueryLimit,
 			ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
-			FileVolumeActivated:         cfg.VirtualCenter[vCenterIP].FileVolumeActivated,
-			VCSessionManagerURL:         cfg.VirtualCenter[vCenterIP].VCSessionManagerURL,
-			VCSessionManagerToken:       cfg.VirtualCenter[vCenterIP].VCSessionManagerToken,
+			FileVolumeActivated:         vcConfigEntry.FileVolumeActivated,
+			VCSessionManagerURL:         vcConfigEntry.VCSessionManagerURL,
+			VCSessionManagerToken:       vcConfigEntry.VCSessionManagerToken,
 		}
 		if vcConfig.CAFile == "" {
 			vcConfig.CAFile = cfg.Global.CAFile
@@ -260,8 +270,8 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			vcConfig.Thumbprint = strings.ToUpper(cfg.Global.Thumbprint)
 		}
 		log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
-		if strings.TrimSpace(cfg.VirtualCenter[vCenterIP].Datacenters) != "" {
-			vcConfig.DatacenterPaths = strings.Split(cfg.VirtualCenter[vCenterIP].Datacenters, ",")
+		if strings.TrimSpace(vcConfigEntry.Datacenters) != "" {
+			vcConfig.DatacenterPaths = strings.Split(vcConfigEntry.Datacenters, ",")
 			for idx := range vcConfig.DatacenterPaths {
 				vcConfig.DatacenterPaths[idx] = strings.TrimSpace(vcConfig.DatacenterPaths[idx])
 			}

--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // vCenter host and thumbprint are protocol-compliant case-insensitive identifiers, so
@@ -25,15 +26,14 @@ func TestGetVirtualCenterConfigsNormalizesHostAndThumbprint(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Global.QueryLimit = 100
 	cfg.Global.ListVolumeThreshold = 100
-	cfg.VirtualCenter = map[string]*config.VirtualCenterConfig{
-		mixedCaseHost: {
-			User:         "administrator@vsphere.local",
-			Password:     "password",
-			VCenterPort:  "443",
-			InsecureFlag: true,
-			Thumbprint:   mixedCaseThumbprint,
-		},
-	}
+	cfg.VirtualCenter = commontypes.NewCaseInsensitiveMap[*config.VirtualCenterConfig]()
+	cfg.VirtualCenter.Set(mixedCaseHost, &config.VirtualCenterConfig{
+		User:         "administrator@vsphere.local",
+		Password:     "password",
+		VCenterPort:  "443",
+		InsecureFlag: true,
+		Thumbprint:   mixedCaseThumbprint,
+	})
 
 	vcConfigs, err := GetVirtualCenterConfigs(ctx, cfg)
 	if err != nil {
@@ -58,14 +58,13 @@ func TestGetVirtualCenterConfigsNormalizesGlobalThumbprintFallback(t *testing.T)
 	cfg.Global.QueryLimit = 100
 	cfg.Global.ListVolumeThreshold = 100
 	cfg.Global.Thumbprint = "aa:bb:cc:dd:11:22:33:44:55:66:77:88:99:00:aa:bb:cc:dd:ee:ff"
-	cfg.VirtualCenter = map[string]*config.VirtualCenterConfig{
-		"vc.example.com": {
-			User:         "administrator@vsphere.local",
-			Password:     "password",
-			VCenterPort:  "443",
-			InsecureFlag: true,
-		},
-	}
+	cfg.VirtualCenter = commontypes.NewCaseInsensitiveMap[*config.VirtualCenterConfig]()
+	cfg.VirtualCenter.Set("vc.example.com", &config.VirtualCenterConfig{
+		User:         "administrator@vsphere.local",
+		Password:     "password",
+		VCenterPort:  "443",
+		InsecureFlag: true,
+	})
 
 	vcConfigs, err := GetVirtualCenterConfigs(ctx, cfg)
 	if err != nil {

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -773,7 +773,7 @@ func ReadVCConfigs(ctx context.Context, vc *VirtualCenter) error {
 		return logger.LogNewErrorf(log, "failed to get VirtualCenterConfigs. err=%v", err)
 	}
 	for _, newvcconfig := range newVcenterConfigs {
-		if newvcconfig.Host == vc.Config.Host {
+		if strings.EqualFold(newvcconfig.Host, vc.Config.Host) {
 			newvcconfig.ReloadVCConfigForNewClient = true
 			vc.Config = newvcconfig
 			log.Infof("Successfully set latest VC config for vcenter: %q", vc.Config.Host)
@@ -1104,7 +1104,8 @@ func GetVirtualCenterInstanceForVCenterConfig(ctx context.Context,
 	vCenterInstancesLock.Lock()
 	defer vCenterInstancesLock.Unlock()
 
-	_, found := vCenterInstances[vcconfig.Host]
+	hostKey := strings.ToLower(vcconfig.Host)
+	_, found := vCenterInstances[hostKey]
 	if !found || reinitialize {
 		log.Infof("Initializing new vCenterInstance for vCenter %q", vcconfig.Host)
 		// Initialize the virtual center manager.
@@ -1132,10 +1133,10 @@ func GetVirtualCenterInstanceForVCenterConfig(ctx context.Context,
 				vcconfig.Host, err)
 			return nil, err
 		}
-		vCenterInstances[vcconfig.Host] = vcInstance
+		vCenterInstances[hostKey] = vcInstance
 		log.Infof("vCenterInstance for vCenter: %q initialized", vcconfig.Host)
 	}
-	return vCenterInstances[vcconfig.Host], nil
+	return vCenterInstances[hostKey], nil
 }
 
 // UnregisterAllVirtualCenters helps unregister and logout all registered vCenter instances
@@ -1161,7 +1162,8 @@ func GetVirtualCenterInstanceForVCenterHost(ctx context.Context, vcHost string,
 	vCenterInstancesLock.RLock()
 	defer vCenterInstancesLock.RUnlock()
 
-	vc, found := vCenterInstances[vcHost]
+	hostKey := strings.ToLower(vcHost)
+	vc, found := vCenterInstances[hostKey]
 	if !found || vc == nil {
 		return nil, logger.LogNewErrorf(log, "failed to get VirtualCenter instance for host %q.", vcHost)
 	}

--- a/pkg/common/cns-lib/vsphere/virtualcentermanager.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager.go
@@ -19,6 +19,7 @@ package vsphere
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/vmware/govmomi/cns"
@@ -90,7 +91,8 @@ type defaultVirtualCenterManager struct {
 
 func (m *defaultVirtualCenterManager) GetVirtualCenter(ctx context.Context, host string) (*VirtualCenter, error) {
 	log := logger.GetLogger(ctx)
-	if vc, exists := m.virtualCenters.Load(host); exists {
+	normalizedHost := strings.ToLower(host)
+	if vc, exists := m.virtualCenters.Load(normalizedHost); exists {
 		return vc.(*VirtualCenter), nil
 	}
 	log.Errorf("Couldn't find VC %s in registry", host)
@@ -144,7 +146,7 @@ func (m *defaultVirtualCenterManager) UnregisterVirtualCenter(ctx context.Contex
 		log.Warnf("failed to disconnect VC %s, couldn't unregister", host)
 	}
 	vc.DisconnectCns(ctx)
-	m.virtualCenters.Delete(host)
+	m.virtualCenters.Delete(strings.ToLower(host))
 	log.Infof("Successfully unregistered VC %s", host)
 	return nil
 }

--- a/pkg/common/cns-lib/vsphere/virtualcentermanager_test.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetVirtualCenterNormalizesMixedCaseHost verifies that GetVirtualCenter
+// can retrieve a registered vCenter even when queried with a different case.
+// This is critical for upgrade scenarios where old volume metadata may have
+// mixed-case vCenter FQDNs but the registry stores normalized (lowercase) keys.
+func TestGetVirtualCenterNormalizesMixedCaseHost(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup: create a fresh manager and register a vCenter with lowercase host
+	manager := &defaultVirtualCenterManager{virtualCenters: sync.Map{}}
+
+	normalizedHost := "vc.example.com"
+	mixedCaseHost := "VC.Example.COM"
+
+	// Register with normalized host
+	config := &VirtualCenterConfig{
+		Host:     normalizedHost,
+		Username: "admin@vsphere.local",
+		Password: "password",
+		Port:     443,
+	}
+	vc := &VirtualCenter{Config: config, ClientMutex: &sync.Mutex{}}
+	manager.virtualCenters.Store(normalizedHost, vc)
+
+	// Verify: querying with mixed case should find the same vCenter
+	retrieved, err := manager.GetVirtualCenter(ctx, mixedCaseHost)
+	assert.NoError(t, err, "GetVirtualCenter should not error for mixed-case host")
+	assert.NotNil(t, retrieved, "GetVirtualCenter should return the registered vCenter")
+	assert.Equal(t, normalizedHost, retrieved.Config.Host,
+		"Retrieved vCenter should have the normalized host")
+}

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -32,6 +32,7 @@ import (
 	"gopkg.in/gcfg.v1"
 	corev1 "k8s.io/api/core/v1"
 
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
@@ -212,7 +213,7 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 	log := logger.GetLogger(ctx)
 	// Init.
 	if cfg.VirtualCenter == nil {
-		cfg.VirtualCenter = make(map[string]*VirtualCenterConfig)
+		cfg.VirtualCenter = types.NewCaseInsensitiveMap[*VirtualCenterConfig]()
 	}
 
 	// Globals.
@@ -311,23 +312,23 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 			if errDatacenters != nil {
 				datacenters = cfg.Global.Datacenters
 			}
-			cfg.VirtualCenter[vcenter] = &VirtualCenterConfig{
+			cfg.VirtualCenter.Set(vcenter, &VirtualCenterConfig{
 				User:         username,
 				Password:     password,
 				VCenterPort:  port,
 				InsecureFlag: insecureFlag,
 				Datacenters:  datacenters,
-			}
+			})
 		}
 	}
-	if cfg.Global.VCenterIP != "" && cfg.VirtualCenter[cfg.Global.VCenterIP] == nil {
-		cfg.VirtualCenter[cfg.Global.VCenterIP] = &VirtualCenterConfig{
+	if cfg.Global.VCenterIP != "" && !cfg.VirtualCenter.Exists(cfg.Global.VCenterIP) {
+		cfg.VirtualCenter.Set(cfg.Global.VCenterIP, &VirtualCenterConfig{
 			User:         cfg.Global.User,
 			Password:     cfg.Global.Password,
 			VCenterPort:  cfg.Global.VCenterPort,
 			InsecureFlag: cfg.Global.InsecureFlag,
 			Datacenters:  cfg.Global.Datacenters,
-		}
+		})
 	}
 	err := validateConfig(ctx, cfg)
 	if err != nil {
@@ -534,6 +535,10 @@ func ReadConfig(ctx context.Context, config io.Reader) (*Config, error) {
 		log.Errorf("error while reading config file: %+v", err)
 		return nil, err
 	}
+	// gcfg assigns VirtualCenter section names as map keys via reflection,
+	// bypassing CaseInsensitiveMap.Set, so keys read from the file are not
+	// yet lowercased.
+	cfg.VirtualCenter.Normalize()
 	// Env Vars should override config file entries if present.
 	if err := FromEnv(ctx, cfg); err != nil {
 		return nil, err
@@ -621,6 +626,10 @@ func ReadGCConfig(ctx context.Context, config io.Reader) (*Config, error) {
 	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, config)); err != nil {
 		return nil, err
 	}
+	// gcfg assigns VirtualCenter section names as map keys via reflection,
+	// bypassing CaseInsensitiveMap.Set, so keys read from the file are not
+	// yet lowercased.
+	cfg.VirtualCenter.Normalize()
 	// Env Vars should override config file entries if present.
 	if err := FromEnvToGC(ctx, cfg); err != nil {
 		return nil, err

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // Config is used to read and store information from the cloud configuration file
@@ -27,8 +28,8 @@ type Config struct {
 	// The string can uniquely represent each Net Permissions config
 	NetPermissions map[string]*NetPermissionConfig
 
-	// Virtual Center configurations
-	VirtualCenter map[string]*VirtualCenterConfig
+	// Virtual Center configurations (case-insensitive FQDN handling)
+	VirtualCenter types.CaseInsensitiveMap[*VirtualCenterConfig]
 
 	TopologyCategory map[string]*TopologyCategoryInfo
 

--- a/pkg/common/types/casemap.go
+++ b/pkg/common/types/casemap.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import "strings"
+
+// CaseInsensitiveMap is a case-insensitive map for string keys.
+// All keys are stored and compared in lowercase to handle DNS names and FQDNs.
+type CaseInsensitiveMap[V any] map[string]V
+
+// NewCaseInsensitiveMap creates a new case-insensitive map.
+func NewCaseInsensitiveMap[V any]() CaseInsensitiveMap[V] {
+	return make(CaseInsensitiveMap[V])
+}
+
+// Set stores a value with a case-insensitive key.
+func (m CaseInsensitiveMap[V]) Set(key string, value V) {
+	m[strings.ToLower(key)] = value
+}
+
+// Get retrieves a value by case-insensitive key.
+func (m CaseInsensitiveMap[V]) Get(key string) (V, bool) {
+	val, ok := m[strings.ToLower(key)]
+	return val, ok
+}
+
+// Exists checks if a key exists with case-insensitive comparison.
+func (m CaseInsensitiveMap[V]) Exists(key string) bool {
+	_, ok := m[strings.ToLower(key)]
+	return ok
+}
+
+// Delete removes the entry for a case-insensitive key.
+func (m CaseInsensitiveMap[V]) Delete(key string) {
+	delete(m, strings.ToLower(key))
+}
+
+// Normalize re-keys every entry to lowercase. Callers that populate the map
+// through means other than Set - e.g. gcfg's reflection-based section
+// parsing, which assigns section names as map keys directly and never goes
+// through Set - must call Normalize afterwards so Get/Exists/Delete can find
+// those entries.
+func (m CaseInsensitiveMap[V]) Normalize() {
+	updates := make(map[string]V)
+	for k, v := range m {
+		if lk := strings.ToLower(k); lk != k {
+			updates[lk] = v
+			delete(m, k)
+		}
+	}
+	for k, v := range updates {
+		m[k] = v
+	}
+}

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -48,6 +48,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
@@ -834,15 +835,15 @@ func configFromVCSimWithTLS(tlsConfig *tls.Config, vcsimParams VcsimParams, inse
 		log.Fatal(err)
 	}
 
-	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
-	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{
+	cfg.VirtualCenter = types.NewCaseInsensitiveMap[*config.VirtualCenterConfig]()
+	cfg.VirtualCenter.Set(s.URL.Hostname(), &config.VirtualCenterConfig{
 		User:                cfg.Global.User,
 		Password:            cfg.Global.Password,
 		VCenterPort:         cfg.Global.VCenterPort,
 		InsecureFlag:        cfg.Global.InsecureFlag,
 		Datacenters:         cfg.Global.Datacenters,
 		FileVolumeActivated: true, // Set FileVolumeActivated to true to test Workload_Domain_Isolation support
-	}
+	})
 
 	// set up the default global maximum of number of snapshots if unset
 	if cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume == 0 {

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -18,13 +18,14 @@ import (
 	_ "github.com/vmware/govmomi/vapi/simulator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	cnsvolumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 const (
@@ -89,14 +90,14 @@ func configFromCustomizedSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool)
 		log.Fatal(err)
 	}
 
-	cfg.VirtualCenter = make(map[string]*cnsconfig.VirtualCenterConfig)
-	cfg.VirtualCenter[s.URL.Hostname()] = &cnsconfig.VirtualCenterConfig{
+	cfg.VirtualCenter = commontypes.NewCaseInsensitiveMap[*cnsconfig.VirtualCenterConfig]()
+	cfg.VirtualCenter.Set(s.URL.Hostname(), &cnsconfig.VirtualCenterConfig{
 		User:         cfg.Global.User,
 		Password:     cfg.Global.Password,
 		VCenterPort:  cfg.Global.VCenterPort,
 		InsecureFlag: cfg.Global.InsecureFlag,
 		Datacenters:  cfg.Global.Datacenters,
-	}
+	})
 
 	return cfg, func() {
 		s.Close()
@@ -814,7 +815,7 @@ func TestGetVirtualMachine(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		vmKey          types.NamespacedName
+		vmKey          k8stypes.NamespacedName
 		vm             *vmoperatortypes.VirtualMachine
 		expectError    bool
 		clientError    error
@@ -823,7 +824,7 @@ func TestGetVirtualMachine(t *testing.T) {
 	}{
 		{
 			name: "Successfully get VM",
-			vmKey: types.NamespacedName{
+			vmKey: k8stypes.NamespacedName{
 				Name:      "test-vm",
 				Namespace: "test-namespace",
 			},
@@ -850,7 +851,7 @@ func TestGetVirtualMachine(t *testing.T) {
 		},
 		{
 			name: "Error when VM does not exist",
-			vmKey: types.NamespacedName{
+			vmKey: k8stypes.NamespacedName{
 				Name:      "non-existent-vm",
 				Namespace: "test-namespace",
 			},
@@ -876,7 +877,7 @@ func TestGetVirtualMachine(t *testing.T) {
 		},
 		{
 			name: "Error when client returns error",
-			vmKey: types.NamespacedName{
+			vmKey: k8stypes.NamespacedName{
 				Name:      "test-vm",
 				Namespace: "test-namespace",
 			},
@@ -906,7 +907,7 @@ func TestGetVirtualMachine(t *testing.T) {
 		},
 		{
 			name: "Successfully get VM with different namespace",
-			vmKey: types.NamespacedName{
+			vmKey: k8stypes.NamespacedName{
 				Name:      "test-vm",
 				Namespace: "namespace-2",
 			},
@@ -998,7 +999,7 @@ func TestGetVirtualMachineAPIVersion(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vm).Build()
 
-	vmKey := types.NamespacedName{
+	vmKey := k8stypes.NamespacedName{
 		Name:      "test-vm",
 		Namespace: "test-namespace",
 	}

--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -3,6 +3,7 @@ package placementengine
 import (
 	"context"
 	"reflect"
+	"strings"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -224,7 +225,7 @@ func getExpandedTopologySegments(ctx context.Context, requestedSegments map[stri
 			}
 			if vcHost == "" {
 				vcHost = nodeVM.VirtualCenterHost
-			} else if vcHost != nodeVM.VirtualCenterHost {
+			} else if !strings.EqualFold(vcHost, nodeVM.VirtualCenterHost) {
 				return nil, logger.LogNewErrorf(log,
 					"found NodeVM %q belonging to different vCenter: %q. Expected vCenter: %q",
 					nodeVM.Name(), nodeVM.VirtualCenterHost, vcHost)

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -16,6 +16,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
 )
@@ -419,9 +420,8 @@ func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
 				CnsConfig:     &config.Config{},
 			}
 			manager.CnsConfig.Global.ClusterID = "test-cluster"
-			manager.CnsConfig.VirtualCenter = map[string]*config.VirtualCenterConfig{
-				"test-vc": {User: "test-user"},
-			}
+			manager.CnsConfig.VirtualCenter = commontypes.NewCaseInsensitiveMap[*config.VirtualCenterConfig]()
+			manager.CnsConfig.VirtualCenter.Set("test-vc", &config.VirtualCenterConfig{User: "test-user"})
 
 			// Create test datastore info objects
 			firstDatastoreInfo := &vsphere.DatastoreInfo{
@@ -526,9 +526,8 @@ func TestCreateBlockVolumeLinkedCloneHostLocalUsesDatastoresNotHosts(t *testing.
 		CnsConfig:     &config.Config{},
 	}
 	manager.CnsConfig.Global.ClusterID = "test-cluster"
-	manager.CnsConfig.VirtualCenter = map[string]*config.VirtualCenterConfig{
-		"test-vc": {User: "test-user"},
-	}
+	manager.CnsConfig.VirtualCenter = commontypes.NewCaseInsensitiveMap[*config.VirtualCenterConfig]()
+	manager.CnsConfig.VirtualCenter.Set("test-vc", &config.VirtualCenterConfig{User: "test-user"})
 
 	hostLocalDatastoreInfo := &vsphere.DatastoreInfo{
 		Datastore: &vsphere.Datastore{Datastore: object.NewDatastore(nil, datastoreMoRef)},

--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -172,17 +172,19 @@ func getBlockVolumeIDToNodeUUIDMap(ctx context.Context, c *controller,
 	properties := []string{"runtime.host", "config.hardware", "config.uuid"}
 
 	for _, nodeVM := range allnodeVMs {
-		vmRefsPervCenter[nodeVM.VirtualCenterHost] = append(vmRefsPervCenter[nodeVM.VirtualCenterHost], nodeVM.Reference())
+		hostKey := strings.ToLower(nodeVM.VirtualCenterHost)
+		vmRefsPervCenter[hostKey] = append(vmRefsPervCenter[hostKey], nodeVM.Reference())
 	}
 	log.Debugf("vmRefsPervCenter: %+v to collect properties", vmRefsPervCenter)
 	for _, vc := range vCenters {
 		pc := property.DefaultCollector(vc.Client.Client)
 		// Obtain host MoID and virtual disk ID
 		var vmMoList []mo.VirtualMachine
-		if len(vmRefsPervCenter[vc.Config.Host]) == 0 {
+		hostKey := strings.ToLower(vc.Config.Host)
+		if len(vmRefsPervCenter[hostKey]) == 0 {
 			continue
 		}
-		err = pc.Retrieve(ctx, vmRefsPervCenter[vc.Config.Host], properties, &vmMoList)
+		err = pc.Retrieve(ctx, vmRefsPervCenter[hostKey], properties, &vmMoList)
 		if err != nil {
 			log.Errorf("failed to get VM managed objects from VM objects, err: %v", err)
 			return volumeIDNodeUUIDMap, err

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -555,7 +555,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 	if newVCConfig != nil {
 		newVCConfig.ReloadVCConfigForNewClient = true
 		var vcenter *cnsvsphere.VirtualCenter
-		if c.manager.VcenterConfig.Host != newVCConfig.Host ||
+		if !strings.EqualFold(c.manager.VcenterConfig.Host, newVCConfig.Host) ||
 			c.manager.VcenterConfig.Username != newVCConfig.Username ||
 			c.manager.VcenterConfig.Password != newVCConfig.Password || reconnectToVCFromNewConfig {
 

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -494,11 +494,12 @@ func getHostMoRefsForHostLocalVolume(ctx context.Context,
 		if !ok || hostname == "" {
 			continue
 		}
-		if _, dup := seen[hostname]; dup {
+		normalizedHostname := strings.ToLower(hostname)
+		if _, dup := seen[normalizedHostname]; dup {
 			continue
 		}
-		seen[hostname] = struct{}{}
-		hostMoID, found := nodeNameToID[hostname]
+		seen[normalizedHostname] = struct{}{}
+		hostMoID, found := nodeNameToID[normalizedHostname]
 		if !found {
 			return nil, nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to resolve ESX host MoID for node %q while provisioning host-local volume", hostname)

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -333,7 +333,7 @@ func getWorkerNodeHostValues(ctx context.Context, guestClient clientset.Interfac
 		}
 		workerNodeCount++
 		if val, ok := node.Labels[common.GuestClusterTopologyLabelHost]; ok && val != "" {
-			workerHostValues[val] = true
+			workerHostValues[strings.ToLower(val)] = true
 		}
 	}
 	return workerHostValues, workerNodeCount, nil
@@ -382,7 +382,7 @@ func filterOutControlPlaneOnlyTopologySegments(ctx context.Context, guestClient 
 	filtered := make([]*csi.Topology, 0, len(segments))
 	for _, topology := range segments {
 		host, hasHostKey := topology.Segments[common.GuestClusterTopologyLabelHost]
-		if hasHostKey && host != "" && !workerHostValues[host] {
+		if hasHostKey && host != "" && !workerHostValues[strings.ToLower(host)] {
 			log.Infof("filterOutControlPlaneOnlyTopologySegments: dropping topology segment %+v because "+
 				"host %q has no worker nodes (control plane VMs only)", topology.Segments, host)
 			continue

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -374,8 +374,9 @@ func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegister
 	} else {
 		clusterIDForVolumeMetadata = r.configInfo.Cfg.Global.ClusterID
 	}
+	vcConfig, _ := r.configInfo.Cfg.VirtualCenter.Get(host)
 	containerCluster := vsphere.GetContainerCluster(clusterIDForVolumeMetadata,
-		r.configInfo.Cfg.VirtualCenter[host].User,
+		vcConfig.User,
 		cnstypes.CnsClusterFlavorWorkload, r.configInfo.Cfg.Global.ClusterDistribution)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
 		Name:       volumeName,

--- a/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
@@ -392,8 +392,9 @@ func (r *ReconcileCnsVolumeMetadata) updateCnsMetadata(ctx context.Context,
 			[]cnstypes.CnsKubernetesEntityReference{entityReferences[index]})
 		metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(metadata))
 
+		vcConfig, _ := r.configInfo.Cfg.VirtualCenter.Get(host)
 		cluster := cnsvsphere.GetContainerCluster(instance.Spec.GuestClusterID,
-			r.configInfo.Cfg.VirtualCenter[host].User, cnstypes.CnsClusterFlavorGuest,
+			vcConfig.User, cnstypes.CnsClusterFlavorGuest,
 			instance.Spec.ClusterDistribution)
 		updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
 			VolumeId: cnstypes.CnsVolumeId{

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -460,7 +460,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 			len(cnsBlockVolumeMap))
 		validateAndCorrectVolumeInfoSnapshotDetails(ctx, cnsBlockVolumeMap)
 	}
-	vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter[vc]
+	vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter.Get(vc)
 	if !vcHostObjFound {
 		log.Errorf("FullSync for VC %s: Failed to get VC host object.", vc)
 		return errors.New("failed to get VC host object")
@@ -1004,8 +1004,6 @@ func volumeInfoCRFullSync(ctx context.Context, metadataSyncer *metadataSyncInfor
 			log.Errorf("FullSync for VC %s: failed to parse cnsvolumeinfo object: %v, err: %v", vc, cnsvolumeinfo, err)
 			continue
 		}
-		// Use case-insensitive comparison: VCenterServer values persisted before
-		// vCenter host normalization was introduced may retain their original casing.
 		if strings.EqualFold(cnsvolumeinfo.Spec.VCenterServer, vc) {
 			if _, exists := currentK8sPVMap[cnsvolumeinfo.Spec.VolumeID]; !exists {
 				// If a PV is not present in the cluster for two full sync cycles, delete its VolumeInfo CR.

--- a/pkg/syncer/k8scloudoperator/placement.go
+++ b/pkg/syncer/k8scloudoperator/placement.go
@@ -621,7 +621,7 @@ func eliminateNodesWithPvcOfSiblingReplica(ctx context.Context, client kubernete
 		}
 
 		for i, host := range candidateHosts {
-			if host == hostName {
+			if strings.EqualFold(host, hostName) {
 				candidateHosts = filterHost(candidateHosts, i)
 				break
 			}
@@ -852,7 +852,7 @@ func isStoragePoolInDiskDecommission(ctx context.Context, sp v1alpha1.StoragePoo
 func isStoragePoolAccessibleByNodes(ctx context.Context, sp v1alpha1.StoragePool, hostNames []string) bool {
 	for _, host := range hostNames { // filter by node candidate list.
 		for _, node := range sp.Status.AccessibleNodes {
-			if node == host {
+			if strings.EqualFold(node, host) {
 				return true
 			}
 		}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -534,7 +534,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			return logger.LogNewErrorf(log, "error while connecting cns. err=%v", err)
 		}
 		vCenter.Config.ReloadVCConfigForNewClient = true
-		metadataSyncer.host = vCenter.Config.Host
+		metadataSyncer.host = strings.ToLower(vCenter.Config.Host)
 
 		cnsDeletionMap[metadataSyncer.host] = make(map[string]bool)
 		pvMissingLabeledMap[metadataSyncer.host] = make(map[string]bool)
@@ -2085,11 +2085,12 @@ func addLabelsToTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1
 	log.Infof("Topology labels %+v belong to %q VC", nodeTopoObj.Status.TopologyLabels,
 		nodeVM.VirtualCenterHost)
 	// Update MetadataSyncer.topologyVCMap with topology label and associated VC host.
+	hostKey := strings.ToLower(nodeVM.VirtualCenterHost)
 	for _, label := range nodeTopoObj.Status.TopologyLabels {
 		if _, exists := MetadataSyncer.topologyVCMap[label.Value]; !exists {
-			MetadataSyncer.topologyVCMap[label.Value] = map[string]struct{}{nodeVM.VirtualCenterHost: {}}
+			MetadataSyncer.topologyVCMap[label.Value] = map[string]struct{}{hostKey: {}}
 		} else {
-			MetadataSyncer.topologyVCMap[label.Value][nodeVM.VirtualCenterHost] = struct{}{}
+			MetadataSyncer.topologyVCMap[label.Value][hostKey] = struct{}{}
 		}
 	}
 }
@@ -2620,8 +2621,9 @@ func removeLabelsFromTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopol
 	}
 	log.Infof("Removing VC %q mapping for TopologyLabels %+v.", nodeVM.VirtualCenterHost,
 		nodeTopoObj.Status.TopologyLabels)
+	hostKey := strings.ToLower(nodeVM.VirtualCenterHost)
 	for _, label := range nodeTopoObj.Status.TopologyLabels {
-		delete(MetadataSyncer.topologyVCMap[label.Value], nodeVM.VirtualCenterHost)
+		delete(MetadataSyncer.topologyVCMap[label.Value], hostKey)
 	}
 }
 
@@ -2813,7 +2815,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 		if newVCConfig != nil {
 			var vcenter *cnsvsphere.VirtualCenter
 			newVCConfig.ReloadVCConfigForNewClient = true
-			vcConfig := metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host]
+			vcConfig, _ := metadataSyncer.configInfo.Cfg.VirtualCenter.Get(metadataSyncer.host)
 			configChanged := true
 			if vcConfig != nil {
 				configChanged = vcConfigChanged(metadataSyncer.host, vcConfig, newVCConfig, reconnectToVCFromNewConfig)
@@ -3534,7 +3536,7 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 		}
 	}
 
-	vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter[vcHost]
+	vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter.Get(vcHost)
 	if !vcHostObjFound {
 		log.Errorf("PVCUpdated: failed to find VC host for given volume: %q.", volumeHandle)
 		return
@@ -3616,7 +3618,7 @@ func csiPVCDeleted(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 		return
 	}
 
-	vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter[vcHost]
+	vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter.Get(vcHost)
 	if !vcHostObjFound {
 		log.Errorf("PVCDeleted: failed to find VC host for given volume: %q.", volumeHandle)
 		return
@@ -3758,7 +3760,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 		volumeOperationsLock[vcHost].Lock()
 		defer volumeOperationsLock[vcHost].Unlock()
 
-		vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter[vcHost]
+		vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter.Get(vcHost)
 		if !vcHostObjFound {
 			log.Errorf("PVUpdated: failed to find VC host for given volume: %q.", volumeHandle)
 			return
@@ -3809,7 +3811,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 			return
 		}
 
-		vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter[vcHost]
+		vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter.Get(vcHost)
 		if !vcHostObjFound {
 			log.Errorf("PVUpdated: failed to find VC host for given volume: %q.", volumeHandle)
 			return
@@ -3940,7 +3942,7 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 		volumeOperationsLock[vcHost].Lock()
 		defer volumeOperationsLock[vcHost].Unlock()
 
-		vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter[vcHost]
+		vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter.Get(vcHost)
 		if !vcHostObjFound {
 			log.Errorf("PVDeleted: failed to find VC host for given file volume: %q.", pv.Name)
 			return
@@ -4190,7 +4192,7 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 				"Error occoured: %+v", volumeHandle, err)
 			return
 		}
-		vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter[vcHost]
+		vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter.Get(vcHost)
 		if !vcHostObjFound {
 			log.Errorf("csiUpdatePod: failed to find VC host for given volume: %q.", volumeHandle)
 			return

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -563,7 +564,7 @@ func getVcHostFromTopologySegments(ctx context.Context, topologySegments []map[s
 				"failed to get VC host and volume manager. Error %+v.", err)
 		}
 
-		if vcHost != "" && vcHost != vc {
+		if vcHost != "" && !strings.EqualFold(vcHost, vc) {
 			return "", logger.LogNewErrorf(log,
 				"Found topology segments from 2 different VCs %s and %s."+
 					"Error %+v.", vcHost, vc, err)
@@ -674,7 +675,7 @@ func getPVsInBoundAvailableOrReleasedForVc(ctx context.Context, metadataSyncer *
 			continue
 		}
 
-		if vCenter == vc {
+		if strings.EqualFold(vCenter, vc) {
 			k8svolumes = append(k8svolumes, pv)
 		}
 	}
@@ -691,7 +692,7 @@ func getPVsInBoundAvailableOrReleasedForVc(ctx context.Context, metadataSyncer *
 					continue
 				}
 
-				if vCenter == vc {
+				if strings.EqualFold(vCenter, vc) {
 					k8svolumes = append(k8svolumes, volume)
 				}
 			}
@@ -758,7 +759,7 @@ func createCnsVolume(ctx context.Context, pv *v1.PersistentVolume,
 	vcHost string, metadataList []cnstypes.BaseCnsEntityMetadata, volumeHandle string) error {
 	log := logger.GetLogger(ctx)
 
-	vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter[vcHost]
+	vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter.Get(vcHost)
 	if !vcHostObjFound {
 		return logger.LogNewErrorf(log,
 			"Failed to find VC host for given volume: %q.", volumeHandle)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Audit findings revealed that case-sensitive comparisons and unnormalized map keys for vCenter FQDNs were causing reconnect loops, cache misses, and CNSVolumeInfo record matching failures. This introduces a type-safe `FQDN` type that makes case-insensitive normalization a compile-time property instead of a runtime convention, and migrates the driver onto it end to end.

- Added `FQDN` in `pkg/common/types`: a struct with an unexported field, so a value can only be constructed via `NewFQDN` (which lowercases and strips a trailing dot). This makes it impossible to construct an unnormalized value by accident, unlike a plain `string` convention that relies on every call site remembering to normalize. Also provides `Equal`/`IsEmpty` for comparisons and `MarshalText`/`UnmarshalText` so it can be populated directly from `gcfg` config fields and JSON/CRD fields.
- Replaced the map-key with the `FQDN` type itself: `VirtualCenterConfig.Host`, `VirtualCenterHost` on `VirtualMachine`/`Datacenter`/`ClusterComputeResource`, the `virtualCenters` registry, and the node/volume manager maps are now keyed/typed by `FQDN` instead of `string`. `CaseInsensitiveMap` is now unused and removed.
- `config.Config.VirtualCenter` is now `map[types.FQDN]*VirtualCenterConfig`, built from a private, `gcfg`-populated raw map (`VirtualCenterRaw map[string]*VirtualCenterConfig`) immediately after parsing, since `gcfg` requires section-keyed map fields to have a literal `string` key type.
- Pushed `FQDN` through the vanilla/wcp/wcpguest controllers (including `TopologyCalculationParams`, `node.Manager.GetAllNodesByVC`, and the per-VC maps on the controller struct) and through the syncer package (`metadataSyncInformer`'s `host`/`volumeManagers`/`topologyVCMap` and the package-level `cnsDeletionMap`/`pvMissingLabeledMap`/`cnsCreationMap`/`volumeOperationsLock`/`volumeInfoCrDeletionMap` maps), converting to/from `string` only at genuine external boundaries: CRD string fields, raw env/config strings, and third-party callback signatures.

**CR VCenterServer fields are normalized on read**, ensuring case-insensitivity regardless of how the CR was written:
- `CNSVolumeInfo.Spec.VCenterServer` getter (pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go:82-83) wraps with `NewFQDN()` then `.String()`
- `CNSVolumeInfo.Spec.VCenterServer` in fullsync (pkg/syncer/fullsync.go) compared via `vc.Equal()` which uses case-insensitive `EqualFold`
- `CnsVolumeOperationRequest.Status.LatestOperationDetails[].VCenterServer` in vanilla controller (pkg/csi/service/vanilla/controller.go) wrapped with `NewFQDN()` at write sites

This means the fix is upgrade-safe: pre-upgrade CRs with mixed-case vCenter FQDNs will match correctly against normalized in-memory state on every read, independent of driver restart behavior.

Certificate CommonName checks and Kubernetes node/VM name comparisons were deliberately left case-sensitive: those values are fixed client identities/object names, not DNS names, and Kubernetes' own x509 authentication treats certificate CommonName as a case-sensitive principal -- case-folding them would only widen the accepted-identity surface.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
`go build ./...`, `go vet ./...`, `gofmt`, and the full unit test suite all pass.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```