### PR TITLE
Fix raw block volume publish for multiple pods on a single node

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -715,28 +715,22 @@ func (osUtils *OsUtils) PublishBlockVol(
 	}
 	log.Debugf("publishBlockVol: device %+v, device mounts %q", *dev, devMnts)
 
-	// Check if device is already mounted.
-	if len(devMnts) == 0 {
-		// Do the bind mount.
-		mntFlags := make([]string, 0)
-		log.Debugf("PublishBlockVolume: Attempting to bind mount %q to %q with mount flags %v",
-			dev.FullPath, params.Target, mntFlags)
-		if err := gofsutil.BindMount(ctx, dev.FullPath, params.Target, mntFlags...); err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"error mounting volume. Parameters: %v err: %v", params, err)
-		}
-		log.Debugf("PublishBlockVolume: Bind mount successful to path %q", params.Target)
-	} else if len(devMnts) == 1 {
-		// Already mounted, make sure it's what we want.
-		if unescape(ctx, devMnts[0].Path) != params.Target {
-			return nil, logger.LogNewErrorCode(log, codes.Internal,
-				"device already in use and mounted elsewhere")
-		}
-		log.Debugf("Volume already published to target. Parameters: [%+v]", params)
-	} else {
-		return nil, logger.LogNewErrorCode(log, codes.AlreadyExists,
-			"block volume already mounted in more than one place")
+	// Check if volume is already published to the requested target.
+	if isTargetInMounts(ctx, params.Target, devMnts) {
+		log.Infof("Volume already published to target. Parameters: [%+v]", params)
+		return &csi.NodePublishVolumeResponse{}, nil
 	}
+
+	// Bind mount device to target. Multiple pods on the same node each get their
+	// own publish target path, similar to PublishMountVol for filesystem volumes.
+	mntFlags := make([]string, 0)
+	log.Debugf("PublishBlockVolume: Attempting to bind mount %q to %q with mount flags %v",
+		dev.FullPath, params.Target, mntFlags)
+	if err := gofsutil.BindMount(ctx, dev.FullPath, params.Target, mntFlags...); err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"error mounting volume. Parameters: %v err: %v", params, err)
+	}
+	log.Debugf("PublishBlockVolume: Bind mount successful to path %q", params.Target)
 	log.Infof("NodePublishVolume successful to path %q", params.Target)
 	// Existing or new mount satisfies request.
 	return &csi.NodePublishVolumeResponse{}, nil

--- a/pkg/csi/service/osutils/linux_os_utils_test.go
+++ b/pkg/csi/service/osutils/linux_os_utils_test.go
@@ -6,10 +6,16 @@ package osutils
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"testing"
 
+	"github.com/akutz/gofsutil"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 	testingexec "k8s.io/utils/exec/testing"
@@ -345,5 +351,95 @@ func TestUnescape(t *testing.T) {
 				t.Errorf("Expected %q to be unescaped as %q, got %q", test.in, test.out, out)
 			}
 		})
