### PR TITLE
Add CA watcher to for reissue server and client certs

### DIFF
--- a/manifests/supervisorcluster/1.32/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.32/cns-csi.yaml
@@ -156,6 +156,12 @@ rules:
   - apiGroups: ["iaas.vmware.com"]
     resources: ["capabilities"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/status"]
+    verbs: ["get", "list", "watch", "update"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.33/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.33/cns-csi.yaml
@@ -170,7 +170,7 @@ rules:
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates/status"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["mobility-operator.vmware.com"]
     resources: ["virtualmachineinframigrations", "volumemigrations"]
     verbs: ["get", "list", "watch"]

--- a/manifests/supervisorcluster/1.34/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.34/cns-csi.yaml
@@ -170,7 +170,7 @@ rules:
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates/status"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["mobility-operator.vmware.com"]
     resources: ["virtualmachineinframigrations", "volumemigrations"]
     verbs: ["get", "list", "watch"]

--- a/manifests/supervisorcluster/1.35/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.35/cns-csi.yaml
@@ -170,7 +170,7 @@ rules:
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates/status"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["mobility-operator.vmware.com"]
     resources: ["virtualmachineinframigrations", "volumemigrations"]
     verbs: ["get", "list", "watch"]

--- a/pkg/common/certwatcher/certwatcher.go
+++ b/pkg/common/certwatcher/certwatcher.go
@@ -31,6 +31,13 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
+// pollInterval backstops fsnotify: matches the poll interval
+// controller-runtime's own certwatcher uses (sigs.k8s.io/controller-runtime/
+// pkg/certwatcher, defaultWatchInterval) for the same reason - fsnotify
+// events can be missed or coalesced, so an unconditional periodic re-read
+// guarantees changes are eventually observed even then.
+const pollInterval = 60 * time.Second
+
 // LoadCertificateAndCAPool reads and parses the certificate,
 // private key, and CA bundle from the given paths.
 func LoadCertificateAndCAPool(certPath, keyPath, caPath string) (tls.Certificate, *x509.CertPool, error) {
@@ -128,11 +135,21 @@ func (cw *CertWatcher) Start(ctx context.Context) error {
 
 	go cw.watch(ctx)
 
-	log.Infof("Started certificate watcher for cert: %s, key: %s, ca: %s", cw.certPath, cw.keyPath, cw.caPath)
-	<-ctx.Done()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
 
-	log.Infof("Stopping certificate watcher for cert: %s", cw.certPath)
-	return cw.watcher.Close()
+	log.Infof("Started certificate watcher for cert: %s, key: %s, ca: %s", cw.certPath, cw.keyPath, cw.caPath)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Infof("Stopping certificate watcher for cert: %s", cw.certPath)
+			return cw.watcher.Close()
+		case <-ticker.C:
+			if err := cw.reload(); err != nil {
+				log.Errorf("failed to poll certificate: %v", err)
+			}
+		}
+	}
 }
 
 func (cw *CertWatcher) watch(ctx context.Context) {
@@ -164,7 +181,7 @@ func (cw *CertWatcher) watch(ctx context.Context) {
 			if err := cw.reload(); err != nil {
 				log.Errorf("failed to reload certificate after change: %v", err)
 			} else {
-				log.Infof("Reloaded certificate from %s", cw.certPath)
+				log.Debugf("Reloaded certificate from %s", cw.certPath)
 			}
 		case err, ok := <-cw.watcher.Errors:
 			if !ok {

--- a/pkg/syncer/cnsoperator/controller/add_cacascade.go
+++ b/pkg/syncer/cnsoperator/controller/add_cacascade.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cacascade"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, cacascade.Add)
+}

--- a/pkg/syncer/cnsoperator/controller/cacascade/ca_cascade_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cacascade/ca_cascade_controller.go
@@ -1,0 +1,371 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cacascade guards against a specific cert-manager gap: when a CA
+// Certificate is reissued (routine renewal or otherwise), cert-manager does
+// not cascade that to Certificates it signs - each leaf only reissues on its
+// own independent schedule. Two leaves signed by the same CA, on two
+// different schedules, can therefore end up trusting two different CA
+// generations of each other for as long as either leaf's own renewal is not
+// yet due - which, for the K8sCloudOperator client/server pair, is up to 90
+// days. During that window every mTLS handshake between vsphere-syncer and
+// csi-provisioner fails with "unknown authority"/"bad certificate".
+//
+// As a fallback for drift the revision watch alone can miss - an
+// out-of-band CA rotation that doesn't advance Status.Revision the way
+// expected, or a reissue that silently didn't converge - this controller
+// also requeues itself on a timer and, on every check, compares each leaf's
+// actual cached CA (read from its own Secret) against the CA's live Secret
+// content directly, rather than trusting its own cascade-annotation
+// bookkeeping alone.
+package cacascade
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
+)
+
+const (
+	maxWorkerThreads = 1
+
+	// lastCascadedCARevisionAnnotation records, on each leaf, the CA
+	// Certificate revision this leaf was last force-reissued against.
+	lastCascadedCARevisionAnnotation = "cns.vmware.com/last-cascaded-ca-revision"
+
+	// driftCheckInterval is how often Reconcile re-runs even without a new
+	// watch event, to actively re-verify each leaf still trusts the live CA.
+	driftCheckInterval = 120 * time.Minute
+)
+
+// Add creates a new CA cascade controller and adds it to the Manager.
+func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
+	_ *cnsconfig.ConfigurationInfo, _ volumes.Manager) error {
+	_, log := logger.GetNewContextWithLogger()
+
+	if clusterFlavor != cnstypes.CnsClusterFlavorWorkload {
+		log.Debug("Not initializing the CA cascade controller as its a non-WCP CSI deployment")
+		return nil
+	}
+
+	log.Infof("Initializing CA cascade controller")
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler.
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileCACascade{
+		client: mgr.GetClient(),
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler.
+//
+// The only watch is on the CA Certificate itself, filtered to its Status
+// changing (a Status change is what a reissue looks like; Spec/metadata-only
+// churn is not interesting). request.NamespacedName is therefore always the
+// CA's own identity - there is no separate owned object to map onto.
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	_, log := logger.GetNewContextWithLogger()
+
+	c, err := controller.New("ca-cascade-controller", mgr,
+		controller.Options{Reconciler: r, MaxConcurrentReconciles: maxWorkerThreads})
+	if err != nil {
+		log.Errorf("failed to create new CA cascade controller with error: %+v", err)
+		return err
+	}
+
+	caPred := predicate.TypedFuncs[*certmanagerv1.Certificate]{
+		CreateFunc: func(e event.TypedCreateEvent[*certmanagerv1.Certificate]) bool {
+			return isTargetCA(e.Object)
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.Certificate]) bool {
+			if !isTargetCA(e.ObjectNew) {
+				return false
+			}
+			return !revisionEqual(e.ObjectOld.Status.Revision, e.ObjectNew.Status.Revision)
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*certmanagerv1.Certificate]) bool {
+			return false
+		},
+	}
+	err = c.Watch(source.Kind(
+		mgr.GetCache(),
+		&certmanagerv1.Certificate{},
+		&handler.TypedEnqueueRequestForObject[*certmanagerv1.Certificate]{},
+		caPred))
+	if err != nil {
+		log.Errorf("failed to watch for changes to the K8sCloudOperator CA Certificate with error: %+v", err)
+		return err
+	}
+	return nil
+}
+
+func isTargetCA(cert *certmanagerv1.Certificate) bool {
+	return cert.Name == k8scloudoperator.K8sCloudOperatorCACertName && cert.Namespace == cnsconfig.DefaultCSINamespace
+}
+
+func revisionEqual(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+var _ reconcile.Reconciler = &ReconcileCACascade{}
+
+type ReconcileCACascade struct {
+	client client.Client
+}
+
+// Reconcile is invoked whenever the K8sCloudOperator CA Certificate's Status
+// changes, or periodically via driftCheckInterval. It force-reissues each
+// leaf that has not yet been cascaded to the CA's current revision, and
+// otherwise actively verifies the leaf still trusts the CA's live content.
+func (r *ReconcileCACascade) Reconcile(ctx context.Context,
+	request reconcile.Request) (reconcile.Result, error) {
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+
+	ca := &certmanagerv1.Certificate{}
+	if err := r.client.Get(ctx, request.NamespacedName, ca); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		log.Errorf("Failed to get CA Certificate %s. Err: %+v", request.NamespacedName, err)
+		return reconcile.Result{}, err
+	}
+
+	if ca.DeletionTimestamp != nil {
+		log.Debugf("CA Certificate %s is being deleted; nothing to cascade", request.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
+	if ca.Status.Revision == nil {
+		log.Debugf("CA Certificate %s has not been issued yet; nothing to cascade", request.NamespacedName)
+		return reconcile.Result{RequeueAfter: driftCheckInterval}, nil
+	}
+	caRevision := *ca.Status.Revision
+
+	leafNames := []string{k8scloudoperator.K8sCloudOperatorServerCertName, k8scloudoperator.K8sCloudOperatorClientCertName}
+	for _, leafName := range leafNames {
+		if err := r.cascadeToLeaf(ctx, ca, leafName, caRevision); err != nil {
+			log.Errorf("Failed to cascade CA revision %d to leaf %s/%s. Err: %+v",
+				caRevision, cnsconfig.DefaultCSINamespace, leafName, err)
+			return reconcile.Result{}, err
+		}
+	}
+	return reconcile.Result{RequeueAfter: driftCheckInterval}, nil
+}
+
+// cascadeToLeaf reissues the named leaf Certificate if it is stale against
+// caRevision. If a reissue was not needed (the leaf's cascade annotation
+// already matches caRevision), it actively re-verifies, independent of that
+// annotation, that the leaf's cached CA still matches the CA's live Secret
+// content, and forces a reissue if they've drifted apart regardless of what
+// the annotation claims.
+func (r *ReconcileCACascade) cascadeToLeaf(ctx context.Context, ca *certmanagerv1.Certificate,
+	leafName string, caRevision int) error {
+	log := logger.GetLogger(ctx)
+
+	key := k8stypes.NamespacedName{Name: leafName, Namespace: cnsconfig.DefaultCSINamespace}
+	leaf := &certmanagerv1.Certificate{}
+	if err := r.client.Get(ctx, key, leaf); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debugf("Leaf Certificate %s not found yet; skipping", key)
+			return nil
+		}
+		return err
+	}
+
+	reissued, err := r.forceReissueIfStale(ctx, ca, leaf, caRevision)
+	if err != nil {
+		return err
+	}
+
+	// Already reissued above - nothing more to do. Skip verifying now:
+	// cert-manager reissues asynchronously, so the Secret can't have
+	// converged yet and would always look stale.
+	if reissued {
+		return nil
+	}
+
+	known, trusted, err := r.leafTrustsLiveCA(ctx, ca, leaf)
+	if err != nil {
+		return err
+	}
+	if known && !trusted {
+		log.Infof("Leaf Certificate %s's cached CA no longer matches the live CA despite matching "+
+			"cascade annotation; forcing reissue", key)
+		return r.reissueLeaf(ctx, leaf, caRevision, "CADriftDetected",
+			"leaf's cached CA no longer matches the live CA; forcing reissue")
+	}
+	return nil
+}
+
+// forceReissueIfStale reissues leaf unless it has already been cascaded to
+// caRevision. Before reissuing, it checks whether the leaf's actual issued
+// Secret already trusts the CA's actual live Secret content despite a stale or
+// missing cascade annotation.
+func (r *ReconcileCACascade) forceReissueIfStale(ctx context.Context, ca, leaf *certmanagerv1.Certificate,
+	caRevision int) (bool, error) {
+	log := logger.GetLogger(ctx)
+	key := k8stypes.NamespacedName{Name: leaf.Name, Namespace: leaf.Namespace}
+
+	if leaf.Annotations[lastCascadedCARevisionAnnotation] == strconv.Itoa(caRevision) {
+		return false, nil // already cascaded to this CA generation
+	}
+
+	known, trusted, err := r.leafTrustsLiveCA(ctx, ca, leaf)
+	if err != nil {
+		return false, err
+	}
+	if known && trusted {
+		log.Infof("Leaf Certificate %s already trusts the live CA despite a stale or missing cascade "+
+			"annotation; backfilling the annotation without forcing a reissue", key)
+		return false, r.recordCascadedRevision(ctx, leaf, caRevision)
+	}
+
+	// Either confirmed stale, or unknown (e.g. the leaf hasn't been issued
+	// for the first time yet) - fall back to forcing a reissue rather than
+	// assuming it's fine.
+	if err := r.reissueLeaf(ctx, leaf, caRevision, "CACascade",
+		fmt.Sprintf("signing CA reissued (revision %d); forcing reissuance to stay in sync", caRevision)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// leafTrustsLiveCA reports whether it was able to determine that leaf's
+// actual cached CA (its own Secret's ca.crt) matches ca's actual live
+// Secret content (tls.crt). known is false whenever either Secret - or the
+// specific key read from it - isn't there yet, since bytes.Equal(nil, nil)
+// would otherwise report two absent values as trusting each other.
+func (r *ReconcileCACascade) leafTrustsLiveCA(ctx context.Context,
+	ca, leaf *certmanagerv1.Certificate) (known, trusted bool, err error) {
+	caSecret := &corev1.Secret{}
+	caSecretKey := k8stypes.NamespacedName{Name: ca.Spec.SecretName, Namespace: ca.Namespace}
+	if err := r.client.Get(ctx, caSecretKey, caSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, false, nil // CA not issued yet; nothing to compare
+		}
+		return false, false, fmt.Errorf("failed to get CA Secret %s: %w", caSecretKey, err)
+	}
+	caCert := caSecret.Data["tls.crt"]
+	if len(caCert) == 0 {
+		return false, false, nil // CA Secret exists but has no tls.crt yet; nothing to compare
+	}
+
+	leafSecret := &corev1.Secret{}
+	leafSecretKey := k8stypes.NamespacedName{Name: leaf.Spec.SecretName, Namespace: leaf.Namespace}
+	if err := r.client.Get(ctx, leafSecretKey, leafSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, false, nil // leaf not issued yet; nothing to compare
+		}
+		return false, false, fmt.Errorf("failed to get leaf Secret %s: %w", leafSecretKey, err)
+	}
+	leafCACert := leafSecret.Data["ca.crt"]
+	if len(leafCACert) == 0 {
+		return false, false, nil // leaf Secret exists but has no ca.crt yet; nothing to compare
+	}
+
+	return true, bytes.Equal(caCert, leafCACert), nil
+}
+
+// reissueLeaf sets the Issuing condition on leaf - the same mechanism cmctl
+// renew uses.
+func (r *ReconcileCACascade) reissueLeaf(ctx context.Context, leaf *certmanagerv1.Certificate,
+	caRevision int, reason, message string) error {
+	log := logger.GetLogger(ctx)
+	key := k8stypes.NamespacedName{Name: leaf.Name, Namespace: leaf.Namespace}
+	log.Infof("CA Certificate %s/%s is now at revision %d; forcing reissuance of leaf %s to stay in sync",
+		cnsconfig.DefaultCSINamespace, k8scloudoperator.K8sCloudOperatorCACertName, caRevision, key)
+
+	now := metav1.Now()
+	issuing := certmanagerv1.CertificateCondition{
+		Type:               certmanagerv1.CertificateConditionIssuing,
+		Status:             cmmeta.ConditionTrue,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: &now,
+	}
+	// Status.Conditions is a listType=map keyed by Type: appending
+	// unconditionally duplicates the entry and the API server rejects the
+	// whole update whenever an Issuing condition already exists (e.g. left
+	// over from a prior cascade, or from cert-manager's own processing).
+	// Replace it in place if present instead.
+	if idx := issuingConditionIndex(leaf.Status.Conditions); idx >= 0 {
+		leaf.Status.Conditions[idx] = issuing
+	} else {
+		leaf.Status.Conditions = append(leaf.Status.Conditions, issuing)
+	}
+	if err := r.client.Status().Update(ctx, leaf); err != nil {
+		return fmt.Errorf("failed to set Issuing condition on %s: %w", key, err)
+	}
+
+	return r.recordCascadedRevision(ctx, leaf, caRevision)
+}
+
+// recordCascadedRevision patches leaf's annotation to record caRevision as
+// the CA generation it has been reconciled against, without touching its
+// Status.
+func (r *ReconcileCACascade) recordCascadedRevision(ctx context.Context, leaf *certmanagerv1.Certificate,
+	caRevision int) error {
+	key := k8stypes.NamespacedName{Name: leaf.Name, Namespace: leaf.Namespace}
+	patch := client.MergeFrom(leaf.DeepCopy())
+	if leaf.Annotations == nil {
+		leaf.Annotations = map[string]string{}
+	}
+	leaf.Annotations[lastCascadedCARevisionAnnotation] = strconv.Itoa(caRevision)
+	if err := r.client.Patch(ctx, leaf, patch); err != nil {
+		return fmt.Errorf("failed to record cascaded CA revision on %s: %w", key, err)
+	}
+	return nil
+}
+
+// issuingConditionIndex returns the index of the existing Issuing condition
+// in conditions, or -1 if none is present.
+func issuingConditionIndex(conditions []certmanagerv1.CertificateCondition) int {
+	for i, c := range conditions {
+		if c.Type == certmanagerv1.CertificateConditionIssuing {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/syncer/cnsoperator/controller/cacascade/ca_cascade_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cacascade/ca_cascade_controller_test.go
@@ -1,0 +1,400 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacascade
+
+import (
+	"context"
+	"testing"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, certmanagerv1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+func newCA(revision *int) *certmanagerv1.Certificate {
+	return &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		},
+		Status: certmanagerv1.CertificateStatus{Revision: revision},
+	}
+}
+
+func newLeaf(name string, annotations map[string]string) *certmanagerv1.Certificate {
+	return &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cnsconfig.DefaultCSINamespace, Annotations: annotations},
+	}
+}
+
+func intPtr(i int) *int { return &i }
+
+func TestRevisionEqual(t *testing.T) {
+	assert.True(t, revisionEqual(nil, nil))
+	assert.False(t, revisionEqual(nil, intPtr(1)))
+	assert.False(t, revisionEqual(intPtr(1), nil))
+	assert.False(t, revisionEqual(intPtr(1), intPtr(2)))
+	assert.True(t, revisionEqual(intPtr(1), intPtr(1)))
+}
+
+func TestIsTargetCA(t *testing.T) {
+	assert.True(t, isTargetCA(newCA(nil)))
+	assert.False(t, isTargetCA(newLeaf(k8scloudoperator.K8sCloudOperatorServerCertName, nil)))
+
+	other := newCA(nil)
+	other.Namespace = "some-other-namespace"
+	assert.False(t, isTargetCA(other))
+}
+
+func TestReconcile_CANotFound_NoOp(t *testing.T) {
+	scheme := newTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	res, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+}
+
+func TestReconcile_CANeverIssued_NoOp(t *testing.T) {
+	scheme := newTestScheme(t)
+	ca := newCA(nil) // Status.Revision is nil: never issued yet
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ca).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+
+	// Neither leaf exists; nothing should have been created or errored on.
+	server := &certmanagerv1.Certificate{}
+	err = fakeClient.Get(context.Background(),
+		k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorServerCertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}, server)
+	assert.Error(t, err, "leaf should not have been created")
+}
+
+func TestReconcile_ForcesReissueOnNewCARevision(t *testing.T) {
+	scheme := newTestScheme(t)
+	ca := newCA(intPtr(5))
+	ca.Spec.SecretName = "ca-secret"
+	server := newLeaf(k8scloudoperator.K8sCloudOperatorServerCertName, nil)
+	server.Spec.SecretName = "server-secret"
+	client := newLeaf(k8scloudoperator.K8sCloudOperatorClientCertName, nil)
+	client.Spec.SecretName = "client-secret"
+	// No Secret objects seeded: leafTrustsLiveCA has nothing to compare yet
+	// (known=false), so this deliberately exercises the "unknown - fall back
+	// to reissuing" branch of forceReissueIfStale, not a confirmed mismatch.
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&certmanagerv1.Certificate{}).
+		WithObjects(ca, server, client).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+
+	certNames := []string{k8scloudoperator.K8sCloudOperatorServerCertName, k8scloudoperator.K8sCloudOperatorClientCertName}
+	for _, name := range certNames {
+		got := &certmanagerv1.Certificate{}
+		require.NoError(t, fakeClient.Get(context.Background(),
+			k8stypes.NamespacedName{Name: name, Namespace: cnsconfig.DefaultCSINamespace}, got))
+
+		assert.Equal(t, "5", got.Annotations[lastCascadedCARevisionAnnotation],
+			"leaf %s should be annotated with the cascaded CA revision", name)
+
+		require.Len(t, got.Status.Conditions, 1)
+		cond := got.Status.Conditions[0]
+		assert.Equal(t, certmanagerv1.CertificateConditionIssuing, cond.Type)
+		assert.Equal(t, cmmeta.ConditionTrue, cond.Status)
+		assert.Equal(t, "CACascade", cond.Reason)
+	}
+}
+
+func TestReconcile_AlreadyCascaded_IsNoOp(t *testing.T) {
+	scheme := newTestScheme(t)
+	ca := newCA(intPtr(5))
+	ca.Spec.SecretName = "ca-secret"
+	// Both leaves already record revision 5: nothing further should happen.
+	annotations := map[string]string{lastCascadedCARevisionAnnotation: "5"}
+	server := newLeaf(k8scloudoperator.K8sCloudOperatorServerCertName, annotations)
+	server.Spec.SecretName = "server-secret"
+	client := newLeaf(k8scloudoperator.K8sCloudOperatorClientCertName, annotations)
+	client.Spec.SecretName = "client-secret"
+	// No Secret objects seeded: the periodic drift check that runs after the
+	// annotation short-circuit has nothing to compare (known=false), so it
+	// deliberately stays a no-op rather than happening to skip by accident.
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&certmanagerv1.Certificate{}).
+		WithObjects(ca, server, client).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+
+	certNames := []string{k8scloudoperator.K8sCloudOperatorServerCertName, k8scloudoperator.K8sCloudOperatorClientCertName}
+	for _, name := range certNames {
+		got := &certmanagerv1.Certificate{}
+		require.NoError(t, fakeClient.Get(context.Background(),
+			k8stypes.NamespacedName{Name: name, Namespace: cnsconfig.DefaultCSINamespace}, got))
+		assert.Empty(t, got.Status.Conditions, "an already-cascaded leaf should not be touched again")
+	}
+}
+
+func TestReconcile_NewerCARevision_ReissuesAgain(t *testing.T) {
+	scheme := newTestScheme(t)
+	ca := newCA(intPtr(6)) // CA has moved on since the leaf was last cascaded
+	ca.Spec.SecretName = "ca-secret"
+	annotations := map[string]string{lastCascadedCARevisionAnnotation: "5"}
+	server := newLeaf(k8scloudoperator.K8sCloudOperatorServerCertName, annotations)
+	server.Spec.SecretName = "server-secret"
+	client := newLeaf(k8scloudoperator.K8sCloudOperatorClientCertName, annotations)
+	client.Spec.SecretName = "client-secret"
+	// No Secret objects seeded: deliberately exercises the "unknown" branch
+	// of forceReissueIfStale, same as TestReconcile_ForcesReissueOnNewCARevision.
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&certmanagerv1.Certificate{}).
+		WithObjects(ca, server, client).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+
+	got := &certmanagerv1.Certificate{}
+	require.NoError(t, fakeClient.Get(context.Background(),
+		k8stypes.NamespacedName{Name: k8scloudoperator.K8sCloudOperatorServerCertName,
+			Namespace: cnsconfig.DefaultCSINamespace}, got))
+	assert.Equal(t, "6", got.Annotations[lastCascadedCARevisionAnnotation])
+	require.Len(t, got.Status.Conditions, 1)
+}
+
+func TestReconcile_LeafNotFound_SkipsWithoutError(t *testing.T) {
+	scheme := newTestScheme(t)
+	ca := newCA(intPtr(5))
+	// Neither leaf exists yet (e.g. not applied yet on this manifest version).
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&certmanagerv1.Certificate{}).
+		WithObjects(ca).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+}
+
+func newSecret(name string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cnsconfig.DefaultCSINamespace},
+		Data:       data,
+	}
+}
+
+func TestReconcile_ExistingIssuingCondition_ReplacedInPlace(t *testing.T) {
+	scheme := newTestScheme(t)
+	ca := newCA(intPtr(5))
+	server := newLeaf(k8scloudoperator.K8sCloudOperatorServerCertName, nil)
+	// Simulate a stale Issuing condition left over from a prior cascade (or
+	// from cert-manager's own processing). Appending a second Issuing entry
+	// would violate the listType=map contract on status.conditions and the
+	// real API server would reject the whole update.
+	server.Status.Conditions = []certmanagerv1.CertificateCondition{{
+		Type:   certmanagerv1.CertificateConditionIssuing,
+		Status: cmmeta.ConditionTrue,
+		Reason: "PriorCascade",
+	}}
+	client := newLeaf(k8scloudoperator.K8sCloudOperatorClientCertName, nil)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&certmanagerv1.Certificate{}).
+		WithObjects(ca, server, client).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+
+	got := &certmanagerv1.Certificate{}
+	require.NoError(t, fakeClient.Get(context.Background(),
+		k8stypes.NamespacedName{Name: k8scloudoperator.K8sCloudOperatorServerCertName,
+			Namespace: cnsconfig.DefaultCSINamespace}, got))
+	require.Len(t, got.Status.Conditions, 1, "the stale Issuing condition should be replaced, not duplicated")
+	assert.Equal(t, "CACascade", got.Status.Conditions[0].Reason)
+}
+
+func TestReconcile_DriftDetected_ForcesReissueDespiteMatchingAnnotation(t *testing.T) {
+	scheme := newTestScheme(t)
+	ca := newCA(intPtr(5))
+	ca.Spec.SecretName = "ca-secret"
+	annotations := map[string]string{lastCascadedCARevisionAnnotation: "5"}
+	server := newLeaf(k8scloudoperator.K8sCloudOperatorServerCertName, annotations)
+	server.Spec.SecretName = "server-secret"
+	client := newLeaf(k8scloudoperator.K8sCloudOperatorClientCertName, annotations)
+	client.Spec.SecretName = "client-secret"
+
+	// The annotation claims both leaves are already cascaded to revision 5,
+	// but their cached CA (ca.crt) no longer matches the CA's actual live
+	// Secret content - e.g. an out-of-band CA rotation that didn't advance
+	// status.revision the way expected.
+	caSecret := newSecret("ca-secret", map[string][]byte{"tls.crt": []byte("live-ca-v2")})
+	serverSecret := newSecret("server-secret", map[string][]byte{"ca.crt": []byte("stale-ca-v1")})
+	clientSecret := newSecret("client-secret", map[string][]byte{"ca.crt": []byte("stale-ca-v1")})
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&certmanagerv1.Certificate{}).
+		WithObjects(ca, server, client, caSecret, serverSecret, clientSecret).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+
+	certNames := []string{k8scloudoperator.K8sCloudOperatorServerCertName, k8scloudoperator.K8sCloudOperatorClientCertName}
+	for _, name := range certNames {
+		got := &certmanagerv1.Certificate{}
+		require.NoError(t, fakeClient.Get(context.Background(),
+			k8stypes.NamespacedName{Name: name, Namespace: cnsconfig.DefaultCSINamespace}, got))
+		require.Len(t, got.Status.Conditions, 1,
+			"leaf %s should be force-reissued despite a matching cascade annotation", name)
+		assert.Equal(t, "CADriftDetected", got.Status.Conditions[0].Reason)
+	}
+}
+
+func TestReconcile_LeafAlreadyTrustsLiveCA_BackfillsAnnotationWithoutReissue(t *testing.T) {
+	scheme := newTestScheme(t)
+	ca := newCA(intPtr(5))
+	ca.Spec.SecretName = "ca-secret"
+	// No cascade annotation at all - e.g. the leaf's own independent renewal
+	// happened to pick up the current CA before this controller ever acted.
+	server := newLeaf(k8scloudoperator.K8sCloudOperatorServerCertName, nil)
+	server.Spec.SecretName = "server-secret"
+	client := newLeaf(k8scloudoperator.K8sCloudOperatorClientCertName, nil)
+	client.Spec.SecretName = "client-secret"
+
+	caSecret := newSecret("ca-secret", map[string][]byte{"tls.crt": []byte("live-ca-v1")})
+	serverSecret := newSecret("server-secret", map[string][]byte{"ca.crt": []byte("live-ca-v1")})
+	clientSecret := newSecret("client-secret", map[string][]byte{"ca.crt": []byte("live-ca-v1")})
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&certmanagerv1.Certificate{}).
+		WithObjects(ca, server, client, caSecret, serverSecret, clientSecret).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+
+	certNames := []string{k8scloudoperator.K8sCloudOperatorServerCertName, k8scloudoperator.K8sCloudOperatorClientCertName}
+	for _, name := range certNames {
+		got := &certmanagerv1.Certificate{}
+		require.NoError(t, fakeClient.Get(context.Background(),
+			k8stypes.NamespacedName{Name: name, Namespace: cnsconfig.DefaultCSINamespace}, got))
+		assert.Equal(t, "5", got.Annotations[lastCascadedCARevisionAnnotation],
+			"leaf %s should have its cascade annotation backfilled", name)
+		assert.Empty(t, got.Status.Conditions,
+			"leaf %s already trusts the live CA, so no reissue should be forced", name)
+	}
+}
+
+func TestReconcile_SecretsExistButDataMissing_ForcesReissueRatherThanBackfill(t *testing.T) {
+	scheme := newTestScheme(t)
+	ca := newCA(intPtr(5))
+	ca.Spec.SecretName = "ca-secret"
+	// No cascade annotation, same as the backfill case above - but here
+	// neither Secret has its expected key populated yet (e.g. still being
+	// written by cert-manager). bytes.Equal(nil, nil) would report two
+	// absent byte slices as "equal", so without treating this as unknown,
+	// the controller would incorrectly conclude trust and skip reissuing.
+	server := newLeaf(k8scloudoperator.K8sCloudOperatorServerCertName, nil)
+	server.Spec.SecretName = "server-secret"
+	client := newLeaf(k8scloudoperator.K8sCloudOperatorClientCertName, nil)
+	client.Spec.SecretName = "client-secret"
+
+	caSecret := newSecret("ca-secret", map[string][]byte{})
+	serverSecret := newSecret("server-secret", map[string][]byte{})
+	clientSecret := newSecret("client-secret", map[string][]byte{})
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&certmanagerv1.Certificate{}).
+		WithObjects(ca, server, client, caSecret, serverSecret, clientSecret).Build()
+	r := &ReconcileCACascade{client: fakeClient}
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      k8scloudoperator.K8sCloudOperatorCACertName,
+			Namespace: cnsconfig.DefaultCSINamespace,
+		}})
+	require.NoError(t, err)
+
+	certNames := []string{k8scloudoperator.K8sCloudOperatorServerCertName, k8scloudoperator.K8sCloudOperatorClientCertName}
+	for _, name := range certNames {
+		got := &certmanagerv1.Certificate{}
+		require.NoError(t, fakeClient.Get(context.Background(),
+			k8stypes.NamespacedName{Name: name, Namespace: cnsconfig.DefaultCSINamespace}, got))
+		require.Len(t, got.Status.Conditions, 1,
+			"leaf %s should be force-reissued, not backfilled, when Secret data can't be compared", name)
+		assert.Equal(t, "CACascade", got.Status.Conditions[0].Reason)
+	}
+}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/fsnotify/fsnotify"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	cnstypes "github.com/vmware/govmomi/cns/types"
@@ -102,6 +103,9 @@ func getGlobalScheme(ctx context.Context) *runtime.Scheme {
 		}
 		if err := vmoperatortypes.AddToScheme(globalScheme); err != nil {
 			log.Errorf("failed to add vmoperatortypes to global scheme: %+v", err)
+		}
+		if err := certmanagerv1.AddToScheme(globalScheme); err != nil {
+			log.Errorf("failed to add certmanagerv1 to global scheme: %+v", err)
 		}
 
 		log.Info("Global scheme initialization completed successfully")

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -71,6 +71,16 @@ const (
 	// certificate issued for this identity are authorized to invoke any RPC,
 	// even though the CA also signs this server's own certificate.
 	k8sCloudOperatorClientCertCN = "vmware-system-csi-k8scloudoperator-client"
+
+	// K8sCloudOperatorCACertName is the cert-manager Certificate name of the
+	// K8sCloudOperator root CA. It signs both K8sCloudOperatorServerCertName
+	// and K8sCloudOperatorClientCertName below.
+	K8sCloudOperatorCACertName = "vmware-system-csi-k8scloudoperator-ca-cert"
+
+	// K8sCloudOperatorServerCertName and K8sCloudOperatorClientCertName are
+	// the two leaves signed by K8sCloudOperatorCACertName.
+	K8sCloudOperatorServerCertName = "vmware-system-csi-k8scloudoperator-server-cert"
+	K8sCloudOperatorClientCertName = "vmware-system-csi-k8scloudoperator-client-cert"
 )
 
 type k8sCloudOperator struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

