### PR TITLE
[WIP] Add shared vCenter session manager support and REST-login resiliency fix (backport)

### DIFF
--- a/docs/book/vc_shared_sessions.md
+++ b/docs/book/vc_shared_sessions.md
@@ -1,0 +1,121 @@
+# vSphere Shared Session capability
+
+One problem that can be found when provisioning a large amount of clusters using
+vSphere CSI is vCenter session exhaustion. This happens because every
+workload cluster needs to request a new session to vSphere to do proper reconciliation.
+
+vSphere 8.0U3 and up uses a new approach of session management, that allows the
+creation and sharing of the sessions among different clusters.
+
+A cluster admin can implement a rest API that, once called, requests a new vCenter
+session and shares with CSI. This session will not count on the total generated
+sessions of vSphere, and instead will be a child derived session.
+
+This configuration can be applied on vSphere CSI with the usage of
+the following CSI configuration:
+
+```shell
+[Global]
+ca-file = "/etc/ssl/certs/trusted-certificates.crt"
+[VirtualCenter "your-vcenter-host"]
+datacenters = "datacenter1"
+vc-session-manager-url = "https://some-session-manager/session"
+vc-session-manager-token = "a-secret-token"
+```
+
+The configuration above will make CSI call the shared session rest API and use the
+provided token to authenticate against vSphere, instead of using a username/password.
+
+The parameter provided at `vc-session-manager-token` is sent as a `Authorization: Bearer` token
+to the session manager, and in case this directive is not configured CSI will send the
+Pod Service Account token instead.
+
+**NOTE**: `ca-file` and `insecure-flag` configure the connection to vCenter only. The session
+manager is reached over a separate connection, and if it is served over HTTPS its certificate
+must be trusted by the CSI pod's system certificate store — mount the issuing CA into the pod,
+or include it in the image. There is deliberately no way to disable verification for the
+session manager, since it is the component that issues vCenter credentials.
+
+Below is an example implementation of a shared session manager rest API. Starting the
+program below and calling `http://127.0.0.1:18080/session` should return a JSON that is expected
+by CSI using session manager to work:
+
+```shell
+$ curl 127.0.0.1:18080/session
+{"token":"cst-VCT-52f8d061-aace-4506-f4e6-fca78293a93f-....."}
+```
+
+**NOTE**: Below implementation is **NOT PRODUCTION READY** and does not implement
+any kind of authentication!
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "log"
+    "net/http"
+    "net/url"
+
+    "github.com/vmware/govmomi"
+    "github.com/vmware/govmomi/session"
+    "github.com/vmware/govmomi/vim25"
+    "github.com/vmware/govmomi/vim25/soap"
+)
+
+const (
+    vcURL      = "https://my-vc.tld"
+    vcUsername = "Administrator@vsphere.local"
+    vcPassword = "somepassword"
+)
+
+var (
+    userPassword = url.UserPassword(vcUsername, vcPassword)
+)
+
+// SharedSessionResponse is the expected response of CPI when using Shared session manager
+type SharedSessionResponse struct {
+    Token string `json:"token"`
+}
+
+func main() {
+    ctx := context.Background()
+    vcURL, err := soap.ParseURL(vcURL)
+    if err != nil {
+        panic(err)
+    }
+    soapClient := soap.NewClient(vcURL, false)
+    c, err := vim25.NewClient(ctx, soapClient)
+    if err != nil {
+        panic(err)
+    }
+    client := &govmomi.Client{
+        Client:         c,
+        SessionManager: session.NewManager(c),
+    }
+    if err := client.SessionManager.Login(ctx, userPassword); err != nil {
+        panic(err)
+    }
+
+    vcsession := func(w http.ResponseWriter, r *http.Request) {
+        clonedtoken, err := client.SessionManager.AcquireCloneTicket(ctx)
+        if err != nil {
+            w.WriteHeader(http.StatusForbidden)
+            return
+        }
+        token := &SharedSessionResponse{Token: clonedtoken}
+        jsonT, err := json.Marshal(token)
+        if err != nil {
+            w.WriteHeader(http.StatusInternalServerError)
+            return
+        }
+        w.WriteHeader(http.StatusOK)
+        w.Write(jsonT)
+    }
+
+    http.HandleFunc("/session", vcsession)
+    log.Printf("starting webserver on port 18080")
+    http.ListenAndServe(":18080", nil)
+}
+```

--- a/pkg/common/cns-lib/vsphere/configured_or_active_user_test.go
+++ b/pkg/common/cns-lib/vsphere/configured_or_active_user_test.go
@@ -1,0 +1,110 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/simulator"
+)
+
+// connectedVCSim returns a VirtualCenter already connected to a vcsim instance,
+// authenticated as simulator.DefaultLogin ("user"). Subtests then mutate
+// vc.Config to model the deployment shape they care about; because the session
+// is live, GetActiveUser answers off it and never reconnects, so config values
+// that are not real endpoints are never dialed.
+func connectedVCSim(t *testing.T) *VirtualCenter {
+	t.Helper()
+
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"c\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+
+	model := simulator.VPX()
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host: server.URL.Hostname(), Port: port, Insecure: true,
+			Username: "user", Password: "pass", // simulator.DefaultLogin
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+	require.NoError(t, vc.Connect(context.Background()))
+	return vc
+}
+
+// TestConfiguredOrActiveUser covers ConfiguredOrActiveUser's paths: the
+// configured username is returned directly with no vCenter call, and each of
+// the three cases where the configured value cannot be trusted as this
+// session's username falls back to the live session lookup.
+func TestConfiguredOrActiveUser(t *testing.T) {
+	t.Run("should return the configured username without any vCenter call", func(t *testing.T) {
+		// vc.Client is nil, so GetActiveUser would fail immediately. Getting a
+		// result at all proves the fallback was never reached.
+		vc := &VirtualCenter{Config: &VirtualCenterConfig{Username: "configured-user"}}
+
+		username, err := vc.ConfiguredOrActiveUser(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "configured-user", username)
+	})
+
+	t.Run("should fall back to the live session user when none is configured", func(t *testing.T) {
+		vc := connectedVCSim(t)
+
+		// The session-manager deployment shape: authenticated, but with no
+		// static username configured.
+		vc.Config.Username = ""
+
+		username, err := vc.ConfiguredOrActiveUser(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "user", username, "should reflect the live session's user")
+	})
+
+	// validateConfig waives the username requirement when VCSessionManagerURL
+	// is set but never clears an already-configured User, so a config can carry
+	// both. The session is then a clone of whoever the session manager
+	// authenticated as, which need not be the configured user -- returning the
+	// configured one would attribute CNS volume metadata to the wrong user.
+	t.Run("should ignore a configured username when the session manager is in use", func(t *testing.T) {
+		vc := connectedVCSim(t)
+
+		vc.Config.Username = "someone-else@vsphere.local"
+		vc.Config.VCSessionManagerURL = "https://session-manager.invalid/session"
+
+		username, err := vc.ConfiguredOrActiveUser(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "user", username,
+			"the session manager's cloned session decides the user, not the configured value")
+	})
+
+	// Under certificate authentication Username holds a PEM-encoded
+	// certificate, not a user. login() selects that path with the same
+	// pem.Decode check.
+	t.Run("should ignore a certificate held in the username field", func(t *testing.T) {
+		vc := connectedVCSim(t)
+
+		vc.Config.Username = "-----BEGIN CERTIFICATE-----\nZm9v\n-----END CERTIFICATE-----\n"
+
+		username, err := vc.ConfiguredOrActiveUser(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "user", username, "should not return the PEM block as a username")
+	})
+}

--- a/pkg/common/cns-lib/vsphere/connect_rest_repair_test.go
+++ b/pkg/common/cns-lib/vsphere/connect_rest_repair_test.go
@@ -1,0 +1,213 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// restClientTo builds a rest.Client that talks to the given base URL, so a test
+// can stand a fake vAPI endpoint in front of it while vc.Client keeps a real
+// SOAP session against vcsim. That split is the point: connect()'s repair path
+// only reaches the rest client, so the two halves can be failed independently.
+func restClientTo(t *testing.T, rawURL string) *rest.Client {
+	t.Helper()
+	u, err := soap.ParseURL(rawURL)
+	require.NoError(t, err)
+	return rest.NewClient(&vim25.Client{Client: soap.NewClient(u, true)})
+}
+
+// vcsimFor starts a vcsim instance and returns its host and port.
+func vcsimFor(t *testing.T) (string, int) {
+	t.Helper()
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"c\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+
+	model := simulator.VPX()
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+	return server.URL.Hostname(), port
+}
+
+// connectedVC returns a VirtualCenter with a live SOAP session against vcsim.
+func connectedVC(t *testing.T, ctx context.Context, host string, port int) *VirtualCenter {
+	t.Helper()
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host: host, Port: port, Insecure: true,
+			Username: "user", Password: "pass", // simulator.DefaultLogin
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+	require.NoError(t, vc.Connect(ctx), "initial connect should succeed")
+	return vc
+}
+
+// TestRepairRestSessionCoolsDownAfterAuthFailure covers the lockout guard on
+// connect()'s rest repair path. The path runs on every connect() and has no
+// attempt limit of its own, so a rest login that vCenter rejects -- a stale
+// password after a rotation, say, which a still-valid SOAP session hides -- must
+// not be retried at connect() speed: vCenter SSO locks an account after 5 failed
+// attempts in 180s, which an active cluster would reach in seconds.
+//
+// Note a vAPI rejection is an HTTP 401, not a SOAP fault, so this is exactly the
+// case IsInvalidLoginError does not recognise on its own.
+func TestRepairRestSessionCoolsDownAfterAuthFailure(t *testing.T) {
+	ctx := context.Background()
+	host, port := vcsimFor(t)
+
+	var logins atomic.Int32
+	vapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Session(): POST .../session?~action=get. Login(): POST .../session
+		// with no query. Both are answered 401 -- the session reads as gone,
+		// and the login to re-establish it is rejected.
+		if r.URL.RawQuery == "" {
+			logins.Add(1)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(vapi.Close)
+
+	vc := connectedVC(t, ctx, host, port)
+	soapClient := vc.Client
+	vc.RestClient = restClientTo(t, vapi.URL)
+
+	for range 5 {
+		require.NoError(t, vc.connect(ctx),
+			"a rejected rest login should not fail the connection")
+	}
+
+	assert.Equal(t, int32(1), logins.Load(),
+		"a rejected rest login should be attempted once, then held off until the cooldown expires")
+	assert.False(t, vc.restLoginCooldownUntil.IsZero(), "the cooldown should have been armed")
+	assert.Same(t, soapClient, vc.Client, "the SOAP client should be left alone throughout")
+
+	// Once the cooldown expires, it tries again rather than giving up for good.
+	vc.restLoginCooldownUntil = time.Now().Add(-time.Second)
+	require.NoError(t, vc.connect(ctx))
+	assert.Equal(t, int32(2), logins.Load(),
+		"an expired cooldown should allow another attempt")
+}
+
+// TestRepairRestSessionRetriesTransportFailuresImmediately is the other half of
+// the guard: a vAPI that is down rather than rejecting credentials must keep
+// being retried at connect() speed, since that is what makes recovery take a
+// single round trip once it comes back. Only authentication failures are held
+// off.
+func TestRepairRestSessionRetriesTransportFailuresImmediately(t *testing.T) {
+	ctx := context.Background()
+	host, port := vcsimFor(t)
+
+	var attempts atomic.Int32
+	var down atomic.Bool
+	down.Store(true)
+	vapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery == "" {
+			attempts.Add(1)
+			if down.Load() {
+				// 503, as a vapi-endpoint that is restarting would answer.
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":"a-session-id"}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(vapi.Close)
+
+	vc := connectedVC(t, ctx, host, port)
+	vc.RestClient = restClientTo(t, vapi.URL)
+
+	for range 3 {
+		require.NoError(t, vc.connect(ctx))
+	}
+	assert.Equal(t, int32(3), attempts.Load(),
+		"an outage should be retried on every connect(), not held off like an auth failure")
+	assert.True(t, vc.restLoginCooldownUntil.IsZero(),
+		"a transport failure should not arm the lockout cooldown")
+
+	// vAPI comes back: the very next connect() re-establishes the session.
+	down.Store(false)
+	require.NoError(t, vc.connect(ctx))
+	assert.Equal(t, "a-session-id", vc.RestClient.SessionID(),
+		"the next connect() after recovery should have re-logged in")
+}
+
+// TestRepairRestSessionTimesOut covers a vAPI endpoint that accepts the
+// connection and then never answers. NewClient sets soap.Client.Timeout to 0 and
+// the rest client shares that transport, so without the repair path's own
+// timeout this attempt would hang forever -- holding ClientMutex, and with it
+// every other caller of Connect, including the SOAP-only ones that have no need
+// of vAPI at all.
+func TestRepairRestSessionTimesOut(t *testing.T) {
+	ctx := context.Background()
+	host, port := vcsimFor(t)
+
+	blocked := make(chan struct{})
+	vapi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery == "" {
+			select {
+			case <-blocked:
+			case <-r.Context().Done():
+			}
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(vapi.Close)
+	// Registered after vapi.Close so it runs before it: cleanups are LIFO, and
+	// Server.Close waits on in-flight handlers, which this one releases.
+	t.Cleanup(func() { close(blocked) })
+
+	originalTimeout := restLoginTimeout
+	restLoginTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { restLoginTimeout = originalTimeout })
+
+	vc := connectedVC(t, ctx, host, port)
+	soapClient := vc.Client
+	vc.RestClient = restClientTo(t, vapi.URL)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- vc.connect(ctx) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "a hung rest login should not fail the connection")
+		assert.Less(t, time.Since(start), 5*time.Second,
+			"connect() should have given up on the hung rest login, not waited on it")
+	case <-time.After(15 * time.Second):
+		t.Fatal("connect() hung on an unresponsive vAPI endpoint")
+	}
+
+	assert.Same(t, soapClient, vc.Client,
+		"giving up on the rest login should leave the SOAP session in place")
+}

--- a/pkg/common/cns-lib/vsphere/connect_rest_session_test.go
+++ b/pkg/common/cns-lib/vsphere/connect_rest_session_test.go
@@ -1,0 +1,260 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// brokenRestClient returns a rest.Client pointed at an address nothing listens
+// on, so any call it makes fails fast with a connection error. Used to prove
+// whether connect() actually invokes RestClient.Session, without needing to
+// intercept traffic to a live server.
+func brokenRestClient(t *testing.T) *rest.Client {
+	t.Helper()
+	u, err := soap.ParseURL("https://127.0.0.1:1")
+	require.NoError(t, err)
+	soapClient := soap.NewClient(u, true)
+	vimClient, err := vim25.NewClient(context.Background(), soapClient)
+	// vim25.NewClient itself may fail to reach the (unreachable) host for its
+	// initial ServiceContent fetch; either way the resulting client's rest
+	// wrapper will fail identically when asked to make a call.
+	if err != nil {
+		vimClient = &vim25.Client{Client: soapClient}
+	}
+	return rest.NewClient(vimClient)
+}
+
+// TestConnectSkipsRedundantRestSessionCheckForSessionManager covers the
+// connect() fast path: once vc.Client and vc.RestClient already exist, it
+// checks both sessions are still valid before deciding not to re-login. For
+// credential-based auth (username/password, cert) the SOAP and REST sessions
+// are two independent logins, so both must be checked. For the shared session
+// manager, the REST session ID is the SOAP session's own cookie (see login()),
+// so they are the same vCenter session object; checking the REST session
+// again is a redundant network call connect() should skip.
+//
+// The session-manager case is proven by swapping in a RestClient that fails any
+// call it makes: a connect() that skipped the check leaves that broken client in
+// place, untouched. The credential cases then cover what connect() does when it
+// does look and finds the rest session unusable -- it re-logins the rest client
+// in place, and leaves the SOAP session and the clients built on it alone,
+// whether or not that rest re-login succeeds. An unusable rest session is
+// deliberately not fatal to connect(), since failing there would tear down a
+// SOAP session already known to be healthy.
+func TestConnectSkipsRedundantRestSessionCheckForSessionManager(t *testing.T) {
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"c\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+
+	model := simulator.VPX()
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("session-manager auth: skips the redundant rest session check", func(t *testing.T) {
+		vc := &VirtualCenter{
+			Config: &VirtualCenterConfig{
+				Host: server.URL.Hostname(), Port: port, Insecure: true,
+				VCSessionManagerURL:   sessionManagerFor(t, ctx, server.URL),
+				VCSessionManagerToken: "a-token",
+			},
+			ClientMutex: &sync.Mutex{},
+		}
+		require.NoError(t, vc.Connect(ctx), "initial connect should succeed")
+
+		// Force any real call on the rest client to fail.
+		broken := brokenRestClient(t)
+		vc.RestClient = broken
+
+		err := vc.connect(ctx)
+		assert.NoError(t, err,
+			"connect() should not have needed the rest client at all in session-manager mode")
+		assert.Same(t, broken, vc.RestClient,
+			"connect() should have left the rest client untouched, proving it never consulted it")
+	})
+
+	t.Run("credential auth: repairs the rest session without touching the soap session", func(t *testing.T) {
+		vc := &VirtualCenter{
+			Config: &VirtualCenterConfig{
+				Host: server.URL.Hostname(), Port: port, Insecure: true,
+				Username: "user", Password: "pass", // simulator.DefaultLogin
+			},
+			ClientMutex: &sync.Mutex{},
+		}
+		require.NoError(t, vc.Connect(ctx), "initial connect should succeed")
+
+		soapClient, restClient := vc.Client, vc.RestClient
+		soapSession, err := soapClient.SessionManager.UserSession(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, soapSession)
+
+		// Drop only the rest session, leaving the SOAP session live: this is
+		// the shape of a vAPI outage, where the rest login is the only half
+		// that is unusable.
+		require.NoError(t, restClient.Logout(ctx))
+		staleRestSession, err := restClient.Session(ctx)
+		require.NoError(t, err)
+		require.Nil(t, staleRestSession, "precondition: rest session should read as gone")
+
+		require.NoError(t, vc.connect(ctx),
+			"an unusable rest session should be recovered, not returned as a connect() failure")
+
+		// The healthy SOAP session, and everything built on it, is left alone.
+		assert.Same(t, soapClient, vc.Client,
+			"connect() should not have recreated a SOAP session that was still valid")
+		newSoapSession, err := vc.Client.SessionManager.UserSession(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, newSoapSession, "the SOAP session should still be live")
+		assert.Equal(t, soapSession.Key, newSoapSession.Key,
+			"the SOAP session should be the same one, not a re-login")
+
+		// And the rest client was re-authenticated in place.
+		assert.Same(t, restClient, vc.RestClient,
+			"connect() should re-login the existing rest client rather than replacing it")
+		restSession, err := vc.RestClient.Session(ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, restSession, "the rest client should hold a live session again")
+	})
+
+	t.Run("credential auth: a rest login that keeps failing leaves the soap session up", func(t *testing.T) {
+		vc := &VirtualCenter{
+			Config: &VirtualCenterConfig{
+				Host: server.URL.Hostname(), Port: port, Insecure: true,
+				Username: "user", Password: "pass", // simulator.DefaultLogin
+			},
+			ClientMutex: &sync.Mutex{},
+		}
+		require.NoError(t, vc.Connect(ctx), "initial connect should succeed")
+
+		soapClient := vc.Client
+		soapSession, err := soapClient.SessionManager.UserSession(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, soapSession)
+
+		// A rest client that fails every call, including its re-login: vAPI is
+		// down for the whole of this connect().
+		broken := brokenRestClient(t)
+		vc.RestClient = broken
+
+		require.NoError(t, vc.connect(ctx),
+			"a rest client that cannot be re-logged-in should not fail connect()")
+
+		// This is the loop being avoided: repeated connect() calls during a vAPI
+		// outage must not keep logging out and rebuilding a working SOAP session.
+		for range 3 {
+			require.NoError(t, vc.connect(ctx))
+		}
+		assert.Same(t, soapClient, vc.Client,
+			"a vAPI outage should never tear down the SOAP client")
+		liveSession, err := vc.Client.SessionManager.UserSession(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, liveSession, "the SOAP session should still be live")
+		assert.Equal(t, soapSession.Key, liveSession.Key,
+			"the SOAP session should be the original one, never logged out and re-created")
+	})
+}
+
+// sessionManagerFor starts a minimal session manager that hands out a real
+// clone ticket from the given vcsim server, and returns its URL.
+func sessionManagerFor(t *testing.T, ctx context.Context, vcsimURL *url.URL) string {
+	t.Helper()
+	ticketClient, err := govmomi.NewClient(ctx, vcsimURL, true)
+	require.NoError(t, err)
+
+	sessionManager := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			ticket, err := ticketClient.SessionManager.AcquireCloneTicket(ctx)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(SharedSessionResponse{Token: ticket})
+		}))
+	t.Cleanup(sessionManager.Close)
+	return sessionManager.URL
+}
+
+// TestConnectRecreatesClientsAfterSessionExpiry drives connect()'s dual-logout
+// path: an existing session that has expired, as opposed to a VirtualCenter
+// that never connected (vc.Client == nil, handled earlier and separately in
+// connect()). Logging out the underlying client directly -- bypassing
+// vc.Connect and cleanupVCClient, so vc.Client and vc.RestClient stay set to
+// now-invalid clients -- reproduces an expired session against vcsim.
+func TestConnectRecreatesClientsAfterSessionExpiry(t *testing.T) {
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"c\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+
+	model := simulator.VPX()
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host: server.URL.Hostname(), Port: port, Insecure: true,
+			Username: "user", Password: "pass", // simulator.DefaultLogin
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+	require.NoError(t, vc.Connect(ctx))
+
+	staleClient, staleRestClient := vc.Client, vc.RestClient
+	require.NoError(t, staleClient.Logout(ctx))
+
+	// Precondition: connect()'s fast path ("no need to re-login") must not
+	// apply here, or the rest of this test would be exercising the wrong branch.
+	userSession, err := staleClient.SessionManager.UserSession(ctx)
+	require.NoError(t, err)
+	require.Nil(t, userSession, "precondition: session should read as expired after logout")
+
+	require.NoError(t, vc.Connect(ctx), "connect() should recover from an expired session")
+
+	assert.NotSame(t, staleClient, vc.Client,
+		"expired session should be replaced with a freshly logged-in client")
+	assert.NotSame(t, staleRestClient, vc.RestClient,
+		"expired session should replace the rest client too")
+
+	newUserSession, err := vc.Client.SessionManager.UserSession(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, newUserSession, "the new client should have a live session")
+	assert.Equal(t, "user", newUserSession.UserName)
+}

--- a/pkg/common/cns-lib/vsphere/get_active_user_test.go
+++ b/pkg/common/cns-lib/vsphere/get_active_user_test.go
@@ -1,0 +1,171 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+)
+
+func writeGetActiveUserTestConfig(t *testing.T) {
+	t.Helper()
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"c\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+}
+
+// newConnectedVC starts a vcsim instance and returns a VirtualCenter already
+// connected to it via simulator.DefaultLogin.
+func newConnectedVC(t *testing.T, ctx context.Context) *VirtualCenter {
+	t.Helper()
+	writeGetActiveUserTestConfig(t)
+
+	model := simulator.VPX()
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host: server.URL.Hostname(), Port: port, Insecure: true,
+			Username: "user", Password: "pass", // simulator.DefaultLogin
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+	require.NoError(t, vc.Connect(ctx))
+	return vc
+}
+
+// TestGetActiveUserSkipsConnect proves GetActiveUser never calls Connect.
+// Every caller reaches it right after something else (GetVCenter, GetVCenters,
+// GetDatacenters, ...) has just called Connect, so connecting here would double
+// an RPC that already just ran.
+//
+// Connect always takes vc.ClientMutex first. Holding that lock in the test
+// turns "GetActiveUser calls Connect" into a hang, which is a decisive, not
+// just probabilistic, way to prove it does not.
+func TestGetActiveUserSkipsConnect(t *testing.T) {
+	ctx := context.Background()
+	vc := newConnectedVC(t, ctx)
+
+	vc.ClientMutex.Lock()
+	defer vc.ClientMutex.Unlock()
+
+	done := make(chan struct{})
+	var username string
+	var err error
+	go func() {
+		defer close(done)
+		username, err = vc.GetActiveUser(ctx)
+	}()
+
+	select {
+	case <-done:
+		require.NoError(t, err)
+		assert.Equal(t, "user", username)
+	case <-time.After(3 * time.Second):
+		t.Fatal("GetActiveUser blocked on ClientMutex, meaning it called Connect on the happy path")
+	}
+}
+
+// TestGetActiveUserFailsWithNoClient covers a VirtualCenter that has never
+// connected. GetActiveUser reports this rather than connecting itself; callers
+// reach it only after Connect, so a nil client here means something upstream
+// already went wrong, and the caller's retry is what re-establishes a session.
+func TestGetActiveUserFailsWithNoClient(t *testing.T) {
+	// vc.Client is deliberately left nil: this VirtualCenter has never connected.
+	vc := &VirtualCenter{Config: &VirtualCenterConfig{}}
+
+	_, err := vc.GetActiveUser(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "client or sessionmanager are nil")
+}
+
+// TestGetActiveUserWithNilSessionManager covers the other half of the same
+// nil-guard: a non-nil vc.Client whose own SessionManager field is nil.
+func TestGetActiveUserWithNilSessionManager(t *testing.T) {
+	vc := &VirtualCenter{
+		Client: &govmomi.Client{}, // non-nil, but SessionManager is left nil
+	}
+
+	_, err := vc.GetActiveUser(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "client or sessionmanager are nil")
+}
+
+// TestGetActiveUserWithUserSessionError covers UserSession returning a hard RPC
+// error (as opposed to the govmomi #2922 nil-session-nil-error case covered
+// separately below). Built with a SessionManager pointed at an address
+// nothing listens on, so the property-collector call behind UserSession fails
+// fast with a connection error.
+func TestGetActiveUserWithUserSessionError(t *testing.T) {
+	u, err := soap.ParseURL("https://127.0.0.1:1")
+	require.NoError(t, err)
+	soapClient := soap.NewClient(u, true)
+	// A real handshake (vim25.NewClient) sets RoundTripper and populates
+	// ServiceContent; skipped here since the host is unreachable, so both are
+	// set by hand. Without RoundTripper, vim25.Client.RoundTrip panics on a nil
+	// field instead of attempting the call; without ServiceContent.SessionManager
+	// (the well-known SessionManager MOID), session.Manager.Reference() panics
+	// dereferencing a nil pointer. Both would fail before the call this test
+	// actually wants to observe failing.
+	vimClient := &vim25.Client{Client: soapClient, RoundTripper: soapClient}
+	vimClient.ServiceContent.SessionManager = &vim25types.ManagedObjectReference{
+		Type: "SessionManager", Value: "SessionManager",
+	}
+	vc := &VirtualCenter{
+		Client: &govmomi.Client{
+			Client:         vimClient,
+			SessionManager: session.NewManager(vimClient),
+		},
+	}
+
+	_, err = vc.GetActiveUser(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "error getting current user")
+}
+
+// TestGetActiveUserFailsOnExpiredSession covers govmomi issue #2922, where
+// SessionManager.UserSession returns a nil session with a nil error once a
+// session is no longer authenticated, rather than an error. Without the
+// nil-session guard that would be reported as a successful lookup of an empty
+// username, which would then be written into CNS volume metadata or passed to
+// a privilege check. Logging out the underlying client directly (bypassing
+// vc.Connect and cleanupVCClient, so vc.Client stays set to the now-invalid
+// client) reproduces that exact return value against vcsim.
+func TestGetActiveUserFailsOnExpiredSession(t *testing.T) {
+	ctx := context.Background()
+	vc := newConnectedVC(t, ctx)
+
+	require.NoError(t, vc.Client.Logout(ctx))
+
+	userSession, err := vc.Client.SessionManager.UserSession(ctx)
+	require.NoError(t, err)
+	require.Nil(t, userSession, "precondition: UserSession should be (nil, nil) after logout")
+
+	_, err = vc.GetActiveUser(ctx)
+	require.Error(t, err, "an expired session must not be reported as success")
+	assert.ErrorContains(t, err, "nil session obtained from session manager")
+}

--- a/pkg/common/cns-lib/vsphere/tagmanager.go
+++ b/pkg/common/cns-lib/vsphere/tagmanager.go
@@ -1,0 +1,69 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/vapi/tags"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// GetTagManager returns a tagManager connected to the given VirtualCenter.
+//
+// It is built fresh on every call rather than cached on VirtualCenter: the
+// RestClient it wraps is replaced whenever connect() re-authenticates, and
+// VirtualCenter is a shared, concurrently accessed singleton, so a cached
+// manager would need its own synchronization to avoid handing out one built
+// from a RestClient that is mid-replacement.
+func (vc *VirtualCenter) GetTagManager(ctx context.Context) (*tags.Manager, error) {
+	log := logger.GetLogger(ctx)
+	// vc == nil is unsafe to let Connect handle: it dereferences vc immediately
+	// (vc.ClientMutex.Lock()) and would panic instead of returning an error.
+	//
+	// A non-nil vc.Client whose own inner Client is nil is also unsafe to leave
+	// to Connect, but for a different reason: connect() only replaces vc.Client
+	// when the outer pointer itself is nil, so this state slips past that
+	// check, and connect() goes on to call session.NewManager(vc.Client.Client)
+	// and use it -- panicking inside govmomi's property collector. Confirmed by
+	// reproducing it directly (session.Manager.UserSession -> property.
+	// DefaultCollector, both against a nil *vim25.Client).
+	//
+	// A nil vc.Client alone does not need a check: connect() explicitly creates
+	// one in that case, matching GetDatacenters and ListDatacenters, which call
+	// Connect unconditionally with no such guard.
+	//
+	// vc.Client is read under ClientMutex here, not bare: connect() rewrites it
+	// under that same lock on every reconnect, and reading it unlocked races
+	// that write (confirmed with -race, forcing a concurrent reconnect against
+	// vcsim -- the existing single-connect concurrency test never exercises
+	// connect()'s write path at all, since a still-valid session takes its
+	// early-return branch, so it can't catch this).
+	if vc == nil {
+		return nil, fmt.Errorf("vCenter not initialized")
+	}
+	vc.ClientMutex.Lock()
+	brokenInnerClient := vc.Client != nil && vc.Client.Client == nil
+	vc.ClientMutex.Unlock()
+	if brokenInnerClient {
+		return nil, fmt.Errorf("vCenter not initialized")
+	}
+
+	if err := vc.Connect(ctx); err != nil {
+		return nil, fmt.Errorf("error connecting to VC: %w", err)
+	}
+
+	// Same reasoning as above, for the RestClient this call is actually built
+	// from: Connect has released the lock by the time it returns here, and a
+	// different concurrent caller's reconnect can still be rewriting
+	// vc.RestClient under it at this exact moment.
+	vc.ClientMutex.Lock()
+	restClient := vc.RestClient
+	vc.ClientMutex.Unlock()
+
+	tagManager := tags.NewManager(restClient)
+	if tagManager == nil {
+		return nil, fmt.Errorf("failed to create a tagManager")
+	}
+	log.Infof("New tag manager with useragent '%s'", tagManager.UserAgent)
+	return tagManager, nil
+}

--- a/pkg/common/cns-lib/vsphere/tagmanager_race_test.go
+++ b/pkg/common/cns-lib/vsphere/tagmanager_race_test.go
@@ -1,0 +1,144 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+// TestGetTagManagerConcurrentAccess drives concurrent GetTagManager and Connect
+// calls against a single, shared VirtualCenter, the way a controller-runtime
+// reconciler with MaxConcurrentReconciles > 1 does in production (see
+// csinodetopology_controller.go). VirtualCenter is a process-wide singleton, so
+// two workers reconciling different objects can call GetTagManager, or trigger a
+// reconnect, on the same instance at the same time.
+//
+// GetTagManager used to cache its result on a vc.tagManager field, written both
+// here (unlocked, after Connect released ClientMutex) and inside connect()
+// (locked). Run under -race, that was two writers to one field with only one of
+// them holding the lock. This test only has teeth under `go test -race`.
+func TestGetTagManagerConcurrentAccess(t *testing.T) {
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"race-test\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+
+	model := simulator.VPX()
+	model.Cluster = 1
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true // needed for the tag manager's REST endpoints
+
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host:     server.URL.Hostname(),
+			Port:     port,
+			Insecure: true,
+			Username: "user", // simulator.DefaultLogin
+			Password: "pass",
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+	ctx := context.Background()
+	require.NoError(t, vc.Connect(ctx))
+
+	const workers = 8
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_, _ = vc.GetTagManager(ctx)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = vc.Connect(ctx)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestGetTagManagerConnectsWhenNeverConnected covers a VirtualCenter that has
+// never connected. GetTagManager used to reject this upfront with "vCenter not
+// initialized", even though the very next line calls Connect, which creates
+// vc.Client when it is nil -- exactly this VirtualCenter's condition. The
+// check ran before the fix that would have satisfied it.
+func TestGetTagManagerConnectsWhenNeverConnected(t *testing.T) {
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"never-connected-test\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+
+	model := simulator.VPX()
+	model.Cluster = 1
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true // needed for the tag manager's REST endpoints
+
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host:     server.URL.Hostname(),
+			Port:     port,
+			Insecure: true,
+			Username: "user", // simulator.DefaultLogin
+			Password: "pass",
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+	// vc.Client is deliberately left nil: this VirtualCenter has never connected.
+
+	tagManager, err := vc.GetTagManager(context.Background())
+	require.NoError(t, err, "GetTagManager should connect on demand, not reject an unconnected VirtualCenter")
+	assert.NotNil(t, tagManager)
+}
+
+// TestGetTagManagerRejectsBrokenInnerClient covers a VirtualCenter whose
+// Client is non-nil but whose own inner Client (the *vim25.Client) is nil --
+// the shape produced by &govmomi.Client{}, which three test fixtures elsewhere
+// in this repo construct deliberately (as a lightweight stand-in for
+// object.NewDatastore, which does not dereference it). None of those fixtures
+// are wired into GetTagManager or Connect today, but if one ever were, Connect
+// cannot repair this state: connect() only replaces vc.Client when the outer
+// pointer itself is nil, so a non-nil vc.Client with a nil inner Client slips
+// past that check and panics inside govmomi's property collector. GetTagManager
+// must keep rejecting it before calling Connect.
+func TestGetTagManagerRejectsBrokenInnerClient(t *testing.T) {
+	vc := &VirtualCenter{
+		Config:      &VirtualCenterConfig{Host: "127.0.0.1", Port: 1},
+		Client:      &govmomi.Client{}, // non-nil, but its own Client field is nil
+		RestClient:  &rest.Client{},
+		ClientMutex: &sync.Mutex{},
+	}
+
+	_, err := vc.GetTagManager(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "vCenter not initialized")
+}

--- a/pkg/common/cns-lib/vsphere/tagmanager_restclient_race_test.go
+++ b/pkg/common/cns-lib/vsphere/tagmanager_restclient_race_test.go
@@ -1,0 +1,94 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/simulator"
+)
+
+// TestGetTagManagerRestClientReadRace covers a race distinct from the one
+// TestGetTagManagerConcurrentAccess catches: that test connects once and the
+// session stays valid throughout, so connect()'s "no need to re-login" fast
+// path never rewrites vc.RestClient again, and there is nothing to race
+// against. This test forces genuine reconnects -- logging out the live client
+// directly, bypassing Connect, so the next Connect() call detects an expired
+// session and actually rewrites vc.Client/vc.RestClient under ClientMutex --
+// concurrently with GetTagManager calls, which read vc.RestClient after their
+// own Connect() call has already released that same lock.
+//
+// Each reconnect gets its own short-timeout context: Connect retries an
+// InvalidLogin error with a 3-minute delay, and repeated logout/reconnect
+// cycles against vcsim can occasionally be misclassified as one, which would
+// otherwise make a broken version of this test hang rather than fail.
+func TestGetTagManagerRestClientReadRace(t *testing.T) {
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"restclient-race-test\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+
+	model := simulator.VPX()
+	model.Cluster = 1
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true
+
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host:     server.URL.Hostname(),
+			Port:     port,
+			Insecure: true,
+			Username: "user", // simulator.DefaultLogin
+			Password: "pass",
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+	ctx := context.Background()
+	require.NoError(t, vc.Connect(ctx))
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 15; i++ {
+			vc.ClientMutex.Lock()
+			client := vc.Client
+			vc.ClientMutex.Unlock()
+			if client != nil {
+				_ = client.Logout(ctx)
+			}
+			callCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			_ = vc.Connect(callCtx)
+			cancel()
+		}
+	}()
+
+	const readers = 8
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 30; j++ {
+				_, _ = vc.GetTagManager(ctx)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -2,11 +2,8 @@ package vsphere
 
 import (
 	"context"
-	"crypto/tls"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -14,10 +11,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
-	"github.com/vmware/govmomi/sts"
-	"github.com/vmware/govmomi/vapi/rest"
-	"github.com/vmware/govmomi/vapi/tags"
-	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -201,6 +194,12 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 		ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
 		MigrationDataStoreURL:       cfg.VirtualCenter[host].MigrationDataStoreURL,
 		FileVolumeActivated:         cfg.VirtualCenter[host].FileVolumeActivated,
+		VCSessionManagerURL:         cfg.VirtualCenter[host].VCSessionManagerURL,
+		VCSessionManagerToken:       cfg.VirtualCenter[host].VCSessionManagerToken,
+	}
+
+	if vcConfig.VCSessionManagerURL != "" {
+		log.Infof("Using Shared Session Manager: %s", vcConfig.VCSessionManagerURL)
 	}
 
 	log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
@@ -247,6 +246,8 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			QueryLimit:                  cfg.Global.QueryLimit,
 			ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
 			FileVolumeActivated:         cfg.VirtualCenter[vCenterIP].FileVolumeActivated,
+			VCSessionManagerURL:         cfg.VirtualCenter[vCenterIP].VCSessionManagerURL,
+			VCSessionManagerToken:       cfg.VirtualCenter[vCenterIP].VCSessionManagerToken,
 		}
 		if vcConfig.CAFile == "" {
 			vcConfig.CAFile = cfg.Global.CAFile
@@ -305,62 +306,6 @@ func CompareKubernetesMetadata(ctx context.Context, k8sMetaData *cnstypes.CnsKub
 		labelsMatch, spew.Sdump(GetLabelsMapFromKeyValue(k8sMetaData.Labels)),
 		spew.Sdump(GetLabelsMapFromKeyValue(cnsMetaData.Labels)))
 	return labelsMatch
-}
-
-// Signer decodes the certificate and private key and returns SAML token needed
-// for authentication.
-func signer(ctx context.Context, client *vim25.Client, username string, password string) (*sts.Signer, error) {
-	pemBlock, _ := pem.Decode([]byte(username))
-	if pemBlock == nil {
-		return nil, nil
-	}
-	certificate, err := tls.X509KeyPair([]byte(username), []byte(password))
-	if err != nil {
-		return nil, fmt.Errorf("failed to load X509 key pair. Error: %+v", err)
-	}
-	tokens, err := sts.NewClient(ctx, client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create STS client. err: %+v", err)
-	}
-	req := sts.TokenRequest{
-		Certificate: &certificate,
-		Delegatable: true,
-	}
-	signer, err := tokens.Issue(ctx, req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to issue SAML token. err: %+v", err)
-	}
-	return signer, nil
-}
-
-// GetTagManager returns tagManager connected to given VirtualCenter.
-func GetTagManager(ctx context.Context, vc *VirtualCenter) (*tags.Manager, error) {
-	log := logger.GetLogger(ctx)
-	// Validate input.
-	if vc == nil || vc.Client == nil || vc.Client.Client == nil {
-		return nil, fmt.Errorf("vCenter not initialized")
-	}
-
-	restClient := rest.NewClient(vc.Client.Client)
-	signer, err := signer(ctx, vc.Client.Client, vc.Config.Username, vc.Config.Password)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the Signer. Error: %v", err)
-	}
-	if signer == nil {
-		user := url.UserPassword(vc.Config.Username, vc.Config.Password)
-		err = restClient.Login(ctx, user)
-	} else {
-		err = restClient.LoginByToken(restClient.WithSigner(ctx, signer))
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to login for the rest client. Error: %v", err)
-	}
-	tagManager := tags.NewManager(restClient)
-	if tagManager == nil {
-		return nil, fmt.Errorf("failed to create a tagManager")
-	}
-	log.Infof("New tag manager with useragent '%s'", tagManager.UserAgent)
-	return tagManager, nil
 }
 
 // GetCandidateDatastoresInClusters gets the shared datastores and vSAN-direct
@@ -601,4 +546,33 @@ func FilterSuspendedDatastores(ctx context.Context, datastoreInfoList []*Datasto
 	}
 	log.Infof("Filtered list of datastores after removing suspended ones are: %+v", filteredList)
 	return filteredList, nil
+}
+
+// IsInvalidLoginError checks if the error is due to invalid credentials (*types.InvalidLogin).
+//
+// The govmomi client returns a soap.soapFaultError containing *types.InvalidLogin as the
+// underlying VimFault. We also check the error message as a fallback.
+func IsInvalidLoginError(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check if it's a soap.soapFaultError containing InvalidLogin
+	// This is the primary check that catches the actual error from vCenter
+	if soap.IsSoapFault(err) {
+		soapFault := soap.ToSoapFault(err)
+		if soapFault != nil && soapFault.VimFault() != nil {
+			if _, ok := soapFault.VimFault().(*types.InvalidLogin); ok {
+				return true
+			}
+		}
+	}
+
+	// Fallback: check if the error message contains the InvalidLogin text
+	// This handles edge cases where type checking doesn't work
+	if strings.Contains(err.Error(), "Cannot complete login due to an incorrect user name or password") {
+		return true
+	}
+
+	return false
 }

--- a/pkg/common/cns-lib/vsphere/vc_session_login_orphan_test.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_login_orphan_test.go
@@ -1,0 +1,87 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+// TestNewClientKeepsSoapSessionOnRestLoginFailure covers the username/password
+// login path adding a second, independent REST login after the existing SOAP
+// login. A failure there must not fail the login as a whole: REST is only
+// needed for tag/topology operations (GetTagManager), which fail and recover
+// on their own if it stays unavailable, and driver startup itself goes through
+// this same login on every Connect() (controller.Init() -> Connect() ->
+// NewClient() -> login()). Failing login() here would make a vAPI outage a
+// hard dependency of starting the driver at all, even though CNS/volume
+// operations need only SOAP.
+//
+// Reproduced by disabling vcsim's vapi endpoints, so the REST login this
+// feature adds has nothing to talk to and fails while the SOAP login succeeds.
+func TestNewClientKeepsSoapSessionOnRestLoginFailure(t *testing.T) {
+	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"[Global]\ncluster-id = \"c\"\n\n"+
+			"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n"+
+			"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", confPath)
+
+	model := simulator.VPX()
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = false // no vapi -> the REST login below fails
+	server := model.Service.NewServer()
+	t.Cleanup(server.Close)
+
+	port, err := strconv.Atoi(server.URL.Port())
+	require.NoError(t, err)
+
+	vc := &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host: server.URL.Hostname(), Port: port, Insecure: true,
+			Username: "user", Password: "pass", // simulator.DefaultLogin
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+	ctx := context.Background()
+
+	client, restClient, err := vc.NewClient(ctx, "orphan-session-test")
+	require.NoError(t, err,
+		"NewClient must succeed on SOAP alone; a REST-only failure must not fail the whole login")
+	require.NotNil(t, client)
+	require.NotNil(t, restClient)
+	t.Cleanup(func() { _ = client.Logout(ctx) })
+
+	// Prove the REST endpoint is actually unreachable in this test setup (vAPI disabled).
+	// This validates the test precondition (REST login cannot succeed), not the auth state.
+	_, err = restClient.Session(ctx)
+	assert.Error(t, err, "REST Session() should fail when vAPI endpoints are disabled")
+
+	// Independently log in and read vCenter's own session list: the SOAP
+	// session from NewClient must be the checker's session plus exactly one
+	// more -- i.e. kept, not logged out as an orphan.
+	checker, err := govmomi.NewClient(ctx, server.URL, true)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = checker.Logout(ctx) })
+
+	var sessionManager mo.SessionManager
+	pc := property.DefaultCollector(checker.Client)
+	require.NoError(t, pc.RetrieveOne(
+		ctx, checker.SessionManager.Reference(), []string{"sessionList"}, &sessionManager))
+
+	assert.Len(t, sessionManager.SessionList, 2,
+		"expected the checking client's session plus the kept SOAP session from NewClient; "+
+			"a lower count means the SOAP session was logged out despite the login succeeding")
+}

--- a/pkg/common/cns-lib/vsphere/vc_session_login_test.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_login_test.go
@@ -1,0 +1,148 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// writeSessionTestConfig points config.GetConfig at a throwaway file, which
+// VirtualCenter.connect needs in order to build the session user agent.
+func writeSessionTestConfig(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "csi-vsphere.conf")
+	contents := "[Global]\ncluster-id = \"session-test\"\n\n" +
+		"[VirtualCenter \"127.0.0.1\"]\nuser = \"user@vsphere.local\"\npassword = \"pass\"\n" +
+		"datacenters = \"DC0\"\ninsecure-flag = \"true\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0600))
+	t.Setenv("VSPHERE_CSI_CONFIG", path)
+}
+
+func TestSoapSessionID(t *testing.T) {
+	t.Run("should fail when the client has no session cookie", func(t *testing.T) {
+		// A client that has never logged in has an empty cookie jar, so
+		// SessionCookie returns nil. Dereferencing it would panic.
+		url, err := soap.ParseURL("https://vcenter.invalid")
+		require.NoError(t, err)
+		soapClient := soap.NewClient(url, true)
+		vimClient := &vim25.Client{Client: soapClient}
+		client := &govmomi.Client{
+			Client:         vimClient,
+			SessionManager: session.NewManager(vimClient),
+		}
+		require.Nil(t, client.SessionCookie(), "precondition: no session cookie")
+
+		_, err = soapSessionID(client)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "no vCenter session cookie")
+	})
+}
+
+// newSharedSessionVC starts a vcsim instance and a session manager stub that
+// hands out real clone tickets for it, and returns a VirtualCenter configured to
+// authenticate through that session manager.
+func newSharedSessionVC(t *testing.T) *VirtualCenter {
+	t.Helper()
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	t.Cleanup(model.Remove)
+	require.NoError(t, model.Create())
+	model.Service.TLS = new(tls.Config)
+	model.Service.RegisterEndpoints = true
+
+	vcsim := model.Service.NewServer()
+	t.Cleanup(vcsim.Close)
+
+	ticketClient, err := govmomi.NewClient(ctx, vcsim.URL, true)
+	require.NoError(t, err)
+
+	sessionManager := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			ticket, err := ticketClient.SessionManager.AcquireCloneTicket(ctx)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(SharedSessionResponse{Token: ticket})
+		}))
+	t.Cleanup(sessionManager.Close)
+
+	port, err := strconv.Atoi(vcsim.URL.Port())
+	require.NoError(t, err)
+
+	return &VirtualCenter{
+		Config: &VirtualCenterConfig{
+			Host:                  vcsim.URL.Hostname(),
+			Port:                  port,
+			Insecure:              true,
+			VCSessionManagerURL:   sessionManager.URL,
+			VCSessionManagerToken: "a-session-manager-token",
+		},
+		ClientMutex: &sync.Mutex{},
+	}
+}
+
+// TestNewClientWithSessionManager covers the shared session login end to end:
+// fetch a token from the session manager, clone the vCenter session with it, and
+// carry that session over to the rest client.
+func TestNewClientWithSessionManager(t *testing.T) {
+	writeSessionTestConfig(t)
+	ctx := context.Background()
+
+	t.Run("should authenticate through the session manager", func(t *testing.T) {
+		vc := newSharedSessionVC(t)
+
+		client, restClient, err := vc.NewClient(ctx, "session-manager-test")
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		require.NotNil(t, restClient)
+
+		// The cloned session must be a real, authenticated vCenter session.
+		userSession, err := client.SessionManager.UserSession(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, userSession, "clone should have produced a live session")
+
+		// And the rest client must have picked up that same session.
+		assert.Equal(t, client.SessionCookie().Value, restClient.SessionID(),
+			"rest client should ride on the cloned soap session")
+	})
+
+	t.Run("should fail when the session manager rejects the request", func(t *testing.T) {
+		vc := newSharedSessionVC(t)
+		vc.Config.VCSessionManagerURL = "https://127.0.0.1:1/session"
+
+		_, _, err := vc.NewClient(ctx, "session-manager-test")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed calling vc session manager")
+	})
+
+	t.Run("should fail when the clone ticket is not accepted", func(t *testing.T) {
+		vc := newSharedSessionVC(t)
+		badTicket := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(SharedSessionResponse{Token: "not-a-real-ticket"})
+			}))
+		t.Cleanup(badTicket.Close)
+		vc.Config.VCSessionManagerURL = badTicket.URL
+
+		_, _, err := vc.NewClient(ctx, "session-manager-test")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "Login failure")
+	})
+}

--- a/pkg/common/cns-lib/vsphere/vc_session_manager.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_manager.go
@@ -1,0 +1,135 @@
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	saFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
+// SharedSessionResponse is the expected structure for a session manager valid
+// token response
+type SharedSessionResponse struct {
+	Token string `json:"token"`
+}
+
+// SharedTokenOptions represents the options that can be used when calling vc session manager
+type SharedTokenOptions struct {
+	// URL is the session manager URL. Eg.: https://my-session-manager/session)
+	URL string
+	// Token is the authorization token that should be passed to session manager
+	Token string
+	// TrustedCertificates contains the certpool of certificates trusted by the client
+	TrustedCertificates *x509.CertPool
+	// InsecureSkipVerify defines if bad certificates requests should be ignored
+	InsecureSkipVerify bool
+	// Timeout defines the client timeout. Defaults to 5 seconds
+	Timeout time.Duration
+	// TokenFile defines a file with token content. Defaults to Kubernetes Service Account file
+	TokenFile string
+}
+
+// newSessionManagerTransport builds the http.Transport used to reach the
+// session manager. Split out from GetSharedToken so the Proxy wiring below
+// can be asserted on directly: a real request only invokes it, once,
+// permanently caching a "no proxy" result if none was configured yet, which
+// would make a live end-to-end proxy test order-dependent and unreliable
+// given every other test in this file also calls GetSharedToken for real.
+func newSessionManagerTransport(options SharedTokenOptions) *http.Transport {
+	return &http.Transport{
+		// http.DefaultTransport sets this; a bare &http.Transport{} literal
+		// does not, and leaves Proxy nil, silently ignoring HTTP_PROXY/
+		// HTTPS_PROXY/NO_PROXY. Needed for deployments that reach the session
+		// manager through an egress proxy.
+		Proxy: http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{
+			RootCAs:            options.TrustedCertificates,
+			InsecureSkipVerify: options.InsecureSkipVerify,
+		},
+	}
+}
+
+// GetSharedToken executes an http request on session manager and gets the session manager
+// token that can be reused on govmomi sessions
+func GetSharedToken(ctx context.Context, options SharedTokenOptions) (string, error) {
+	if options.URL == "" {
+		return "", fmt.Errorf("URL of session manager cannot be empty")
+	}
+
+	if options.TokenFile == "" {
+		options.TokenFile = saFile
+	}
+
+	// If the token is empty, we should use service account from the Pod instead
+	if options.Token == "" {
+		saValue, err := os.ReadFile(options.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("failed reading token from service account: %w", err)
+		}
+		// A manually created token file commonly picks up a trailing newline
+		// (e.g. `echo token > file` rather than `echo -n`). An Authorization
+		// header value containing a raw newline isn't sent to the session
+		// manager at all: net/http rejects it client-side with "invalid header
+		// field value", which gives no hint the actual problem is the file's
+		// whitespace.
+		options.Token = strings.TrimSpace(string(saValue))
+	}
+
+	timeout := 5 * time.Second
+	if options.Timeout != 0 {
+		timeout = options.Timeout
+	}
+
+	transport := newSessionManagerTransport(options)
+
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+	// This transport is per-call, so its idle connections have no other user.
+	// Left alone they would stay established indefinitely (a zero-value
+	// Transport has no IdleConnTimeout), holding a socket and its reader and
+	// writer goroutines long after this function returns.
+	defer transport.CloseIdleConnections()
+
+	// Bind the caller's context so cancellation and deadlines are honoured.
+	// options.Timeout only caps the total call; it cannot abort one early.
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, options.URL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed creating new http client: %w", err)
+	}
+	authToken := fmt.Sprintf("Bearer %s", options.Token)
+	request.Header.Add("Authorization", authToken)
+
+	resp, err := client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("failed calling vc session manager: %w", err)
+	}
+	// Close on every exit path, not just the success one. net/http guarantees a
+	// non-nil Body even when the response has none, and the caller always owns it.
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("invalid vc session manager response: %s", resp.Status)
+	}
+
+	token := &SharedSessionResponse{}
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(token); err != nil {
+		return "", fmt.Errorf("failed decoding vc session manager response: %w", err)
+	}
+
+	if token.Token == "" {
+		return "", fmt.Errorf("returned vc session token is empty")
+	}
+	return token.Token, nil
+}

--- a/pkg/common/cns-lib/vsphere/vc_session_manager_test.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_manager_test.go
@@ -1,0 +1,349 @@
+package vsphere_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vclib "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+)
+
+const (
+	validToken    = "validtoken"
+	validResponse = "a-valid-response"
+)
+
+var (
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authZHdr := r.Header.Get("Authorization")
+		if authZHdr != fmt.Sprintf("Bearer %s", validToken) {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if r.URL.Path == "/timeout" {
+			time.Sleep(15 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/invalid-token" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not a json"))
+			return
+		}
+		if r.URL.Path == "/session" {
+			token := vclib.SharedSessionResponse{
+				Token: validResponse,
+			}
+			response, err := json.Marshal(&token)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(response)
+			return
+		}
+		if r.URL.Path == "/empty" {
+			token := vclib.SharedSessionResponse{
+				Token: "",
+			}
+			response, err := json.Marshal(&token)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(response)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+)
+
+func TestGetSharedToken(t *testing.T) {
+	ctx := context.Background()
+	t.Run("when options are invalid", func(t *testing.T) {
+		t.Run("should fail when no URL is sent", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{})
+			assert.ErrorContains(t, err, "URL of session manager cannot be empty")
+		})
+
+		t.Run("should fail when no token is passed and SA token cannot be read", func(t *testing.T) {
+			// TokenFile is set to a path that cannot exist rather than relying on
+			// the default service-account path being absent: these tests also run
+			// inside pods (Prow), where that file IS mounted, and GetSharedToken
+			// would then read it and go on to dial the URL below -- failing on a
+			// connection error that has nothing to do with reading the token.
+			missingTokenFile := filepath.Join(t.TempDir(), "no-such-token")
+
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:       "http://something.tld/lala",
+				TokenFile: missingTokenFile,
+			})
+			assert.ErrorContains(t, err, "failed reading token from service account")
+			assert.ErrorContains(t, err, missingTokenFile)
+		})
+
+		t.Run("should fail when passed URL is invalid", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:   "https://some-session-manager.tld:xxxxx/session",
+				Token: "anything",
+			})
+			assert.ErrorContains(t, err, "invalid port")
+		})
+	})
+
+	t.Run("when using a valid session manager", func(t *testing.T) {
+		server := httptest.NewTLSServer(handler)
+
+		certpool := x509.NewCertPool()
+		certpool.AddCert(server.Certificate())
+		t.Cleanup(server.Close)
+
+		// Note this covers options.Timeout (the http.Client timeout), not the
+		// caller's context. Cancellation is covered by TestGetSharedTokenHonoursContext.
+		t.Run("should respect the options timeout", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/timeout", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+				Timeout:             5 * time.Millisecond,
+			})
+			assert.ErrorContains(t, err, "context deadline exceeded")
+		})
+		t.Run("should fail when calling an invalid path", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 server.URL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "404 Not Found")
+		})
+		t.Run("should fail when an empty token is returned", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/empty", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "returned vc session token is empty")
+		})
+
+		t.Run("should fail when an invalid json is returned", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/invalid-token", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "failed decoding vc session manager response")
+		})
+
+		t.Run("should fail when no cert is passed and insecureskipverify is false", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:   reqURL,
+				Token: validToken,
+			})
+			assert.ErrorContains(t, err, "tls: failed to verify certificate: x509")
+		})
+
+		t.Run("should return a valid token for the right request and insecureskip=true", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                reqURL,
+				InsecureSkipVerify: true,
+				Token:              validToken,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+
+		t.Run("should return a valid token for the right request and cert", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+
+		t.Run("should return a valid token when using a file as a token", func(t *testing.T) {
+			tokenFile, err := os.CreateTemp("", "")
+			require.NoError(t, err)
+			require.NoError(t, tokenFile.Close())
+			require.NoError(t, os.WriteFile(tokenFile.Name(), []byte(validToken), 0755))
+
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				TokenFile:           tokenFile.Name(),
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+
+		// A raw newline in a header value isn't sent at all: net/http rejects
+		// it client-side before the request ever reaches the server. A file
+		// created with `echo token > file` rather than `echo -n` is exactly
+		// this shape.
+		t.Run("should trim a trailing newline from a token file", func(t *testing.T) {
+			tokenFile, err := os.CreateTemp("", "")
+			require.NoError(t, err)
+			require.NoError(t, tokenFile.Close())
+			require.NoError(t, os.WriteFile(tokenFile.Name(), []byte(validToken+"\n"), 0755))
+
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				TokenFile:           tokenFile.Name(),
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+	})
+
+}
+
+// TestGetSharedTokenHonoursContext checks that the caller's context actually
+// reaches the request. options.Timeout caps the total call but cannot abort one
+// early, so without the context bound to the request a cancelled caller — a pod
+// shutting down, or an operation whose deadline has passed — would still block
+// for the full timeout.
+func TestGetSharedTokenHonoursContext(t *testing.T) {
+	// Blocks until the client goes away, so the only way out is cancellation.
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-r.Context().Done():
+			case <-released:
+			}
+		}))
+	t.Cleanup(func() {
+		close(released)
+		server.Close()
+	})
+
+	// Runs the call off the test goroutine so an ignored context surfaces as a
+	// fast, explicit failure instead of hanging until the go test deadline.
+	callWithContext := func(t *testing.T, ctx context.Context) error {
+		t.Helper()
+		done := make(chan error, 1)
+		go func() {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:     server.URL,
+				Token:   validToken,
+				Timeout: time.Hour, // must not be what unblocks us
+			})
+			done <- err
+		}()
+
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(10 * time.Second):
+			t.Fatal("GetSharedToken did not return well after its context was done; " +
+				"the caller's context is not reaching the request")
+			return nil
+		}
+	}
+
+	t.Run("should abort when the context deadline passes", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		err := callWithContext(t, ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("should abort when the context is cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		time.AfterFunc(50*time.Millisecond, cancel)
+
+		err := callWithContext(t, ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// TestGetSharedTokenReleasesConnections guards against connections outliving the
+// call that opened them. Two things are needed for that and both have been wrong
+// here: the response body must be closed on every exit path (not just the success
+// one), and the per-call Transport must have its idle connections closed, since a
+// zero-value Transport has no IdleConnTimeout and would otherwise hold the socket
+// and its goroutines open indefinitely. GetSharedToken runs on every login and
+// reconnect, so anything left behind accumulates.
+func TestGetSharedTokenReleasesConnections(t *testing.T) {
+	const requests = 10
+
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "non-200 response", status: http.StatusForbidden, body: "denied"},
+		{name: "undecodable response", status: http.StatusOK, body: "not a json"},
+		{name: "empty token response", status: http.StatusOK, body: `{"token":""}`},
+		{name: "valid response", status: http.StatusOK, body: `{"token":"` + validResponse + `"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var opened, closed int64
+			server := httptest.NewUnstartedServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tc.status)
+					_, _ = w.Write([]byte(tc.body))
+				}))
+			server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+				switch state {
+				case http.StateNew:
+					atomic.AddInt64(&opened, 1)
+				case http.StateClosed:
+					atomic.AddInt64(&closed, 1)
+				}
+			}
+			server.Start()
+			t.Cleanup(server.Close)
+
+			for i := 0; i < requests; i++ {
+				_, _ = vclib.GetSharedToken(context.Background(), vclib.SharedTokenOptions{
+					URL:   server.URL,
+					Token: validToken,
+				})
+			}
+
+			// Assert the invariant (everything opened is released) rather than a
+			// connection count, so this still holds if the client is later reworked
+			// to reuse connections instead of building a Transport per call.
+			totalOpened := atomic.LoadInt64(&opened)
+			require.GreaterOrEqual(t, totalOpened, int64(1),
+				"expected the calls to open at least one connection")
+
+			// Teardown is observed asynchronously by the server, so poll.
+			assert.Eventually(t, func() bool {
+				return atomic.LoadInt64(&closed) == totalOpened
+			}, 10*time.Second, 20*time.Millisecond,
+				"expected all %d connections to be closed, saw %d; a connection left "+
+					"established means a response body or an idle Transport was leaked",
+				totalOpened, atomic.LoadInt64(&closed))
+		})
+	}
+}