+	}
+}
+
+func TestIsTargetInMounts(t *testing.T) {
+	ctx := context.Background()
+	pod1Target := "/var/lib/kubelet/pods/pod-1/volumeDevices/kubernetes.io~csi/pvc-abc/vol"
+	pod2Target := "/var/lib/kubelet/pods/pod-2/volumeDevices/kubernetes.io~csi/pvc-abc/vol"
+
+	tests := []struct {
+		name   string
+		target string
+		mnts   []gofsutil.Info
+		want   bool
+	}{
+		{
+			name:   "no existing mounts",
+			target: pod1Target,
+			mnts:   nil,
+			want:   false,
+		},
+		{
+			name:   "first pod publish target",
+			target: pod1Target,
+			mnts: []gofsutil.Info{
+				{Device: "/dev/sdb", Path: pod1Target},
+			},
+			want: true,
+		},
+		{
+			name:   "second pod publish target while first is mounted",
+			target: pod2Target,
+			mnts: []gofsutil.Info{
+				{Device: "/dev/sdb", Path: pod1Target},
+			},
+			want: false,
+		},
+		{
+			name:   "second pod target among multiple mounts",
+			target: pod2Target,
+			mnts: []gofsutil.Info{
+				{Device: "/dev/sdb", Path: pod1Target},
+				{Device: "/dev/sdb", Path: pod2Target},
+			},
+			want: true,
+		},
+		{
+			name:   "escaped mount path matches unescaped target",
+			target: "/var/lib/kubelet/pods/pod-1/volumeDevices/kubernetes.io~csi/foo bar/vol",
+			mnts: []gofsutil.Info{
+				{Device: "/dev/sdb", Path: `/var/lib/kubelet/pods/pod-1/volumeDevices/kubernetes.io~csi/foo\040bar/vol`},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isTargetInMounts(ctx, tc.target, tc.mnts); got != tc.want {
+				t.Fatalf("isTargetInMounts(%q) = %v, want %v", tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPublishBlockVol_ReadOnlyRejected(t *testing.T) {
+	ctx := context.Background()
+	target := filepath.Join(t.TempDir(), "vol")
+	if err := os.WriteFile(target, nil, 0o644); err != nil {
+		t.Fatalf("failed to create target file: %v", err)
+	}
+
+	osUtils := &OsUtils{
+		Mounter: &mount.SafeFormatAndMount{Interface: mount.NewFakeMounter(nil)},
+	}
+	req := &csi.NodePublishVolumeRequest{VolumeId: "vol-1"}
+	dev := &Device{FullPath: "/dev/sdb", RealDev: "/dev/sdb"}
+	params := NodePublishParams{
+		VolID:  "vol-1",
+		Target: target,
+		Ro:     true,
+	}
+
+	_, err := osUtils.PublishBlockVol(ctx, req, dev, params)
+	if err == nil {
+		t.Fatal("expected read-only block publish to fail")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected %s, got %s: %v", codes.InvalidArgument, status.Code(err), err)
 	}
 }

--- a/tests/e2e/raw_block_volume.go
+++ b/tests/e2e/raw_block_volume.go
@@ -1335,4 +1335,134 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 			volumeSnapshot, pandoraSyncWaitTime, volumeID, snapshotId, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
+	/*
+		Test multiple pods on the same node sharing a single RWO raw block PVC.
+
+		Steps
+		1. Create a raw block PVC.
+		2. Create pod1 and wait for it to become ready.
+		3. Create pod2 on the same node using the same PVC.
+		4. Verify both pods are running and the volume is attached once.
+		5. Write data from pod1 and verify it from pod2.
+		6. Delete pod1 and verify pod2 still has access.
+		7. Delete pod2 and verify the volume is detached.
+	*/
+	ginkgo.It("[ef-vanilla-block][pq-n1-vanilla-block][pq-n2-vanilla-block][cf-vks][csi-block-vanilla]"+
+		"[csi-block-vanilla-parallelized][csi-guest]Multiple pods on the same node can use a single "+
+		"raw block volume", ginkgo.Label(p1, block, vanilla, tkg, vc70), func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		if vanillaCluster {
+			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		} else if guestCluster {
+			ginkgo.By("CNS_TEST: Running for GC setup")
+			scParameters[svStorageClassName] = storagePolicyName
+		}
+
+		ginkgo.By("Creating Storage Class and PVC")
+		sc, err := createStorageClass(client, scParameters, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := adminClient.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating raw block PVC")
+		pvcspec := getPersistentVolumeClaimSpecWithStorageClass(namespace, "", sc, nil, "")
+		pvcspec.Spec.VolumeMode = &rawBlockVolumeMode
+		pvc, err = fpv.CreatePVC(ctx, client, namespace, pvcspec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
+		pvs, err := WaitForPVClaimBoundPhase(ctx, client, []*corev1.PersistentVolumeClaim{pvc},
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
+		pv := pvs[0]
+		volumeID := pv.Spec.CSI.VolumeHandle
+		if guestCluster {
+			svcPVCName = volumeID
+			volumeID = getVolumeIDFromSupervisorCluster(svcPVCName)
+			gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
+		}
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvc.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = fpv.WaitForPersistentVolumeDeleted(ctx, adminClient, pv.Name, poll, pollTimeoutShort)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating first pod")
+		pod1, err := createPod(ctx, client, namespace, nil, []*corev1.PersistentVolumeClaim{pvc}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		nodeName := pod1.Spec.NodeName
+		gomega.Expect(nodeName).NotTo(gomega.BeEmpty())
+
+		var vmUUID string
+		if vanillaCluster {
+			vmUUID = getNodeUUID(ctx, client, nodeName)
+		} else if guestCluster {
+			vmUUID, err = getVMUUIDFromNodeName(nodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			verifyCRDInSupervisorWithWait(ctx, f, nodeName+"-"+svcPVCName,
+				crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
+		}
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID, nodeName))
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+		ginkgo.By("Creating second pod on the same node using the same PVC")
+		nodeSelector := map[string]string{"kubernetes.io/hostname": nodeName}
+		pod2, err := createPod(ctx, client, namespace, nodeSelector, []*corev1.PersistentVolumeClaim{pvc}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pod2.Spec.NodeName).To(gomega.Equal(nodeName))
+
+		ginkgo.By("Verify volume remains attached once with two pods on the same node")
+		isDiskAttached, err = e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+		volumeIndex := 1
+		devicePath := fmt.Sprintf("%v%v", pod_devicePathPrefix, volumeIndex)
+		rand.New(rand.NewSource(time.Now().Unix()))
+		testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
+		ginkgo.By(fmt.Sprintf("Creating a 1mb test data file %v", testdataFile))
+		op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
+			"bs=1M", "count=1").Output()
+		fmt.Println(op)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			op, err = exec.Command("rm", "-f", testdataFile).Output()
+			fmt.Println(op)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By(fmt.Sprintf("Write data from pod %s", pod1.Name))
+		verifyIOOnRawBlockVolume(namespace, pod1.Name, devicePath, testdataFile, 0, 1)
+
+		ginkgo.By(fmt.Sprintf("Read data from pod %s", pod2.Name))
+		verifyDataFromRawBlockVolume(namespace, pod2.Name, devicePath, testdataFile, 0, 1)
+
+		ginkgo.By(fmt.Sprintf("Deleting pod %s while pod %s keeps using the volume", pod1.Name, pod2.Name))
+		err = fpod.DeletePodWithWait(ctx, client, pod1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify pod %s can still write to the volume", pod2.Name))
+		verifyIOOnRawBlockVolume(namespace, pod2.Name, devicePath, testdataFile, 0, 1)
+
+		ginkgo.By(fmt.Sprintf("Deleting pod %s", pod2.Name))
+		err = fpod.DeletePodWithWait(ctx, client, pod2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Waiting for volume to be detached after all pods are deleted")
+		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, volumeID, nodeName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), "Volume is still attached to the node")
+	})
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PublishBlockVol incorrectly rejected a second bind mount when another pod on the same node was already using the volume. Allow per-target bind mounts and treat an existing publish to the requested target as idempotent, matching PublishMountVol behavior for filesystem volumes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Added unit tests for specific function changed, as well as project compatible e2e test that verifies that two pods can concurrently start and read/write to the block volume

**Special notes for your reviewer**:
I did not address SINGLE_NODE_MULTI_WRITER vs SINGLE_NODE_WRITER capabilities missing in the driver. Newer CSI spec prefers SINGLE_NODE_MULTI_WRITER. But that is outside the scope of this PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
BugFix: Do not reject RWO block volume being used by second pod
```