cert-manager treats the CA Certificate and each leaf Certificate as independent objects with independent renewal schedules. There is nothing that says "when the CA gets a new private key, immediately reissue everything it signs." 
This PR adds a watcher on CA certs and reissues server and client certs accordingly.

**Testing done**:

Started with CA at revision 1, both leaf certs already annotated last-cascaded-ca-revision: "1".
Created pvc-cacascade-test-before in svc-tkg-n3fn8 → Bound in ~5s (pre-rotation).
Force-renewed the CA by setting its Issuing condition (same mechanism cmctl renew uses) → CA reissued to revision 2 within seconds.

cacascade controller reconciled and forced reissuance on both leaves - confirmed via:
Serial number diff: 
CA 3535E5A3... → 3E63C811..., 
server 0185F2D9... → 41476DE3..., 
client 4C31FBF6... → 275577D1...

Verified that both leaf annotations updated to "2".

certwatcher logs show Reloaded certificate.

Created pvc-cacascade-test-after in the same namespace after rotation → Bound in ~3s

Complete logs:

Test 1 - Force reissue CA cert to see server and client certs also get rotated

1. Baseline - controller starts, both leaves already trust the CA (first-ever reconcile, before rotation):
```
2026-09-07T12:09:08.310337398Z  [info]  Initializing CA cascade controller
2026-09-07T12:09:09.912992026Z  [info]  Leaf Certificate vmware-system-csi/vmware-system-csi-k8scloudoperator-server-cert already trusts the live CA despite a stale or missing cascade annotation; backfilling the annotation without forcing a reissue
2026-09-07T12:09:10.150235095Z  [info]  Leaf Certificate vmware-system-csi/vmware-system-csi-k8scloudoperator-client-cert already trusts the live CA despite a stale or missing cascade annotation; backfilling the annotation without forcing a reissue
```

