### PR TITLE
GetHostMOID does not need a network hop

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -375,6 +375,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-client-certs
+              readOnly: true
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v4.12.0_vmware.1
           args:
@@ -571,6 +574,9 @@ spec:
             - mountPath: /etc/vmware/wcp/webhook-certs/client-ca
               name: client-ca
               readOnly: true
+            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
+              name: k8s-cloud-operator-server-certs
+              readOnly: true
         - name: csi-snapshotter
           image: localhost:5000/vmware.io/csi-snapshotter:v8.2.0_vmware.1
           args:
@@ -609,6 +615,12 @@ spec:
             items:
             - key: "ca.crt"
               path: "ca.crt"
+        - name: k8s-cloud-operator-server-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-server-cert
+        - name: k8s-cloud-operator-client-certs
+          secret:
+            secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
@@ -701,6 +713,81 @@ metadata:
   namespace: vmware-system-csi
 spec:
   selfSigned: {}
+---
+# The following resources issue the mTLS identities for the K8sCloudOperator
+# gRPC service (vsphere-syncer, port 29000): a root CA (bootstrapped off the
+# existing vmware-system-csi-selfsigned-issuer above, which is stateless and
+# can mint any number of independent CAs), and two leaf certificates signed
+# by that CA - one server identity for vsphere-syncer, one client identity
+# shared by callers within this Pod (vsphere-csi-controller). Only a
+# certificate whose CommonName matches the client identity below is
+# authorized to call any RPC on this service.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-cert
+  namespace: vmware-system-csi
+spec:
+  duration: 4320h # 180d
+  renewBefore: 2160h # 90d
+  isCA: true
+  commonName: vmware-system-csi-k8scloudoperator-ca
+  secretName: vmware-system-csi-k8scloudoperator-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-selfsigned-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-ca-issuer
+  namespace: vmware-system-csi
+spec:
+  ca:
+    secretName: vmware-system-csi-k8scloudoperator-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-server-cert
+  namespace: vmware-system-csi
+spec:
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  dnsNames:
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
+  commonName: vmware-system-csi-k8scloudoperator-server
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: vsphere-csi-controller
+  name: vmware-system-csi-k8scloudoperator-client-cert
+  namespace: vmware-system-csi
+spec:
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  commonName: vmware-system-csi-k8scloudoperator-client
+  issuerRef:
+    kind: Issuer
+    name: vmware-system-csi-k8scloudoperator-ca-issuer
+  secretName: vmware-system-csi-k8scloudoperator-client-cert
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -515,9 +515,6 @@ spec:
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
-            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
-              name: k8s-cloud-operator-client-certs
-              readOnly: true
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
@@ -758,6 +755,8 @@ metadata:
   name: vmware-system-csi-k8scloudoperator-ca-cert
   namespace: vmware-system-csi
 spec:
+  duration: 4320h # 180d
+  renewBefore: 2160h # 90d
   isCA: true
   commonName: vmware-system-csi-k8scloudoperator-ca
   secretName: vmware-system-csi-k8scloudoperator-ca-secret
@@ -787,6 +786,8 @@ metadata:
   name: vmware-system-csi-k8scloudoperator-server-cert
   namespace: vmware-system-csi
 spec:
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
   dnsNames:
     - localhost
   ipAddresses:
@@ -805,6 +806,8 @@ metadata:
   name: vmware-system-csi-k8scloudoperator-client-cert
   namespace: vmware-system-csi
 spec:
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
   commonName: vmware-system-csi-k8scloudoperator-client
   issuerRef:
     kind: Issuer

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -515,9 +515,6 @@ spec:
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
-            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
-              name: k8s-cloud-operator-client-certs
-              readOnly: true
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
@@ -758,6 +755,8 @@ metadata:
   name: vmware-system-csi-k8scloudoperator-ca-cert
   namespace: vmware-system-csi
 spec:
+  duration: 4320h # 180d
+  renewBefore: 2160h # 90d
   isCA: true
   commonName: vmware-system-csi-k8scloudoperator-ca
   secretName: vmware-system-csi-k8scloudoperator-ca-secret
@@ -787,6 +786,8 @@ metadata:
   name: vmware-system-csi-k8scloudoperator-server-cert
   namespace: vmware-system-csi
 spec:
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
   dnsNames:
     - localhost
   ipAddresses:
