### PR TITLE
Make FQDN comparison case-insensitive with type-safe FQDN type

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -44,6 +44,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
@@ -316,7 +317,7 @@ func (volumeMigration *volumeMigration) GetVolumePath(ctx context.Context, volum
 	log.Infof("Could not retrieve mapping of volume path and VolumeID in the cache for VolumeID: %q. "+
 		"volume may not be registered", volumeID)
 	volumeIds := []cnstypes.CnsVolumeId{{Id: volumeID}}
-	var host string
+	var host commontypes.FQDN
 	if volumeMigration.cnsConfig == nil || len(volumeMigration.cnsConfig.VirtualCenter) == 0 {
 		return "", logger.LogNewError(log, "could not find vcenter config")
 	}
@@ -468,7 +469,7 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context,
 	datastoreName := datastorePathSplit[len(datastorePathSplit)-1]
 	var datacenters string
 	var user string
-	var host string
+	var host commontypes.FQDN
 	if volumeMigration.cnsConfig == nil || len(volumeMigration.cnsConfig.VirtualCenter) == 0 {
 		return "", false, logger.LogNewError(log, "could not find vcenter config")
 	}
@@ -534,7 +535,7 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context,
 		// Check vCenter API Version
 		// Format:
 		// https://<vc_ip>/folder/<vm_vmdk_path>?dcPath=<datacenter-path>&dsName=<datastoreName>
-		backingDiskURLPath := "https://" + host + "/folder/" +
+		backingDiskURLPath := "https://" + host.String() + "/folder/" +
 			vmdkPath + "?dcPath=" + url.PathEscape(datacenter) + "&dsName=" + url.PathEscape(datastoreName)
 		bUseVslmAPIs, err := common.UseVslmAPIs(ctx, vCenter.Client.ServiceContent.About)
 		if err != nil {

--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -28,6 +28,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
@@ -71,7 +72,7 @@ type Manager interface {
 	// GetAllNodesByVC refreshes and returns VirtualMachine for all registered
 	// nodes in the given VC. If nodes are added or removed concurrently, they
 	// may or may not be reflected in the result of a call to this method.
-	GetAllNodesByVC(ctx context.Context, vcHost string) ([]*vsphere.VirtualMachine, error)
+	GetAllNodesByVC(ctx context.Context, vcHost types.FQDN) ([]*vsphere.VirtualMachine, error)
 	// UnregisterNode unregisters a registered node given its name.
 	UnregisterNode(ctx context.Context, nodeName string) error
 	// UnregisterAllNodes unregisters all registered nodes with the node manager.
@@ -282,7 +283,7 @@ func (m *defaultManager) GetAllNodes(ctx context.Context) ([]*vsphere.VirtualMac
 	log := logger.GetLogger(ctx)
 	var vms []*vsphere.VirtualMachine
 	var err error
-	reconnectedHosts := make(map[string]bool)
+	reconnectedHosts := make(map[types.FQDN]bool)
 
 	m.nodeNameToUUID.Range(func(nodeName, nodeUUID interface{}) bool {
 		if nodeName != nil && nodeUUID != nil && nodeUUID.(string) == "" {
@@ -344,11 +345,12 @@ func (m *defaultManager) GetAllNodes(ctx context.Context) ([]*vsphere.VirtualMac
 }
 
 // GetAllNodesByVC refreshes and returns VirtualMachine for all registered nodes in the given vcHost.
-func (m *defaultManager) GetAllNodesByVC(ctx context.Context, vcHost string) ([]*vsphere.VirtualMachine, error) {
+func (m *defaultManager) GetAllNodesByVC(ctx context.Context,
+	vcHost types.FQDN) ([]*vsphere.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	var vms []*vsphere.VirtualMachine
 	var err error
-	reconnectedHosts := make(map[string]bool)
+	reconnectedHosts := make(map[types.FQDN]bool)
 
 	m.nodeNameToUUID.Range(func(nodeName, nodeUUID interface{}) bool {
 		if nodeName != nil && nodeUUID != nil && nodeUUID.(string) == "" {

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
@@ -178,7 +179,8 @@ func (nodes *Nodes) GetAllNodes(ctx context.Context) (
 }
 
 // GetAllNodesByVC returns VirtualMachine objects for all registered nodes for a particular VC.
-func (nodes *Nodes) GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine, error) {
+func (nodes *Nodes) GetAllNodesByVC(ctx context.Context,
+	vcHost commontypes.FQDN) ([]*cnsvsphere.VirtualMachine, error) {
 	return nodes.cnsNodeManager.GetAllNodesByVC(ctx, vcHost)
 }
 

--- a/pkg/common/cns-lib/node/nodes_test.go
+++ b/pkg/common/cns-lib/node/nodes_test.go
@@ -27,6 +27,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types"
 )
 
@@ -79,7 +80,8 @@ func (s *stubNodeManager) GetAllNodes(ctx context.Context) ([]*cnsvsphere.Virtua
 	return nil, nil
 }
 
-func (s *stubNodeManager) GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine, error) {
+func (s *stubNodeManager) GetAllNodesByVC(ctx context.Context,
+	vcHost commontypes.FQDN) ([]*cnsvsphere.VirtualMachine, error) {
 	return nil, nil
 }
 

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -43,6 +43,7 @@ import (
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
 )
@@ -248,7 +249,7 @@ var (
 	// managerInstance is a Manager singleton.
 	managerInstance *defaultManager
 	// managerInstanceMap hold volume manager for vCenter servers
-	managerInstanceMap = make(map[string]*defaultManager)
+	managerInstanceMap = make(map[commontypes.FQDN]*defaultManager)
 	// managerInstanceLock is used for mitigating race condition during
 	// read/write on manager instance.
 	managerInstanceLock sync.Mutex
@@ -431,7 +432,7 @@ func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
 	log := logger.GetLogger(ctx)
 	log.Debugf("Invoked MonitorCreateVolumeTask for task: %v", task.Reference())
 	if m.multivCenterTopologyDeployment {
-		vCenterServerForVolumeOperationCR = m.virtualCenter.Config.Host
+		vCenterServerForVolumeOperationCR = m.virtualCenter.Config.Host.String()
 	}
 
 	taskInfo, err = m.waitOnTask(ctx, task.Reference())
@@ -607,7 +608,7 @@ func (m *defaultManager) createVolumeWithImprovedIdempotency(ctx context.Context
 	}
 	var vCenterServerForVolumeOperationCR string
 	if m.multivCenterTopologyDeployment {
-		vCenterServerForVolumeOperationCR = m.virtualCenter.Config.Host
+		vCenterServerForVolumeOperationCR = m.virtualCenter.Config.Host.String()
 	}
 
 	// Determine if CNS CreateVolume needs to be invoked.
@@ -767,7 +768,7 @@ func (m *defaultManager) createVolumeWithTransaction(ctx context.Context, spec *
 	}
 	var vCenterServerForVolumeOperationCR string
 	if m.multivCenterTopologyDeployment {
-		vCenterServerForVolumeOperationCR = m.virtualCenter.Config.Host
+		vCenterServerForVolumeOperationCR = m.virtualCenter.Config.Host.String()
 	}
 
 	volumeOperationDetails, finalErr = m.operationStore.GetRequestDetails(ctx, volNameFromInputSpec)
@@ -3828,8 +3829,8 @@ func (m *defaultManager) ClearVolumeControlFlags(ctx context.Context, volumeID s
 }
 
 // GetAllManagerInstances returns all Manager instances
-func GetAllManagerInstances(ctx context.Context) map[string]*defaultManager {
-	newManagerInstanceMap := make(map[string]*defaultManager)
+func GetAllManagerInstances(ctx context.Context) map[commontypes.FQDN]*defaultManager {
+	newManagerInstanceMap := make(map[commontypes.FQDN]*defaultManager)
 	if len(managerInstanceMap) != 0 {
 		newManagerInstanceMap = managerInstanceMap
 	} else if managerInstance != nil {

--- a/pkg/common/cns-lib/vsphere/cluster_compute_resource.go
+++ b/pkg/common/cns-lib/vsphere/cluster_compute_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
@@ -30,7 +31,7 @@ type ClusterComputeResource struct {
 	// ClusterComputeResource represents a vSphere cluster.
 	*object.ClusterComputeResource
 	// VirtualCenterHost denotes the virtual center host address.
-	VirtualCenterHost string
+	VirtualCenterHost commontypes.FQDN
 }
 
 // GetHosts returns all hosts under the ClusterComputeResource.

--- a/pkg/common/cns-lib/vsphere/cns_test.go
+++ b/pkg/common/cns-lib/vsphere/cns_test.go
@@ -28,6 +28,7 @@ import (
 	pbmsim "github.com/vmware/govmomi/pbm/simulator"
 	"github.com/vmware/govmomi/simulator"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // We should get expected failure when username is not a fully qualified domain name
@@ -55,7 +56,7 @@ func TestConnectCnsWithInvalidUser(t *testing.T) {
 	model.Service.RegisterSDK(pbmsim.New())
 	cfg.Global.InsecureFlag = true
 
-	cfg.Global.VCenterIP = s.URL.Hostname()
+	cfg.Global.VCenterIP = types.NewFQDN(s.URL.Hostname())
 	cfg.Global.VCenterPort = s.URL.Port()
 	// Username doesn't have fully qualified domain name
 	cfg.Global.User = "username-without-fqdn"
@@ -77,13 +78,14 @@ func TestConnectCnsWithInvalidUser(t *testing.T) {
 		os.Remove("test_vsphere.conf")
 	}()
 
-	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
-	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{
-		User:         cfg.Global.User,
-		Password:     cfg.Global.Password,
-		VCenterPort:  cfg.Global.VCenterPort,
-		InsecureFlag: cfg.Global.InsecureFlag,
-		Datacenters:  cfg.Global.Datacenters,
+	cfg.VirtualCenter = map[types.FQDN]*config.VirtualCenterConfig{
+		types.NewFQDN(s.URL.Hostname()): {
+			User:         cfg.Global.User,
+			Password:     cfg.Global.Password,
+			VCenterPort:  cfg.Global.VCenterPort,
+			InsecureFlag: cfg.Global.InsecureFlag,
+			Datacenters:  cfg.Global.Datacenters,
+		},
 	}
 
 	// CNS based CSI requires a valid cluster name.

--- a/pkg/common/cns-lib/vsphere/configured_or_active_user_test.go
+++ b/pkg/common/cns-lib/vsphere/configured_or_active_user_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi/simulator"
@@ -42,7 +44,7 @@ func connectedVCSim(t *testing.T) *VirtualCenter {
 
 	vc := &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host: server.URL.Hostname(), Port: port, Insecure: true,
+			Host: commontypes.NewFQDN(server.URL.Hostname()), Port: port, Insecure: true,
 			Username: "user", Password: "pass", // simulator.DefaultLogin
 		},
 		ClientMutex: &sync.Mutex{},

--- a/pkg/common/cns-lib/vsphere/connect_rest_repair_test.go
+++ b/pkg/common/cns-lib/vsphere/connect_rest_repair_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // restClientTo builds a rest.Client that talks to the given base URL, so a test
@@ -60,7 +61,7 @@ func connectedVC(t *testing.T, ctx context.Context, host string, port int) *Virt
 	t.Helper()
 	vc := &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host: host, Port: port, Insecure: true,
+			Host: types.NewFQDN(host), Port: port, Insecure: true,
 			Username: "user", Password: "pass", // simulator.DefaultLogin
 		},
 		ClientMutex: &sync.Mutex{},

--- a/pkg/common/cns-lib/vsphere/connect_rest_session_test.go
+++ b/pkg/common/cns-lib/vsphere/connect_rest_session_test.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"testing"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi"
@@ -82,7 +84,7 @@ func TestConnectSkipsRedundantRestSessionCheckForSessionManager(t *testing.T) {
 	t.Run("session-manager auth: skips the redundant rest session check", func(t *testing.T) {
 		vc := &VirtualCenter{
 			Config: &VirtualCenterConfig{
-				Host: server.URL.Hostname(), Port: port, Insecure: true,
+				Host: commontypes.NewFQDN(server.URL.Hostname()), Port: port, Insecure: true,
 				VCSessionManagerURL:   sessionManagerFor(t, ctx, server.URL),
 				VCSessionManagerToken: "a-token",
 			},
@@ -104,7 +106,7 @@ func TestConnectSkipsRedundantRestSessionCheckForSessionManager(t *testing.T) {
 	t.Run("credential auth: repairs the rest session without touching the soap session", func(t *testing.T) {
 		vc := &VirtualCenter{
 			Config: &VirtualCenterConfig{
-				Host: server.URL.Hostname(), Port: port, Insecure: true,
+				Host: commontypes.NewFQDN(server.URL.Hostname()), Port: port, Insecure: true,
 				Username: "user", Password: "pass", // simulator.DefaultLogin
 			},
 			ClientMutex: &sync.Mutex{},
@@ -147,7 +149,7 @@ func TestConnectSkipsRedundantRestSessionCheckForSessionManager(t *testing.T) {
 	t.Run("credential auth: a rest login that keeps failing leaves the soap session up", func(t *testing.T) {
 		vc := &VirtualCenter{
 			Config: &VirtualCenterConfig{
-				Host: server.URL.Hostname(), Port: port, Insecure: true,
+				Host: commontypes.NewFQDN(server.URL.Hostname()), Port: port, Insecure: true,
 				Username: "user", Password: "pass", // simulator.DefaultLogin
 			},
 			ClientMutex: &sync.Mutex{},
@@ -230,7 +232,7 @@ func TestConnectRecreatesClientsAfterSessionExpiry(t *testing.T) {
 	ctx := context.Background()
 	vc := &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host: server.URL.Hostname(), Port: port, Insecure: true,
+			Host: commontypes.NewFQDN(server.URL.Hostname()), Port: port, Insecure: true,
 			Username: "user", Password: "pass", // simulator.DefaultLogin
 		},
 		ClientMutex: &sync.Mutex{},

--- a/pkg/common/cns-lib/vsphere/datacenter.go
+++ b/pkg/common/cns-lib/vsphere/datacenter.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 
 	"github.com/vmware/govmomi/find"
@@ -38,7 +39,7 @@ type Datacenter struct {
 	// Datacenter represents the govmomi Datacenter.
 	*object.Datacenter
 	// VirtualCenterHost represents the virtual center host address.
-	VirtualCenterHost string
+	VirtualCenterHost commontypes.FQDN
 }
 
 func (dc *Datacenter) String() string {

--- a/pkg/common/cns-lib/vsphere/get_active_user_test.go
+++ b/pkg/common/cns-lib/vsphere/get_active_user_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi"
@@ -49,7 +51,7 @@ func newConnectedVC(t *testing.T, ctx context.Context) *VirtualCenter {
 
 	vc := &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host: server.URL.Hostname(), Port: port, Insecure: true,
+			Host: commontypes.NewFQDN(server.URL.Hostname()), Port: port, Insecure: true,
 			Username: "user", Password: "pass", // simulator.DefaultLogin
 		},
 		ClientMutex: &sync.Mutex{},

--- a/pkg/common/cns-lib/vsphere/tagmanager_race_test.go
+++ b/pkg/common/cns-lib/vsphere/tagmanager_race_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi"
@@ -50,7 +52,7 @@ func TestGetTagManagerConcurrentAccess(t *testing.T) {
 
 	vc := &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host:     server.URL.Hostname(),
+			Host:     commontypes.NewFQDN(server.URL.Hostname()),
 			Port:     port,
 			Insecure: true,
 			Username: "user", // simulator.DefaultLogin
@@ -105,7 +107,7 @@ func TestGetTagManagerConnectsWhenNeverConnected(t *testing.T) {
 
 	vc := &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host:     server.URL.Hostname(),
+			Host:     commontypes.NewFQDN(server.URL.Hostname()),
 			Port:     port,
 			Insecure: true,
 			Username: "user", // simulator.DefaultLogin
@@ -132,7 +134,7 @@ func TestGetTagManagerConnectsWhenNeverConnected(t *testing.T) {
 // must keep rejecting it before calling Connect.
 func TestGetTagManagerRejectsBrokenInnerClient(t *testing.T) {
 	vc := &VirtualCenter{
-		Config:      &VirtualCenterConfig{Host: "127.0.0.1", Port: 1},
+		Config:      &VirtualCenterConfig{Host: commontypes.NewFQDN("127.0.0.1"), Port: 1},
 		Client:      &govmomi.Client{}, // non-nil, but its own Client field is nil
 		RestClient:  &rest.Client{},
 		ClientMutex: &sync.Mutex{},

--- a/pkg/common/cns-lib/vsphere/tagmanager_restclient_race_test.go
+++ b/pkg/common/cns-lib/vsphere/tagmanager_restclient_race_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
+
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi/simulator"
 )
@@ -51,7 +53,7 @@ func TestGetTagManagerRestClientReadRace(t *testing.T) {
 
 	vc := &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host:     server.URL.Hostname(),
+			Host:     commontypes.NewFQDN(server.URL.Hostname()),
 			Port:     port,
 			Insecure: true,
 			Username: "user", // simulator.DefaultLogin

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
@@ -161,40 +162,39 @@ func CreateCnsKuberenetesEntityReference(entityType string, entityName string,
 // vSphere Configuration specified in the argument.
 func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCenterConfig, error) {
 	log := logger.GetLogger(ctx)
-	var err error
-	vCenterIPs, err := GetVcenterIPs(cfg) //  make([]string, 0)
+	host, vcConfigEntry, err := getFirstVirtualCenter(cfg)
 	if err != nil {
 		return nil, err
 	}
-	host := vCenterIPs[0]
-	port, err := strconv.Atoi(cfg.VirtualCenter[host].VCenterPort)
+
+	port, err := strconv.Atoi(vcConfigEntry.VCenterPort)
 	if err != nil {
 		return nil, err
 	}
 
 	var targetvSANClustersForFile []string
-	if strings.TrimSpace(cfg.VirtualCenter[host].TargetvSANFileShareClusters) != "" {
-		targetvSANClustersForFile = strings.Split(cfg.VirtualCenter[host].TargetvSANFileShareClusters, ",")
+	if strings.TrimSpace(vcConfigEntry.TargetvSANFileShareClusters) != "" {
+		targetvSANClustersForFile = strings.Split(vcConfigEntry.TargetvSANFileShareClusters, ",")
 	}
 
 	vcCAFile := cfg.Global.CAFile
 	vcThumbprint := cfg.Global.Thumbprint
 
 	vcConfig := &VirtualCenterConfig{
-		Host:                        strings.ToLower(host),
+		Host:                        host,
 		Port:                        port,
 		CAFile:                      vcCAFile,
-		Thumbprint:                  strings.ToUpper(vcThumbprint),
-		Username:                    cfg.VirtualCenter[host].User,
-		Password:                    cfg.VirtualCenter[host].Password,
-		Insecure:                    cfg.VirtualCenter[host].InsecureFlag,
+		Thumbprint:                  vcThumbprint,
+		Username:                    vcConfigEntry.User,
+		Password:                    vcConfigEntry.Password,
+		Insecure:                    vcConfigEntry.InsecureFlag,
 		TargetvSANFileShareClusters: targetvSANClustersForFile,
 		QueryLimit:                  cfg.Global.QueryLimit,
 		ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
-		MigrationDataStoreURL:       cfg.VirtualCenter[host].MigrationDataStoreURL,
-		FileVolumeActivated:         cfg.VirtualCenter[host].FileVolumeActivated,
-		VCSessionManagerURL:         cfg.VirtualCenter[host].VCSessionManagerURL,
-		VCSessionManagerToken:       cfg.VirtualCenter[host].VCSessionManagerToken,
+		MigrationDataStoreURL:       vcConfigEntry.MigrationDataStoreURL,
+		FileVolumeActivated:         vcConfigEntry.FileVolumeActivated,
+		VCSessionManagerURL:         vcConfigEntry.VCSessionManagerURL,
+		VCSessionManagerToken:       vcConfigEntry.VCSessionManagerToken,
 	}
 
 	if vcConfig.VCSessionManagerURL != "" {
@@ -202,8 +202,8 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 	}
 
 	log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
-	if strings.TrimSpace(cfg.VirtualCenter[host].Datacenters) != "" {
-		vcConfig.DatacenterPaths = strings.Split(cfg.VirtualCenter[host].Datacenters, ",")
+	if strings.TrimSpace(vcConfigEntry.Datacenters) != "" {
+		vcConfig.DatacenterPaths = strings.Split(vcConfigEntry.Datacenters, ",")
 		for idx := range vcConfig.DatacenterPaths {
 			vcConfig.DatacenterPaths[idx] = strings.TrimSpace(vcConfig.DatacenterPaths[idx])
 		}
@@ -216,40 +216,35 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 // vSphere Configuration specified in the argument.
 func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*VirtualCenterConfig, error) {
 	log := logger.GetLogger(ctx)
-	var err error
-	VirtualCenterConfigs := make([]*VirtualCenterConfig, 0)
-	vCenterIPs, err := GetVcenterIPs(cfg)
-	if err != nil {
-		return nil, err
+	if len(cfg.VirtualCenter) == 0 {
+		return nil, errors.New("unable get vCenter Hosts from VSphereConfig")
 	}
-	for _, vCenterIP := range vCenterIPs {
-		port, err := strconv.Atoi(cfg.VirtualCenter[vCenterIP].VCenterPort)
+	VirtualCenterConfigs := make([]*VirtualCenterConfig, 0, len(cfg.VirtualCenter))
+	for host, vcConfigEntry := range cfg.VirtualCenter {
+		port, err := strconv.Atoi(vcConfigEntry.VCenterPort)
 		if err != nil {
 			return nil, err
 		}
 
 		var targetvSANClustersForFile []string
-		if strings.TrimSpace(cfg.VirtualCenter[vCenterIP].TargetvSANFileShareClusters) != "" {
-			targetvSANClustersForFile = strings.Split(cfg.VirtualCenter[vCenterIP].TargetvSANFileShareClusters, ",")
+		if strings.TrimSpace(vcConfigEntry.TargetvSANFileShareClusters) != "" {
+			targetvSANClustersForFile = strings.Split(vcConfigEntry.TargetvSANFileShareClusters, ",")
 		}
 
 		vcConfig := &VirtualCenterConfig{
-			// vCenter FQDN/IP is a protocol-compliant case-insensitive identifier
-			// (used as a map key and in equality checks throughout the driver),
-			// so it is normalized to lowercase at this single entry point.
-			Host:                        strings.ToLower(vCenterIP),
+			Host:                        host,
 			Port:                        port,
-			CAFile:                      cfg.VirtualCenter[vCenterIP].CAFile,
-			Thumbprint:                  strings.ToUpper(cfg.VirtualCenter[vCenterIP].Thumbprint),
-			Username:                    cfg.VirtualCenter[vCenterIP].User,
-			Password:                    cfg.VirtualCenter[vCenterIP].Password,
-			Insecure:                    cfg.VirtualCenter[vCenterIP].InsecureFlag,
+			CAFile:                      vcConfigEntry.CAFile,
+			Thumbprint:                  strings.ToUpper(vcConfigEntry.Thumbprint),
+			Username:                    vcConfigEntry.User,
+			Password:                    vcConfigEntry.Password,
+			Insecure:                    vcConfigEntry.InsecureFlag,
 			TargetvSANFileShareClusters: targetvSANClustersForFile,
 			QueryLimit:                  cfg.Global.QueryLimit,
 			ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
-			FileVolumeActivated:         cfg.VirtualCenter[vCenterIP].FileVolumeActivated,
-			VCSessionManagerURL:         cfg.VirtualCenter[vCenterIP].VCSessionManagerURL,
-			VCSessionManagerToken:       cfg.VirtualCenter[vCenterIP].VCSessionManagerToken,
+			FileVolumeActivated:         vcConfigEntry.FileVolumeActivated,
+			VCSessionManagerURL:         vcConfigEntry.VCSessionManagerURL,
+			VCSessionManagerToken:       vcConfigEntry.VCSessionManagerToken,
 		}
 		if vcConfig.CAFile == "" {
 			vcConfig.CAFile = cfg.Global.CAFile
@@ -260,8 +255,8 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			vcConfig.Thumbprint = strings.ToUpper(cfg.Global.Thumbprint)
 		}
 		log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
-		if strings.TrimSpace(cfg.VirtualCenter[vCenterIP].Datacenters) != "" {
-			vcConfig.DatacenterPaths = strings.Split(cfg.VirtualCenter[vCenterIP].Datacenters, ",")
+		if strings.TrimSpace(vcConfigEntry.Datacenters) != "" {
+			vcConfig.DatacenterPaths = strings.Split(vcConfigEntry.Datacenters, ",")
 			for idx := range vcConfig.DatacenterPaths {
 				vcConfig.DatacenterPaths[idx] = strings.TrimSpace(vcConfig.DatacenterPaths[idx])
 			}
@@ -271,17 +266,13 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 	return VirtualCenterConfigs, nil
 }
 
-// GetVcenterIPs returns list of vCenter IPs from VSphereConfig.
-func GetVcenterIPs(cfg *config.Config) ([]string, error) {
-	var err error
-	vCenterIPs := make([]string, 0)
-	for key := range cfg.VirtualCenter {
-		vCenterIPs = append(vCenterIPs, key)
+// getFirstVirtualCenter returns an arbitrary vCenter entry from VSphereConfig.
+// Used only for single-vCenter deployments, where exactly one entry exists.
+func getFirstVirtualCenter(cfg *config.Config) (commontypes.FQDN, *config.VirtualCenterConfig, error) {
+	for host, vcConfigEntry := range cfg.VirtualCenter {
+		return host, vcConfigEntry, nil
 	}
-	if len(vCenterIPs) == 0 {
-		err = errors.New("unable get vCenter Hosts from VSphereConfig")
-	}
-	return vCenterIPs, err
+	return commontypes.FQDN{}, nil, errors.New("unable get vCenter Hosts from VSphereConfig")
 }
 
 // GetLabelsMapFromKeyValue creates a  map object from given parameter.
@@ -439,7 +430,7 @@ func GetDatastoreInfoByURL(ctx context.Context, vc *VirtualCenter,
 }
 
 // isVsan67u3Release returns true if it is vSAN 67u3 Release of vCenter.
-func isVsan67u3Release(ctx context.Context, m *defaultVirtualCenterManager, host string) (bool, error) {
+func isVsan67u3Release(ctx context.Context, m *defaultVirtualCenterManager, host commontypes.FQDN) (bool, error) {
 	log := logger.GetLogger(ctx)
 	log.Debug("Checking if vCenter version is of vsan 67u3 release")
 	vc, err := m.GetVirtualCenter(ctx, host)

--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // vCenter host and thumbprint are protocol-compliant case-insensitive identifiers, so
@@ -25,8 +26,8 @@ func TestGetVirtualCenterConfigsNormalizesHostAndThumbprint(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Global.QueryLimit = 100
 	cfg.Global.ListVolumeThreshold = 100
-	cfg.VirtualCenter = map[string]*config.VirtualCenterConfig{
-		mixedCaseHost: {
+	cfg.VirtualCenter = map[commontypes.FQDN]*config.VirtualCenterConfig{
+		commontypes.NewFQDN(mixedCaseHost): {
 			User:         "administrator@vsphere.local",
 			Password:     "password",
 			VCenterPort:  "443",
@@ -43,7 +44,7 @@ func TestGetVirtualCenterConfigsNormalizesHostAndThumbprint(t *testing.T) {
 		t.Fatalf("expected 1 VirtualCenterConfig, got %d", len(vcConfigs))
 	}
 
-	assert.Equal(t, "vc.example.com", vcConfigs[0].Host,
+	assert.Equal(t, commontypes.NewFQDN("vc.example.com"), vcConfigs[0].Host,
 		"vCenter host should be normalized to lowercase")
 	assert.Equal(t, "AA:BB:CC:DD:11:22:33:44:55:66:77:88:99:00:AA:BB:CC:DD:EE:FF", vcConfigs[0].Thumbprint,
 		"thumbprint should be normalized to uppercase to match govmomi's SHA1/SHA256 format")
@@ -58,8 +59,8 @@ func TestGetVirtualCenterConfigsNormalizesGlobalThumbprintFallback(t *testing.T)
 	cfg.Global.QueryLimit = 100
 	cfg.Global.ListVolumeThreshold = 100
 	cfg.Global.Thumbprint = "aa:bb:cc:dd:11:22:33:44:55:66:77:88:99:00:aa:bb:cc:dd:ee:ff"
-	cfg.VirtualCenter = map[string]*config.VirtualCenterConfig{
-		"vc.example.com": {
+	cfg.VirtualCenter = map[commontypes.FQDN]*config.VirtualCenterConfig{
+		commontypes.NewFQDN("vc.example.com"): {
 			User:         "administrator@vsphere.local",
 			Password:     "password",
 			VCenterPort:  "443",

--- a/pkg/common/cns-lib/vsphere/vc_session_login_orphan_test.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_login_orphan_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi"
@@ -50,7 +52,7 @@ func TestNewClientKeepsSoapSessionOnRestLoginFailure(t *testing.T) {
 
 	vc := &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host: server.URL.Hostname(), Port: port, Insecure: true,
+			Host: commontypes.NewFQDN(server.URL.Hostname()), Port: port, Insecure: true,
 			Username: "user", Password: "pass", // simulator.DefaultLogin
 		},
 		ClientMutex: &sync.Mutex{},

--- a/pkg/common/cns-lib/vsphere/vc_session_login_test.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_login_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // writeSessionTestConfig points config.GetConfig at a throwaway file, which
@@ -88,7 +89,7 @@ func newSharedSessionVC(t *testing.T) *VirtualCenter {
 
 	return &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host:                  vcsim.URL.Hostname(),
+			Host:                  commontypes.NewFQDN(vcsim.URL.Hostname()),
 			Port:                  port,
 			Insecure:              true,
 			VCSessionManagerURL:   sessionManager.URL,

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -48,6 +48,7 @@ import (
 	"github.com/vmware/govmomi/vslm"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
@@ -126,7 +127,7 @@ var (
 	// VCenter instance. It is a singleton.
 	vCenterInstance *VirtualCenter
 	// Map of VCenter Hostname and vCenter instances
-	vCenterInstances = make(map[string]*VirtualCenter)
+	vCenterInstances = make(map[commontypes.FQDN]*VirtualCenter)
 
 	// Has the vCenter instance been initialized?
 	vCenterInitialized bool
@@ -146,7 +147,7 @@ type VirtualCenterConfig struct {
 	// Scheme represents the connection scheme. (Ex: https)
 	Scheme string
 	// Host represents the virtual center host address.
-	Host string
+	Host commontypes.FQDN
 	// Username represents the virtual center username.
 	Username string `sensitive:"true"`
 	// Password represents the virtual center password in clear text.
@@ -223,7 +224,7 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 		vc.Config.Scheme = DefaultScheme
 	}
 
-	url, err := soap.ParseURL(net.JoinHostPort(vc.Config.Host, strconv.Itoa(vc.Config.Port)))
+	url, err := soap.ParseURL(net.JoinHostPort(vc.Config.Host.String(), strconv.Itoa(vc.Config.Port)))
 	if err != nil {
 		log.Errorf("failed to parse URL %s with err: %v", url, err)
 		return nil, nil, err
@@ -252,7 +253,7 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	// every 10 minutes.
 	vimClient.RoundTripper = session.KeepAlive(vimClient.RoundTripper, 10*time.Minute)
 	err = vimClient.UseServiceVersion("vsan")
-	if err != nil && vc.Config.Host != "127.0.0.1" {
+	if err != nil && !vc.Config.Host.Equal("127.0.0.1") {
 		// Skipping error for simulator connection for unit tests.
 		log.Errorf("Failed to set vimClient service version to vsan. err: %v", err)
 		return nil, nil, err
@@ -1104,7 +1105,8 @@ func GetVirtualCenterInstanceForVCenterConfig(ctx context.Context,
 	vCenterInstancesLock.Lock()
 	defer vCenterInstancesLock.Unlock()
 
-	_, found := vCenterInstances[vcconfig.Host]
+	hostKey := vcconfig.Host
+	_, found := vCenterInstances[hostKey]
 	if !found || reinitialize {
 		log.Infof("Initializing new vCenterInstance for vCenter %q", vcconfig.Host)
 		// Initialize the virtual center manager.
@@ -1132,10 +1134,10 @@ func GetVirtualCenterInstanceForVCenterConfig(ctx context.Context,
 				vcconfig.Host, err)
 			return nil, err
 		}
-		vCenterInstances[vcconfig.Host] = vcInstance
+		vCenterInstances[hostKey] = vcInstance
 		log.Infof("vCenterInstance for vCenter: %q initialized", vcconfig.Host)
 	}
-	return vCenterInstances[vcconfig.Host], nil
+	return vCenterInstances[hostKey], nil
 }
 
 // UnregisterAllVirtualCenters helps unregister and logout all registered vCenter instances
@@ -1155,7 +1157,7 @@ func UnregisterAllVirtualCenters(ctx context.Context) error {
 }
 
 // GetVirtualCenterInstanceForVCenterHost returns the vcenter object for given vCenter host.
-func GetVirtualCenterInstanceForVCenterHost(ctx context.Context, vcHost string,
+func GetVirtualCenterInstanceForVCenterHost(ctx context.Context, vcHost commontypes.FQDN,
 	reconnect bool) (*VirtualCenter, error) {
 	log := logger.GetLogger(ctx)
 	vCenterInstancesLock.RLock()

--- a/pkg/common/cns-lib/vsphere/virtualcenter_config_string_test.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter_config_string_test.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 func TestVirtualCenterConfigStringRedactsSensitiveFields(t *testing.T) {
 	cfg := &VirtualCenterConfig{
-		Host:                  "vc.example.com",
+		Host:                  types.NewFQDN("vc.example.com"),
 		Username:              "administrator@vsphere.local",
 		Password:              "S3cretPassw0rd!",
 		VCSessionManagerToken: "top-secret-token",
@@ -40,7 +42,7 @@ func TestVirtualCenterConfigStringRedactsSensitiveFields(t *testing.T) {
 		if strings.Contains(out, cfg.VCSessionManagerToken) {
 			t.Errorf("expected VCSessionManagerToken to be redacted, got: %s", out)
 		}
-		if !strings.Contains(out, cfg.Host) {
+		if !strings.Contains(out, cfg.Host.String()) {
 			t.Errorf("expected non-sensitive Host field to be preserved, got: %s", out)
 		}
 	}
@@ -49,7 +51,7 @@ func TestVirtualCenterConfigStringRedactsSensitiveFields(t *testing.T) {
 func TestVirtualCenterStringRedactsSensitiveFields(t *testing.T) {
 	vc := &VirtualCenter{
 		Config: &VirtualCenterConfig{
-			Host:     "vc.example.com",
+			Host:     types.NewFQDN("vc.example.com"),
 			Username: "administrator@vsphere.local",
 			Password: "S3cretPassw0rd!",
 		},

--- a/pkg/common/cns-lib/vsphere/virtualcentermanager.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/vmware/govmomi/cns"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
@@ -37,7 +38,7 @@ var (
 // VirtualCenterManager provides functionality to manage virtual centers.
 type VirtualCenterManager interface {
 	// GetVirtualCenter returns the VirtualCenter instance given the host.
-	GetVirtualCenter(ctx context.Context, host string) (*VirtualCenter, error)
+	GetVirtualCenter(ctx context.Context, host commontypes.FQDN) (*VirtualCenter, error)
 	// GetAllVirtualCenters returns all VirtualCenter instances. If virtual
 	// centers are added or removed concurrently, they may or may not be
 	// reflected in the result of a call to this method.
@@ -47,20 +48,20 @@ type VirtualCenterManager interface {
 	RegisterVirtualCenter(ctx context.Context, config *VirtualCenterConfig) (*VirtualCenter, error)
 	// UnregisterVirtualCenter disconnects and unregisters the virtual center
 	// given it's host.
-	UnregisterVirtualCenter(ctx context.Context, host string) error
+	UnregisterVirtualCenter(ctx context.Context, host commontypes.FQDN) error
 	// UnregisterAllVirtualCenters disconnects and unregisters all virtual centers.
 	UnregisterAllVirtualCenters(ctx context.Context) error
 	// IsvSANFileServicesSupported checks if vSAN file services is supported or not.
-	IsvSANFileServicesSupported(ctx context.Context, host string) (bool, error)
+	IsvSANFileServicesSupported(ctx context.Context, host commontypes.FQDN) (bool, error)
 	// IsOnlineExtendVolumeSupported checks if online extend volume is supported
 	// or not on the vCenter Host.
-	IsOnlineExtendVolumeSupported(ctx context.Context, host string) (bool, error)
+	IsOnlineExtendVolumeSupported(ctx context.Context, host commontypes.FQDN) (bool, error)
 	// IsCnsSnapshotSupported checks if cns volume snapshot is supported
 	// or not on the vCenter Host.
-	IsCnsSnapshotSupported(ctx context.Context, host string) (bool, error)
+	IsCnsSnapshotSupported(ctx context.Context, host commontypes.FQDN) (bool, error)
 	// IsCnsTransactionSupported checks if cns transaction is supported
 	// or not on the vCenter Host.
-	IsCnsTransactionSupported(ctx context.Context, host string) (bool, error)
+	IsCnsTransactionSupported(ctx context.Context, host commontypes.FQDN) (bool, error)
 }
 
 var (
@@ -88,7 +89,8 @@ type defaultVirtualCenterManager struct {
 	virtualCenters sync.Map
 }
 
-func (m *defaultVirtualCenterManager) GetVirtualCenter(ctx context.Context, host string) (*VirtualCenter, error) {
+func (m *defaultVirtualCenterManager) GetVirtualCenter(ctx context.Context,
+	host commontypes.FQDN) (*VirtualCenter, error) {
 	log := logger.GetLogger(ctx)
 	if vc, exists := m.virtualCenters.Load(host); exists {
 		return vc.(*VirtualCenter), nil
@@ -127,7 +129,7 @@ func (m *defaultVirtualCenterManager) RegisterVirtualCenter(ctx context.Context,
 	return vc, nil
 }
 
-func (m *defaultVirtualCenterManager) UnregisterVirtualCenter(ctx context.Context, host string) error {
+func (m *defaultVirtualCenterManager) UnregisterVirtualCenter(ctx context.Context, host commontypes.FQDN) error {
 	log := logger.GetLogger(ctx)
 	vc, err := m.GetVirtualCenter(ctx, host)
 	if err != nil {
@@ -153,8 +155,8 @@ func (m *defaultVirtualCenterManager) UnregisterAllVirtualCenters(ctx context.Co
 	var err error
 	log := logger.GetLogger(ctx)
 	m.virtualCenters.Range(func(hostInf, _ interface{}) bool {
-		if err = m.UnregisterVirtualCenter(ctx, hostInf.(string)); err != nil {
-			log.Warnf("failed to unregister vCenter: %q, err: %+v", hostInf.(string), err)
+		if err = m.UnregisterVirtualCenter(ctx, hostInf.(commontypes.FQDN)); err != nil {
+			log.Warnf("failed to unregister vCenter: %q, err: %+v", hostInf.(commontypes.FQDN), err)
 		}
 		return true
 	})
@@ -162,7 +164,8 @@ func (m *defaultVirtualCenterManager) UnregisterAllVirtualCenters(ctx context.Co
 }
 
 // IsvSANFileServicesSupported checks if vSAN file services is supported or not.
-func (m *defaultVirtualCenterManager) IsvSANFileServicesSupported(ctx context.Context, host string) (bool, error) {
+func (m *defaultVirtualCenterManager) IsvSANFileServicesSupported(ctx context.Context,
+	host commontypes.FQDN) (bool, error) {
 	log := logger.GetLogger(ctx)
 	is67u3Release, err := isVsan67u3Release(ctx, m, host)
 	if err != nil {
@@ -173,7 +176,8 @@ func (m *defaultVirtualCenterManager) IsvSANFileServicesSupported(ctx context.Co
 }
 
 // IsOnlineExtendVolumeSupported checks if online extend volume is supported or not.
-func (m *defaultVirtualCenterManager) IsOnlineExtendVolumeSupported(ctx context.Context, host string) (bool, error) {
+func (m *defaultVirtualCenterManager) IsOnlineExtendVolumeSupported(ctx context.Context,
+	host commontypes.FQDN) (bool, error) {
 	log := logger.GetLogger(ctx)
 
 	// Get VC instance.
@@ -192,7 +196,8 @@ func (m *defaultVirtualCenterManager) IsOnlineExtendVolumeSupported(ctx context.
 }
 
 // IsCnsSnapshotSupported checks if cns snapshot is supported or not.
-func (m *defaultVirtualCenterManager) IsCnsSnapshotSupported(ctx context.Context, host string) (bool, error) {
+func (m *defaultVirtualCenterManager) IsCnsSnapshotSupported(ctx context.Context,
+	host commontypes.FQDN) (bool, error) {
 	log := logger.GetLogger(ctx)
 
 	// Get VC instance.
@@ -215,7 +220,8 @@ func (m *defaultVirtualCenterManager) IsCnsSnapshotSupported(ctx context.Context
 }
 
 // IsCnsTransactionSupported checks if cns transaction is supported or not.
-func (m *defaultVirtualCenterManager) IsCnsTransactionSupported(ctx context.Context, host string) (bool, error) {
+func (m *defaultVirtualCenterManager) IsCnsTransactionSupported(ctx context.Context,
+	host commontypes.FQDN) (bool, error) {
 	log := logger.GetLogger(ctx)
 
 	// Get VC instance.

--- a/pkg/common/cns-lib/vsphere/virtualcentermanager_test.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
+)
+
+// TestGetVirtualCenterNormalizesMixedCaseHost verifies that GetVirtualCenter
+// can retrieve a registered vCenter even when queried with a different case.
+// This is critical for upgrade scenarios where old volume metadata may have
+// mixed-case vCenter FQDNs but the registry stores normalized (lowercase) keys.
+func TestGetVirtualCenterNormalizesMixedCaseHost(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup: create a fresh manager and register a vCenter with lowercase host
+	manager := &defaultVirtualCenterManager{virtualCenters: sync.Map{}}
+
+	normalizedHost := commontypes.NewFQDN("vc.example.com")
+	mixedCaseHost := commontypes.NewFQDN("VC.Example.COM")
+
+	// Register with normalized host
+	config := &VirtualCenterConfig{
+		Host:     normalizedHost,
+		Username: "admin@vsphere.local",
+		Password: "password",
+		Port:     443,
+	}
+	vc := &VirtualCenter{Config: config, ClientMutex: &sync.Mutex{}}
+	manager.virtualCenters.Store(normalizedHost, vc)
+
+	// Verify: querying with mixed case should find the same vCenter
+	retrieved, err := manager.GetVirtualCenter(ctx, mixedCaseHost)
+	assert.NoError(t, err, "GetVirtualCenter should not error for mixed-case host")
+	assert.NotNil(t, retrieved, "GetVirtualCenter should return the registered vCenter")
+	assert.Equal(t, normalizedHost, retrieved.Config.Host,
+		"Retrieved vCenter should have the normalized host")
+}

--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25/mo"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 
 	"github.com/vmware/govmomi/object"
@@ -46,7 +47,7 @@ type VirtualMachine struct {
 	// Datacenter represents the datacenter to which the virtual machine belongs.
 	Datacenter *Datacenter
 	// VirtualCenterHost represents the virtual machine's vCenter host.
-	VirtualCenterHost string
+	VirtualCenterHost commontypes.FQDN
 	// UUID represents the virtual machine's UUID.
 	UUID string
 }

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -32,6 +32,7 @@ import (
 	"gopkg.in/gcfg.v1"
 	corev1 "k8s.io/api/core/v1"
 
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
@@ -212,15 +213,12 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 	log := logger.GetLogger(ctx)
 	// Init.
 	if cfg.VirtualCenter == nil {
-		cfg.VirtualCenter = make(map[string]*VirtualCenterConfig)
+		cfg.VirtualCenter = make(map[types.FQDN]*VirtualCenterConfig)
 	}
 
 	// Globals.
 	if v := os.Getenv("VSPHERE_VCENTER"); v != "" {
-		// vCenter FQDN/IP is a protocol-compliant case-insensitive identifier that is
-		// later used as an exact-match map key against VirtualCenterConfig.Host, which
-		// is normalized to lowercase, so normalize this copy the same way.
-		cfg.Global.VCenterIP = strings.ToLower(v)
+		cfg.Global.VCenterIP = types.NewFQDN(v)
 	}
 	if v := os.Getenv("VSPHERE_PORT"); v != "" {
 		cfg.Global.VCenterPort = v
@@ -311,7 +309,7 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 			if errDatacenters != nil {
 				datacenters = cfg.Global.Datacenters
 			}
-			cfg.VirtualCenter[vcenter] = &VirtualCenterConfig{
+			cfg.VirtualCenter[types.NewFQDN(vcenter)] = &VirtualCenterConfig{
 				User:         username,
 				Password:     password,
 				VCenterPort:  port,
@@ -320,7 +318,7 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 			}
 		}
 	}
-	if cfg.Global.VCenterIP != "" && cfg.VirtualCenter[cfg.Global.VCenterIP] == nil {
+	if _, exists := cfg.VirtualCenter[cfg.Global.VCenterIP]; !cfg.Global.VCenterIP.IsEmpty() && !exists {
 		cfg.VirtualCenter[cfg.Global.VCenterIP] = &VirtualCenterConfig{
 			User:         cfg.Global.User,
 			Password:     cfg.Global.Password,
@@ -384,7 +382,7 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	}
 	for vcServer, vcConfig := range cfg.VirtualCenter {
 		log.Debugf("Initializing vc server %s", vcServer)
-		if vcServer == "" {
+		if vcServer.IsEmpty() {
 			log.Error(ErrInvalidVCenterIP)
 			return ErrInvalidVCenterIP
 		}
@@ -424,10 +422,8 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 		if !insecure {
 			vcConfig.InsecureFlag = cfg.Global.InsecureFlag
 		}
-		if setCfgGlobalvCenter && cfg.Global.VCenterIP == "" {
-			// Normalize to lowercase to match VirtualCenterConfig.Host, which downstream
-			// code looks up by exact-match against this value.
-			cfg.Global.VCenterIP = strings.ToLower(vcServer)
+		if setCfgGlobalvCenter && cfg.Global.VCenterIP.IsEmpty() {
+			cfg.Global.VCenterIP = vcServer
 		}
 		// Print out the config.
 		log.Debugf("vc server %s config: %+v", vcServer, vcConfig)
@@ -534,11 +530,31 @@ func ReadConfig(ctx context.Context, config io.Reader) (*Config, error) {
 		log.Errorf("error while reading config file: %+v", err)
 		return nil, err
 	}
+	if err := buildVirtualCenterMap(ctx, cfg); err != nil {
+		return nil, err
+	}
 	// Env Vars should override config file entries if present.
 	if err := FromEnv(ctx, cfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil
+}
+
+// buildVirtualCenterMap builds the FQDN-keyed cfg.VirtualCenter from the raw,
+// gcfg-populated cfg.VirtualCenterRaw, which is section-name-keyed and may
+// carry any casing the operator used in the config file.
+func buildVirtualCenterMap(ctx context.Context, cfg *Config) error {
+	log := logger.GetLogger(ctx)
+	cfg.VirtualCenter = make(map[types.FQDN]*VirtualCenterConfig, len(cfg.VirtualCenterRaw))
+	for host, vcConfig := range cfg.VirtualCenterRaw {
+		fqdn := types.NewFQDN(host)
+		if _, exists := cfg.VirtualCenter[fqdn]; exists {
+			return logger.LogNewErrorf(log,
+				"duplicate vCenter entry %q in config after normalizing case", host)
+		}
+		cfg.VirtualCenter[fqdn] = vcConfig
+	}
+	return nil
 }
 
 // GetCnsconfig returns Config from specified config file path.
@@ -619,6 +635,9 @@ func ReadGCConfig(ctx context.Context, config io.Reader) (*Config, error) {
 	}
 	cfg := &Config{}
 	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, config)); err != nil {
+		return nil, err
+	}
+	if err := buildVirtualCenterMap(ctx, cfg); err != nil {
 		return nil, err
 	}
 	// Env Vars should override config file entries if present.

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -23,20 +23,22 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 var (
 	ctx           context.Context
 	cancel        context.CancelFunc
-	idealVCConfig map[string]*VirtualCenterConfig
+	idealVCConfig map[types.FQDN]*VirtualCenterConfig
 )
 
 func init() {
 	// Create context
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
-	idealVCConfig = map[string]*VirtualCenterConfig{
-		"1.1.1.1": {
+	idealVCConfig = map[types.FQDN]*VirtualCenterConfig{
+		types.NewFQDN("1.1.1.1"): {
 			User:         "Administrator@vsphere.local",
 			Password:     "Password",
 			VCenterPort:  "443",
@@ -162,8 +164,8 @@ func TestValidateConfigWithInvalidClusterId(t *testing.T) {
 }
 
 func TestValidateConfigWithInvalidUsername(t *testing.T) {
-	vcConfigInvalidUsername := map[string]*VirtualCenterConfig{
-		"1.1.1.1": {
+	vcConfigInvalidUsername := map[types.FQDN]*VirtualCenterConfig{
+		types.NewFQDN("1.1.1.1"): {
 			User:         "Administrator",
 			Password:     "Password",
 			VCenterPort:  "443",
@@ -182,8 +184,8 @@ func TestValidateConfigWithInvalidUsername(t *testing.T) {
 }
 
 func TestValidateConfigWithValidUsername1(t *testing.T) {
-	vcConfigValidUsername := map[string]*VirtualCenterConfig{
-		"1.1.1.1": {
+	vcConfigValidUsername := map[types.FQDN]*VirtualCenterConfig{
+		types.NewFQDN("1.1.1.1"): {
 			User:         "Administrator@vsphere.local",
 			Password:     "Password",
 			VCenterPort:  "443",
@@ -202,8 +204,8 @@ func TestValidateConfigWithValidUsername1(t *testing.T) {
 }
 
 func TestValidateConfigWithSessionManager(t *testing.T) {
-	vcConfigValidUsername := map[string]*VirtualCenterConfig{
-		"1.1.1.1": {
+	vcConfigValidUsername := map[types.FQDN]*VirtualCenterConfig{
+		types.NewFQDN("1.1.1.1"): {
 			VCenterPort:         "443",
 			Datacenters:         "dc1",
 			InsecureFlag:        true,
@@ -221,8 +223,8 @@ func TestValidateConfigWithSessionManager(t *testing.T) {
 }
 
 func TestValidateConfigWithSessionManagerAndToken(t *testing.T) {
-	vcConfigValidUsername := map[string]*VirtualCenterConfig{
-		"1.1.1.1": {
+	vcConfigValidUsername := map[types.FQDN]*VirtualCenterConfig{
+		types.NewFQDN("1.1.1.1"): {
 			VCenterPort:           "443",
 			Datacenters:           "dc1",
 			InsecureFlag:          true,
@@ -247,8 +249,8 @@ func TestValidateConfigWithSessionManagerAndToken(t *testing.T) {
 // VCSessionManagerToken at all, so a token with no URL configured has nowhere
 // to be sent and must not silently pass validation.
 func TestValidateConfigWithSessionManagerTokenButNoURL(t *testing.T) {
-	vcConfigTokenOnly := map[string]*VirtualCenterConfig{
-		"1.1.1.1": {
+	vcConfigTokenOnly := map[types.FQDN]*VirtualCenterConfig{
+		types.NewFQDN("1.1.1.1"): {
 			VCenterPort:           "443",
 			Datacenters:           "dc1",
 			InsecureFlag:          true,
@@ -267,8 +269,8 @@ func TestValidateConfigWithSessionManagerTokenButNoURL(t *testing.T) {
 }
 
 func TestValidateConfigWithValidUsername2(t *testing.T) {
-	vcConfigValidUsername := map[string]*VirtualCenterConfig{
-		"1.1.1.1": {
+	vcConfigValidUsername := map[types.FQDN]*VirtualCenterConfig{
+		types.NewFQDN("1.1.1.1"): {
 			User:         "vsphere.local\\Administrator",
 			Password:     "Password",
 			VCenterPort:  "443",

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // Config is used to read and store information from the cloud configuration file
@@ -27,8 +28,14 @@ type Config struct {
 	// The string can uniquely represent each Net Permissions config
 	NetPermissions map[string]*NetPermissionConfig
 
-	// Virtual Center configurations
-	VirtualCenter map[string]*VirtualCenterConfig
+	// VirtualCenterRaw is populated directly by gcfg from the config file's
+	// [VirtualCenter "<host>"] sections. Do not use directly -- use VirtualCenter,
+	// which is FQDN-keyed and built from this right after gcfg parses.
+	VirtualCenterRaw map[string]*VirtualCenterConfig `gcfg:"VirtualCenter"`
+
+	// VirtualCenter is the FQDN-keyed (case-insensitive) view of the configured
+	// vCenters. Built from VirtualCenterRaw by BuildVirtualCenterMap.
+	VirtualCenter map[types.FQDN]*VirtualCenterConfig `gcfg:"-"`
 
 	TopologyCategory map[string]*TopologyCategoryInfo
 
@@ -51,7 +58,7 @@ type Config struct {
 
 	Global struct {
 		//vCenter IP address or FQDN
-		VCenterIP string
+		VCenterIP types.FQDN
 		// Kubernetes Cluster ID
 		ClusterID string `gcfg:"cluster-id"`
 		// SupervisorID is the UUID representing Supervisor Cluster. ClusterID is being deprecated

--- a/pkg/common/types/fqdn.go
+++ b/pkg/common/types/fqdn.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import "strings"
+
+// FQDN is a normalized, case-insensitive DNS name (RFC 1034/1035), used for
+// vCenter and ESXi host identifiers. The unexported field means a value can
+// only be constructed via NewFQDN, so it can never carry unnormalized casing.
+type FQDN struct {
+	host string
+}
+
+// NewFQDN normalizes s (lowercase, no trailing dot) and returns it as an FQDN.
+func NewFQDN(s string) FQDN {
+	return FQDN{host: strings.TrimSuffix(strings.ToLower(s), ".")}
+}
+
+// String returns the normalized host value.
+func (f FQDN) String() string {
+	return f.host
+}
+
+// Equal reports whether f refers to the same host as other, a raw
+// (possibly differently-cased) host string.
+func (f FQDN) Equal(other string) bool {
+	return strings.EqualFold(f.host, other)
+}
+
+// IsEmpty reports whether f is the zero value.
+func (f FQDN) IsEmpty() bool {
+	return f.host == ""
+}
+
+// UnmarshalText allows FQDN to be populated directly from config (gcfg) and
+// JSON/CRD fields, normalizing on the way in.
+func (f *FQDN) UnmarshalText(text []byte) error {
+	*f = NewFQDN(string(text))
+	return nil
+}
+
+// MarshalText allows FQDN to be serialized back to its normalized string form.
+func (f FQDN) MarshalText() ([]byte, error) {
+	return []byte(f.host), nil
+}

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -48,6 +48,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
@@ -799,7 +800,7 @@ func configFromVCSimWithTLS(tlsConfig *tls.Config, vcsimParams VcsimParams, inse
 	model.Service.RegisterSDK(pbmsim.New())
 
 	cfg.Global.InsecureFlag = insecureAllowed
-	cfg.Global.VCenterIP = s.URL.Hostname()
+	cfg.Global.VCenterIP = types.NewFQDN(s.URL.Hostname())
 	cfg.Global.VCenterPort = s.URL.Port()
 	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
@@ -834,8 +835,8 @@ func configFromVCSimWithTLS(tlsConfig *tls.Config, vcsimParams VcsimParams, inse
 		log.Fatal(err)
 	}
 
-	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
-	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{
+	cfg.VirtualCenter = make(map[types.FQDN]*config.VirtualCenterConfig)
+	cfg.VirtualCenter[types.NewFQDN(s.URL.Hostname())] = &config.VirtualCenterConfig{
 		User:                cfg.Global.User,
 		Password:            cfg.Global.Password,
 		VCenterPort:         cfg.Global.VCenterPort,

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -18,13 +18,14 @@ import (
 	_ "github.com/vmware/govmomi/vapi/simulator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	cnsvolumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 const (
@@ -72,7 +73,7 @@ func configFromCustomizedSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool)
 
 	cfg.Global.InsecureFlag = insecureAllowed
 
-	cfg.Global.VCenterIP = s.URL.Hostname()
+	cfg.Global.VCenterIP = commontypes.NewFQDN(s.URL.Hostname())
 	cfg.Global.VCenterPort = s.URL.Port()
 	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
@@ -89,13 +90,14 @@ func configFromCustomizedSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool)
 		log.Fatal(err)
 	}
 
-	cfg.VirtualCenter = make(map[string]*cnsconfig.VirtualCenterConfig)
-	cfg.VirtualCenter[s.URL.Hostname()] = &cnsconfig.VirtualCenterConfig{
-		User:         cfg.Global.User,
-		Password:     cfg.Global.Password,
-		VCenterPort:  cfg.Global.VCenterPort,
-		InsecureFlag: cfg.Global.InsecureFlag,
-		Datacenters:  cfg.Global.Datacenters,
+	cfg.VirtualCenter = map[commontypes.FQDN]*cnsconfig.VirtualCenterConfig{
+		commontypes.NewFQDN(s.URL.Hostname()): {
+			User:         cfg.Global.User,
+			Password:     cfg.Global.Password,
+			VCenterPort:  cfg.Global.VCenterPort,
+			InsecureFlag: cfg.Global.InsecureFlag,
+			Datacenters:  cfg.Global.Datacenters,
+		},
 	}
 
 	return cfg, func() {
@@ -814,7 +816,7 @@ func TestGetVirtualMachine(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		vmKey          types.NamespacedName
+		vmKey          k8stypes.NamespacedName
 		vm             *vmoperatortypes.VirtualMachine
 		expectError    bool
 		clientError    error
@@ -823,7 +825,7 @@ func TestGetVirtualMachine(t *testing.T) {
 	}{
 		{
 			name: "Successfully get VM",
-			vmKey: types.NamespacedName{
+			vmKey: k8stypes.NamespacedName{
 				Name:      "test-vm",
 				Namespace: "test-namespace",
 			},
@@ -850,7 +852,7 @@ func TestGetVirtualMachine(t *testing.T) {
 		},
 		{
 			name: "Error when VM does not exist",
-			vmKey: types.NamespacedName{
+			vmKey: k8stypes.NamespacedName{
 				Name:      "non-existent-vm",
 				Namespace: "test-namespace",
 			},
@@ -876,7 +878,7 @@ func TestGetVirtualMachine(t *testing.T) {
 		},
 		{
 			name: "Error when client returns error",
-			vmKey: types.NamespacedName{
+			vmKey: k8stypes.NamespacedName{
 				Name:      "test-vm",
 				Namespace: "test-namespace",
 			},
@@ -906,7 +908,7 @@ func TestGetVirtualMachine(t *testing.T) {
 		},
 		{
 			name: "Successfully get VM with different namespace",
-			vmKey: types.NamespacedName{
+			vmKey: k8stypes.NamespacedName{
 				Name:      "test-vm",
 				Namespace: "namespace-2",
 			},
@@ -998,7 +1000,7 @@ func TestGetVirtualMachineAPIVersion(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vm).Build()
 
-	vmKey := types.NamespacedName{
+	vmKey := k8stypes.NamespacedName{
 		Name:      "test-vm",
 		Namespace: "test-namespace",
 	}

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
@@ -75,7 +76,7 @@ var onceForAuthorizationService sync.Once
 // authManagerIntance is instance of authManager and implements interface for
 // AuthorizationService.
 var authManagerInstance *AuthManager
-var authManagerInstances = make(map[string]*AuthManager)
+var authManagerInstances = make(map[commontypes.FQDN]*AuthManager)
 
 // GetAuthorizationService returns the singleton AuthorizationService.
 func GetAuthorizationService(ctx context.Context, vc *cnsvsphere.VirtualCenter) (AuthorizationService, error) {
@@ -96,7 +97,8 @@ func GetAuthorizationService(ctx context.Context, vc *cnsvsphere.VirtualCenter) 
 }
 
 // GetAuthorizationServices returns the AuthManager instances for supplied vCenter servers
-func GetAuthorizationServices(ctx context.Context, vcs []*cnsvsphere.VirtualCenter) (map[string]*AuthManager, error) {
+func GetAuthorizationServices(ctx context.Context,
+	vcs []*cnsvsphere.VirtualCenter) (map[commontypes.FQDN]*AuthManager, error) {
 	log := logger.GetLogger(ctx)
 	onceForAuthorizationService.Do(func() {
 		log.Info("Initializing authorization service...")

--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -10,6 +10,7 @@ import (
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -223,8 +224,8 @@ func getExpandedTopologySegments(ctx context.Context, requestedSegments map[stri
 					"failed to retrieve NodeVM %q. Error - %+v", nodeTopologyInstance.Spec.NodeID, err)
 			}
 			if vcHost == "" {
-				vcHost = nodeVM.VirtualCenterHost
-			} else if vcHost != nodeVM.VirtualCenterHost {
+				vcHost = nodeVM.VirtualCenterHost.String()
+			} else if !nodeVM.VirtualCenterHost.Equal(vcHost) {
 				return nil, logger.LogNewErrorf(log,
 					"found NodeVM %q belonging to different vCenter: %q. Expected vCenter: %q",
 					nodeVM.Name(), nodeVM.VirtualCenterHost, vcHost)
@@ -380,7 +381,7 @@ func GetTopologyInfoFromNodes(ctx context.Context, reqParams interface{}) (
 		// Finally, filter the accessible topologies with topology domains where datastore is preferred.
 		var preferredAccessibleTopology []map[string]string
 		for _, segments := range combinedAccessibleTopology {
-			PreferredDSURLs := common.GetPreferredDatastoresInSegments(ctx, segments, params.VCHost)
+			PreferredDSURLs := common.GetPreferredDatastoresInSegments(ctx, segments, commontypes.NewFQDN(params.VCHost))
 			if len(PreferredDSURLs) != 0 {
 				if _, ok := PreferredDSURLs[params.DatastoreURL]; ok {
 					preferredAccessibleTopology = append(preferredAccessibleTopology, segments)

--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -13,6 +13,7 @@ import (
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/csinodetopology/v1alpha1"
 )
@@ -34,7 +35,7 @@ var (
 	// preferredDatastoresMap is a map of topology domain to list of
 	// datastore URLs preferred in that domain for each VC.
 	// Ex: {"vc1": {"zone1": [DSURL1, DSURL2], "zone2": [DSURL3]}, "vc2": {"zone3": [DSURL5]} }
-	preferredDatastoresMap = make(map[string]map[string][]string)
+	preferredDatastoresMap = make(map[commontypes.FQDN]map[string][]string)
 	// preferredDatastoresMapInstanceLock guards the preferredDatastoresMap from read-write overlaps.
 	preferredDatastoresMapInstanceLock = &sync.RWMutex{}
 	// tagVCEntityMoRefMap maintains a cache of topology tags to the vCenter IP/FQDN & the MoRef of the
@@ -43,7 +44,7 @@ var (
 	//    "region-1": {"vc1": [{Type:Datacenter Value:datacenter-3}], "vc2": [{Type:Datacenter Value:datacenter-5}] },
 	//	  "zone-1": {"vc1": [{Type:ClusterComputeResource Value:domain-c12}] },
 	//	  "zone-2": {"vc2": [{Type:ClusterComputeResource Value:domain-c8] },}
-	tagVCEntityMoRefMap = make(map[string]map[string][]mo.Reference)
+	tagVCEntityMoRefMap = make(map[string]map[commontypes.FQDN][]mo.Reference)
 )
 
 // DiscoverTagEntities populates tagVCEntityMoRefMap with tagName -> VC -> associated MoRefs mapping.
@@ -104,7 +105,7 @@ func DiscoverTagEntities(ctx context.Context) error {
 					continue
 				}
 				if _, exists := tagVCEntityMoRefMap[tag.Name]; !exists {
-					tagVCEntityMoRefMap[tag.Name] = map[string][]mo.Reference{vcenterCfg.Host: objMORs}
+					tagVCEntityMoRefMap[tag.Name] = map[commontypes.FQDN][]mo.Reference{vcenterCfg.Host: objMORs}
 				} else {
 					tagVCEntityMoRefMap[tag.Name][vcenterCfg.Host] = objMORs
 				}
@@ -357,7 +358,7 @@ func filterMaintenanceModeHosts(ctx context.Context, hostList []*cnsvsphere.Host
 
 // areEntityMorefsPresentForTag retrieves the entities in given VC which have the
 // input tag associated with them.
-func areEntityMorefsPresentForTag(tag, vcHost string) ([]mo.Reference, bool) {
+func areEntityMorefsPresentForTag(tag string, vcHost commontypes.FQDN) ([]mo.Reference, bool) {
 	vcEntityMap, exists := tagVCEntityMoRefMap[tag]
 	if !exists {
 		return nil, false
@@ -371,14 +372,14 @@ func areEntityMorefsPresentForTag(tag, vcHost string) ([]mo.Reference, bool) {
 
 // GetAccessibilityRequirementsByVC clubs the accessibility requirements by the VC they belong to.
 func GetAccessibilityRequirementsByVC(ctx context.Context, topoReq *csi.TopologyRequirement) (
-	map[string][]map[string]string, error) {
+	map[commontypes.FQDN][]map[string]string, error) {
 	log := logger.GetLogger(ctx)
 	// NOTE: We are only checking for preferred segments as vSphere CSI driver follows strict topology.
 	if topoReq.GetPreferred() == nil {
 		return nil, logger.LogNewErrorf(log, "No preferred segments specified in the "+
 			"accessibility requirements.")
 	}
-	vcTopoSegmentsMap := make(map[string][]map[string]string)
+	vcTopoSegmentsMap := make(map[commontypes.FQDN][]map[string]string)
 	for _, topology := range topoReq.GetPreferred() {
 		segments := topology.GetSegments()
 		vcHost, err := getVCForTopologySegments(ctx, segments)
@@ -393,11 +394,12 @@ func GetAccessibilityRequirementsByVC(ctx context.Context, topoReq *csi.Topology
 
 // getVCForTopologySegments uses the tagVCEntityMoRefMap to retrieve the
 // VC instance for the given topology segments map in a multi-VC environment.
-func getVCForTopologySegments(ctx context.Context, topologySegments map[string]string) (string, error) {
+func getVCForTopologySegments(ctx context.Context,
+	topologySegments map[string]string) (commontypes.FQDN, error) {
 	log := logger.GetLogger(ctx)
 	// vcCountMap keeps a cumulative count of the occurrences of
 	// VCs across all labels in the given topology segment.
-	vcCountMap := make(map[string]int)
+	vcCountMap := make(map[commontypes.FQDN]int)
 
 	// Find the VC which contains all the labels given in the topologySegments.
 	// For example, if tagVCEntityMoRefMap looks like
@@ -416,7 +418,7 @@ func getVCForTopologySegments(ctx context.Context, topologySegments map[string]s
 			// Refresh cache to see if the tag has been added recently.
 			err := DiscoverTagEntities(ctx)
 			if err != nil {
-				return "", logger.LogNewErrorf(log,
+				return commontypes.FQDN{}, logger.LogNewErrorf(log,
 					"failed to update cache with tag to VC to MoRef mapping. Error: %+v", err)
 			}
 			vcMap, exists = tagVCEntityMoRefMap[label]
@@ -426,11 +428,11 @@ func getVCForTopologySegments(ctx context.Context, topologySegments map[string]s
 				vcCountMap[vc] = vcCountMap[vc] + 1
 			}
 		} else {
-			return "", logger.LogNewErrorf(log, "Topology label %q not found in tag to vCenter mapping.",
+			return commontypes.FQDN{}, logger.LogNewErrorf(log, "Topology label %q not found in tag to vCenter mapping.",
 				topologyKey+":"+label)
 		}
 	}
-	var commonVCList []string
+	var commonVCList []commontypes.FQDN
 	numTopoLabels := len(topologySegments)
 	for vc, count := range vcCountMap {
 		// Add VCs to the commonVCList if they satisfied all the labels in the topology segment.
@@ -440,14 +442,14 @@ func getVCForTopologySegments(ctx context.Context, topologySegments map[string]s
 	}
 	switch {
 	case len(commonVCList) > 1:
-		return "", logger.LogNewErrorf(log, "Topology segment(s) %+v belong to more than one vCenter: %+v",
-			topologySegments, commonVCList)
+		return commontypes.FQDN{}, logger.LogNewErrorf(log,
+			"Topology segment(s) %+v belong to more than one vCenter: %+v", topologySegments, commonVCList)
 	case len(commonVCList) == 1:
 		log.Infof("Topology segment(s) %+v belong to vCenter: %q", topologySegments, commonVCList[0])
 		return commonVCList[0], nil
 	}
-	return "", logger.LogNewErrorf(log, "failed to find the vCenter associated with topology segments %+v",
-		topologySegments)
+	return commontypes.FQDN{}, logger.LogNewErrorf(log,
+		"failed to find the vCenter associated with topology segments %+v", topologySegments)
 }
 
 // RefreshPreferentialDatastoresForMultiVCenter refreshes the preferredDatastoresMap variable
@@ -462,7 +464,7 @@ func RefreshPreferentialDatastoresForMultiVCenter(ctx context.Context) error {
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to get VirtualCenterConfig from CNS config. Error: %+v", err)
 	}
-	prefDatastoresMap := make(map[string]map[string][]string)
+	prefDatastoresMap := make(map[commontypes.FQDN]map[string][]string)
 	for _, vcConfig := range vcenterconfigs {
 		// Get VC instance.
 		vcMgr := cnsvsphere.GetVirtualCenterManager(ctx)
@@ -541,7 +543,7 @@ func RefreshPreferentialDatastoresForMultiVCenter(ctx context.Context) error {
 // GetPreferredDatastoresInSegments fetches preferred datastores in
 // given topology segments as a map for faster retrieval.
 func GetPreferredDatastoresInSegments(ctx context.Context, segments map[string]string,
-	vcHost string) map[string]struct{} {
+	vcHost commontypes.FQDN) map[string]struct{} {
 	log := logger.GetLogger(ctx)
 	allPreferredDSURLs := make(map[string]struct{})
 

--- a/pkg/csi/service/common/topology_fetchhosts_test.go
+++ b/pkg/csi/service/common/topology_fetchhosts_test.go
@@ -28,6 +28,7 @@ import (
 	vim25types "github.com/vmware/govmomi/vim25/types"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // buildVirtualCenter constructs a minimal cnsvsphere.VirtualCenter backed by
@@ -35,7 +36,7 @@ import (
 // calls against the vcsim server.
 func buildVirtualCenter(client *govmomi.Client) *cnsvsphere.VirtualCenter {
 	return &cnsvsphere.VirtualCenter{
-		Config:      &cnsvsphere.VirtualCenterConfig{Host: "127.0.0.1"},
+		Config:      &cnsvsphere.VirtualCenterConfig{Host: commontypes.NewFQDN("127.0.0.1")},
 		Client:      client,
 		ClientMutex: &sync.Mutex{},
 	}

--- a/pkg/csi/service/common/types.go
+++ b/pkg/csi/service/common/types.go
@@ -25,6 +25,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 var (
@@ -65,10 +66,10 @@ type Manager struct {
 // participating vCenter server.
 type Managers struct {
 	// map of VC Host to *VirtualCenterConfig
-	VcenterConfigs map[string]*cnsvsphere.VirtualCenterConfig
+	VcenterConfigs map[commontypes.FQDN]*cnsvsphere.VirtualCenterConfig
 	CnsConfig      *config.Config
 	// map of VC Host to Volume Manager
-	VolumeManagers map[string]cnsvolume.Manager
+	VolumeManagers map[commontypes.FQDN]cnsvolume.Manager
 	VcenterManager cnsvsphere.VirtualCenterManager
 }
 

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -43,6 +43,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
@@ -114,7 +115,7 @@ func GetVCenters(ctx context.Context, managers *Managers) ([]*cnsvsphere.Virtual
 // Before returning VirtualCenter objects, vcenter connection is established if
 // session doesn't exist.
 func GetVCenterFromVCHost(ctx context.Context, vCenterManager cnsvsphere.VirtualCenterManager,
-	vCenterHost string) (*cnsvsphere.VirtualCenter, error) {
+	vCenterHost commontypes.FQDN) (*cnsvsphere.VirtualCenter, error) {
 	log := logger.GetLogger(ctx)
 	vcenter, err := vCenterManager.GetVirtualCenter(ctx, vCenterHost)
 	if err != nil {

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
@@ -815,7 +816,7 @@ func DeleteVolumeUtil(ctx context.Context, volManager cnsvolume.Manager, volumeI
 // ExpandVolumeUtil is the helper function to extend CNS volume for given
 // volumeId.
 func ExpandVolumeUtil(ctx context.Context, vCenterManager vsphere.VirtualCenterManager,
-	vCenterHost string, volumeManager cnsvolume.Manager, volumeID string, capacityInMb int64,
+	vCenterHost commontypes.FQDN, volumeManager cnsvolume.Manager, volumeID string, capacityInMb int64,
 	extraParams interface{}) (string, error) {
 	var err error
 	log := logger.GetLogger(ctx)

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -16,6 +16,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
 )
@@ -380,7 +381,7 @@ func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
 			getVCenterInternal = func(_ context.Context, _ *Manager) (*vsphere.VirtualCenter, error) {
 				return &vsphere.VirtualCenter{
 					Config: &vsphere.VirtualCenterConfig{
-						Host: "test-vc",
+						Host: commontypes.NewFQDN("test-vc"),
 						// Deliberately different from the CnsConfig user below, so
 						// the VSphereUser assertion shows which of the two the
 						// create spec is built from. In a real deployment both come
@@ -419,8 +420,8 @@ func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
 				CnsConfig:     &config.Config{},
 			}
 			manager.CnsConfig.Global.ClusterID = "test-cluster"
-			manager.CnsConfig.VirtualCenter = map[string]*config.VirtualCenterConfig{
-				"test-vc": {User: "test-user"},
+			manager.CnsConfig.VirtualCenter = map[commontypes.FQDN]*config.VirtualCenterConfig{
+				commontypes.NewFQDN("test-vc"): {User: "test-user"},
 			}
 
 			// Create test datastore info objects
@@ -488,7 +489,7 @@ func TestCreateBlockVolumeLinkedCloneHostLocalUsesDatastoresNotHosts(t *testing.
 	getVCenterInternal = func(_ context.Context, _ *Manager) (*vsphere.VirtualCenter, error) {
 		return &vsphere.VirtualCenter{
 			Config: &vsphere.VirtualCenterConfig{
-				Host: "test-vc",
+				Host: commontypes.NewFQDN("test-vc"),
 				// GetVirtualCenterConfig populates Username from
 				// cfg.VirtualCenter[host].User, so a real VC for this host would
 				// carry one. Without it CreateBlockVolumeUtil's
@@ -526,8 +527,8 @@ func TestCreateBlockVolumeLinkedCloneHostLocalUsesDatastoresNotHosts(t *testing.
 		CnsConfig:     &config.Config{},
 	}
 	manager.CnsConfig.Global.ClusterID = "test-cluster"
-	manager.CnsConfig.VirtualCenter = map[string]*config.VirtualCenterConfig{
-		"test-vc": {User: "test-user"},
+	manager.CnsConfig.VirtualCenter = map[commontypes.FQDN]*config.VirtualCenterConfig{
+		commontypes.NewFQDN("test-vc"): {User: "test-user"},
 	}
 
 	hostLocalDatastoreInfo := &vsphere.DatastoreInfo{

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -45,6 +45,7 @@ import (
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -65,7 +66,7 @@ type NodeManagerInterface interface {
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
 	GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error)
 	GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error)
-	GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine, error)
+	GetAllNodesByVC(ctx context.Context, vcHost commontypes.FQDN) ([]*cnsvsphere.VirtualMachine, error)
 }
 
 // TopologyCalculatorInterface handles post-creation topology calculation for vanilla controller.
@@ -80,8 +81,8 @@ type TopologyCalculationParams struct {
 	NodeManager         NodeManagerInterface
 	VolumeInfo          *cnsvolume.CnsVolumeInfo
 	VCenter             *cnsvsphere.VirtualCenter
-	TopologySegmentsMap map[string][]map[string]string
-	VCHost              string
+	TopologySegmentsMap map[commontypes.FQDN][]map[string]string
+	VCHost              commontypes.FQDN
 }
 
 // defaultTopologyCalculator is the default implementation of TopologyCalculatorInterface
@@ -141,7 +142,7 @@ type controller struct {
 	// Deprecated
 	// To be removed after multi vCenter support is added
 	authMgr     common.AuthorizationService
-	authMgrs    map[string]*common.AuthManager
+	authMgrs    map[commontypes.FQDN]*common.AuthManager
 	topologyMgr commoncotypes.ControllerTopologyService
 	csi.UnimplementedControllerServer
 	csi.UnimplementedSnapshotMetadataServer
@@ -208,8 +209,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		CnsConfig:      config,
 		VcenterManager: vcManager,
 	}
-	c.managers.VcenterConfigs = make(map[string]*cnsvsphere.VirtualCenterConfig)
-	c.managers.VolumeManagers = make(map[string]cnsvolume.Manager)
+	c.managers.VcenterConfigs = make(map[commontypes.FQDN]*cnsvsphere.VirtualCenterConfig)
+	c.managers.VolumeManagers = make(map[commontypes.FQDN]cnsvolume.Manager)
 	// Get VirtualCenterManager instance and validate version.
 	vcenterconfigs, err := cnsvsphere.GetVirtualCenterConfigs(ctx, config)
 	if err != nil {
@@ -446,11 +447,11 @@ func (c *controller) ReloadConfiguration() error {
 }
 
 func (c *controller) filterDatastores(ctx context.Context, sharedDatastores []*cnsvsphere.DatastoreInfo,
-	vcHost string) ([]*cnsvsphere.DatastoreInfo, error) {
+	vcHost commontypes.FQDN) ([]*cnsvsphere.DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
 	var dsMap map[string]*cnsvsphere.DatastoreInfo
-	if c.authMgrs[vcHost] != nil {
-		dsMap = c.authMgrs[vcHost].GetDatastoreMapForBlockVolumes(ctx)
+	if authMgr := c.authMgrs[vcHost]; authMgr != nil {
+		dsMap = authMgr.GetDatastoreMapForBlockVolumes(ctx)
 	}
 	if len(dsMap) == 0 {
 		return nil, logger.LogNewError(log,
@@ -502,7 +503,8 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 				// Get vCenter.
 				// Need to extract fault from err returned by GetVirtualCenter.
 				// Currently, just return "csi.fault.Internal".
-				vCenter, err := common.GetVCenterFromVCHost(ctx, c.managers.VcenterManager, c.managers.CnsConfig.Global.VCenterIP)
+				vCenter, err := common.GetVCenterFromVCHost(ctx, c.managers.VcenterManager,
+					c.managers.CnsConfig.Global.VCenterIP)
 				if err != nil {
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to get vCenter. err: %+v", err)
@@ -540,7 +542,8 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 						"failed to find datastoreURL for datastore name: %q", scParams.Datastore)
 				}
 			} else if c.managers.VcenterConfigs[c.managers.CnsConfig.Global.VCenterIP].MigrationDataStoreURL != "" {
-				scParams.DatastoreURL = c.managers.VcenterConfigs[c.managers.CnsConfig.Global.VCenterIP].MigrationDataStoreURL
+				scParams.DatastoreURL =
+					c.managers.VcenterConfigs[c.managers.CnsConfig.Global.VCenterIP].MigrationDataStoreURL
 			}
 		}
 	}
@@ -623,7 +626,7 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 		volumeInfo               *cnsvolume.CnsVolumeInfo
 		faultType                string
 		vcenter                  *cnsvsphere.VirtualCenter
-		vcHost                   string
+		vcHost                   commontypes.FQDN
 		volumeMgr                cnsvolume.Manager
 	)
 	// Get operation store.
@@ -659,7 +662,7 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 
 			// Get vCenter instance.
 			if volumeOperationDetails.OperationDetails.VCenterServer != "" {
-				vcHost = volumeOperationDetails.OperationDetails.VCenterServer
+				vcHost = commontypes.NewFQDN(volumeOperationDetails.OperationDetails.VCenterServer)
 			} else {
 				vcHost = c.managers.CnsConfig.Global.VCenterIP
 			}
@@ -684,7 +687,7 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 
 			// Get vCenter instance.
 			if volumeOperationDetails.OperationDetails.VCenterServer != "" {
-				vcHost = volumeOperationDetails.OperationDetails.VCenterServer
+				vcHost = commontypes.NewFQDN(volumeOperationDetails.OperationDetails.VCenterServer)
 			} else {
 				vcHost = c.managers.CnsConfig.Global.VCenterIP
 			}
@@ -742,7 +745,7 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 	// Get accessibility requirements.
 	topologyRequirement = req.GetAccessibilityRequirements()
 
-	vcTopologySegmentsMap := make(map[string][]map[string]string)
+	vcTopologySegmentsMap := make(map[commontypes.FQDN][]map[string]string)
 	if multivCenterTopologyDeployment {
 		if topologyRequirement == nil {
 			return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCode(log, codes.InvalidArgument,
@@ -759,8 +762,9 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 		if topologyRequirement != nil {
 			// Get accessibility requirements.
 			for _, topology := range topologyRequirement.Preferred {
-				vcTopologySegmentsMap[c.managers.CnsConfig.Global.VCenterIP] = append(
-					vcTopologySegmentsMap[c.managers.CnsConfig.Global.VCenterIP],
+				vcIP := c.managers.CnsConfig.Global.VCenterIP
+				vcTopologySegmentsMap[vcIP] = append(
+					vcTopologySegmentsMap[vcIP],
 					topology.GetSegments())
 			}
 			log.Debugf("Topology accessibility requirements per VC are %+v", vcTopologySegmentsMap)
@@ -1060,7 +1064,7 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 	}
 	if len(c.managers.VcenterConfigs) > 1 {
 		// Create CNSVolumeInfo CR for the volume ID.
-		err = volumeInfoService.CreateVolumeInfo(ctx, volumeInfo.VolumeID.Id, vcHost)
+		err = volumeInfoService.CreateVolumeInfo(ctx, volumeInfo.VolumeID.Id, vcHost.String())
 		if err != nil {
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to store volumeID %q for vCenter %q in CNSVolumeInfo CR. Error: %+v",
@@ -1106,7 +1110,7 @@ func calculateAccessibleTopologiesForDatastore(ctx context.Context, vcenter *cns
 
 	datastoreAccessibleTopology, err = placementengine.GetTopologyInfoFromNodes(ctx,
 		placementengine.VanillaRetrieveTopologyInfoParams{
-			VCHost:                    vcenter.Config.Host,
+			VCHost:                    vcenter.Config.Host.String(),
 			NodeNames:                 accessibleNodeNames,
 			DatastoreURL:              datastoreURL,
 			RequestedTopologySegments: topologySegments,
@@ -1146,7 +1150,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 		faultType                string
 		volumeID                 string
 		vcenter                  *cnsvsphere.VirtualCenter
-		vcHost                   string
+		vcHost                   commontypes.FQDN
 	)
 	// Get operation store
 	var operationStore cnsvolumeoperationrequest.VolumeOperationRequest
@@ -1186,7 +1190,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 		} else if cnsvolume.IsTaskPending(volumeOperationDetails) {
 			volTaskAlreadyRegistered = true
 			if volumeOperationDetails.OperationDetails.VCenterServer != "" {
-				vcHost = volumeOperationDetails.OperationDetails.VCenterServer
+				vcHost = commontypes.NewFQDN(volumeOperationDetails.OperationDetails.VCenterServer)
 			} else {
 				vcHost = c.managers.CnsConfig.Global.VCenterIP
 			}
@@ -1248,7 +1252,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 					"accessibility requirements cannot be nil for a multi-VC environment")
 			}
 		}
-		vcTopologySegmentsMap := make(map[string][]map[string]string)
+		vcTopologySegmentsMap := make(map[commontypes.FQDN][]map[string]string)
 		if topologyRequirement != nil {
 			// Get accessibility requirements.
 			vcTopologySegmentsMap, err = common.GetAccessibilityRequirementsByVC(ctx, topologyRequirement)
@@ -1389,7 +1393,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 				// In case task was successful from previous run but the CR was not created.
 				if len(c.managers.VcenterConfigs) > 1 {
 					// Create CNSVolumeInfo CR for the volume ID in case of multi VC deployment.
-					err = volumeInfoService.CreateVolumeInfo(ctx, volumeID, vcHost)
+					err = volumeInfoService.CreateVolumeInfo(ctx, volumeID, vcHost.String())
 					if err != nil {
 						return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 							"failed to store volumeID %q for vCenter %q in CNSVolumeInfo CR. Error: %+v",
@@ -1557,7 +1561,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 			err            error
 			volumePath     string
 			volumeManager  cnsvolume.Manager
-			vCenterHost    string
+			vCenterHost    commontypes.FQDN
 			vCenterManager cnsvsphere.VirtualCenterManager
 		)
 
@@ -1928,7 +1932,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	controllerExpandVolumeInternal := func() (
 		*csi.ControllerExpandVolumeResponse, string, error) {
 		var (
-			vCenterHost    string
+			vCenterHost    commontypes.FQDN
 			vCenterManager cnsvsphere.VirtualCenterManager
 			volumeManager  cnsvolume.Manager
 			err            error
@@ -2371,7 +2375,7 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	var (
-		vCenterHost                              string
+		vCenterHost                              commontypes.FQDN
 		vCenterManager                           cnsvsphere.VirtualCenterManager
 		volumeManager                            cnsvolume.Manager
 		err                                      error
@@ -2531,7 +2535,7 @@ func (c *controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshot
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	var (
-		vCenterHost    string
+		vCenterHost    commontypes.FQDN
 		vCenterManager cnsvsphere.VirtualCenterManager
 		volumeManager  cnsvolume.Manager
 		err            error
@@ -2607,7 +2611,7 @@ func (c *controller) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRe
 		var (
 			vCenterManager cnsvsphere.VirtualCenterManager
 			volManager     cnsvolume.Manager
-			vCenterHost    string
+			vCenterHost    commontypes.FQDN
 			snapshots      []*csi.Snapshot
 			nextToken      string
 			err            error
@@ -2723,7 +2727,7 @@ func getSnapshotsAndSourceVolumeDetails(ctx context.Context, vCenterManager cnsv
 	)
 	log := logger.GetLogger(ctx)
 	// Check for snapshot support
-	isCnsSnapshotSupported, err := vCenterManager.IsCnsSnapshotSupported(ctx, vcHost)
+	isCnsSnapshotSupported, err := vCenterManager.IsCnsSnapshotSupported(ctx, commontypes.NewFQDN(vcHost))
 	if err != nil {
 		return nil, nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to check if cns snapshot is supported on VC %s due to error: %v", vcHost, err)
@@ -2805,7 +2809,7 @@ func queryAllVolumeSnapshotsForMultiVC(ctx context.Context, c *controller, token
 		for vcHost, volManager := range c.managers.VolumeManagers {
 			// fetch snapshots and associated source volume details
 			perVCSnapQueryEntries, volumeDetails, err := getSnapshotsAndSourceVolumeDetails(ctx, vCenterManager,
-				volManager, vcHost)
+				volManager, vcHost.String())
 			if err != nil {
 				log.Errorf("failed to retrieve snapshots/source volume info for vCenter %s, err: %+v", vcHost, err)
 				return nil, "", err

--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -34,6 +34,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo"
@@ -167,22 +168,24 @@ func getBlockVolumeIDToNodeUUIDMap(ctx context.Context, c *controller,
 		return nil, fmt.Errorf("failed to get vCenters from Managers, err: %v", err)
 	}
 
-	vmRefsPervCenter := make(map[string][]types.ManagedObjectReference)
-	vmMoListPervCenter := make(map[string][]mo.VirtualMachine)
+	vmRefsPervCenter := make(map[commontypes.FQDN][]types.ManagedObjectReference)
+	vmMoListPervCenter := make(map[commontypes.FQDN][]mo.VirtualMachine)
 	properties := []string{"runtime.host", "config.hardware", "config.uuid"}
 
 	for _, nodeVM := range allnodeVMs {
-		vmRefsPervCenter[nodeVM.VirtualCenterHost] = append(vmRefsPervCenter[nodeVM.VirtualCenterHost], nodeVM.Reference())
+		hostKey := nodeVM.VirtualCenterHost
+		vmRefsPervCenter[hostKey] = append(vmRefsPervCenter[hostKey], nodeVM.Reference())
 	}
 	log.Debugf("vmRefsPervCenter: %+v to collect properties", vmRefsPervCenter)
 	for _, vc := range vCenters {
 		pc := property.DefaultCollector(vc.Client.Client)
 		// Obtain host MoID and virtual disk ID
 		var vmMoList []mo.VirtualMachine
-		if len(vmRefsPervCenter[vc.Config.Host]) == 0 {
+		hostKey := vc.Config.Host
+		if len(vmRefsPervCenter[hostKey]) == 0 {
 			continue
 		}
-		err = pc.Retrieve(ctx, vmRefsPervCenter[vc.Config.Host], properties, &vmMoList)
+		err = pc.Retrieve(ctx, vmRefsPervCenter[hostKey], properties, &vmMoList)
 		if err != nil {
 			log.Errorf("failed to get VM managed objects from VM objects, err: %v", err)
 			return volumeIDNodeUUIDMap, err
@@ -223,21 +226,21 @@ func getBlockVolumeIDToNodeUUIDMap(ctx context.Context, c *controller,
 // If multi-vcenter-csi-topology feature is enabled and volumeInfoService is instantiated volume manager is returned for
 // the vCenter IP mapped to the requested VolumeID. vCenter for the requested volume is obtained from volumeInfoService.
 func getVCenterAndVolumeManagerForVolumeID(ctx context.Context, controller *controller, volumeId string,
-	volumeInfoService cnsvolumeinfo.VolumeInfoService) (string, cnsvolume.Manager, error) {
+	volumeInfoService cnsvolumeinfo.VolumeInfoService) (commontypes.FQDN, cnsvolume.Manager, error) {
 	log := logger.GetLogger(ctx)
 	var (
 		volumeManager      cnsvolume.Manager
 		volumeManagerfound bool
-		vCenter            string
-		err                error
+		vCenter            commontypes.FQDN
 	)
 	if len(controller.managers.VcenterConfigs) > 1 {
 		// Multi vCenter Deployment
-		vCenter, err = volumeInfoService.GetvCenterForVolumeID(ctx, volumeId)
+		vCenterStr, err := volumeInfoService.GetvCenterForVolumeID(ctx, volumeId)
 		if err != nil {
-			return "", nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return commontypes.FQDN{}, nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to get vCenter for the volumeID: %q with err=%+v", volumeId, err)
 		}
+		vCenter = commontypes.NewFQDN(vCenterStr)
 		if volumeManager, volumeManagerfound = controller.managers.VolumeManagers[vCenter]; !volumeManagerfound {
 			return vCenter, nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"could not get volume manager for the vCenter: %q", vCenter)
@@ -246,14 +249,14 @@ func getVCenterAndVolumeManagerForVolumeID(ctx context.Context, controller *cont
 		// Single vCenter Deployment
 		vCenterConfig, vCenterFound := controller.managers.VcenterConfigs[controller.managers.CnsConfig.Global.VCenterIP]
 		if !vCenterFound {
-			return "", nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return commontypes.FQDN{}, nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"could not get vCenter config for the vCenter: %q",
 				controller.managers.CnsConfig.Global.VCenterIP)
 		}
 		vCenter = vCenterConfig.Host
 		if volumeManager, volumeManagerfound =
 			controller.managers.VolumeManagers[vCenter]; !volumeManagerfound {
-			return "", nil, logger.LogNewErrorCodef(log, codes.Internal,
+			return commontypes.FQDN{}, nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"could not get volume manager for the vCenter: %q", vCenter)
 		}
 	}
@@ -268,7 +271,7 @@ func getVCenterManagerForVCenter(ctx context.Context, controller *controller) vs
 
 // GetVolumeManagerFromVCHost retreives the volume manager associated with
 // vCenterHost under managers. Error out if the vCenterHost does not exist.
-func GetVolumeManagerFromVCHost(ctx context.Context, managers *common.Managers, vCenterHost string) (
+func GetVolumeManagerFromVCHost(ctx context.Context, managers *common.Managers, vCenterHost commontypes.FQDN) (
 	cnsvolume.Manager, error) {
 	log := logger.GetLogger(ctx)
 	volumeMgr, exists := managers.VolumeManagers[vCenterHost]

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -47,6 +47,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -177,7 +178,8 @@ func (f *FakeNodeManager) GetAllNodes(ctx context.Context) ([]*cnsvsphere.Virtua
 	return f.cnsNodeManager.GetAllNodes(ctx)
 }
 
-func (f *FakeNodeManager) GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine, error) {
+func (f *FakeNodeManager) GetAllNodesByVC(ctx context.Context,
+	vcHost commontypes.FQDN) ([]*cnsvsphere.VirtualMachine, error) {
 	// This function is required only for multi VC env.
 	return nil, nil
 }
@@ -255,9 +257,9 @@ func getControllerTest(t *testing.T) *controllerTest {
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 		managers := &common.Managers{
-			VcenterConfigs: make(map[string]*cnsvsphere.VirtualCenterConfig),
+			VcenterConfigs: make(map[commontypes.FQDN]*cnsvsphere.VirtualCenterConfig),
 			CnsConfig:      config,
-			VolumeManagers: make(map[string]cnsvolume.Manager),
+			VolumeManagers: make(map[commontypes.FQDN]cnsvolume.Manager),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 		managers.VcenterConfigs[vcenterconfig.Host] = vcenterconfig
@@ -291,7 +293,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 			managers:     managers,
 			nodeMgr:      nodeManager,
 			authMgr:      &fakeAuthMgr,
-			authMgrs:     make(map[string]*common.AuthManager),
+			authMgrs:     make(map[commontypes.FQDN]*common.AuthManager),
 			topologyCalc: &MockTopologyCalculator{shouldSkip: true}, // Skip topology calculation in tests
 		}
 		c.authMgrs[vcenterconfig.Host], _ =

--- a/pkg/csi/service/vanilla/controller_topology_test.go
+++ b/pkg/csi/service/vanilla/controller_topology_test.go
@@ -47,6 +47,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -167,8 +168,8 @@ func (f *FakeNodeManagerTopology) GetAllNodes(ctx context.Context) ([]*cnsvspher
 	return f.cnsNodeManager.GetAllNodes(ctx)
 }
 
-func (f *FakeNodeManagerTopology) GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine,
-	error) {
+func (f *FakeNodeManagerTopology) GetAllNodesByVC(ctx context.Context,
+	vcHost commontypes.FQDN) ([]*cnsvsphere.VirtualMachine, error) {
 	// For topology testing, return all nodes since we're working with a single vCenter
 	return f.cnsNodeManager.GetAllNodes(ctx)
 }
@@ -467,9 +468,9 @@ func getControllerTestWithTopology(t *testing.T) *controllerTestTopology {
 			VcenterManager: vcManager,
 		}
 		managers := &common.Managers{
-			VcenterConfigs: make(map[string]*cnsvsphere.VirtualCenterConfig),
+			VcenterConfigs: make(map[commontypes.FQDN]*cnsvsphere.VirtualCenterConfig),
 			CnsConfig:      config,
-			VolumeManagers: make(map[string]cnsvolume.Manager),
+			VolumeManagers: make(map[commontypes.FQDN]cnsvolume.Manager),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 		managers.VcenterConfigs[vcenterconfig.Host] = vcenterconfig
@@ -508,7 +509,7 @@ func getControllerTestWithTopology(t *testing.T) *controllerTestTopology {
 			managers: managers,
 			nodeMgr:  nodeManager,
 			authMgr:  fakeAuthMgr,
-			authMgrs: make(map[string]*common.AuthManager),
+			authMgrs: make(map[commontypes.FQDN]*common.AuthManager),
 			topologyMgr: &FakeTopologyManager{
 				nodeLabels: mockNodeLabels,
 			},

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -59,6 +59,7 @@ import (
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -1469,7 +1470,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 				// Create CNSVolumeInfo CR for the volume ID.
 				capacity := resource.NewQuantity(volSizeBytes, resource.BinarySI)
 				err = volumeInfoService.CreateVolumeInfoWithPolicyInfo(ctx, volumeInfo.VolumeID.Id, pvcNamespace,
-					storagePolicyID, scName, vc.Config.Host, capacity, isLinkedCloneRequest)
+					storagePolicyID, scName, vc.Config.Host.String(), capacity, isLinkedCloneRequest)
 				if err != nil {
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to store volumeID %q pvcNamespace %q StoragePolicyID %q StorageClassName %q "+
@@ -2460,7 +2461,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			vCenterHost = key
 			dcMorefValue = value
 		}
-		vc, err := c.manager.VcenterManager.GetVirtualCenter(ctx, vCenterHost)
+		vc, err := c.manager.VcenterManager.GetVirtualCenter(ctx, commontypes.NewFQDN(vCenterHost))
 		if err != nil {
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 				"cannot get virtual center %s from virtualcentermanager while attaching disk with error %+v",
@@ -2614,7 +2615,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 					vCenterHost = key
 					dcMorefValue = value
 				}
-				vc, err := c.manager.VcenterManager.GetVirtualCenter(ctx, vCenterHost)
+				vc, err := c.manager.VcenterManager.GetVirtualCenter(ctx, commontypes.NewFQDN(vCenterHost))
 				if err != nil {
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"cannot get virtual center %s from virtualcentermanager while attaching disk with error %+v",
@@ -2682,7 +2683,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 							vCenterHost = key
 							dcMorefValue = value
 						}
-						vc, err := c.manager.VcenterManager.GetVirtualCenter(ctx, vCenterHost)
+						vc, err := c.manager.VcenterManager.GetVirtualCenter(ctx, commontypes.NewFQDN(vCenterHost))
 						if err != nil {
 							return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 								"cannot get virtual center %s from virtualcentermanager while attaching disk with error %+v",

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -293,7 +293,8 @@ func getDatacenterFromConfig(cfg *cnsconfig.Config) (map[string]string, error) {
 func getVCDatacentersFromConfig(cfg *cnsconfig.Config) (map[string][]string, error) {
 	var err error
 	vcdcMap := make(map[string][]string)
-	for key, value := range cfg.VirtualCenter {
+	for host, value := range cfg.VirtualCenter {
+		key := host.String()
 		dcList := strings.Split(value.Datacenters, ",")
 		for _, dc := range dcList {
 			dcMoID := strings.TrimSpace(dc)
@@ -494,11 +495,12 @@ func getHostMoRefsForHostLocalVolume(ctx context.Context,
 		if !ok || hostname == "" {
 			continue
 		}
-		if _, dup := seen[hostname]; dup {
+		normalizedHostname := strings.ToLower(hostname)
+		if _, dup := seen[normalizedHostname]; dup {
 			continue
 		}
-		seen[hostname] = struct{}{}
-		hostMoID, found := nodeNameToID[hostname]
+		seen[normalizedHostname] = struct{}{}
+		hostMoID, found := nodeNameToID[normalizedHostname]
 		if !found {
 			return nil, nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to resolve ESX host MoID for node %q while provisioning host-local volume", hostname)

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -333,7 +333,7 @@ func getWorkerNodeHostValues(ctx context.Context, guestClient clientset.Interfac
 		}
 		workerNodeCount++
 		if val, ok := node.Labels[common.GuestClusterTopologyLabelHost]; ok && val != "" {
-			workerHostValues[val] = true
+			workerHostValues[strings.ToLower(val)] = true
 		}
 	}
 	return workerHostValues, workerNodeCount, nil
@@ -382,7 +382,7 @@ func filterOutControlPlaneOnlyTopologySegments(ctx context.Context, guestClient 
 	filtered := make([]*csi.Topology, 0, len(segments))
 	for _, topology := range segments {
 		host, hasHostKey := topology.Segments[common.GuestClusterTopologyLabelHost]
-		if hasHostKey && host != "" && !workerHostValues[host] {
+		if hasHostKey && host != "" && !workerHostValues[strings.ToLower(host)] {
 			log.Infof("filterOutControlPlaneOnlyTopologySegments: dropping topology segment %+v because "+
 				"host %q has no worker nodes (control plane VMs only)", topology.Segments, host)
 			continue

--- a/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
+++ b/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	cnsvolumeinfoconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo/config"
@@ -166,11 +167,10 @@ func (volumeInfo *volumeInfo) GetvCenterForVolumeID(ctx context.Context, volumeI
 		return "", logger.LogNewErrorf(log, "failed to parse cnsvolumeinfo object: %v, err: %v", info, err)
 	}
 	log.Infof("Volume ID %q is associated with VC %q", volumeID, cnsvolumeinfo.Spec.VCenterServer)
-	// Normalize to lowercase: this value is used as an exact-match key against
-	// VirtualCenterConfig.Host-keyed maps (e.g. VolumeManagers), which are always
-	// lowercase. CRs persisted before host normalization was introduced may still
-	// carry their original casing.
-	return strings.ToLower(cnsvolumeinfo.Spec.VCenterServer), nil
+	// Normalize: this value is used as an exact-match key against FQDN-keyed
+	// maps (e.g. VolumeManagers). CRs persisted before host normalization was
+	// introduced may still carry their original casing.
+	return commontypes.NewFQDN(cnsvolumeinfo.Spec.VCenterServer).String(), nil
 }
 
 // CreateVolumeInfo creates VolumeInfo CR to persist VolumeID to vCenter mapping

--- a/pkg/syncer/clusterstoragepolicyinfo_fullsync.go
+++ b/pkg/syncer/clusterstoragepolicyinfo_fullsync.go
@@ -26,6 +26,7 @@ import (
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	clusterspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/clusterstoragepolicyinfo/v1alpha1"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
@@ -36,7 +37,7 @@ import (
 // clusterstoragepolicyinfo) continues to own attribute syncing, InfraStoragePolicyInfo creation,
 // and owner-reference management once a CR exists; this function only guarantees the CR's presence.
 func clusterStoragePolicyInfoFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer,
-	vc string, vcenter *cnsvsphere.VirtualCenter) {
+	vc commontypes.FQDN, vcenter *cnsvsphere.VirtualCenter) {
 	log := logger.GetLogger(ctx)
 
 	if !metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.SupportsExposingStoragePolicyAttributes) {

--- a/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/clusterstoragepolicyinfo/controller_test.go
@@ -56,6 +56,7 @@ import (
 	infraspiv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/infrastoragepolicyinfo/v1alpha1"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -4171,7 +4172,7 @@ func setupLCSim(t *testing.T, numClusters, hostsPerCluster int) (
 		t.Fatalf("failed to create govmomi client: %v", err)
 	}
 	vc = &cnsvsphere.VirtualCenter{
-		Config:      &cnsvsphere.VirtualCenterConfig{Host: "127.0.0.1"},
+		Config:      &cnsvsphere.VirtualCenterConfig{Host: commontypes.NewFQDN("127.0.0.1")},
 		Client:      c,
 		ClientMutex: &sync.Mutex{},
 	}
@@ -4210,7 +4211,7 @@ func setupLCSimIsolatedDatastores(t *testing.T, numClusters int) (
 		t.Fatalf("failed to create govmomi client: %v", err)
 	}
 	vc = &cnsvsphere.VirtualCenter{
-		Config:      &cnsvsphere.VirtualCenterConfig{Host: "127.0.0.1"},
+		Config:      &cnsvsphere.VirtualCenterConfig{Host: commontypes.NewFQDN("127.0.0.1")},
 		Client:      c,
 		ClientMutex: &sync.Mutex{},
 	}

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -90,7 +91,7 @@ var (
 					Type:  "Datacenter",
 					Value: dcMoref,
 				}),
-			VirtualCenterHost: host,
+			VirtualCenterHost: commontypes.NewFQDN(host),
 		}, nil
 	}
 	getVMByUUIDFromVCenter = func(ctx context.Context, dc *cnsvsphere.Datacenter,
@@ -1008,7 +1009,8 @@ func (r *ReconcileCnsNodeVMAttachment) updateErrorOnInstanceToDisallowAttach(ctx
 func getVCDatacentersFromConfig(cfg *config.Config) (map[string][]string, error) {
 	var err error
 	vcdcMap := make(map[string][]string)
-	for key, value := range cfg.VirtualCenter {
+	for host, value := range cfg.VirtualCenter {
+		key := host.String()
 		dcList := strings.Split(value.Datacenters, ",")
 		for _, dc := range dcList {
 			dcMoID := strings.TrimSpace(dc)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller_test.go
@@ -45,6 +45,7 @@ import (
 	v1a1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	cnsoptypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types"
 )
@@ -152,8 +153,8 @@ func TestReconcileDetachWithVolumeIDFallback(t *testing.T) {
 		scheme: s,
 		configInfo: &config.ConfigurationInfo{
 			Cfg: &config.Config{
-				VirtualCenter: map[string]*config.VirtualCenterConfig{
-					"test-vc": {
+				VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+					commontypes.NewFQDN("test-vc"): {
 						Datacenters: "dc-1",
 					},
 				},
@@ -291,8 +292,8 @@ func TestReconcileDetachWithVolumeIDFallbackFailure(t *testing.T) {
 		scheme: s,
 		configInfo: &config.ConfigurationInfo{
 			Cfg: &config.Config{
-				VirtualCenter: map[string]*config.VirtualCenterConfig{
-					"test-vc": {
+				VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+					commontypes.NewFQDN("test-vc"): {
 						Datacenters: "dc-1",
 					},
 				},

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -944,7 +944,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
 			// Create CNSVolumeInfo CR for static pv (pvCapacity set earlier from PVC or backend)
 			err = r.volumeInfoService.CreateVolumeInfoWithPolicyInfo(ctx, volumeID, instance.Namespace,
-				volume.StoragePolicyId, storageClassName, vc.Config.Host, &pvCapacity, false)
+				volume.StoragePolicyId, storageClassName, vc.Config.Host.String(), &pvCapacity, false)
 			if err != nil {
 				log.Errorf("failed to store volumeID %q namespace %s StoragePolicyID %q StorageClassName %q and vCenter %q "+
 					"in CNSVolumeInfo CR. Error: %+v", volumeID, instance.Namespace, volume.StoragePolicyId,

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -61,6 +61,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
@@ -608,7 +609,7 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			config *config.ConfigurationInfo, reinitialize bool) (*cnsvsphere.VirtualCenter, error) {
 			return &cnsvsphere.VirtualCenter{
 				Config: &cnsvsphere.VirtualCenterConfig{
-					Host: "dummy-vcenter",
+					Host: commontypes.NewFQDN("dummy-vcenter"),
 				},
 			}, nil
 		})
@@ -617,7 +618,7 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			ctx context.Context,
 			r *ReconcileCnsRegisterVolume,
 			instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
-			host string,
+			host commontypes.FQDN,
 			isTKGSHAEnabled bool,
 		) (*cnstypes.CnsVolumeCreateSpec, error) {
 			return &cnstypes.CnsVolumeCreateSpec{
@@ -770,7 +771,7 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 
 		patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(ctx context.Context,
 			config *config.ConfigurationInfo, reinitialize bool) (*cnsvsphere.VirtualCenter, error) {
-			return &cnsvsphere.VirtualCenter{Config: &cnsvsphere.VirtualCenterConfig{Host: "vc"}}, nil
+			return &cnsvsphere.VirtualCenter{Config: &cnsvsphere.VirtualCenterConfig{Host: commontypes.NewFQDN("vc")}}, nil
 		})
 		patches.ApplyFunc(common.QueryVolumeByID, func(ctx context.Context, vm cnsvolume.Manager,
 			volumeID string, querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
@@ -801,7 +802,7 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			})
 		patches.ApplyFunc(constructCreateSpecForInstance, func(ctx context.Context,
 			r *ReconcileCnsRegisterVolume, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
-			host string, isTKGSHAEnabled bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+			host commontypes.FQDN, isTKGSHAEnabled bool) (*cnstypes.CnsVolumeCreateSpec, error) {
 			return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}, nil
 		})
 		patches.ApplyFunc(setInstanceError, func(ctx context.Context, r *ReconcileCnsRegisterVolume,
@@ -876,7 +877,7 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 
 		patches.ApplyFunc(cnsvsphere.GetVirtualCenterInstance, func(ctx context.Context,
 			config *config.ConfigurationInfo, reinitialize bool) (*cnsvsphere.VirtualCenter, error) {
-			return &cnsvsphere.VirtualCenter{Config: &cnsvsphere.VirtualCenterConfig{Host: "vc"}}, nil
+			return &cnsvsphere.VirtualCenter{Config: &cnsvsphere.VirtualCenterConfig{Host: commontypes.NewFQDN("vc")}}, nil
 		})
 		patches.ApplyFunc(common.QueryVolumeByID, func(ctx context.Context, vm cnsvolume.Manager,
 			volumeID string, querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsVolume, error) {
@@ -903,7 +904,7 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			})
 		patches.ApplyFunc(constructCreateSpecForInstance, func(ctx context.Context,
 			r *ReconcileCnsRegisterVolume, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
-			host string, isTKGSHAEnabled bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+			host commontypes.FQDN, isTKGSHAEnabled bool) (*cnstypes.CnsVolumeCreateSpec, error) {
 			return &cnstypes.CnsVolumeCreateSpec{Name: "fake", VolumeType: "BLOCK"}, nil
 		})
 		patches.ApplyFunc(getK8sStorageClassNameWithImmediateBindingModeForPolicy,
@@ -1898,8 +1899,8 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityE
 	}
 
 	cfg := &config.Config{
-		VirtualCenter: map[string]*config.VirtualCenterConfig{
-			"test-host": {User: "test-user"},
+		VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+			commontypes.NewFQDN("test-host"): {User: "test-user"},
 		},
 	}
 	cfg.Global.ClusterID = "test-cluster"
@@ -1910,7 +1911,7 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityE
 	origCapability := isVSphereDPLPModernAppEnabled
 	t.Cleanup(func() { isVSphereDPLPModernAppEnabled = origCapability })
 	isVSphereDPLPModernAppEnabled = true
-	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, commontypes.NewFQDN("test-host"), false)
 	assert.NoError(t, err)
 	if assert.NotNil(t, spec.VolumeId, "VolumeId should be set") {
 		assert.Equal(t, volumeID, spec.VolumeId.Id, "VolumeId.Id should be VolumeID")
@@ -1942,8 +1943,8 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityD
 	}
 
 	cfg := &config.Config{
-		VirtualCenter: map[string]*config.VirtualCenterConfig{
-			"test-host": {User: "test-user"},
+		VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+			commontypes.NewFQDN("test-host"): {User: "test-user"},
 		},
 	}
 	cfg.Global.ClusterID = "test-cluster"
@@ -1954,7 +1955,7 @@ func TestConstructCreateSpecForInstanceWithBothVolumeIDAndDiskURLPathCapabilityD
 	origCapability := isVSphereDPLPModernAppEnabled
 	t.Cleanup(func() { isVSphereDPLPModernAppEnabled = origCapability })
 	isVSphereDPLPModernAppEnabled = false
-	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, commontypes.NewFQDN("test-host"), false)
 	assert.NoError(t, err)
 	assert.Nil(t, spec.VolumeId, "VolumeId should not be set on the legacy VolumeID-only path")
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
@@ -1979,8 +1980,8 @@ func TestConstructCreateSpecForInstanceWithVolumeIDOnly(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		VirtualCenter: map[string]*config.VirtualCenterConfig{
-			"test-host": {User: "test-user"},
+		VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+			commontypes.NewFQDN("test-host"): {User: "test-user"},
 		},
 	}
 	cfg.Global.ClusterID = "test-cluster"
@@ -1988,7 +1989,7 @@ func TestConstructCreateSpecForInstanceWithVolumeIDOnly(t *testing.T) {
 		configInfo: &config.ConfigurationInfo{Cfg: cfg},
 	}
 
-	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, commontypes.NewFQDN("test-host"), false)
 	assert.NoError(t, err)
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
@@ -2011,8 +2012,8 @@ func TestConstructCreateSpecForInstanceWithDiskURLPathOnly(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		VirtualCenter: map[string]*config.VirtualCenterConfig{
-			"test-host": {User: "test-user"},
+		VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+			commontypes.NewFQDN("test-host"): {User: "test-user"},
 		},
 	}
 	cfg.Global.ClusterID = "test-cluster"
@@ -2020,7 +2021,7 @@ func TestConstructCreateSpecForInstanceWithDiskURLPathOnly(t *testing.T) {
 		configInfo: &config.ConfigurationInfo{Cfg: cfg},
 	}
 
-	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, commontypes.NewFQDN("test-host"), false)
 	assert.NoError(t, err)
 	backing, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
 	assert.True(t, ok, "BackingObjectDetails should be *CnsBlockBackingDetails")
@@ -2044,8 +2045,8 @@ func TestConstructCreateSpecForInstanceWithoutStorageClassName(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		VirtualCenter: map[string]*config.VirtualCenterConfig{
-			"test-host": {User: "test-user"},
+		VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+			commontypes.NewFQDN("test-host"): {User: "test-user"},
 		},
 	}
 	cfg.Global.ClusterID = "test-cluster"
@@ -2054,7 +2055,7 @@ func TestConstructCreateSpecForInstanceWithoutStorageClassName(t *testing.T) {
 		k8sclient:  k8sfake.NewClientset(),
 	}
 
-	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, commontypes.NewFQDN("test-host"), false)
 	assert.NoError(t, err)
 	assert.Nil(t, spec.Profile, "Profile should not be set when StorageClassName is empty")
 }
@@ -2082,8 +2083,8 @@ func TestConstructCreateSpecForInstanceWithStorageClassName(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		VirtualCenter: map[string]*config.VirtualCenterConfig{
-			"test-host": {User: "test-user"},
+		VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+			commontypes.NewFQDN("test-host"): {User: "test-user"},
 		},
 	}
 	cfg.Global.ClusterID = "test-cluster"
@@ -2092,7 +2093,7 @@ func TestConstructCreateSpecForInstanceWithStorageClassName(t *testing.T) {
 		k8sclient:  k8sfake.NewClientset(sc),
 	}
 
-	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, commontypes.NewFQDN("test-host"), false)
 	assert.NoError(t, err)
 	if assert.Len(t, spec.Profile, 1, "Profile should contain a single entry") {
 		profile, ok := spec.Profile[0].(*vim25types.VirtualMachineDefinedProfileSpec)
@@ -2118,8 +2119,8 @@ func TestConstructCreateSpecForInstanceWithMissingStorageClass(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		VirtualCenter: map[string]*config.VirtualCenterConfig{
-			"test-host": {User: "test-user"},
+		VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+			commontypes.NewFQDN("test-host"): {User: "test-user"},
 		},
 	}
 	cfg.Global.ClusterID = "test-cluster"
@@ -2128,7 +2129,7 @@ func TestConstructCreateSpecForInstanceWithMissingStorageClass(t *testing.T) {
 		k8sclient:  k8sfake.NewClientset(),
 	}
 
-	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, commontypes.NewFQDN("test-host"), false)
 	assert.Error(t, err)
 	assert.Nil(t, spec)
 }
@@ -2154,8 +2155,8 @@ func TestConstructCreateSpecForInstanceWithStorageClassMissingPolicyIDParam(t *t
 	}
 
 	cfg := &config.Config{
-		VirtualCenter: map[string]*config.VirtualCenterConfig{
-			"test-host": {User: "test-user"},
+		VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{
+			commontypes.NewFQDN("test-host"): {User: "test-user"},
 		},
 	}
 	cfg.Global.ClusterID = "test-cluster"
@@ -2164,7 +2165,7 @@ func TestConstructCreateSpecForInstanceWithStorageClassMissingPolicyIDParam(t *t
 		k8sclient:  k8sfake.NewClientset(sc),
 	}
 
-	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, "test-host", false)
+	spec, err := constructCreateSpecForInstance(context.TODO(), r, instance, commontypes.NewFQDN("test-host"), false)
 	assert.Error(t, err)
 	assert.Nil(t, spec)
 }
@@ -2312,7 +2313,7 @@ func TestReconcileRejectsUnassignedStorageClassPolicy(t *testing.T) {
 
 	createSpecCalled := false
 	patches.ApplyFunc(constructCreateSpecForInstance, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
-		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ string, _ bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ commontypes.FQDN, _ bool) (*cnstypes.CnsVolumeCreateSpec, error) {
 		createSpecCalled = true
 		return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}, nil
 	})
@@ -2387,7 +2388,7 @@ func TestReconcileReusesSpecifiedStorageClassNameWithoutLateDiscovery(t *testing
 		scheme:    scheme,
 		k8sclient: k8sclientFake,
 		configInfo: &config.ConfigurationInfo{Cfg: &config.Config{
-			VirtualCenter: map[string]*config.VirtualCenterConfig{"vc": {User: "test-user"}},
+			VirtualCenter: map[commontypes.FQDN]*config.VirtualCenterConfig{commontypes.NewFQDN("vc"): {User: "test-user"}},
 		}},
 		volumeManager: &mockVolumeManager{
 			createVolumeFunc: func(_ context.Context, _ *cnstypes.CnsVolumeCreateSpec,
@@ -2405,7 +2406,7 @@ func TestReconcileReusesSpecifiedStorageClassNameWithoutLateDiscovery(t *testing
 		return newFakeVCWithClient(), nil
 	})
 	patches.ApplyFunc(constructCreateSpecForInstance, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
-		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ string, _ bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ commontypes.FQDN, _ bool) (*cnstypes.CnsVolumeCreateSpec, error) {
 		return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}, nil
 	})
 	patches.ApplyFunc(common.QueryVolumeByID, func(_ context.Context, _ cnsvolume.Manager,
@@ -4581,7 +4582,7 @@ func TestBuildNodeAffinityFromSegments(t *testing.T) {
 // can be constructed in tests (the host method itself is patched, so no network call is made).
 func newFakeVCWithClient() *cnsvsphere.VirtualCenter {
 	return &cnsvsphere.VirtualCenter{
-		Config: &cnsvsphere.VirtualCenterConfig{Host: "dummy-vcenter"},
+		Config: &cnsvsphere.VirtualCenterConfig{Host: commontypes.NewFQDN("dummy-vcenter")},
 		Client: &govmomi.Client{Client: &vim25.Client{}},
 	}
 }
@@ -4825,7 +4826,7 @@ func newHostLocalReconcileFixture(patches *gomonkey.Patches, storageLocality str
 		return newFakeVCWithClient(), nil
 	})
 	patches.ApplyFunc(constructCreateSpecForInstance, func(_ context.Context, _ *ReconcileCnsRegisterVolume,
-		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ string, _ bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+		_ *cnsregistervolumev1alpha1.CnsRegisterVolume, _ commontypes.FQDN, _ bool) (*cnstypes.CnsVolumeCreateSpec, error) {
 		return &cnstypes.CnsVolumeCreateSpec{Name: "fake-volume", VolumeType: "BLOCK"}, nil
 	})
 	patches.ApplyFunc(common.QueryVolumeByID, func(_ context.Context, _ cnsvolume.Manager,

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -42,6 +42,7 @@ import (
 	cnsstoragepolicyquotasv1alpha3 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha3"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -360,7 +361,7 @@ func getStoragePolicyIDForStorageClass(ctx context.Context, k8sClient clientset.
 // constructCreateSpecForInstance creates CNS CreateVolume spec.
 func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegisterVolume,
 	instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
-	host string, useSupervisorId bool) (*cnstypes.CnsVolumeCreateSpec, error) {
+	host commontypes.FQDN, useSupervisorId bool) (*cnstypes.CnsVolumeCreateSpec, error) {
 	var volumeName string
 	if instance.Spec.VolumeID != "" {
 		volumeName = staticPvNamePrefix + instance.Spec.VolumeID
@@ -374,8 +375,9 @@ func constructCreateSpecForInstance(ctx context.Context, r *ReconcileCnsRegister
 	} else {
 		clusterIDForVolumeMetadata = r.configInfo.Cfg.Global.ClusterID
 	}
+	vcConfig := r.configInfo.Cfg.VirtualCenter[host]
 	containerCluster := vsphere.GetContainerCluster(clusterIDForVolumeMetadata,
-		r.configInfo.Cfg.VirtualCenter[host].User,
+		vcConfig.User,
 		cnstypes.CnsClusterFlavorWorkload, r.configInfo.Cfg.Global.ClusterDistribution)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
 		Name:       volumeName,

--- a/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
@@ -392,8 +392,9 @@ func (r *ReconcileCnsVolumeMetadata) updateCnsMetadata(ctx context.Context,
 			[]cnstypes.CnsKubernetesEntityReference{entityReferences[index]})
 		metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(metadata))
 
+		vcConfig := r.configInfo.Cfg.VirtualCenter[host]
 		cluster := cnsvsphere.GetContainerCluster(instance.Spec.GuestClusterID,
-			r.configInfo.Cfg.VirtualCenter[host].User, cnstypes.CnsClusterFlavorGuest,
+			vcConfig.User, cnstypes.CnsClusterFlavorGuest,
 			instance.Spec.ClusterDistribution)
 		updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
 			VolumeId: cnstypes.CnsVolumeId{

--- a/pkg/syncer/cnsoperator/util/hostlocal_zones_test.go
+++ b/pkg/syncer/cnsoperator/util/hostlocal_zones_test.go
@@ -30,6 +30,7 @@ import (
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 )
 
 // --- helpers for GetHostLocalAccessibleZones --------------------------------------------
@@ -67,7 +68,7 @@ func setupHostLocalSim(t *testing.T, numClusters int) (
 		t.Fatalf("failed to create govmomi client: %v", err)
 	}
 	vc = &cnsvsphere.VirtualCenter{
-		Config:      &cnsvsphere.VirtualCenterConfig{Host: "127.0.0.1"},
+		Config:      &cnsvsphere.VirtualCenterConfig{Host: commontypes.NewFQDN("127.0.0.1")},
 		Client:      c,
 		ClientMutex: &sync.Mutex{},
 	}

--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -44,6 +44,7 @@ import (
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
@@ -424,9 +425,9 @@ func GetNetworkProvider(ctx context.Context) (string, error) {
 }
 
 // GetVCDatacenterFromConfig returns datacenter registered for each vCenter
-func GetVCDatacentersFromConfig(cfg *config.Config) ([]string, string, error) {
+func GetVCDatacentersFromConfig(cfg *config.Config) ([]string, commontypes.FQDN, error) {
 	dcList := make([]string, 0)
-	vcHost := ""
+	var vcHost commontypes.FQDN
 	if len(cfg.VirtualCenter) > 1 {
 		return dcList, vcHost, fmt.Errorf("invalid configuration. Expected only 1 VC but found %d", len(cfg.VirtualCenter))
 	}

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -52,6 +52,7 @@ import (
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -80,7 +81,7 @@ var queryVolumeByIDFn = common.QueryVolumeByID
 
 // CsiFullSync reconciles volume metadata on a vanilla k8s cluster with volume
 // metadata on CNS.
-func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc string) error {
+func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc commontypes.FQDN) error {
 	log := logger.GetLogger(ctx)
 	log.Infof("FullSync for VC %s: start", vc)
 	fullSyncStartTime := time.Now()
@@ -525,7 +526,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 		log.Errorf("FullSync for VC %s: failed to compute pv_missing update specs with err %+v", vc, err)
 		return err
 	}
-	prometheus.CnsVolumePVMissingGaugeVec.WithLabelValues(vc).Set(float64(missingPVCount))
+	prometheus.CnsVolumePVMissingGaugeVec.WithLabelValues(vc.String()).Set(float64(missingPVCount))
 	if len(missingPVUpdateSpecs) > 0 {
 		log.Infof("FullSync for VC %s: applying pv_missing label to %d volume(s)",
 			vc, len(missingPVUpdateSpecs))
@@ -543,7 +544,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 			log.Errorf("FullSync for VC %s: failed to compute pv_retained update specs with err %+v", vc, err)
 			return err
 		}
-		prometheus.CnsVolumePVRetainedGaugeVec.WithLabelValues(vc).Set(float64(retainedPVCount))
+		prometheus.CnsVolumePVRetainedGaugeVec.WithLabelValues(vc.String()).Set(float64(retainedPVCount))
 		if len(retainedPVUpdateSpecs) > 0 {
 			log.Infof("FullSync for VC %s: applying pv_retained label to %d volume(s)",
 				vc, len(retainedPVUpdateSpecs))
@@ -850,7 +851,7 @@ func setFileShareAnnotationsOnPVC(ctx context.Context, k8sClient clientset.Inter
 // starts. So the k8sPVMap has stale values. This means that the volumeInfo CR which
 // may have got created during the full sync, might be added to the deletion map.
 // This entry will be removed from the deletion map in the next full sync cycle.
-func cleanUpVolumeInfoCrDeletionMap(ctx context.Context, metadataSyncer *metadataSyncInformer, vc string) {
+func cleanUpVolumeInfoCrDeletionMap(ctx context.Context, metadataSyncer *metadataSyncInformer, vc commontypes.FQDN) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("Cleaning up VolumeInfo CRs.")
 
@@ -883,7 +884,7 @@ func cleanUpVolumeInfoCrDeletionMap(ctx context.Context, metadataSyncer *metadat
 
 // volumeInfoCRFullSync creates VolumeInfo CR if it does not already exist for a volume.
 // It also deletes VolumeInfo CR if its corresponding PV does not exist.
-func volumeInfoCRFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc string) {
+func volumeInfoCRFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc commontypes.FQDN) {
 	log := logger.GetLogger(ctx)
 
 	log.Debugf("Starting volumeInfo CR full sync.")
@@ -950,7 +951,7 @@ func volumeInfoCRFullSync(ctx context.Context, metadataSyncer *metadataSyncInfor
 		// Create VolumeInfo CR if not found.
 		if !crExists {
 			if len(metadataSyncer.configInfo.Cfg.VirtualCenter) > 1 {
-				err := volumeInfoService.CreateVolumeInfo(ctx, volumeID, vc)
+				err := volumeInfoService.CreateVolumeInfo(ctx, volumeID, vc.String())
 				if err != nil {
 					log.Errorf("FullSync for VC %s: failed to create VolumeInfo CR for volume %s."+
 						"Error: %+v", vc, volumeID, err)
@@ -979,7 +980,7 @@ func volumeInfoCRFullSync(ctx context.Context, metadataSyncer *metadataSyncInfor
 					pvcCapacity := pvc.Status.Capacity[v1.ResourceStorage]
 					if pvc.Spec.StorageClassName != nil {
 						err = volumeInfoService.CreateVolumeInfoWithPolicyInfo(ctx, volumeID, pvc.Namespace,
-							scNameToPolicyIdMap[*pvc.Spec.StorageClassName], *pvc.Spec.StorageClassName, vc,
+							scNameToPolicyIdMap[*pvc.Spec.StorageClassName], *pvc.Spec.StorageClassName, vc.String(),
 							&pvcCapacity, isLinkedCloneVolume)
 						if err != nil {
 							log.Warnf("FullSync for VC %s: failed to create VolumeInfo CR for volume %s."+
@@ -1004,9 +1005,7 @@ func volumeInfoCRFullSync(ctx context.Context, metadataSyncer *metadataSyncInfor
 			log.Errorf("FullSync for VC %s: failed to parse cnsvolumeinfo object: %v, err: %v", vc, cnsvolumeinfo, err)
 			continue
 		}
-		// Use case-insensitive comparison: VCenterServer values persisted before
-		// vCenter host normalization was introduced may retain their original casing.
-		if strings.EqualFold(cnsvolumeinfo.Spec.VCenterServer, vc) {
+		if vc.Equal(cnsvolumeinfo.Spec.VCenterServer) {
 			if _, exists := currentK8sPVMap[cnsvolumeinfo.Spec.VolumeID]; !exists {
 				// If a PV is not present in the cluster for two full sync cycles, delete its VolumeInfo CR.
 				if _, existsInCrDeletionMap := volumeInfoCrDeletionMap[vc][cnsvolumeinfo.Spec.VolumeID]; existsInCrDeletionMap {
@@ -1123,7 +1122,7 @@ func validateAndCorrectVolumeInfoSnapshotDetails(ctx context.Context,
 // If the volume is successfully created, it is removed from `cnsCreationMap`.
 func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVolumeCreateSpec,
 	metadataSyncer *metadataSyncInformer, wg *sync.WaitGroup, migrationFeatureStateForFullSync bool,
-	volManager volumes.Manager, vc string) {
+	volManager volumes.Manager, vc commontypes.FQDN) {
 	log := logger.GetLogger(ctx)
 	defer wg.Done()
 	currentK8sPVMap := make(map[string]*v1.PersistentVolume)
@@ -1185,7 +1184,7 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 
 			if len(metadataSyncer.configInfo.Cfg.VirtualCenter) > 1 {
 				// Create CNSVolumeInfo CR for the volume ID.
-				err = volumeInfoService.CreateVolumeInfo(ctx, volumeID, vc)
+				err = volumeInfoService.CreateVolumeInfo(ctx, volumeID, vc.String())
 				if err != nil {
 					log.Errorf("FullSync for VC %s: failed to store volumeID %q in CNSVolumeInfo CR. Error: %+v",
 						vc, volumeID, err)
@@ -1205,7 +1204,7 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 // createSpec.
 func fullSyncUpdateVolumes(ctx context.Context, updateSpecArray []cnstypes.CnsVolumeMetadataUpdateSpec,
 	metadataSyncer *metadataSyncInformer, wg *sync.WaitGroup, volManager volumes.Manager,
-	vc string) {
+	vc commontypes.FQDN) {
 	defer wg.Done()
 	log := logger.GetLogger(ctx)
 	for _, updateSpec := range updateSpecArray {
@@ -1220,7 +1219,7 @@ func fullSyncUpdateVolumes(ctx context.Context, updateSpecArray []cnstypes.CnsVo
 // buildCnsMetadataList build metadata list for given PV.
 // Metadata list may include PV metadata, PVC metadata and POD metadata.
 func buildCnsMetadataList(ctx context.Context, pv *v1.PersistentVolume, pvToPVCMap pvcMap,
-	pvcToPodMap podMap, clusterID string, vc string) []cnstypes.BaseCnsEntityMetadata {
+	pvcToPodMap podMap, clusterID string, vc commontypes.FQDN) []cnstypes.BaseCnsEntityMetadata {
 	log := logger.GetLogger(ctx)
 	var metadataList []cnstypes.BaseCnsEntityMetadata
 	// Get pv metadata.
@@ -1332,7 +1331,7 @@ func preserveHealthLabelsOnK8sPVMetadata(k8sMetadataList []cnstypes.BaseCnsEntit
 func fullSyncConstructVolumeMaps(ctx context.Context, pvList []*v1.PersistentVolume,
 	cnsVolumeList []cnstypes.CnsVolume, pvToPVCMap pvcMap, pvcToPodMap podMap,
 	metadataSyncer *metadataSyncInformer, migrationFeatureStateForFullSync bool,
-	volManager volumes.Manager, vc string) (
+	volManager volumes.Manager, vc commontypes.FQDN) (
 	map[string][]cnstypes.BaseCnsEntityMetadata, map[string][]cnstypes.BaseCnsEntityMetadata,
 	map[string]bool, error) {
 	log := logger.GetLogger(ctx)
@@ -1420,7 +1419,7 @@ func fullSyncGetVolumeSpecs(ctx context.Context, vCenterVersion string, pvList [
 	volumeToCnsEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata,
 	volumeToK8sEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata,
 	volumeClusterDistributionMap map[string]bool, containerCluster cnstypes.CnsContainerCluster,
-	migrationFeatureStateForFullSync bool, vc string) (
+	migrationFeatureStateForFullSync bool, vc commontypes.FQDN) (
 	[]cnstypes.CnsVolumeCreateSpec, []cnstypes.CnsVolumeMetadataUpdateSpec) {
 	log := logger.GetLogger(ctx)
 	var createSpecArray []cnstypes.CnsVolumeCreateSpec
@@ -1651,7 +1650,7 @@ func fullSyncGetVolumeSpecs(ctx context.Context, vCenterVersion string, pvList [
 func getMissingPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstypes.CnsVolume,
 	k8sPVMap map[string]string, metadataSyncer *metadataSyncInformer,
 	migrationFeatureStateForFullSync bool, containerCluster cnstypes.CnsContainerCluster,
-	vc string) ([]cnstypes.CnsVolumeMetadataUpdateSpec, int, error) {
+	vc commontypes.FQDN) ([]cnstypes.CnsVolumeMetadataUpdateSpec, int, error) {
 	log := logger.GetLogger(ctx)
 	var updateSpecArray []cnstypes.CnsVolumeMetadataUpdateSpec
 
@@ -1796,7 +1795,7 @@ func isPVEntityLabeledExclusively(vol cnstypes.CnsVolume, labelKey, labelValue s
 // Returns (spec, false) if there is nothing to update (every PV entity is
 // already labeled, or no candidate entity could be synthesized).
 func buildPVMissingUpdateSpec(ctx context.Context, vol cnstypes.CnsVolume,
-	containerCluster cnstypes.CnsContainerCluster, vc string) (cnstypes.CnsVolumeMetadataUpdateSpec, bool) {
+	containerCluster cnstypes.CnsContainerCluster, vc commontypes.FQDN) (cnstypes.CnsVolumeMetadataUpdateSpec, bool) {
 	log := logger.GetLogger(ctx)
 	var entityMetadata []cnstypes.BaseCnsEntityMetadata
 	foundInClusterPV := false
@@ -1891,7 +1890,7 @@ func buildPVMissingUpdateSpec(ctx context.Context, vol cnstypes.CnsVolume,
 // pv_retained gauge for this VC.
 func getRetainedPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstypes.CnsVolume,
 	k8sPVs []*v1.PersistentVolume, containerCluster cnstypes.CnsContainerCluster,
-	vc string) ([]cnstypes.CnsVolumeMetadataUpdateSpec, int, error) {
+	vc commontypes.FQDN) ([]cnstypes.CnsVolumeMetadataUpdateSpec, int, error) {
 	log := logger.GetLogger(ctx)
 	var updateSpecArray []cnstypes.CnsVolumeMetadataUpdateSpec
 
@@ -1942,7 +1941,7 @@ func getRetainedPVVolumeUpdateSpecs(ctx context.Context, cnsVolumeList []cnstype
 // Returns (spec, false) if there is nothing to update (every PV entity is
 // already labeled, or no candidate entity could be synthesized).
 func buildPVRetainedUpdateSpec(ctx context.Context, vol cnstypes.CnsVolume,
-	containerCluster cnstypes.CnsContainerCluster, vc string) (cnstypes.CnsVolumeMetadataUpdateSpec, bool) {
+	containerCluster cnstypes.CnsContainerCluster, vc commontypes.FQDN) (cnstypes.CnsVolumeMetadataUpdateSpec, bool) {
 	log := logger.GetLogger(ctx)
 	var entityMetadata []cnstypes.BaseCnsEntityMetadata
 	foundInClusterPV := false
@@ -2010,7 +2009,7 @@ func buildPVRetainedUpdateSpec(ctx context.Context, vol cnstypes.CnsVolume,
 // pvcToPodMap maps PVC to the array of PODs using the PVC, key is
 // "pod.Namespace/pvc.Name".
 func buildPVCMapPodMap(ctx context.Context, pvList []*v1.PersistentVolume,
-	metadataSyncer *metadataSyncInformer, vc string) (pvcMap, podMap, error) {
+	metadataSyncer *metadataSyncInformer, vc commontypes.FQDN) (pvcMap, podMap, error) {
 	log := logger.GetLogger(ctx)
 	pvToPVCMap := make(pvcMap)
 	pvcToPodMap := make(podMap)
@@ -2052,7 +2051,7 @@ func buildPVCMapPodMap(ctx context.Context, pvList []*v1.PersistentVolume,
 // list from CNS and returns true if update operation is required. Otherwise,
 // returns false.
 func isUpdateRequired(ctx context.Context, vCenterVersion string, k8sMetadataList []cnstypes.BaseCnsEntityMetadata,
-	cnsMetadataList []cnstypes.BaseCnsEntityMetadata, volumeClusterDistributionSet bool, vc string) bool {
+	cnsMetadataList []cnstypes.BaseCnsEntityMetadata, volumeClusterDistributionSet bool, vc commontypes.FQDN) bool {
 	log := logger.GetLogger(ctx)
 	log.Debugw("FullSync: isUpdateRequired called", "vc", vc, "k8sMetadataList", k8sMetadataList,
 		"cnsMetadataList", cnsMetadataList)
@@ -2111,7 +2110,7 @@ func isUpdateRequired(ctx context.Context, vCenterVersion string, k8sMetadataLis
 // The map names are retained for historical/test compatibility; their meaning
 // for cnsDeletionMap has shifted from "to be deleted" to "missing PV, awaiting
 // label".
-func cleanupCnsMaps(k8sPVs map[string]string, vc string) {
+func cleanupCnsMaps(k8sPVs map[string]string, vc commontypes.FQDN) {
 	// Cleanup cnsCreationMap.
 	cnsCreationMapForVc := cnsCreationMap[vc]
 	for volID := range cnsCreationMapForVc {
@@ -2917,7 +2916,8 @@ func annotateSnapshotsFromCNSResults(
 // 4. Queries CNS sequentially, one volume at a time (CNS does not parallelize requests)
 // 5. For each CNS query result, immediately annotates matching VolumeSnapshots
 // This ensures supervisor snapshots have complete metadata that can be mirrored to guest cluster snapshots.
-func setChangeIDAnnotationOnSupervisorSnapshots(ctx context.Context, metadataSyncer *metadataSyncInformer, vc string) {
+func setChangeIDAnnotationOnSupervisorSnapshots(ctx context.Context, metadataSyncer *metadataSyncInformer,
+	vc commontypes.FQDN) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("setChangeIDAnnotationOnSupervisorSnapshots: Start for VC: %s", vc)
 

--- a/pkg/syncer/fullsync_test.go
+++ b/pkg/syncer/fullsync_test.go
@@ -51,6 +51,7 @@ import (
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -169,7 +170,7 @@ func testFullSyncAtScale(t *testing.T, pvCount int) {
 			},
 		}
 		patches := gomonkey.ApplyFunc(cnsvsphere.GetVirtualCenterInstanceForVCenterHost,
-			func(ctx context.Context, vcHost string, reconnect bool) (*cnsvsphere.VirtualCenter, error) {
+			func(ctx context.Context, vcHost commontypes.FQDN, reconnect bool) (*cnsvsphere.VirtualCenter, error) {
 				return mockVC, nil
 			})
 		defer patches.Reset()
@@ -189,7 +190,8 @@ func testFullSyncAtScale(t *testing.T, pvCount int) {
 			pvcByName[pvc.Name] = pvc
 		}
 		patches.ApplyFunc(buildPVCMapPodMap,
-			func(_ context.Context, pvList []*v1.PersistentVolume, _ *metadataSyncInformer, _ string) (pvcMap, podMap, error) {
+			func(_ context.Context, pvList []*v1.PersistentVolume, _ *metadataSyncInformer,
+				_ commontypes.FQDN) (pvcMap, podMap, error) {
 				pvcMapResult := make(pvcMap, len(pvList))
 				for _, pv := range pvList {
 					if pv.Spec.ClaimRef != nil {
@@ -203,7 +205,7 @@ func testFullSyncAtScale(t *testing.T, pvCount int) {
 
 		t.Logf("Running CsiFullSync with %d PVs...", pvCount)
 		startSync := time.Now()
-		syncErr = CsiFullSync(ctx, metadataSyncer, "test-vcenter")
+		syncErr = CsiFullSync(ctx, metadataSyncer, commontypes.NewFQDN("test-vcenter"))
 		syncTime = time.Since(startSync)
 
 		queryCount = mockVolMgr.queryCallCount
@@ -504,13 +506,13 @@ func setupMetadataSyncerForFullSync(
 	// Create mock config
 	cfg := &cnsconfig.ConfigurationInfo{
 		Cfg: &cnsconfig.Config{
-			VirtualCenter: map[string]*cnsconfig.VirtualCenterConfig{
-				"test-vcenter": {},
+			VirtualCenter: map[commontypes.FQDN]*cnsconfig.VirtualCenterConfig{
+				commontypes.NewFQDN("test-vcenter"): {},
 			},
 		},
 	}
 	// Set Global.VCenterIP and ClusterID
-	cfg.Cfg.Global.VCenterIP = "test-vcenter"
+	cfg.Cfg.Global.VCenterIP = commontypes.NewFQDN("test-vcenter")
 	cfg.Cfg.Global.ClusterID = "test-cluster-id"
 
 	// Create fake informer manager with listers
@@ -518,18 +520,18 @@ func setupMetadataSyncerForFullSync(
 	informerManager.Listen()
 
 	// Initialize volumeManagers map for multi-vCenter support
-	volumeManagers := make(map[string]volumes.Manager)
-	volumeManagers["test-vcenter"] = mockVolMgr
+	volumeManagers := make(map[commontypes.FQDN]volumes.Manager)
+	volumeManagers[commontypes.NewFQDN("test-vcenter")] = mockVolMgr
 
 	// Initialize package-level maps normally set up by InitMetadataSyncer.
-	volumeOperationsLock = make(map[string]*sync.Mutex)
-	volumeOperationsLock["test-vcenter"] = &sync.Mutex{}
-	cnsDeletionMap = make(map[string]map[string]bool)
-	cnsDeletionMap["test-vcenter"] = make(map[string]bool)
-	pvMissingLabeledMap = make(map[string]map[string]bool)
-	pvMissingLabeledMap["test-vcenter"] = make(map[string]bool)
-	cnsCreationMap = make(map[string]map[string]bool)
-	cnsCreationMap["test-vcenter"] = make(map[string]bool)
+	volumeOperationsLock = make(map[commontypes.FQDN]*sync.Mutex)
+	volumeOperationsLock[commontypes.NewFQDN("test-vcenter")] = &sync.Mutex{}
+	cnsDeletionMap = make(map[commontypes.FQDN]map[string]bool)
+	cnsDeletionMap[commontypes.NewFQDN("test-vcenter")] = make(map[string]bool)
+	pvMissingLabeledMap = make(map[commontypes.FQDN]map[string]bool)
+	pvMissingLabeledMap[commontypes.NewFQDN("test-vcenter")] = make(map[string]bool)
+	cnsCreationMap = make(map[commontypes.FQDN]map[string]bool)
+	cnsCreationMap[commontypes.NewFQDN("test-vcenter")] = make(map[string]bool)
 
 	ms := &metadataSyncInformer{
 		clusterFlavor:      cnstypes.CnsClusterFlavorVanilla,
@@ -537,7 +539,7 @@ func setupMetadataSyncerForFullSync(
 		volumeManager:      mockVolMgr,
 		volumeManagers:     volumeManagers,
 		configInfo:         cfg,
-		host:               "test-vcenter",
+		host:               commontypes.NewFQDN("test-vcenter"),
 		k8sInformerManager: informerManager,
 		pvLister:           informerManager.GetPVLister(),
 		pvcLister:          informerManager.GetPVCLister(),
@@ -1567,7 +1569,7 @@ func TestSetChangeIDAnnotationOnSupervisorSnapshots(t *testing.T) {
 	defer patchSnapshotClient.Reset()
 
 	// Call should handle error gracefully
-	setChangeIDAnnotationOnSupervisorSnapshots(ctx, mockMetadataSyncer, "test-vc")
+	setChangeIDAnnotationOnSupervisorSnapshots(ctx, mockMetadataSyncer, commontypes.NewFQDN("test-vc"))
 	// If we get here without panicking, test passes
 }
 
@@ -2310,10 +2312,10 @@ func TestReconcileKeepAfterDeleteVmFlags(t *testing.T) {
 // carrying a mockCOCommonForFullSync so the function's PVC-namespace cache
 // lookup returns false (i.e. "no cached PVC"), matching the production code
 // path we want to exercise.
-func pvMissingTestSetup(t *testing.T, vc, clusterID string) *metadataSyncInformer {
+func pvMissingTestSetup(t *testing.T, vc commontypes.FQDN, clusterID string) *metadataSyncInformer {
 	t.Helper()
-	cnsDeletionMap = map[string]map[string]bool{vc: {}}
-	pvMissingLabeledMap = map[string]map[string]bool{vc: {}}
+	cnsDeletionMap = map[commontypes.FQDN]map[string]bool{vc: {}}
+	pvMissingLabeledMap = map[commontypes.FQDN]map[string]bool{vc: {}}
 	clusterIDforVolumeMetadata = clusterID
 	return &metadataSyncInformer{
 		coCommonInterface: &mockCOCommonForFullSync{},
@@ -2358,7 +2360,7 @@ func hasPVMissingTrueLabel(spec cnstypes.CnsVolumeMetadataUpdateSpec) bool {
 func TestGetMissingPVVolumeUpdateSpecs_GracePeriod(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	vc := "test-vc"
+	vc := commontypes.NewFQDN("test-vc")
 	clusterID := "test-cluster"
 	ms := pvMissingTestSetup(t, vc, clusterID)
 
@@ -2397,7 +2399,7 @@ func TestGetMissingPVVolumeUpdateSpecs_GracePeriod(t *testing.T) {
 func TestGetMissingPVVolumeUpdateSpecs_PVExists(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	vc := "test-vc"
+	vc := commontypes.NewFQDN("test-vc")
 	clusterID := "test-cluster"
 	ms := pvMissingTestSetup(t, vc, clusterID)
 
@@ -2431,7 +2433,7 @@ func TestGetMissingPVVolumeUpdateSpecs_PVExists(t *testing.T) {
 func TestGetMissingPVVolumeUpdateSpecs_StripsExistingLabels(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	vc := "test-vc"
+	vc := commontypes.NewFQDN("test-vc")
 	clusterID := "test-cluster"
 	ms := pvMissingTestSetup(t, vc, clusterID)
 
@@ -2474,7 +2476,7 @@ func TestGetMissingPVVolumeUpdateSpecs_StripsExistingLabels(t *testing.T) {
 func TestGetMissingPVVolumeUpdateSpecs_AlreadyLabeled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	vc := "test-vc"
+	vc := commontypes.NewFQDN("test-vc")
 	clusterID := "test-cluster"
 	ms := pvMissingTestSetup(t, vc, clusterID)
 
@@ -2511,7 +2513,7 @@ func TestGetMissingPVVolumeUpdateSpecs_AlreadyLabeled(t *testing.T) {
 func TestGetMissingPVVolumeUpdateSpecs_StripsStalePVRetained(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	vc := "test-vc"
+	vc := commontypes.NewFQDN("test-vc")
 	clusterID := "test-cluster"
 	ms := pvMissingTestSetup(t, vc, clusterID)
 
@@ -2558,7 +2560,7 @@ func TestGetMissingPVVolumeUpdateSpecs_StripsStalePVRetained(t *testing.T) {
 func TestGetMissingPVVolumeUpdateSpecs_ReconcilesCoexistingLabels(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	vc := "test-vc"
+	vc := commontypes.NewFQDN("test-vc")
 	clusterID := "test-cluster"
 	ms := pvMissingTestSetup(t, vc, clusterID)
 
@@ -2606,7 +2608,7 @@ func TestGetMissingPVVolumeUpdateSpecs_ReconcilesCoexistingLabels(t *testing.T) 
 func TestGetMissingPVVolumeUpdateSpecs_SkipsOnceLocallyLabeled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	vc := "test-vc"
+	vc := commontypes.NewFQDN("test-vc")
 	clusterID := "test-cluster"
 	ms := pvMissingTestSetup(t, vc, clusterID)
 
@@ -2640,7 +2642,7 @@ func TestGetMissingPVVolumeUpdateSpecs_SkipsOnceLocallyLabeled(t *testing.T) {
 func TestGetMissingPVVolumeUpdateSpecs_SynthesizesPVEntity(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	vc := "test-vc"
+	vc := commontypes.NewFQDN("test-vc")
 	clusterID := "test-cluster"
 	ms := pvMissingTestSetup(t, vc, clusterID)
 
@@ -2676,7 +2678,7 @@ func TestGetMissingPVVolumeUpdateSpecs_SynthesizesPVEntity(t *testing.T) {
 func TestGetMissingPVVolumeUpdateSpecs_ForeignClusterIgnored(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	vc := "test-vc"
+	vc := commontypes.NewFQDN("test-vc")
 	clusterID := "test-cluster"
 	ms := pvMissingTestSetup(t, vc, clusterID)
 

--- a/pkg/syncer/k8scloudoperator/placement.go
+++ b/pkg/syncer/k8scloudoperator/placement.go
@@ -621,7 +621,7 @@ func eliminateNodesWithPvcOfSiblingReplica(ctx context.Context, client kubernete
 		}
 
 		for i, host := range candidateHosts {
-			if host == hostName {
+			if strings.EqualFold(host, hostName) {
 				candidateHosts = filterHost(candidateHosts, i)
 				break
 			}
@@ -852,7 +852,7 @@ func isStoragePoolInDiskDecommission(ctx context.Context, sp v1alpha1.StoragePoo
 func isStoragePoolAccessibleByNodes(ctx context.Context, sp v1alpha1.StoragePool, hostNames []string) bool {
 	for _, host := range hostNames { // filter by node candidate list.
 		for _, node := range sp.Status.AccessibleNodes {
-			if node == host {
+			if strings.EqualFold(node, host) {
 				return true
 			}
 		}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -66,6 +66,7 @@ import (
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -487,15 +488,15 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	}
 
 	// Initialize cnsDeletionMap used by Full Sync.
-	cnsDeletionMap = make(map[string]map[string]bool)
+	cnsDeletionMap = make(map[commontypes.FQDN]map[string]bool)
 	// Initialize pvMissingLabeledMap used by Full Sync.
-	pvMissingLabeledMap = make(map[string]map[string]bool)
+	pvMissingLabeledMap = make(map[commontypes.FQDN]map[string]bool)
 	// Initialize cnsCreationMap used by Full Sync.
-	cnsCreationMap = make(map[string]map[string]bool)
+	cnsCreationMap = make(map[commontypes.FQDN]map[string]bool)
 	// Initialize volumeOperationsLock map
-	volumeOperationsLock = make(map[string]*sync.Mutex)
+	volumeOperationsLock = make(map[commontypes.FQDN]*sync.Mutex)
 	// Initialize volumeInfoCrDeletionMap used by Full Sync.
-	volumeInfoCrDeletionMap = make(map[string]map[string]bool)
+	volumeInfoCrDeletionMap = make(map[commontypes.FQDN]map[string]bool)
 
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		// Initialize client to supervisor cluster, if metadata syncer is being
@@ -616,7 +617,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to get VirtualCenterConfigs. err: %v", err)
 		}
-		metadataSyncer.volumeManagers = make(map[string]volumes.Manager)
+		metadataSyncer.volumeManagers = make(map[commontypes.FQDN]volumes.Manager)
 		var multivCenterTopologyDeployment bool
 		if len(vcconfigs) > 1 {
 			multivCenterTopologyDeployment = true
@@ -656,7 +657,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to get kubeconfig with error: %v", err)
 		}
-		metadataSyncer.topologyVCMap = make(map[string]map[string]struct{})
+		metadataSyncer.topologyVCMap = make(map[string]map[commontypes.FQDN]struct{})
 		err = startTopologyCRInformer(ctx, k8sConfig)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to start informer on %q instances. Error: %v",
@@ -2087,7 +2088,7 @@ func addLabelsToTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1
 	// Update MetadataSyncer.topologyVCMap with topology label and associated VC host.
 	for _, label := range nodeTopoObj.Status.TopologyLabels {
 		if _, exists := MetadataSyncer.topologyVCMap[label.Value]; !exists {
-			MetadataSyncer.topologyVCMap[label.Value] = map[string]struct{}{nodeVM.VirtualCenterHost: {}}
+			MetadataSyncer.topologyVCMap[label.Value] = map[commontypes.FQDN]struct{}{nodeVM.VirtualCenterHost: {}}
 		} else {
 			MetadataSyncer.topologyVCMap[label.Value][nodeVM.VirtualCenterHost] = struct{}{}
 		}
@@ -2631,7 +2632,7 @@ func getVCForTopologySegments(ctx context.Context, topologySegments map[string][
 	log := logger.GetLogger(ctx)
 	// vcCountMap keeps a cumulative count of the occurrences of
 	// VCs across all labels in the given topology segment.
-	vcCountMap := make(map[string]int)
+	vcCountMap := make(map[commontypes.FQDN]int)
 
 	// Find the VC which contains all the labels given in the topologySegments.
 	// For example, if topologyVCMap looks like
@@ -2655,7 +2656,7 @@ func getVCForTopologySegments(ctx context.Context, topologySegments map[string][
 			}
 		}
 	}
-	var commonVCList []string
+	var commonVCList []commontypes.FQDN
 	for vc, count := range vcCountMap {
 		// Add VCs to the commonVCList if they satisfied all the labels in the topology segment.
 		if count == numTopoLabels {
@@ -2668,7 +2669,7 @@ func getVCForTopologySegments(ctx context.Context, topologySegments map[string][
 			topologySegments, commonVCList)
 	case len(commonVCList) == 1:
 		log.Infof("Topology segment(s) %+v belong to VC: %q", topologySegments, commonVCList[0])
-		return commonVCList[0], nil
+		return commonVCList[0].String(), nil
 	}
 	return "", logger.LogNewErrorf(log, "failed to find the VC associated with topology segments %+v",
 		topologySegments)
@@ -2709,7 +2710,7 @@ func updateTriggerCsiFullSyncInstance(ctx context.Context,
 // this comparison can be tested without the surrounding function's much
 // larger surface (VC connection, singleton reset, and process exit on
 // unrecoverable errors).
-func vcConfigChanged(currentHost string, oldVCConfig *cnsconfig.VirtualCenterConfig,
+func vcConfigChanged(currentHost commontypes.FQDN, oldVCConfig *cnsconfig.VirtualCenterConfig,
 	newVCConfig *cnsvsphere.VirtualCenterConfig, forceReconnect bool) bool {
 	return currentHost != newVCConfig.Host ||
 		oldVCConfig.User != newVCConfig.Username ||
@@ -3464,7 +3465,7 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 	var (
 		volumeHandle string
 		err          error
-		vcHost       string
+		vcHost       commontypes.FQDN
 		cnsVolumeMgr volumes.Manager
 	)
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorVanilla && pv.Spec.VsphereVolume != nil {
@@ -3657,7 +3658,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 		err              error
 		containerCluster cnstypes.CnsContainerCluster
 		cnsVolumeMgr     volumes.Manager
-		vcHost           string
+		vcHost           commontypes.FQDN
 	)
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorVanilla && newPv.Spec.VsphereVolume != nil {
 		// In case if feature state switch is enabled after syncer is deployed,
@@ -3998,7 +3999,7 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 	} else {
 		var (
 			volumeHandle string
-			vcHost       string
+			vcHost       commontypes.FQDN
 			err          error
 			cnsVolumeMgr volumes.Manager
 		)

--- a/pkg/syncer/metadatasyncer_test.go
+++ b/pkg/syncer/metadatasyncer_test.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -2454,10 +2455,10 @@ func TestCsiPVDeleted_BlockVolume_ImprovedVolumeVisibility(t *testing.T) {
 	volumeInfoService = nil
 	IsPodVMOnStretchSupervisorFSSEnabled = false
 
-	const vcHost = "test-vc-host"
+	vcHost := commontypes.NewFQDN("test-vc-host")
 
 	setup := func(t *testing.T, fssEnabled bool) (*metadataSyncInformer, *recordingVolumeManager) {
-		volumeOperationsLock = map[string]*sync.Mutex{vcHost: {}}
+		volumeOperationsLock = map[commontypes.FQDN]*sync.Mutex{vcHost: {}}
 
 		co, err := unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
 		assert.NoError(t, err)
@@ -2571,14 +2572,14 @@ func TestVCConfigChanged(t *testing.T) {
 	}
 	baseNew := func() *cnsvsphere.VirtualCenterConfig {
 		return &cnsvsphere.VirtualCenterConfig{
-			Host:                  "vc.tld",
+			Host:                  commontypes.NewFQDN("vc.tld"),
 			Username:              baseOld.User,
 			Password:              baseOld.Password,
 			VCSessionManagerURL:   baseOld.VCSessionManagerURL,
 			VCSessionManagerToken: baseOld.VCSessionManagerToken,
 		}
 	}
-	const currentHost = "vc.tld"
+	currentHost := commontypes.NewFQDN("vc.tld")
 
 	testCases := []struct {
 		name           string
@@ -2599,7 +2600,7 @@ func TestVCConfigChanged(t *testing.T) {
 		},
 		{
 			name:      "host changed",
-			mutateNew: func(c *cnsvsphere.VirtualCenterConfig) { c.Host = "other-vc.tld" },
+			mutateNew: func(c *cnsvsphere.VirtualCenterConfig) { c.Host = commontypes.NewFQDN("other-vc.tld") },
 			want:      true,
 		},
 		{

--- a/pkg/syncer/pv_to_backingdiskobjectid_mapping.go
+++ b/pkg/syncer/pv_to_backingdiskobjectid_mapping.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -32,7 +33,7 @@ import (
 
 // TODO: refactor pv to backingdiskobjectid and volume health code to reduce duplicated code
 func csiGetPVtoBackingDiskObjectIdMapping(ctx context.Context, k8sclient clientset.Interface,
-	metadataSyncer *metadataSyncInformer, vc string) {
+	metadataSyncer *metadataSyncInformer, vc commontypes.FQDN) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("csiGetPVtoBackingDiskObjectIdMapping for %s: start", vc)
 	// Call CNS QueryAll to get container volumes by cluster ID.

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -41,6 +41,7 @@ import (
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
@@ -158,13 +159,13 @@ func TestSyncerWorkflows(t *testing.T) {
 
 	// Initialize metadata syncer object.
 	metadataSyncer = &metadataSyncInformer{
-		volumeManagers: make(map[string]cnsvolumes.Manager),
+		volumeManagers: make(map[commontypes.FQDN]cnsvolumes.Manager),
 	}
 	metadataSyncer.configInfo = configInfo
 	metadataSyncer.volumeManager = volumeManager
 	metadataSyncer.volumeManagers[virtualCenter.Config.Host] = volumeManager
 	metadataSyncer.host = virtualCenter.Config.Host
-	volumeOperationsLock = make(map[string]*sync.Mutex)
+	volumeOperationsLock = make(map[commontypes.FQDN]*sync.Mutex)
 	volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
 
 	// Create the kubernetes client from config or env.
@@ -626,7 +627,7 @@ func runTestFullSyncWorkflows(t *testing.T) {
 			CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: gbInMb},
 		},
 	}
-	cnsCreationMap = make(map[string]map[string]bool)
+	cnsCreationMap = make(map[commontypes.FQDN]map[string]bool)
 	cnsCreationMap[csiConfig.Global.VCenterIP] = make(map[string]bool)
 
 	volumeInfo, _, err := volumeManager.CreateVolume(ctx, &createSpec, nil)
@@ -654,9 +655,9 @@ func runTestFullSyncWorkflows(t *testing.T) {
 	if len(queryResult.Volumes) != 1 && queryResult.Volumes[0].VolumeId.Id != volumeInfo.VolumeID.Id {
 		t.Fatalf("failed to find the newly created volume with ID: %s", volumeInfo.VolumeID.Id)
 	}
-	cnsDeletionMap = make(map[string]map[string]bool)
+	cnsDeletionMap = make(map[commontypes.FQDN]map[string]bool)
 	cnsDeletionMap[csiConfig.Global.VCenterIP] = make(map[string]bool)
-	pvMissingLabeledMap = make(map[string]map[string]bool)
+	pvMissingLabeledMap = make(map[commontypes.FQDN]map[string]bool)
 	pvMissingLabeledMap[csiConfig.Global.VCenterIP] = make(map[string]bool)
 	// PV does not exist in K8S, but volume exists in CNS cache.
 	// Per the cns-health-initiative design, fullsync no longer unregisters
@@ -987,17 +988,17 @@ func TestGetVCForTopologySegments(t *testing.T) {
 
 	tests := []struct {
 		name                      string
-		topologyVCMap             map[string]map[string]struct{}
+		topologyVCMap             map[string]map[commontypes.FQDN]struct{}
 		requestedTopologySegments map[string][]string
 		expectedVC                string
 		expectingErr              bool
 	}{
 		{
 			name: "Higher-level topology label present in more than one VC",
-			topologyVCMap: map[string]map[string]struct{}{
-				"region-1": {"10.100.100.0": {}, "10.100.100.1": {}},
-				"zone-1":   {"10.100.100.0": {}},
-				"zone-2":   {"10.100.100.1": {}},
+			topologyVCMap: map[string]map[commontypes.FQDN]struct{}{
+				"region-1": {commontypes.NewFQDN("10.100.100.0"): {}, commontypes.NewFQDN("10.100.100.1"): {}},
+				"zone-1":   {commontypes.NewFQDN("10.100.100.0"): {}},
+				"zone-2":   {commontypes.NewFQDN("10.100.100.1"): {}},
 			},
 			requestedTopologySegments: map[string][]string{
 				"topology.csi.vmware.com/region": {"region-1"},
@@ -1008,10 +1009,10 @@ func TestGetVCForTopologySegments(t *testing.T) {
 		},
 		{
 			name: "Invalid topology label given as input",
-			topologyVCMap: map[string]map[string]struct{}{
-				"region-1": {"10.100.100.0": {}, "10.100.100.1": {}},
-				"zone-1":   {"10.100.100.0": {}},
-				"zone-2":   {"10.100.100.1": {}},
+			topologyVCMap: map[string]map[commontypes.FQDN]struct{}{
+				"region-1": {commontypes.NewFQDN("10.100.100.0"): {}, commontypes.NewFQDN("10.100.100.1"): {}},
+				"zone-1":   {commontypes.NewFQDN("10.100.100.0"): {}},
+				"zone-2":   {commontypes.NewFQDN("10.100.100.1"): {}},
 			},
 			requestedTopologySegments: map[string][]string{
 				"topology.csi.vmware.com/region": {"region-1"},
@@ -1022,10 +1023,10 @@ func TestGetVCForTopologySegments(t *testing.T) {
 		},
 		{
 			name: "Topology label belongs to more than one VC",
-			topologyVCMap: map[string]map[string]struct{}{
-				"region-1": {"10.100.100.0": {}, "10.100.100.1": {}},
-				"zone-1":   {"10.100.100.0": {}, "10.100.100.1": {}},
-				"zone-2":   {"10.100.100.1": {}},
+			topologyVCMap: map[string]map[commontypes.FQDN]struct{}{
+				"region-1": {commontypes.NewFQDN("10.100.100.0"): {}, commontypes.NewFQDN("10.100.100.1"): {}},
+				"zone-1":   {commontypes.NewFQDN("10.100.100.0"): {}, commontypes.NewFQDN("10.100.100.1"): {}},
+				"zone-2":   {commontypes.NewFQDN("10.100.100.1"): {}},
 			},
 			requestedTopologySegments: map[string][]string{
 				"topology.csi.vmware.com/region": {"region-1"},
@@ -1036,10 +1037,10 @@ func TestGetVCForTopologySegments(t *testing.T) {
 		},
 		{
 			name: "Leaf-level topology label present in more than one VC",
-			topologyVCMap: map[string]map[string]struct{}{
-				"region-1": {"10.100.100.0": {}},
-				"region-2": {"10.100.100.1": {}},
-				"zone-1":   {"10.100.100.0": {}, "10.100.100.1": {}},
+			topologyVCMap: map[string]map[commontypes.FQDN]struct{}{
+				"region-1": {commontypes.NewFQDN("10.100.100.0"): {}},
+				"region-2": {commontypes.NewFQDN("10.100.100.1"): {}},
+				"zone-1":   {commontypes.NewFQDN("10.100.100.0"): {}, commontypes.NewFQDN("10.100.100.1"): {}},
 			},
 			requestedTopologySegments: map[string][]string{
 				"topology.csi.vmware.com/region": {"region-2"},
@@ -1050,13 +1051,13 @@ func TestGetVCForTopologySegments(t *testing.T) {
 		},
 		{
 			name: "Topology labels distinct across VCs",
-			topologyVCMap: map[string]map[string]struct{}{
-				"region-1": {"10.100.100.0": {}},
-				"region-2": {"10.100.100.1": {}},
-				"zone-1":   {"10.100.100.0": {}},
-				"zone-2":   {"10.100.100.1": {}},
-				"city-1":   {"10.100.100.0": {}},
-				"city-2":   {"10.100.100.1": {}},
+			topologyVCMap: map[string]map[commontypes.FQDN]struct{}{
+				"region-1": {commontypes.NewFQDN("10.100.100.0"): {}},
+				"region-2": {commontypes.NewFQDN("10.100.100.1"): {}},
+				"zone-1":   {commontypes.NewFQDN("10.100.100.0"): {}},
+				"zone-2":   {commontypes.NewFQDN("10.100.100.1"): {}},
+				"city-1":   {commontypes.NewFQDN("10.100.100.0"): {}},
+				"city-2":   {commontypes.NewFQDN("10.100.100.1"): {}},
 			},
 			requestedTopologySegments: map[string][]string{
 				"topology.csi.vmware.com/region": {"region-2"},
@@ -1068,11 +1069,11 @@ func TestGetVCForTopologySegments(t *testing.T) {
 		},
 		{
 			name: "Multiple values for same topology key",
-			topologyVCMap: map[string]map[string]struct{}{
-				"region-1": {"10.100.100.0": {}},
-				"region-2": {"10.100.100.0": {}},
-				"zone-1":   {"10.100.100.0": {}},
-				"zone-2":   {"10.100.100.1": {}},
+			topologyVCMap: map[string]map[commontypes.FQDN]struct{}{
+				"region-1": {commontypes.NewFQDN("10.100.100.0"): {}},
+				"region-2": {commontypes.NewFQDN("10.100.100.0"): {}},
+				"zone-1":   {commontypes.NewFQDN("10.100.100.0"): {}},
+				"zone-2":   {commontypes.NewFQDN("10.100.100.1"): {}},
 			},
 			requestedTopologySegments: map[string][]string{
 				"topology.csi.vmware.com/region": {"region-1", "region-2"},

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
@@ -80,7 +81,7 @@ var (
 	// initiative design). A separate map is maintained for each VC.
 	// The historical name is preserved to minimize churn in the syncer code
 	// and tests.
-	cnsDeletionMap map[string]map[string]bool
+	cnsDeletionMap map[commontypes.FQDN]map[string]bool
 
 	// pvMissingLabeledMap tracks, per VC, the CNS volume IDs that full sync
 	// has already labeled pv_missing=true. Once a volume is recorded here,
@@ -89,24 +90,24 @@ var (
 	// PV-missing across many cycles is only ever labeled once. Cleared when
 	// the volume's PV reappears in K8s (see cleanupCnsMaps), so it is
 	// re-evaluated and re-labeled if it goes missing again later.
-	pvMissingLabeledMap map[string]map[string]bool
+	pvMissingLabeledMap map[commontypes.FQDN]map[string]bool
 
 	// cnsCreationMap tracks volumes that exist in K8s but not in CNS
 	// If a volume exists in this map across two fullsync cycles,
 	// the volume is created in CNS
 	// A separate map is maintained for each VC.
-	cnsCreationMap map[string]map[string]bool
+	cnsCreationMap map[commontypes.FQDN]map[string]bool
 
 	// Metadata syncer and full sync share a global lock
 	// to mitigate race conditions related to
 	// static provisioning of volumes
 	// There is a separate lock for each VC.
-	volumeOperationsLock map[string]*sync.Mutex
+	volumeOperationsLock map[commontypes.FQDN]*sync.Mutex
 
 	// volumeInfoCrDeletionMap tracks CRs for volumes that exist in
 	// the cluster but the corresponding PV for that volume does not exist.
 	// A separate map is maintained for each VC.
-	volumeInfoCrDeletionMap map[string]map[string]bool
+	volumeInfoCrDeletionMap map[commontypes.FQDN]map[string]bool
 )
 
 type (
@@ -137,7 +138,7 @@ type metadataSyncInformer struct {
 	fileVolumeClient client.Client
 	// map of VC Host to Volume Manager
 	// Use this for Vanilla flavor Multi vCenter Topology feature
-	volumeManagers     map[string]volumes.Manager
+	volumeManagers     map[commontypes.FQDN]volumes.Manager
 	configInfo         *config.ConfigurationInfo
 	k8sInformerManager *k8s.InformerManager
 	// topologyVCMap maintains a cache of topology tags to the vCenter IP/FQDN which holds the tag.
@@ -146,9 +147,9 @@ type metadataSyncInformer struct {
 	//            zone2: {VC2: struct{}{}}}
 	// The vCenter IP/FQDN under each tag are maintained as a map of string with nil values to improve
 	// retrieval and deletion performance.
-	topologyVCMap map[string]map[string]struct{}
+	topologyVCMap map[string]map[commontypes.FQDN]struct{}
 	clusterFlavor cnstypes.CnsClusterFlavor
-	host          string
+	host          commontypes.FQDN
 	// Snapshot clients cached after first initialization so the event-handler path
 	// (pvcsiSnapshotDeleted) and full sync do not construct fresh HTTP clients per call.
 	// Access them via getCachedSnapshotClients, which lazily creates and caches them under

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	commontypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -466,7 +467,7 @@ func SyncerInitConfigInfo(ctx context.Context) (*cnsconfig.ConfigurationInfo, er
 // the metadataSyncer's host and volumeManager fields.
 func getVcHostAndVolumeManagerForVolumeID(ctx context.Context,
 	metadataSyncer *metadataSyncInformer,
-	volumeID string) (string, volumes.Manager, error) {
+	volumeID string) (commontypes.FQDN, volumes.Manager, error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("Getting VC from in-memory map for volume %s", volumeID)
 
@@ -474,7 +475,7 @@ func getVcHostAndVolumeManagerForVolumeID(ctx context.Context,
 	// volumeManagers map is not populated
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		if metadataSyncer.volumeManager == nil {
-			return "", nil, logger.LogNewErrorf(log,
+			return commontypes.FQDN{}, nil, logger.LogNewErrorf(log,
 				"volume manager not initialized for WORKLOAD cluster")
 		}
 		return metadataSyncer.host, metadataSyncer.volumeManager, nil
@@ -484,7 +485,7 @@ func getVcHostAndVolumeManagerForVolumeID(ctx context.Context,
 		vCenter := metadataSyncer.configInfo.Cfg.Global.VCenterIP
 		cnsVolumeMgr, volMgrFound := metadataSyncer.volumeManagers[vCenter]
 		if !volMgrFound {
-			return "", nil, logger.LogNewErrorf(log,
+			return commontypes.FQDN{}, nil, logger.LogNewErrorf(log,
 				"could not get volume manager for the vCenter: %q", vCenter)
 		}
 		log.Debugf("Identified VC %s for single VC setup for volume %s", vCenter, volumeID)
@@ -493,15 +494,16 @@ func getVcHostAndVolumeManagerForVolumeID(ctx context.Context,
 	}
 
 	if volumeInfoService != nil {
-		vCenter, err := volumeInfoService.GetvCenterForVolumeID(ctx, volumeID)
+		vCenterStr, err := volumeInfoService.GetvCenterForVolumeID(ctx, volumeID)
 		if err != nil {
 			log.Errorf("failed to get vCenter for the volumeID: %q with err=%+v", volumeID, err)
-			return "", nil, logger.LogNewErrorf(log,
+			return commontypes.FQDN{}, nil, logger.LogNewErrorf(log,
 				"failed to get vCenter for the volumeID: %q with err=%+v", volumeID, err)
 		}
+		vCenter := commontypes.NewFQDN(vCenterStr)
 		volumeManager, volumeManagerfound := metadataSyncer.volumeManagers[vCenter]
 		if !volumeManagerfound {
-			return "", nil, logger.LogNewErrorf(log,
+			return commontypes.FQDN{}, nil, logger.LogNewErrorf(log,
 				"could not get volume manager for the vCenter: %q", vCenter)
 		}
 
@@ -509,7 +511,7 @@ func getVcHostAndVolumeManagerForVolumeID(ctx context.Context,
 		return vCenter, volumeManager, nil
 	}
 
-	return "", nil, logger.LogNewErrorf(log,
+	return commontypes.FQDN{}, nil, logger.LogNewErrorf(log,
 		"failed to get VC host and volume manager. VolumeInfoService is not initialized.")
 }
 
@@ -546,12 +548,12 @@ func getTopologySegmentsFromNodeAffinityRules(ctx context.Context,
 // the right VC for the given volume. If overlapping topology segments are found in nodeAffinity rules,
 // error is returned.
 func getVcHostFromTopologySegments(ctx context.Context, topologySegments []map[string][]string,
-	volumeName string) (string, error) {
+	volumeName string) (commontypes.FQDN, error) {
 	log := logger.GetLogger(ctx)
-	var vcHost string
+	var vcHost commontypes.FQDN
 
 	if len(topologySegments) == 0 {
-		return "", logger.LogNewErrorf(log,
+		return commontypes.FQDN{}, logger.LogNewErrorf(log,
 			"Invalid volume %s as it does not have node affinity rules", volumeName)
 	}
 
@@ -559,16 +561,16 @@ func getVcHostFromTopologySegments(ctx context.Context, topologySegments []map[s
 
 		vc, err := getVCForTopologySegments(ctx, topology)
 		if err != nil {
-			return "", logger.LogNewErrorf(log,
+			return commontypes.FQDN{}, logger.LogNewErrorf(log,
 				"failed to get VC host and volume manager. Error %+v.", err)
 		}
 
-		if vcHost != "" && vcHost != vc {
-			return "", logger.LogNewErrorf(log,
+		if !vcHost.IsEmpty() && !vcHost.Equal(vc) {
+			return commontypes.FQDN{}, logger.LogNewErrorf(log,
 				"Found topology segments from 2 different VCs %s and %s."+
 					"Error %+v.", vcHost, vc, err)
 		}
-		vcHost = vc
+		vcHost = commontypes.NewFQDN(vc)
 	}
 
 	log.Debugf("Identified VC %s from topology segments for volume %s", vcHost, volumeName)
@@ -577,7 +579,7 @@ func getVcHostFromTopologySegments(ctx context.Context, topologySegments []map[s
 }
 
 // Given a VC, this method returns the volume manager for it to invoke CNS APIs.
-func getVolManagerForVcHost(ctx context.Context, vc string,
+func getVolManagerForVcHost(ctx context.Context, vc commontypes.FQDN,
 	metadataSyncer *metadataSyncInformer) (volumes.Manager, error) {
 	log := logger.GetLogger(ctx)
 
@@ -604,7 +606,7 @@ func getVolManagerForVcHost(ctx context.Context, vc string,
 // getVcHostAndVolumeManagerFromPvNodeAffinity returns VC host and the corresponding
 // volume manager that can access the given volume on VC based on the nodeAffinity rules.
 func getVcHostAndVolumeManagerFromPvNodeAffinity(ctx context.Context, pv *v1.PersistentVolume,
-	metadataSyncer *metadataSyncInformer) (string, volumes.Manager, error) {
+	metadataSyncer *metadataSyncInformer) (commontypes.FQDN, volumes.Manager, error) {
 	log := logger.GetLogger(ctx)
 
 	log.Debugf("Getting VC from topology segments for volume %s", pv.Name)
@@ -612,12 +614,12 @@ func getVcHostAndVolumeManagerFromPvNodeAffinity(ctx context.Context, pv *v1.Per
 	topologySegments := getTopologySegmentsFromNodeAffinityRules(ctx, pv)
 	vcHost, err := getVcHostFromTopologySegments(ctx, topologySegments, pv.Name)
 	if err != nil {
-		return "", nil, err
+		return commontypes.FQDN{}, nil, err
 	}
 
 	volManager, err := getVolManagerForVcHost(ctx, vcHost, metadataSyncer)
 	if err != nil {
-		return "", nil, err
+		return commontypes.FQDN{}, nil, err
 	}
 
 	return vcHost, volManager, nil
@@ -630,7 +632,7 @@ func getVcHostAndVolumeManagerFromPvNodeAffinity(ctx context.Context, pv *v1.Per
 // For all K8s volumes, the corresponding VC is looked up from the in-memory map.
 // In case this info is not available, it is obtained from PV's nodeAffinity rules.
 func getPVsInBoundAvailableOrReleasedForVc(ctx context.Context, metadataSyncer *metadataSyncInformer,
-	vc string) ([]*v1.PersistentVolume, error) {
+	vc commontypes.FQDN) ([]*v1.PersistentVolume, error) {
 
 	log := logger.GetLogger(ctx)
 	k8svolumes := make([]*v1.PersistentVolume, 0)
@@ -674,7 +676,7 @@ func getPVsInBoundAvailableOrReleasedForVc(ctx context.Context, metadataSyncer *
 			continue
 		}
 
-		if vCenter == vc {
+		if vc.Equal(vCenter) {
 			k8svolumes = append(k8svolumes, pv)
 		}
 	}
@@ -713,12 +715,12 @@ func getPVsInBoundAvailableOrReleasedForVc(ctx context.Context, metadataSyncer *
 // it means that the volume does not need to be re-created.
 func createVolumeOnMultiVc(ctx context.Context, pv *v1.PersistentVolume,
 	metadataSyncer *metadataSyncInformer, volumeType string, metadataList []cnstypes.BaseCnsEntityMetadata,
-	volumeHandle string) (string, volumes.Manager, error) {
+	volumeHandle string) (commontypes.FQDN, volumes.Manager, error) {
 	log := logger.GetLogger(ctx)
 
 	vcconfigs, err := cnsvsphere.GetVirtualCenterConfigs(ctx, metadataSyncer.configInfo.Cfg)
 	if err != nil {
-		return "", nil, logger.LogNewErrorf(log, "failed to get VirtualCenterConfigs. err: %v", err)
+		return commontypes.FQDN{}, nil, logger.LogNewErrorf(log, "failed to get VirtualCenterConfigs. err: %v", err)
 	}
 
 	for _, vcconfig := range vcconfigs {
@@ -733,7 +735,7 @@ func createVolumeOnMultiVc(ctx context.Context, pv *v1.PersistentVolume,
 		}
 		log.Debugf("Failed to create volume %q on VC %s", volumeHandle, vcconfig.Host)
 	}
-	return "", nil, logger.LogNewErrorf(log,
+	return commontypes.FQDN{}, nil, logger.LogNewErrorf(log,
 		"Failed to create volume %s on any of the VCs", volumeHandle)
 }
 
@@ -755,7 +757,7 @@ func generateEventOnPv(ctx context.Context, pv *v1.PersistentVolume,
 
 func createCnsVolume(ctx context.Context, pv *v1.PersistentVolume,
 	metadataSyncer *metadataSyncInformer, cnsVolumeMgr volumes.Manager, volumeType string,
-	vcHost string, metadataList []cnstypes.BaseCnsEntityMetadata, volumeHandle string) error {
+	vcHost commontypes.FQDN, metadataList []cnstypes.BaseCnsEntityMetadata, volumeHandle string) error {
 	log := logger.GetLogger(ctx)
 
 	vcHostObj, vcHostObjFound := metadataSyncer.configInfo.Cfg.VirtualCenter[vcHost]
@@ -801,7 +803,7 @@ func createCnsVolume(ctx context.Context, pv *v1.PersistentVolume,
 			pv.Spec.CSI.VolumeHandle)
 		if len(metadataSyncer.configInfo.Cfg.VirtualCenter) > 1 {
 			// Create CNSVolumeInfo CR for the volume ID.
-			err = volumeInfoService.CreateVolumeInfo(ctx, pv.Spec.CSI.VolumeHandle, vcHost)
+			err = volumeInfoService.CreateVolumeInfo(ctx, pv.Spec.CSI.VolumeHandle, vcHost.String())
 			if err != nil {
 				log.Errorf("Failed to store volumeID %q for vCenter %q in CNSVolumeInfo CR. Error: %+v",
 					pv.Spec.CSI.VolumeHandle, vcHost, err)


### PR DESCRIPTION
Audit findings revealed that case-sensitive comparisons and unnormalized map keys for vCenter FQDNs were causing reconnect loops, cache misses, and CNSVolumeInfo record matching failures. This introduces a type-safe FQDN type that makes case-insensitive normalization a compile-time property instead of a runtime convention, and migrates the driver onto it end to end.

- Added FQDN in pkg/common/types: a struct with an unexported field, so a value can only be constructed via NewFQDN (which lowercases and strips a trailing dot). This makes it impossible to construct an unnormalized value by accident, unlike a plain string convention that relies on every call site remembering to normalize. Also provides EqualString/EqualFQDN for comparisons and MarshalText/UnmarshalText so it can be populated directly from gcfg config fields and JSON/CRD fields.
- Replaced the map-key with the FQDN type itself: VirtualCenterConfig.Host, VirtualCenterHost on VirtualMachine/Datacenter/ClusterComputeResource, the virtualCenters registry, and the node/volume manager maps are now keyed/typed by FQDN instead of string. 
- config.Config.VirtualCenter is now map[types.FQDN]*VirtualCenterConfig, built from a private, gcfg-populated raw map (VirtualCenterRaw map[string]*VirtualCenterConfig) immediately after parsing, since gcfg requires section-keyed map fields to have a literal string key type.
- Pushed FQDN through the vanilla/wcp/wcpguest controllers (including TopologyCalculationParams, node.Manager.GetAllNodesByVC, and the per-VC maps on the controller struct) and through the syncer package (metadataSyncInformer's host/volumeManagers/topologyVCMap and the package-level cnsDeletionMap/pvMissingLabeledMap/cnsCreationMap/ volumeOperationsLock/volumeInfoCrDeletionMap maps), converting to/from string only at genuine external boundaries: CRD string fields, raw env/config strings, and third-party callback signatures.

Certificate CommonName checks and Kubernetes node/VM name comparisons were deliberately left case-sensitive: those values are fixed client identities/object names, not DNS names, and Kubernetes' own x509 authentication treats certificate CommonName as a case-sensitive principal -- case-folding them would only widen the accepted-identity surface.


**CR VCenterServer fields are normalized on read, ensuring case-insensitivity regardless of how the CR was written:**

CNSVolumeInfo.Spec.VCenterServer getter (pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go:82-83) wraps with NewFQDN() then .String()
CNSVolumeInfo.Spec.VCenterServer in fullsync (pkg/syncer/fullsync.go) compared via vc.Equal() which uses case-insensitive EqualFold
CnsVolumeOperationRequest.Status.LatestOperationDetails[].VCenterServer in vanilla controller (pkg/csi/service/vanilla/controller.go) wrapped with NewFQDN() at write sites
This means the fix is upgrade-safe: pre-upgrade CRs with mixed-case vCenter FQDNs will match correctly against normalized in-memory state on every read, independent of driver restart behavior.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Testing done: 
**WCP:** https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1980/
**VKS:** https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1533/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