2. CA force-renewed → revision 2 detected, cascade attempted, initially blocked by the RBAC gap (this is the failure we found and you then patched):

```
2026-09-07T12:15:26.9733466Z    [info]   CA Certificate .../vmware-system-csi-k8scloudoperator-ca-cert is now at revision 2; forcing reissuance of leaf .../vmware-system-csi-k8scloudoperator-server-cert to stay in sync
```

4. Cascade succeeds on both leaves:
```
2026-09-07T12:26:22.576532917Z  [info]  CA Certificate .../vmware-system-csi-k8scloudoperator-ca-cert is now at revision 2; forcing reissuance of leaf .../vmware-system-csi-k8scloudoperator-server-cert to stay in sync
2026-09-07T12:26:22.736435275Z  [info]  CA Certificate .../vmware-system-csi-k8scloudoperator-ca-cert is now at revision 2; forcing reissuance of leaf .../vmware-system-csi-k8scloudoperator-client-cert to stay in sync
```

Test 2 - Force reissue server cert to ensure that does not cause any activity in cascade controller and CA and client certs remain the same.

Force-renewed ONLY the server leaf (not the CA), via the same Issuing-condition patch used before, but targeted at the leaf this time:

```
kubectl patch certificate vmware-system-csi-k8scloudoperator-server-cert -n vmware-system-csi \
  --type=merge --subresource=status -p \
  '{"status":{"conditions":[{"type":"Issuing","status":"True","reason":"ManualLeafOnlyTest",
    "message":"leaf-only renewal independent of CA","lastTransitionTime":"<timestamp>"}]}}'
```

== server after ==
serial=726A7B2F82D326ED27B622E04FB30017E10A0A08
notBefore=Sep  8 07:33:12 2026 GMT
notAfter=Dec  7 07:33:12 2026 GMT

Verified CA and client were untouched:

```
kubectl get certificate vmware-system-csi-k8scloudoperator-ca-cert -n vmware-system-csi -o jsonpath='{.status.revision}'
# 3   (unchanged)

diff baseline-ca.crt after-ca.crt        # -> no output = IDENTICAL
diff baseline-client.crt after-client.crt # -> no output = IDENTICAL

kubectl get certificate .../server-cert -o jsonpath='{...last-cascaded-ca-revision}'  # -> 3
```



WCP precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1983/
VKS precheckin (successful): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1539/