@@ -805,6 +806,8 @@ metadata:
   name: vmware-system-csi-k8scloudoperator-client-cert
   namespace: vmware-system-csi
 spec:
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
   commonName: vmware-system-csi-k8scloudoperator-client
   issuerRef:
     kind: Issuer

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -515,9 +515,6 @@ spec:
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
-            - mountPath: /etc/vmware/wcp/k8s-cloud-operator-certs
-              name: k8s-cloud-operator-client-certs
-              readOnly: true
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.17.0_vmware.1
           args:
@@ -757,6 +754,8 @@ metadata:
   name: vmware-system-csi-k8scloudoperator-ca-cert
   namespace: vmware-system-csi
 spec:
+  duration: 4320h # 180d
+  renewBefore: 2160h # 90d
   isCA: true
   commonName: vmware-system-csi-k8scloudoperator-ca
   secretName: vmware-system-csi-k8scloudoperator-ca-secret
@@ -786,6 +785,8 @@ metadata:
   name: vmware-system-csi-k8scloudoperator-server-cert
   namespace: vmware-system-csi
 spec:
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
   dnsNames:
     - localhost
   ipAddresses:
@@ -804,6 +805,8 @@ metadata:
   name: vmware-system-csi-k8scloudoperator-client-cert
   namespace: vmware-system-csi
 spec:
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
   commonName: vmware-system-csi-k8scloudoperator-client
   issuerRef:
     kind: Issuer

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1073,7 +1073,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			}
 			log.Infof("Will select datastore %s as per the provided storage pool %s", selectedDatastoreURL, storagePool)
 
-			hostMoid, err := getHostMOIDFromK8sCloudOperatorService(ctx, accessibleNodes[0])
+			hostMoid, err := getHostMOID(ctx, accessibleNodes[0])
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to get ESX Host Moid from API server. Error: %+v", err)

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -18,7 +18,6 @@ package wcp
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"strconv"
@@ -30,9 +29,7 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,7 +40,6 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns/v1alpha1"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/certwatcher"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
@@ -51,13 +47,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
 )
-
-// defaultK8sCloudOperatorClientCertDir is the directory containing the mTLS
-// identity (tls.crt, tls.key) this client presents to the K8sCloudOperator
-// gRPC service, and the CA bundle (ca.crt) used to authenticate the server.
-const defaultK8sCloudOperatorClientCertDir = k8scloudoperator.DefaultK8sCloudOperatorCertDir
 
 // validateCreateBlockReqParam is a helper function used to validate the parameter
 // name received in the CreateVolume request for block volumes on WCP CSI driver.
@@ -250,79 +240,31 @@ func validateWCPListSnapshotRequest(ctx context.Context, req *csi.ListSnapshotsR
 	return nil
 }
 