--- a/pkg/common/cns-lib/vsphere/vc_session_manager_transport_test.go
+++ b/pkg/common/cns-lib/vsphere/vc_session_manager_transport_test.go
@@ -1,0 +1,32 @@
+package vsphere
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewSessionManagerTransportHonoursProxyEnv guards against a bare
+// &http.Transport{} literal, which leaves Proxy nil and silently ignores
+// HTTP_PROXY/HTTPS_PROXY/NO_PROXY -- unlike http.DefaultTransport, which sets
+// Proxy: http.ProxyFromEnvironment. A deployment that reaches the session
+// manager through an egress proxy would otherwise always connect directly and
+// fail (or bypass network policy meant to route through the proxy).
+//
+// Asserted by comparing function pointers via reflection rather than a live
+// request: ProxyFromEnvironment's environment lookup is cached process-wide
+// behind a sync.Once the first time it's actually invoked, and every other
+// test in this file calls GetSharedToken for real, so a live end-to-end proxy
+// test would be order-dependent and unreliable.
+func TestNewSessionManagerTransportHonoursProxyEnv(t *testing.T) {
+	transport := newSessionManagerTransport(SharedTokenOptions{})
+
+	require.NotNil(t, transport.Proxy, "Proxy must not be nil, or HTTP_PROXY/HTTPS_PROXY/NO_PROXY are silently ignored")
+	assert.Equal(t,
+		reflect.ValueOf(http.ProxyFromEnvironment).Pointer(),
+		reflect.ValueOf(transport.Proxy).Pointer(),
+		"Proxy should be http.ProxyFromEnvironment")
+}

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	neturl "net/url"
 	"reflect"
 	"strconv"
