### PR TITLE
Fix orphaned CnsVolumeOperationRequest CRs on NotFound delete and warn on stale InProgress instances

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -1722,6 +1722,9 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 		// In such a case, send back success as the volume is already deleted.
 		if IsNotFoundFault(ctx, faultType) {
 			log.Infof("DeleteVolume: VolumeID %q, not found, thus returning success", volumeID)
+			volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
+				nil, volumeOperationDetails.OperationDetails.TaskInvocationTimestamp,
+				task.Reference().Value, "", taskInfo.ActivationId, taskInvocationStatusSuccess, "", "")
 			return "", nil
 		}
 

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -44,6 +44,12 @@ const (
 	// EnvCSINamespace represents the environment variable which
 	// stores the namespace in which the CSI driver is running.
 	EnvCSINamespace = "CSI_NAMESPACE"
+	// staleInProgressWarningThreshold is the age past which an instance still
+	// showing TaskInvocationStatusInProgress is flagged as a likely-orphaned
+	// CnsVolumeOperationRequest. Legitimate CNS tasks complete well within this
+	// window, so an instance older than this has very likely stopped receiving
+	// task-completion updates and will never be cleaned up by this loop.
+	staleInProgressWarningThreshold = 24 * time.Hour
 )
 
 // VolumeOperationRequest is an interface that supports handling idempotency
@@ -445,6 +451,15 @@ func (or *operationRequestStore) cleanupStaleInstances(cleanupInterval int) {
 				if latestOperationDetailsLength != 0 &&
 					instance.Status.LatestOperationDetails[latestOperationDetailsLength-1].TaskStatus ==
 						TaskInvocationStatusInProgress {
+					if time.Since(instance.Status.LatestOperationDetails[latestOperationDetailsLength-1].
+						TaskInvocationTimestamp.Time) > staleInProgressWarningThreshold {
+						log.Warnf("CnsVolumeOperationRequest instance %q has been stuck at TaskStatus "+
+							"InProgress for over %s (since %s). It will never be cleaned up by this loop; "+
+							"this likely indicates a lost task-completion notification and needs manual "+
+							"investigation.", instance.Name, staleInProgressWarningThreshold,
+							instance.Status.LatestOperationDetails[latestOperationDetailsLength-1].
+								TaskInvocationTimestamp.Time)
+					}
 					continue
 				}
 				// Delete instance if TaskInvocationTimestamp is older than 15 minutes


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix orphaned CnsVolumeOperationRequest CRs on NotFound delete and warn on stale InProgress instances

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Run e2e tests

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix orphaned CnsVolumeOperationRequest CRs on NotFound delete and warn on stale InProgress instances
```
