### PR TITLE
Fix flaky concurrent pod verification in CnsNodeVmAttachment e2e test

### DIFF
--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -243,8 +244,11 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 		}()
 
 		ginkgo.By("Create 2 Pods concurrently with these PVCs mounted as volumes")
-		go verifyPodCreation(ctx, f, client, namespace, pvc1, pv1)
-		verifyPodCreation(ctx, f, client, namespace, pvc2, pv2)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go verifyPodCreation(ctx, f, client, namespace, pvc1, pv1, &wg)
+		verifyPodCreation(ctx, f, client, namespace, pvc2, pv2, nil)
+		wg.Wait()
 
 	})
 

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2856,8 +2856,11 @@ func verifyIsDetachedInSupervisor(ctx context.Context, f *framework.Framework,
 // verifyPodCreation helps to create/verify and delete the pod in given
 // namespace. It takes client, namespace, pvc, pv as input.
 func verifyPodCreation(ctx context.Context, f *framework.Framework, client clientset.Interface, namespace string,
-	pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) {
+	pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, wg *sync.WaitGroup) {
 	defer ginkgo.GinkgoRecover()
+	if wg != nil {
+		defer wg.Done()
+	}
 	ginkgo.By("Create pod and wait for this to be in running phase")
 	pod, err := createPod(ctx, client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2872,12 +2875,13 @@ func verifyPodCreation(ctx context.Context, f *framework.Framework, client clien
 	expectedInstanceName := pod.Spec.NodeName + "-" + svcPVCName
 	vcVersion = getVCversion(ctx, vcAddress)
 	isBatchAttachSupported := isVersionGreaterOrEqual(vcVersion, batchAttachSupportedVCVersion)
+	crdNameToVerify := crdCNSNodeVMAttachment
 	if isBatchAttachSupported {
 		expectedInstanceName = pod.Spec.NodeName
+		crdNameToVerify = crdCNSNodeVMBatchAttachment
 	}
 	verifyCRDInSupervisorWithWait(ctx, f, expectedInstanceName,
-		crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
-	// TODO for batchAttach
+		crdNameToVerify, crdVersion, crdGroup, true)
 	verifyIsAttachedInSupervisor(ctx, f, pod.Spec.NodeName, svcPVCName, crdVersion, crdGroup)
 
 	ginkgo.By("Deleting the pod")
@@ -2892,7 +2896,7 @@ func verifyPodCreation(ctx context.Context, f *framework.Framework, client clien
 
 	ginkgo.By("Verify CnsNodeVmAttachment CRDs are deleted")
 	verifyCRDInSupervisorWithWait(ctx, f, expectedInstanceName,
-		crdCNSNodeVMAttachment, crdVersion, crdGroup, false)
+		crdNameToVerify, crdVersion, crdGroup, false)
 
 }
 
@@ -2911,8 +2915,9 @@ func verifyCRDInSupervisorWithWait(ctx context.Context, f *framework.Framework,
 	resourceClient := dynamicClient.Resource(gvr).Namespace("")
 	var instanceFound bool
 
-	const timeout time.Duration = 30
+	const timeout time.Duration = 2 * time.Minute
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
+		instanceFound = false
 		list, err := resourceClient.List(ctx, metav1.ListOptions{})
 		if err != nil || list == nil {
 			continue
@@ -2952,11 +2957,14 @@ func verifyCRDInSupervisorWithWait(ctx context.Context, f *framework.Framework,
 				}
 			}
 		}
-		if isCreated {
-			gomega.Expect(instanceFound).To(gomega.BeTrue())
-		} else {
-			gomega.Expect(instanceFound).To(gomega.BeFalse())
+		if instanceFound == isCreated {
+			return
 		}
+	}
+	if isCreated {
+		gomega.Expect(instanceFound).To(gomega.BeTrue())
+	} else {
+		gomega.Expect(instanceFound).To(gomega.BeFalse())
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- `verifyPodCreation` was launched in an unjoined goroutine for the first pod in the "Verify CnsNodeVmAttachements crd existence when pods are created concurrently" test, so the test's deferred PVC cleanup and `AfterEach` could run before that goroutine finished. This deleted the PVCs out from under a pod still coming up, and the resulting assertion failure was misattributed to `AfterEach`. Fixed by synchronizing the goroutine with a `sync.WaitGroup`.
- Fixed `verifyCRDInSupervisorWithWait`'s retry timeout, which was declared as `30` (nanoseconds) instead of `30 * time.Second`, making its polling loop effectively a single no-op check.

**Testing done**:
Yes