@@ -37,6 +38,7 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -60,7 +62,25 @@ const (
 	statusSuccess = "success"
 	// failed request
 	statusFailUnknown = "fail-unknown"
+
+	// restLoginCooldown is how long connect() waits before attempting another
+	// rest login after one was rejected as an authentication failure. This
+	// branch has no Connect()-level InvalidLogin retry loop (unlike master's
+	// maxLoginRetries/retryDelay), so the value is defined directly here: a
+	// flat 3-minute delay matching vCenter's SSO lockout window (5 attempts in
+	// 180s). The rest re-login path runs on every connect() and has no attempt
+	// limit of its own, so without a cooldown a wrong password would spend that
+	// budget within seconds on an active cluster and lock the account out.
+	restLoginCooldown = 3 * time.Minute
 )
+
+// restLoginTimeout bounds a rest re-login attempt on connect()'s repair path.
+// NewClient sets soap.Client.Timeout to 0 and the rest client shares that
+// transport, so an endpoint that accepts the connection and then never answers
+// would otherwise hang that attempt indefinitely -- while holding ClientMutex,
+// which every other caller of Connect is queued behind. A variable rather than
+// a constant so tests can shorten it.
+var restLoginTimeout = 60 * time.Second
 
 // VirtualCenter holds details of a virtual center instance.
 type VirtualCenter struct {
@@ -68,6 +88,8 @@ type VirtualCenter struct {
 	Config *VirtualCenterConfig
 	// Client represents the govmomi client instance for the connection.
 	Client *govmomi.Client
+	// RestClient represents the govmomi rest client
+	RestClient *rest.Client
 	// PbmClient represents the govmomi PBM Client instance.
 	PbmClient *pbm.Client
 	// CnsClient represents the CNS client instance.
@@ -78,6 +100,12 @@ type VirtualCenter struct {
 	VslmClient *vslm.Client
 	// ClientMutex is used for exclusive connection creation.
 	ClientMutex *sync.Mutex
+	// restLoginCooldownUntil is the time before which connect() will not
+	// attempt another rest re-login, set when one was rejected as an
+	// authentication failure. Zero means no cooldown is in effect. Read and
+	// written only from connect(), which callers reach through Connect while it
+	// holds ClientMutex, the same protection vc.Client and vc.RestClient have.
+	restLoginCooldownUntil time.Time
 }
 
 type MetricRoundTripper struct {
@@ -148,10 +176,16 @@ type VirtualCenterConfig struct {
 	ReloadVCConfigForNewClient bool
 	// FileVolumeActivated indicates whether file service has been enabled on any vSAN cluster or not
 	FileVolumeActivated bool
+	// VCSessionManagerURL is the path of a rest api capable of generating vCenter Cloned tokens
+	// to be reused by clients. When this is used, Username and Password configuration are ignored
+	VCSessionManagerURL string
+	// VCSessionManagerToken is the token that should be passed to authenticate against the session manager
+	// If empty, the Pod service account will be used
+	VCSessionManagerToken string
 }
 
 // NewClient creates a new govmomi Client instance.
-func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govmomi.Client, error) {
+func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govmomi.Client, *rest.Client, error) {
 	log := logger.GetLogger(ctx)
 	if vc.Config.Scheme == "" {
 		vc.Config.Scheme = DefaultScheme
@@ -160,14 +194,14 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	url, err := soap.ParseURL(net.JoinHostPort(vc.Config.Host, strconv.Itoa(vc.Config.Port)))
 	if err != nil {
 		log.Errorf("failed to parse URL %s with err: %v", url, err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	soapClient := soap.NewClient(url, vc.Config.Insecure)
 	if len(vc.Config.CAFile) > 0 && !vc.Config.Insecure {
 		if err := soapClient.SetRootCAs(vc.Config.CAFile); err != nil {
 			log.Errorf("failed to load CA file: %v", err)
-			return nil, err
+			return nil, nil, err
 		}
 	} else if len(vc.Config.Thumbprint) > 0 && !vc.Config.Insecure {
 		soapClient.SetThumbprint(url.Host, vc.Config.Thumbprint)
@@ -179,7 +213,7 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	vimClient, err := vim25.NewClient(ctx, soapClient)
 	if err != nil {
 		log.Errorf("failed to create new client with err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Invoke KeepAlive on the vimClient RoundTripper to keep the connection alive
@@ -189,7 +223,7 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 	if err != nil && vc.Config.Host != "127.0.0.1" {
 		// Skipping error for simulator connection for unit tests.
 		log.Errorf("Failed to set vimClient service version to vsan. err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	vimClient.UserAgent = useragent
 	client := &govmomi.Client{
@@ -197,22 +231,24 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 		SessionManager: session.NewManager(vimClient),
 	}
 
-	err = vc.login(ctx, client)
+	restClient := rest.NewClient(client.Client)
+
+	err = vc.login(ctx, client, restClient)
 	if err != nil {
 		log.Errorf("failed to login to vc. err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	s, err := client.SessionManager.UserSession(ctx)
 	if err != nil {
 		log.Errorf("failed to get UserSession. err: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	// Refer to this issue - https://github.com/vmware/govmomi/issues/2922
 	// When Session Manager -> UserSession can return nil user session with nil error
 	// so handling the case for nil session.
 	if s == nil {
-		return nil, errors.New("nil session obtained from session manager")
+		return nil, nil, errors.New("nil session obtained from session manager")
 	}
 	log.Infof("New session ID for '%s' = %s", s.UserName, s.Key)
 
@@ -220,46 +256,190 @@ func (vc *VirtualCenter) NewClient(ctx context.Context, useragent string) (*govm
 		vc.Config.RoundTripperCount = DefaultRoundTripperCount
 	}
 	rt := vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(vc.Config.RoundTripperCount))
-	client.RoundTripper = &MetricRoundTripper{"soap", rt}
-	return client, nil
+	client.RoundTripper = &MetricRoundTripper{clientName: "soap", roundTripper: rt}
+	return client, restClient, nil
+}
+
+// soapSessionID returns the value of the SOAP session cookie, which vCenter also
+// accepts as a REST session id and is how the rest client rides along on a cloned
+// session.
+//
+// soap.Client.SessionCookie returns nil when the jar holds no session cookie, so
+// it is checked rather than dereferenced. In practice a successful CloneSession
+// leaves the cookie in place, but the caller cannot prove that, and a nil
+// dereference on a login path that gets retried would crash the pod rather than
+// fail the call.
+func soapSessionID(client *govmomi.Client) (string, error) {
+	cookie := client.SessionCookie()
+	if cookie == nil {
+		return "", errors.New("no vCenter session cookie found after cloning the session")
+	}
+	if cookie.Value == "" {
+		return "", errors.New("vCenter session cookie after cloning the session is empty")
+	}
+	return cookie.Value, nil
 }
 
 // login calls SessionManager.LoginByToken if certificate and private key are
 // configured. Otherwise, calls SessionManager.Login with user and password.
-func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) error {
+func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client, restClient *rest.Client) error {
 	log := logger.GetLogger(ctx)
 	var err error
 
+	// If session manager is used, username and password can be discarded/ignored.
+	// After CloneSession succeeds, the only remaining step is restClient.SessionID,
+	// a local field set with no vCenter call, so there is no step left that can
+	// fail here.
+	if vc.Config.VCSessionManagerURL != "" {
+		token, err := GetSharedToken(ctx, SharedTokenOptions{
+			URL:   vc.Config.VCSessionManagerURL,
+			Token: vc.Config.VCSessionManagerToken,
+		})
+		if err != nil {
+			log.Errorf("error getting shared session token: %s", err)
+			return err
+		}
+		if err := client.SessionManager.CloneSession(ctx, token); err != nil {
+			log.Errorf("error getting cloned session token: %s", err)
+			return err
+		}
+		if err := vc.restLogin(ctx, client, restClient); err != nil {
+			log.Errorf("error deriving rest session from cloned session: %s", err)
+			return err
+		}
+		return nil
+	}
+
 	b, _ := pem.Decode([]byte(vc.Config.Username))
 	if b == nil {
-		return client.SessionManager.Login(ctx,
-			neturl.UserPassword(vc.Config.Username, vc.Config.Password))
+		if err := client.SessionManager.Login(ctx, neturl.UserPassword(vc.Config.Username, vc.Config.Password)); err != nil {
+			log.Errorf("error logging soap client: %v", err)
+			return err
+		}
+		if err := vc.restLogin(ctx, client, restClient); err != nil {
+			// Keep the SOAP session and succeed anyway: REST is only needed
+			// for tag/topology operations, which fail on their own -- and recover on
+			// their own -- if they need it and it is still down. Failing the whole
+			// login here would mean a vAPI outage blocks everything that needs only
+			// SOAP, including driver startup, since Connect() runs from
+			// controller.Init(). The next connect() call re-logins the rest client
+			// on its own, without touching this SOAP session, once vAPI is
+			// reachable again.
+			log.Warnf("error logging rest client, continuing with SOAP-only session: %v", err)
+		}
+		return nil
 	}
+
+	signer, err := vc.issueSTSSigner(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	header := soap.Header{Security: signer}
+	if err := client.SessionManager.LoginByToken(client.Client.WithHeader(ctx, header)); err != nil {
+		return err
+	}
+
+	if err := restLoginByToken(ctx, restClient, signer); err != nil {
+		// See the equivalent comment in the username/password branch above.
+		log.Warnf("error logging rest client by token, continuing with SOAP-only session: %v", err)
+	}
+	return nil
+}
+
+// issueSTSSigner loads the configured certificate/private key pair and issues a
+// SAML token from vCenter's STS for it.
+func (vc *VirtualCenter) issueSTSSigner(ctx context.Context, client *govmomi.Client) (*sts.Signer, error) {
+	log := logger.GetLogger(ctx)
 
 	cert, err := tls.X509KeyPair([]byte(vc.Config.Username), []byte(vc.Config.Password))
 	if err != nil {
 		log.Errorf("failed to load X509 key pair with err: %v", err)
-		return err
+		return nil, err
 	}
 
 	tokens, err := sts.NewClient(ctx, client.Client)
 	if err != nil {
 		log.Errorf("failed to create STS client with err: %v", err)
-		return err
+		return nil, err
 	}
 
+	// Certificate (rather than Userinfo) makes this a Holder-of-Key token,
+	// bound to this request's private key and normally usable only by the
+	// connection that negotiated it. The signer built from it is reused on a
+	// second, separate connection -- the rest client's LoginByToken -- which is
+	// a delegation: the rest client presents a token it did not itself
+	// negotiate. Delegatable is what permits a HoK token to be reused that way;
+	// govc's own login command does the identical one-token, two-logins pattern
+	// (cli/session/login.go: issueToken, loginByToken, loginRestByToken) and
+	// also sets it for the same reason.
 	req := sts.TokenRequest{
 		Certificate: &cert,
+		Delegatable: true,
 	}
 
 	signer, err := tokens.Issue(ctx, req)
 	if err != nil {
 		log.Errorf("failed to issue SAML token with err: %v", err)
-		return err
+		return nil, err
+	}
+	return signer, nil
+}
+
+func restLoginByToken(ctx context.Context, restClient *rest.Client, signer *sts.Signer) error {
+	return restClient.LoginByToken(restClient.WithSigner(ctx, signer))
+}
+
+// restLogin authenticates only the rest client, against a SOAP session that is
+// already authenticated. It is what login() uses for the rest half of a fresh
+// login, and what connect() uses to repair a rest session on a client whose
+// SOAP session is still healthy -- the rest client shares the SOAP client's
+// transport, so it can be re-authenticated on its own without disturbing the
+// SOAP session or any of the dependent clients (pbm, cns, vslm, vsan) built on
+// top of it.
+func (vc *VirtualCenter) restLogin(ctx context.Context, client *govmomi.Client, restClient *rest.Client) error {
+	// With the shared session manager the rest client does not hold a session of
+	// its own: its session id is the SOAP session's cookie, so "re-login" is just
+	// re-deriving that id from the current SOAP session.
+	if vc.Config.VCSessionManagerURL != "" {
+		sessionID, err := soapSessionID(client)
+		if err != nil {
+			return err
+		}
+		restClient.SessionID(sessionID)
+		return nil
 	}
 
-	header := soap.Header{Security: signer}
-	return client.SessionManager.LoginByToken(client.Client.WithHeader(ctx, header))
+	if b, _ := pem.Decode([]byte(vc.Config.Username)); b == nil {
+		return restClient.Login(ctx, neturl.UserPassword(vc.Config.Username, vc.Config.Password))
+	}
+
+	// Certificate auth: the token issued for the original login is not kept
+	// around, so a rest-only re-login issues a fresh one. That is an STS call
+	// against vCenter, not vAPI, so it works while vAPI is the part that is down.
+	signer, err := vc.issueSTSSigner(ctx, client)
+	if err != nil {
+		return err
+	}
+	return restLoginByToken(ctx, restClient, signer)
+}
+
+// cleanupVCClient logs out and clears the VC client to ensure a clean state.
+// This helper is used during error handling and retry logic.
+func (vc *VirtualCenter) cleanupVCClient(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+	if vc.Client != nil {
+		if err := vc.Client.Logout(ctx); err != nil {
+			log.With("err", err).Warn("Could not logout of VC session")
+		}
+	}
+	if vc.RestClient != nil {
+		// TODO: On vSphere U3, with a shared session this may return an error as logging
+		// out from Soap also logs out from rest.
+		if err := vc.RestClient.Logout(ctx); err != nil {
+			log.With("err", err).Warn("Could not logout of VC rest session")
+		}
+	}
 }
 
 // Connect establishes a new connection with vSphere with updated credentials.
@@ -299,7 +479,13 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		log.Errorf("failed to get useragent for vCenter session. error: %+v", err)
 		return err
 	}
-	if vc.Client == nil {
+
+	// Once initialised, don't nullify vc.Client or dependent clients.
+	// This function will detect the invalid session (after logout)
+	// and recreate dependent clients.
+	// Nullifying vc.Client would cause connect() to return early
+	// before dependent clients are recreated, leaving them with stale sessions.
+	if vc.Client == nil || vc.RestClient == nil {
 		if vc.Config.ReloadVCConfigForNewClient {
 			err = ReadVCConfigs(ctx, vc)
 			if err != nil {
@@ -307,13 +493,15 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			}
 		}
 		log.Infof("VirtualCenter.connect() creating new client")
-		if vc.Client, err = vc.NewClient(ctx, useragent); err != nil {
+		if vc.Client, vc.RestClient, err = vc.NewClient(ctx, useragent); err != nil {
 			log.Errorf("failed to create govmomi client with err: %v", err)
 			if !vc.Config.Insecure {
 				log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 			}
 			return err
 		}
+
+		vc.restLoginCooldownUntil = time.Time{}
 		log.Infof("VirtualCenter.connect() successfully created new client")
 		return nil
 	}
@@ -323,10 +511,60 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 	// SessionMgr.UserSession(ctx) retrieves and returns the SessionManager's
 	// CurrentSession field. Nil is returned if the session is not
 	// authenticated or timed out.
-	if userSession, err := sessionMgr.UserSession(ctx); err != nil {
+
+	userSession, err := sessionMgr.UserSession(ctx)
+	if err != nil {
 		log.Errorf("failed to obtain user session with err: %v", err)
+		// An error here can mean the vcenter itself is down so
+		// we should return early with error
 		return err
-	} else if userSession != nil {
+	}
+
+	// When authenticated through the shared session manager, the rest client's
+	// session ID is the SOAP session's own cookie (see login()), so they are the
+	// same vCenter session object rather than two independent ones. The logout
+	// TODOs above already rely on this: on vSphere U3+ logging out of one logs
+	// out of the other. So userSession above already speaks for the rest
+	// session too, and checking it again would just be a second network call
+	// for the same answer.
+	restSessionValid := userSession != nil
+	if vc.Config.VCSessionManagerURL == "" {
+		restSession, err := vc.RestClient.Session(ctx)
+		if err != nil {
+			// Deliberately not returned. govmomi maps only HTTP 401 to
+			// (nil, nil); any other failure -- a vAPI endpoint restarting, a
+			// 503 mid-upgrade, a network blip -- comes back as an error. If
+			// that were returned, Connect would treat the whole connection as
+			// failed and call cleanupVCClient, which logs out the SOAP session
+			// that userSession above just proved healthy, and leaves both
+			// client pointers non-nil but dead for anything not going through
+			// Connect. A REST session that cannot be read is instead treated
+			// as one that needs re-establishing, which the code below does.
+			log.Errorf("failed to obtain rest user session, will re-login. err: %v", err)
+			restSessionValid = false
+		} else {
+			restSessionValid = restSession != nil
+		}
+	}
+
+	// No need to re-login
+	if userSession != nil && restSessionValid {
+		return nil
+	}
+
+	if userSession != nil {
+		// Only the rest session is unusable; the SOAP session this client holds
+		// is live. Re-authenticate the rest client in place rather than tearing
+		// the whole client down: restClient rides on the same soap.Client, so it
+		// can be re-logged-in on its own, and the SOAP session plus every
+		// dependent client (pbm, cns, vslm, vsan) built on it stay valid.
+		//
+		// Tearing down here is what made a vAPI outage a churn loop: login()
+		// deliberately succeeds with a SOAP-only session when the rest login
+		// fails, so each Connect() would log out a working SOAP session, build a
+		// new one, fail the rest login again, and leave the next Connect() to do
+		// the same -- a full re-login per call for as long as vAPI stayed down.
+		vc.repairRestSession(ctx)
 		return nil
 	}
 
@@ -339,6 +577,14 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		}
 	}
 
+	if vc.RestClient != nil {
+		// TODO: On U3 shared session this may return an error, if the Soap logout
+		// happened correctly, but can be safely ignored
+		if err := vc.RestClient.Logout(ctx); err != nil {
+			log.Infof("failed to logout current rest session. still clearing idle sessions. err: %v", err)
+		}
+	}
+
 	// If session has expired, create a new instance.
 	log.Infof("Creating a new client session as the existing one isn't valid or not authenticated")
 	if vc.Config.ReloadVCConfigForNewClient {
@@ -347,13 +593,14 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			return err
 		}
 	}
-	if vc.Client, err = vc.NewClient(ctx, useragent); err != nil {
+	if vc.Client, vc.RestClient, err = vc.NewClient(ctx, useragent); err != nil {
 		log.Errorf("failed to create govmomi client with err: %v", err)
 		if !vc.Config.Insecure {
 			log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 		}
 		return err
 	}
+	vc.restLoginCooldownUntil = time.Time{}
 	// Recreate PbmClient if created using timed out VC Client.
 	if vc.PbmClient != nil {
 		if vc.PbmClient, err = pbm.NewClient(ctx, vc.Client.Client); err != nil {
@@ -386,7 +633,57 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 		}
 		vc.VsanClient.RoundTripper = &MetricRoundTripper{"vsan", vc.VsanClient.RoundTripper}
 	}
+
 	return nil
+}
+
+// repairRestSession re-authenticates the rest client of a VirtualCenter whose
+// SOAP session is still valid. A failure is never fatal, matching login(): a
+// vAPI outage leaves a usable SOAP-only connection, and callers that need vAPI
+// fail on their own and recover when a later connect() retries this.
+//
+// Retries are immediate for transport-shaped failures, which is what makes
+// recovery from a vAPI outage take a single round trip once it is back. An
+// authentication failure is different: it will not recover on its own, and this
+// path runs on every connect() with no attempt limit, so retrying one at full
+// speed would burn through vCenter's SSO lockout budget. Those get a cooldown.
+func (vc *VirtualCenter) repairRestSession(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+
+	if remaining := time.Until(vc.restLoginCooldownUntil); remaining > 0 {
+		log.Warnf("not attempting a rest re-login for another %v: the last attempt was rejected as an "+
+			"authentication failure, and retrying it every connect() risks locking the account out",
+			remaining.Truncate(time.Second))
+		return
+	}
+
+	loginCtx, cancel := context.WithTimeout(ctx, restLoginTimeout)
+	defer cancel()
+
+	if err := vc.restLogin(loginCtx, vc.Client, vc.RestClient); err != nil {
+		if isRestAuthFailure(ctx, err) {
+			vc.restLoginCooldownUntil = time.Now().Add(restLoginCooldown)
+			log.Errorf("rest re-login was rejected as an authentication failure, "+
+				"continuing with SOAP-only session and not retrying for %v: %v", restLoginCooldown, err)
+		} else {
+			log.Warnf("failed to re-login rest client, continuing with SOAP-only session: %v", err)
+		}
+		return
+	}
+	vc.restLoginCooldownUntil = time.Time{}
+	log.Infof("re-logged in rest client without recreating the SOAP session")
+}
+
+// isRestAuthFailure reports whether err is vCenter rejecting the credentials
+// rather than a transport-level failure.
+//
+// A vAPI login rejection arrives as an HTTP 401, which govmomi returns as its
+// own status error rather than a SOAP fault, so IsInvalidLoginError alone does
+// not recognise it. IsInvalidLoginError still matters for the certificate path,
+// where the rest login is preceded by an STS token issue -- a SOAP call, which
+// faults with InvalidLogin in the usual way when the certificate is rejected.
+func isRestAuthFailure(ctx context.Context, err error) bool {
+	return rest.IsStatusError(err, http.StatusUnauthorized) || IsInvalidLoginError(ctx, err)
 }
 
 // ReadVCConfigs will ensure we are always reading the latest config
@@ -461,6 +758,63 @@ func (vc *VirtualCenter) getDatacenters(ctx context.Context, dcPaths []string) (
 	return dcs, nil
 }
 
+// GetActiveUser returns the current logged in user. It is fetched from govmomi.Session
+// to reflect the real current user being used.
+//
+// This makes a single attempt and does not establish or repair a session.
+// Every caller reaches it just after something else (GetVCenter, GetVCenters,
+// GetDatacenters, ...) has already called Connect, so there is a session by
+// then and a Connect here would only duplicate the UserSession round trip
+// below. In the narrow case where the session dies in between, the error is
+// returned and the caller's own retry -- the CSI sidecar for volume
+// operations, the periodic refresh for the auth manager -- reconnects.
+func (vc *VirtualCenter) GetActiveUser(ctx context.Context) (string, error) {
+	if vc.Client == nil || vc.Client.SessionManager == nil {
+		return "", fmt.Errorf("client or sessionmanager are nil")
+	}
+
+	userSession, err := vc.Client.SessionManager.UserSession(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error getting current user: %w", err)
+	}
+
+	// Refer to this issue - https://github.com/vmware/govmomi/issues/2922
+	// Session Manager -> UserSession can return nil user session with nil error
+	// so handling the case for nil session.
+	if userSession == nil {
+		return "", errors.New("nil session obtained from session manager")
+	}
+	return userSession.UserName, nil
+}
+
+// ConfiguredOrActiveUser returns vc.Config.Username when that value is actually
+// the username the session is authenticated as. That is a local read with no
+// vCenter round trip, and covers the common username/password case. Otherwise it
+// falls back to GetActiveUser, which asks vCenter for the live session's user.
+//
+// Two cases must not use the configured value, because in both of them it is
+// either not a username or not this session's username:
+//
+//   - Shared session manager (VCSessionManagerURL). The session is a clone of
+//     whichever user the session manager authenticated as, which has nothing to
+//     do with Username. Username is expected to be empty here, but that is not
+//     enforced: validateConfig only waives the username/password requirement
+//     when VCSessionManagerURL is set, it never clears an already-configured
+//     User. So the mode, not the emptiness of Username, is what decides.
+//   - Certificate authentication. Username holds a PEM-encoded certificate
+//     rather than a user, and Password holds its private key -- see login(),
+//     which selects that path with this same pem.Decode check. Returning the
+//     PEM block as a username would put it in CNS volume metadata.
+func (vc *VirtualCenter) ConfiguredOrActiveUser(ctx context.Context) (string, error) {
+	if vc.Config.Username == "" || vc.Config.VCSessionManagerURL != "" {
+		return vc.GetActiveUser(ctx)
+	}
+	if block, _ := pem.Decode([]byte(vc.Config.Username)); block != nil {
+		return vc.GetActiveUser(ctx)
+	}
+	return vc.Config.Username, nil
+}
+
 // GetDatacenters returns Datacenters found on the VirtualCenter. If no
 // datacenters are mentioned in the VirtualCenterConfig during registration, all
 // Datacenters for the given VirtualCenter will be returned. If DatacenterPaths
@@ -489,7 +843,16 @@ func (vc *VirtualCenter) Disconnect(ctx context.Context) error {
 		log.Errorf("failed to logout with err: %v", err)
 		return err
 	}
+
+	// We don't return an error here because logging out from Rest failing
+	// can happen on VC shared sessions
+	if vc.RestClient != nil {
+		if err := vc.RestClient.Logout(ctx); err != nil {
+			log.Infof("failed to logout rest with err: %v", err)
+		}
+	}
 	vc.Client = nil
+	vc.RestClient = nil
 	return nil
 }
 

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -570,20 +570,7 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 
 	log.Infof("logging out current session and clearing idle sessions")
 
-	if vc.Client != nil && vc.Client.Client != nil {
-		err = vc.Client.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout current session. still clearing idle sessions. err: %v", err)
-		}
-	}
-
-	if vc.RestClient != nil {
-		// TODO: On U3 shared session this may return an error, if the Soap logout
-		// happened correctly, but can be safely ignored
-		if err := vc.RestClient.Logout(ctx); err != nil {
-			log.Infof("failed to logout current rest session. still clearing idle sessions. err: %v", err)
-		}
-	}
+	vc.cleanupVCClient(ctx)
 
 	// If session has expired, create a new instance.
 	log.Infof("Creating a new client session as the existing one isn't valid or not authenticated")

--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -211,7 +211,7 @@ func (vm *VirtualMachine) GetTagManager(ctx context.Context) (*tags.Manager, err
 		log.Errorf("failed to get virtualCenter. Error: %v", err)
 		return nil, err
 	}
-	return GetTagManager(ctx, virtualCenter)
+	return virtualCenter.GetTagManager(ctx)
 }
 
 // GetAncestors returns ancestors of VM.

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -114,16 +114,18 @@ const (
 
 // Errors
 var (
-	// ErrUsernameMissing is returned when the provided username is empty.
-	ErrUsernameMissing = errors.New("username is missing")
+	// ErrUsernameMissing is returned when the provided username is empty and
+	// vc-session-manager-url is not configured as an alternative.
+	ErrUsernameMissing = errors.New("username or vc-session-manager-url is missing")
 
 	// ErrInvalidUsername is returned when vCenter username provided in vSphere config
 	// secret is invalid. e.g. If username is not a fully qualified domain name, then
 	// it will be considered as invalid username.
 	ErrInvalidUsername = errors.New("username is invalid, make sure it is a fully qualified domain username")
 
-	// ErrPasswordMissing is returned when the provided password is empty.
-	ErrPasswordMissing = errors.New("password is missing")
+	// ErrPasswordMissing is returned when the provided password is empty and
+	// vc-session-manager-url is not configured as an alternative.
+	ErrPasswordMissing = errors.New("password or vc-session-manager-url is missing")
 
 	// ErrInvalidVCenterIP is returned when the provided vCenter IP address is
 	// missing from the provided configuration.
@@ -386,15 +388,15 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 
 		if vcConfig.User == "" {
 			vcConfig.User = cfg.Global.User
-			if vcConfig.User == "" {
-				log.Errorf("vcConfig.User is empty for vc %s!", vcServer)
+			if vcConfig.User == "" && vcConfig.VCSessionManagerURL == "" {
+				log.Errorf("vcConfig.User or vcConfig.VCSessionManagerURL should be configured for vc %s!", vcServer)
 				return ErrUsernameMissing
 			}
 		}
 
 		// vCenter server username provided in vSphere config secret should contain domain name,
 		// CSI driver will crash if username doesn't contain domain name.
-		if !isValidvCenterUsernameWithDomain(vcConfig.User) {
+		if !isValidvCenterUsernameWithDomain(vcConfig.User) && vcConfig.VCSessionManagerURL == "" {
 			log.Errorf("username %v specified in vSphere config secret is invalid, "+
 				"make sure that username is a fully qualified domain name.", vcConfig.User)
 			return ErrInvalidUsername
@@ -402,8 +404,8 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 
 		if vcConfig.Password == "" {
 			vcConfig.Password = cfg.Global.Password
-			if vcConfig.Password == "" {
-				log.Errorf("vcConfig.Password is empty for vc %s!", vcServer)
+			if vcConfig.Password == "" && vcConfig.VCSessionManagerURL == "" {
+				log.Errorf("vcConfig.Password or vcConfig.VCSessionManagerURL should be configured for vc %s!", vcServer)
 				return ErrPasswordMissing
 			}
 		}

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -201,6 +201,71 @@ func TestValidateConfigWithValidUsername1(t *testing.T) {
 	}
 }
 
+func TestValidateConfigWithSessionManager(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			VCenterPort:         "443",
+			Datacenters:         "dc1",
+			InsecureFlag:        true,
+			VCSessionManagerURL: "http://xxx.yyy.com/tld",
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as valid session manager was used. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithSessionManagerAndToken(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			VCenterPort:           "443",
+			Datacenters:           "dc1",
+			InsecureFlag:          true,
+			VCSessionManagerURL:   "http://xxx.yyy.com/tld",
+			VCSessionManagerToken: "a-secret-token",
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as a valid session manager with a token was used. Config given - %+v", *cfg)
+	}
+}
+
+// TestValidateConfigWithSessionManagerTokenButNoURL confirms that
+// VCSessionManagerToken alone does not bypass the username/password
+// requirement -- only VCSessionManagerURL does. Per the docs, when the URL is
+// unset CSI falls back to the Pod service account token rather than using
+// VCSessionManagerToken at all, so a token with no URL configured has nowhere
+// to be sent and must not silently pass validation.
+func TestValidateConfigWithSessionManagerTokenButNoURL(t *testing.T) {
+	vcConfigTokenOnly := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			VCenterPort:           "443",
+			Datacenters:           "dc1",
+			InsecureFlag:          true,
+			VCSessionManagerToken: "a-secret-token",
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigTokenOnly,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err == nil {
+		t.Errorf("Expected error: a session manager token with no URL and no username/password "+
+			"should not validate. Config given - %+v", *cfg)
+	}
+}
+
 func TestValidateConfigWithValidUsername2(t *testing.T) {
 	vcConfigValidUsername := map[string]*VirtualCenterConfig{
 		"1.1.1.1": {

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -160,6 +160,14 @@ type VirtualCenterConfig struct {
 	MigrationDataStoreURL string `gcfg:"migration-datastore-url"`
 	// FileVolumeActivated indicates whether file service has been enabled on any vSAN cluster or not
 	FileVolumeActivated bool
+	// VCSessionManagerURL is the path of a rest api capable of generating vCenter Cloned tokens
+	// to be reused by clients. When this is used, Username and Password configuration are ignored
+	VCSessionManagerURL string `gcfg:"vc-session-manager-url"`
+	// VCSessionManagerToken is the token that should be passed to authenticate against the session manager
+	// If empty, the Pod service account will be used.
+	// Marked sensitive so VirtualCenterConfig.String() redacts it: this is a bearer credential for the
+	// component that issues vCenter sessions, and the config is logged in full at debug level.
+	VCSessionManagerToken string `gcfg:"vc-session-manager-token" sensitive:"true"`
 }
 
 // GCConfig contains information used by guest cluster to access a supervisor

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -337,7 +337,11 @@ func getDatastoresWithBlockVolumePrivs(ctx context.Context, vc *cnsvsphere.Virtu
 	authMgr := object.NewAuthorizationManager(vc.Client.Client)
 	privIds := []string{DsPriv, SysReadPriv}
 
-	userName := vc.Config.Username
+	userName, err := vc.ConfiguredOrActiveUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Invoke authMgr function HasUserPrivilegeOnEntities.
 	result, err := authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds) // entities empty -> error
 	if err != nil {
@@ -440,10 +444,14 @@ func getFSEnabledClustersWithPriv(ctx context.Context, vc *cnsvsphere.VirtualCen
 		clusterComputeResources = append(clusterComputeResources, clusterComputeResource...)
 	}
 
+	userName, err := vc.ConfiguredOrActiveUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Get Clusters with HostConfigStoragePriv.
 	authMgr := object.NewAuthorizationManager(vc.Client.Client)
 	privIds := []string{HostConfigStoragePriv}
-	userName := vc.Config.Username
 	var entities []vim25types.ManagedObjectReference
 	clusterComputeResourcesMap := make(map[string]*object.ClusterComputeResource)
 	for _, cluster := range clusterComputeResources {

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1998,6 +1998,11 @@ func (c *K8sOrchestrator) GetVolumeAttachment(ctx context.Context, volumeId stri
 // This will not return VCP-CSI migrated volumes.
 func (c *K8sOrchestrator) GetAllVolumes() []string {
 	volumeIDs := make([]string, 0)
+	if c.volumeIDToPvcMap == nil {
+		return volumeIDs
+	}
+	c.volumeIDToPvcMap.RLock()
+	defer c.volumeIDToPvcMap.RUnlock()
 	for volumeID := range c.volumeIDToPvcMap.items {
 		volumeIDs = append(volumeIDs, volumeID)
 	}

--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -84,16 +84,10 @@ func DiscoverTagEntities(ctx context.Context) error {
 				vcenterCfg.Host, err)
 		}
 		// Get tag manager instance.
-		tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+		tagManager, err := vcenter.GetTagManager(ctx)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create tagManager. Error: %v", err)
 		}
-		defer func() {
-			err := tagManager.Logout(ctx)
-			if err != nil {
-				log.Errorf("failed to logout tagManager. Error: %v", err)
-			}
-		}()
 		for _, cat := range categories {
 			topoTags, err := tagManager.GetTagsForCategory(ctx, cat)
 			if err != nil {
@@ -481,17 +475,12 @@ func RefreshPreferentialDatastoresForMultiVCenter(ctx context.Context) error {
 				vcConfig.Host, err)
 		}
 		// Get tag manager instance.
-		tagMgr, err := cnsvsphere.GetTagManager(ctx, vc)
+		tagMgr, err := vc.GetTagManager(ctx)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to create tag manager for vCenter %q. Error: %+v",
 				vcConfig.Host, err)
 		}
-		defer func() {
-			err := tagMgr.Logout(ctx)
-			if err != nil {
-				log.Errorf("failed to logout tagManager for vCenter %q. Error: %v", vcConfig.Host, err)
-			}
-		}()
+
 		// Get tags for category reserved for preferred datastore tagging.
 		tagIds, err := tagMgr.ListTagsForCategory(ctx, PreferredDatastoresCategory)
 		if err != nil {

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -94,6 +94,11 @@ func CreateBlockVolumeUtil(
 		}
 	}
 
+	username, err := vc.ConfiguredOrActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
+
 	var clusterMorefs []vim25types.ManagedObjectReference
 	var datastoreInfoList []*vsphere.DatastoreInfo
 
@@ -103,7 +108,7 @@ func CreateBlockVolumeUtil(
 		clusterID = manager.CnsConfig.Global.SupervisorID
 	}
 	containerCluster := vsphere.GetContainerCluster(clusterID,
-		manager.CnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor,
+		username, clusterFlavor,
 		manager.CnsConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
@@ -455,10 +460,15 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{},
 		datastores = append(datastores, ds.Reference())
 	}
 
+	username, err := params.Vcenter.ConfiguredOrActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
+
 	var containerClusterArray []cnstypes.CnsContainerCluster
 	clusterID := params.CNSConfig.Global.ClusterID
 	containerCluster := vsphere.GetContainerCluster(clusterID,
-		params.CNSConfig.VirtualCenter[params.Vcenter.Config.Host].User, params.ClusterFlavor,
+		username, params.ClusterFlavor,
 		params.CNSConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
@@ -648,9 +658,14 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 	if useSupervisorId {
 		clusterID = cnsConfig.Global.SupervisorID
 	}
+
+	username, err := vc.ConfiguredOrActiveUser(ctx)
+	if err != nil {
+		return nil, csifault.CSIInternalFault, err
+	}
 	var containerClusterArray []cnstypes.CnsContainerCluster
 	containerCluster := vsphere.GetContainerCluster(clusterID,
-		cnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor,
+		username, clusterFlavor,
 		cnsConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25/types"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
@@ -335,12 +338,33 @@ func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Mock getVCenterInternal to return a mock VirtualCenter
 			originalGetVCenter := getVCenterInternal
+
+			// Create a new vcsim instance for use against govmomi client
+			model := simulator.VPX()
+			defer model.Remove()
+			err := model.Create()
+			require.NoError(t, err, "failed to create virtual VC for govmomi client")
+
+			// Create a vcsim server
+			s := model.Service.NewServer()
+			defer s.Close()
+
+			// Create a new client
+			client, err := govmomi.NewClient(context.Background(), s.URL, true)
+			require.NoError(t, err, "failed to create new govmomi client")
+
 			getVCenterInternal = func(_ context.Context, _ *Manager) (*vsphere.VirtualCenter, error) {
 				return &vsphere.VirtualCenter{
 					Config: &vsphere.VirtualCenterConfig{
-						Host:            "test-vc",
+						Host: "test-vc",
+						// Deliberately different from the CnsConfig user below, so
+						// the VSphereUser assertion shows which of the two the
+						// create spec is built from. In a real deployment both come
+						// from cfg.VirtualCenter[host].User and are equal.
+						Username:        "vc-config-user",
 						DatacenterPaths: []string{},
 					},
+					Client: client,
 				}, nil
 			}
 			defer func() { getVCenterInternal = originalGetVCenter }()
@@ -403,7 +427,7 @@ func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
 			// Call the actual CreateBlockVolumeUtil function
 			// Note that the cluster flavor does not have a significance for this test
 			// because it depends on the VolFromSnapshotOnTargetDs flag.
-			_, _, err := CreateBlockVolumeUtil(context.Background(), cnstypes.CnsClusterFlavorWorkload,
+			_, _, err = CreateBlockVolumeUtil(context.Background(), cnstypes.CnsClusterFlavorWorkload,
 				manager, spec, sharedDatastores, []string{}, opts, nil)
 
 			// Verify no error occurred
@@ -412,6 +436,11 @@ func TestCreateBlockVolumeFromSnapshotTargetDatastore(t *testing.T) {
 			// Verify the datastore behavior
 			assert.NotNil(t, capturedCreateSpec, "Create spec should have been captured")
 			assert.Len(t, capturedCreateSpec.Datastores, tc.expectedDatastoreCount, tc.description)
+
+			// The recorded user comes from the VirtualCenter's own config, not
+			// from CnsConfig.VirtualCenter[host].User.
+			assert.Equal(t, "vc-config-user", capturedCreateSpec.Metadata.ContainerCluster.VSphereUser,
+				"container cluster user should come from the vCenter config")
 
 			// Run the test case specific validation
 			tc.validateFunc(t, capturedCreateSpec.Datastores)

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -499,17 +499,11 @@ func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine,
 			nodeVM.VirtualCenterHost, err)
 	}
 	// Get tag manager instance.
-	tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+	tagManager, err := vcenter.GetTagManager(ctx)
 	if err != nil {
 		log.Errorf("failed to create tagManager. Error: %v", err)
 		return nil, err
 	}
-	defer func() {
-		err := tagManager.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout tagManager. Error: %v", err)
-		}
-	}()
 
 	// Create a map of TopologyCategories with category as key and value as empty string.
 	var isZoneRegion bool

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2345,6 +2345,23 @@ func updateTriggerCsiFullSyncInstance(ctx context.Context,
 	return nil
 }
 
+// vcConfigChanged reports whether newVCConfig differs from currentHost/
+// oldVCConfig in a way that requires reconnecting to vCenter with new
+// credentials, or whether the caller has already decided a reconnect is
+// required regardless (forceReconnect). Split out from ReloadConfiguration so
+// this comparison can be tested without the surrounding function's much
+// larger surface (VC connection, singleton reset, and process exit on
+// unrecoverable errors).
+func vcConfigChanged(currentHost string, oldVCConfig *cnsconfig.VirtualCenterConfig,
+	newVCConfig *cnsvsphere.VirtualCenterConfig, forceReconnect bool) bool {
+	return currentHost != newVCConfig.Host ||
+		oldVCConfig.User != newVCConfig.Username ||
+		oldVCConfig.Password != newVCConfig.Password ||
+		oldVCConfig.VCSessionManagerURL != newVCConfig.VCSessionManagerURL ||
+		oldVCConfig.VCSessionManagerToken != newVCConfig.VCSessionManagerToken ||
+		forceReconnect
+}
+
 // ReloadConfiguration reloads configuration from the secret, and update
 // controller's cached configs. The function takes metadatasyncerInformer and
 // reconnectToVCFromNewConfig as parameters. If reconnectToVCFromNewConfig
@@ -2440,10 +2457,14 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 		if newVCConfig != nil {
 			var vcenter *cnsvsphere.VirtualCenter
 			newVCConfig.ReloadVCConfigForNewClient = true
-			if metadataSyncer.host != newVCConfig.Host ||
-				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User != newVCConfig.Username ||
-				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].Password != newVCConfig.Password ||
-				reconnectToVCFromNewConfig {
+			vcConfig := metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host]
+			configChanged := true
+			if vcConfig != nil {
+				configChanged = vcConfigChanged(metadataSyncer.host, vcConfig, newVCConfig, reconnectToVCFromNewConfig)
+			} else {
+				log.Warnf("previous vCenter config for host %q not found during reload; forcing reconnect", metadataSyncer.host)
+			}
+			if configChanged {
 				// Verify if new configuration has valid credentials by connecting
 				// to vCenter. Proceed only if the connection succeeds, else return
 				// error.

--- a/pkg/syncer/metadatasyncer_test.go
+++ b/pkg/syncer/metadatasyncer_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,8 @@ import (
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	storagepolicyv1alpha2 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha2"
 	sqperiodicsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagequotaperiodicsync/v1alpha1"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 )
 
@@ -1517,6 +1520,86 @@ func TestUpdateStorageQuotaPeriodicSyncCR(t *testing.T) {
 
 			// The function handles errors gracefully by logging them
 			// We verify it completes execution without panicking
+		})
+	}
+}
+
+func TestVCConfigChanged(t *testing.T) {
+	baseOld := &cnsconfig.VirtualCenterConfig{
+		User:                  "administrator@vsphere.local",
+		Password:              "old-password",
+		VCSessionManagerURL:   "https://session-manager.tld/session",
+		VCSessionManagerToken: "old-token",
+	}
+	baseNew := func() *cnsvsphere.VirtualCenterConfig {
+		return &cnsvsphere.VirtualCenterConfig{
+			Host:                  "vc.tld",
+			Username:              baseOld.User,
+			Password:              baseOld.Password,
+			VCSessionManagerURL:   baseOld.VCSessionManagerURL,
+			VCSessionManagerToken: baseOld.VCSessionManagerToken,
+		}
+	}
+	const currentHost = "vc.tld"
+
+	testCases := []struct {
+		name           string
+		mutateNew      func(*cnsvsphere.VirtualCenterConfig)
+		forceReconnect bool
+		want           bool
+	}{
+		{
+			name:      "nothing changed",
+			mutateNew: func(c *cnsvsphere.VirtualCenterConfig) {},
+			want:      false,
+		},
+		{
+			name:           "force reconnect with nothing else changed",
+			mutateNew:      func(c *cnsvsphere.VirtualCenterConfig) {},
+			forceReconnect: true,
+			want:           true,
+		},
+		{
+			name:      "host changed",
+			mutateNew: func(c *cnsvsphere.VirtualCenterConfig) { c.Host = "other-vc.tld" },
+			want:      true,
+		},
+		{
+			name:      "username changed",
+			mutateNew: func(c *cnsvsphere.VirtualCenterConfig) { c.Username = "someone-else@vsphere.local" },
+			want:      true,
+		},
+		{
+			name:      "password changed",
+			mutateNew: func(c *cnsvsphere.VirtualCenterConfig) { c.Password = "new-password" },
+			want:      true,
+		},
+		{
+			name: "session manager URL changed",
+			mutateNew: func(c *cnsvsphere.VirtualCenterConfig) {
+				c.VCSessionManagerURL = "https://other-session-manager.tld/session"
+			},
+			want: true,
+		},
+		{
+			name:      "session manager token changed",
+			mutateNew: func(c *cnsvsphere.VirtualCenterConfig) { c.VCSessionManagerToken = "new-token" },
+			want:      true,
+		},
+		{
+			name:      "session manager token cleared",
+			mutateNew: func(c *cnsvsphere.VirtualCenterConfig) { c.VCSessionManagerToken = "" },
+			want:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			newVCConfig := baseNew()
+			tc.mutateNew(newVCConfig)
+
+			got := vcConfigChanged(currentHost, baseOld, newVCConfig, tc.forceReconnect)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/tests/e2e/gc_metadata_syncer.go
+++ b/tests/e2e/gc_metadata_syncer.go
@@ -30,6 +30,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -1211,8 +1212,19 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 
 		// Changing the reclaim policy of the pv to retain.
 		ginkgo.By("Changing the volume reclaim policy")
-		pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
-		pv, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latestPv, getErr := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			latestPv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
+			updatedPv, updateErr := client.CoreV1().PersistentVolumes().Update(ctx, latestPv, metav1.UpdateOptions{})
+			if updateErr != nil {
+				return updateErr
+			}
+			pv = updatedPv
+			return nil
+		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Delete the PVC")
@@ -1436,8 +1448,19 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 
 		// Changing the reclaim policy of the pv to retain.
 		ginkgo.By("Changing the volume reclaim policy")
-		pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
-		pv, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latestPv, getErr := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			latestPv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
+			updatedPv, updateErr := client.CoreV1().PersistentVolumes().Update(ctx, latestPv, metav1.UpdateOptions{})
+			if updateErr != nil {
+				return updateErr
+			}
+			pv = updatedPv
+			return nil
+		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Delete the PVC")


### PR DESCRIPTION
## Summary
Squashed backport to `release-3.7` of two master commits:

- 84622818 — Add support for authenticating vCenter via a shared session manager (#4031)
- 08ec13fe — Don't fail login() when only the REST login fails (#4253)

**Feature:** a session manager can hand CSI a cloned vCenter session (`vc-session-manager-url` / `vc-session-manager-token` config), so many clusters can share sessions against one vCenter instead of each maintaining its own, avoiding vCenter session exhaustion at scale.

**Resiliency fix:** `login()` no longer fails the whole connection when only the REST (vAPI) half fails. A REST-only outage previously blocked driver startup and reconnects even though CNS/volume operations need only the SOAP session. Now the SOAP session is kept and REST is retried on the next `connect()`, with a cooldown after an authentication rejection to avoid spending vCenter's SSO lockout budget.

Both commits needed conflict resolution against this branch's older codebase. Where a hunk depended on master-only infrastructure that was never backported to `release-3.7`, it was either adapted to stand alone or dropped:

### From 84622818 (session manager)
- Dropped `ReRegisterVolume` (pkg/common/cns-lib/volume/manager.go): depends on `clusterId`/`clusterDistribution` fields and fault helpers from PR #3788, which landed on release-3.8 but was never backported to release-3.7. Nothing else on this branch calls it.
- Dropped `TestCreateBlockVolumeLinkedCloneHostLocalUsesDatastoresNotHosts`: exercises a `Hosts` field on `CnsVolumeCreateSpec` that only exists in a newer govmomi (v0.55.1) than this branch vendors (v0.53.0). Kept the rest of that file's diff.
- Re-derived the `metadatasyncer_test.go` conflict by hand after the initial automatic resolution pulled in ~1000 lines of unrelated master-only VAC/StoragePolicyUsage v1alpha3 migration tests that don't exist on this branch. Replaced with the real upstream diff: one import addition plus `TestVCConfigChanged`.
- Everything else (the session manager feature itself, `ConfiguredOrActiveUser`, config plumbing, and tests) is unchanged from the original commit.

### From 08ec13fe (REST-login resiliency)
- `restLoginCooldown` and `isRestAuthFailure` depend on a `Connect()`-level InvalidLogin retry loop (`maxLoginRetries`/`retryDelay`) that exists on master but not on this branch. Adapted rather than dropped: `restLoginCooldown` is now a standalone `3 * time.Minute` constant, and the small, self-contained `IsInvalidLoginError` helper was ported into `utils.go` so `isRestAuthFailure` works unchanged.
- Everything else (`restLogin`/`repairRestSession`, cooldown tracking, `issueSTSSigner`, and their tests) is taken as-is, plus an unrelated e2e retry-on-conflict fix bundled into the same upstream commit.

## Test plan
- [x] `go build ./...` clean (aside from a pre-existing, unrelated `crypto/tls/fipsonly` toolchain issue in `pkg/syncer/admissionhandler`, not touched by this change)
- [x] `go vet` clean on all touched packages
- [x] `go test` passes on all touched packages (`pkg/common/cns-lib/...`, `pkg/csi/service/common/...`, `pkg/syncer/...`)