-// getK8sCloudOperatorClientConnection is a helper function that creates a
-// clientConnection to k8sCloudOperator GRPC service running on syncer container.
-func getK8sCloudOperatorClientConnection(ctx context.Context) (*grpc.ClientConn, error) {
-	transportCreds, err := newClientTransportCredentials()
-	if err != nil {
-		return nil, fmt.Errorf("failed to set up TLS credentials for k8s cloud operator gRPC client: %w", err)
-	}
-	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithTransportCredentials(transportCreds))
-	port := common.GetK8sCloudOperatorServicePort(ctx)
-	k8sCloudOperatorServiceAddr := "127.0.0.1:" + strconv.Itoa(port)
-	// Connect to k8s cloud operator gRPC service.
-	conn, err := grpc.NewClient(k8sCloudOperatorServiceAddr, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return conn, nil
-}
-
-// newClientTransportCredentials builds the mTLS client
-// credentials used to authenticate this client to the K8sCloudOperator gRPC
-// service and to verify the server's identity.
-func newClientTransportCredentials() (credentials.TransportCredentials, error) {
-	certPath := defaultK8sCloudOperatorClientCertDir + "/tls.crt"
-	keyPath := defaultK8sCloudOperatorClientCertDir + "/tls.key"
-	caPath := defaultK8sCloudOperatorClientCertDir + "/ca.crt"
-
-	cert, caCertPool, err := certwatcher.LoadCertificateAndCAPool(certPath, keyPath, caPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return credentials.NewTLS(&tls.Config{
-		MinVersion: tls.VersionTLS12,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_AES_128_GCM_SHA256,
-			tls.TLS_AES_256_GCM_SHA384,
-		},
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      caCertPool,
-	}), nil
-}
-
-// getHostMOIDFromK8sCloudOperatorService gets the host-moid from
-// K8sCloudOperator gRPC service.
-func getHostMOIDFromK8sCloudOperatorService(ctx context.Context, nodeName string) (string, error) {
+// getHostMOID returns the ESX host moid for the given node, read from the
+// Node object's host-moid annotation.
+func getHostMOID(ctx context.Context, nodeName string) (string, error) {
 	log := logger.GetLogger(ctx)
-	conn, err := getK8sCloudOperatorClientConnection(ctx)
+	// Read the Node's host-moid annotation directly rather than over the
+	// K8sCloudOperator gRPC service.
+	c, err := newK8sClient(ctx)
 	if err != nil {
-		log.Errorf("failed to establish the connection to k8s cloud operator service. Error: %+v", err)
-		return "", err
-	}
-	defer conn.Close()
-
-	// Create a client stub for gRPC service.
-	client := k8scloudoperator.NewK8SCloudOperatorClient(conn)
-
-	// Call GetHostAnnotation method on the client stub.
-	res, err := client.GetHostAnnotation(ctx,
-		&k8scloudoperator.HostAnnotationRequest{
-			HostName:      nodeName,
-			AnnotationKey: common.HostMoidAnnotationKey,
-		})
-	if err != nil {
-		msg := fmt.Sprintf("failed to get the host moid annotation from the gRPC service. Error: %+v", err)
-		log.Error(msg)
-		return "", err
+		return "", logger.LogNewErrorCode(log, codes.Internal, "failed to create kubernetes client")
 	}
 
-	log.Infof("Got host-moid: %s annotation from the K8sCloudOperator gRPC service", res.AnnotationValue)
-	return res.AnnotationValue, nil
+	node, err := c.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to get node %q. Error: %+v", nodeName, err)
+	}
+
+	hostMoid, ok := node.Annotations[common.HostMoidAnnotationKey]
+	if !ok {
+		return "", logger.LogNewErrorCodef(log, codes.NotFound,
+			"%q annotation not found on node %q", common.HostMoidAnnotationKey, nodeName)
+	}
+
+	log.Infof("Got host-moid: %s annotation on node %s", hostMoid, nodeName)
+	return hostMoid, nil
 }
 
 // getDatacenterFromConfig gets the vcenter-datacenter where WCP PodVM cluster

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -405,8 +405,8 @@ func (k8sCloudOperator *k8sCloudOperator) GetHostAnnotation(ctx context.Context,
 	}
 	hostMoid, ok := node.Annotations[key]
 	if !ok {
-		log.Errorf("failed to get the node annotation for the key %s: %s", key, err)
-		return nil, err
+		return nil, logger.LogNewErrorCodef(log, codes.NotFound,
+			"annotation %q not found on node %q", key, nodeName)
 	}
 	log.Infof("Found the %s: %s annotation on Node: %s", key, hostMoid, nodeName)
 	response := &HostAnnotationResponse{

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -405,8 +405,8 @@ func (k8sCloudOperator *k8sCloudOperator) GetHostAnnotation(ctx context.Context,
 	}
 	hostMoid, ok := node.Annotations[key]
 	if !ok {
-		return nil, logger.LogNewErrorCodef(log, codes.NotFound,
-			"annotation %q not found on node %q", key, nodeName)
+		log.Errorf("failed to get the node annotation for the key %s: %s", key, err)
+		return nil, err
 	}
 	log.Infof("Found the %s: %s annotation on Node: %s", key, hostMoid, nodeName)
 	response := &HostAnnotationResponse{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The function getHostMOID does not require a network hop as the caller is the CSI driver and the server is the syncer,

This PR calls this function directly.

Also https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/4250 did not add the TLS related changes which could bread PVC creation in 1.32 K8s testbeds.

**Testing done**:

Created a PVC with vSAN SNA storage policy:

```
data0-hostmoid-verify-1-0   Bound     sample-vsan-sna-thick
hostmoid-verify-1-0         Running   1/1
```

Logs:
```
controller.go:1053           Storage pool Accessible nodes for volume topology: [lvn-dvm-10-162-190-23...]
controller.go:1074           Will select datastore ... as per the provided storage pool ...
controller_helper.go:269     Got host-moid: host-31 annotation on node lvn-dvm-10-162-190-23.dvm.lvn.broadcom.net
```

No mTLS errors observed.

WCP precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1968/
VKS precheckin (passed): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1521/

