### PR TITLE
Fix staticcheck incompatibility with newer Go export data format

### DIFF
--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -25,7 +25,7 @@ go version
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-go install honnef.co/go/tools/cmd/staticcheck@2025.1
+go install honnef.co/go/tools/cmd/staticcheck@latest
 
 GOOS=linux "$(go env GOPATH)"/bin/staticcheck --version
 

--- a/pkg/csi/service/wcpguest/controller_timeout_test.go
+++ b/pkg/csi/service/wcpguest/controller_timeout_test.go
@@ -1364,7 +1364,7 @@ func TestControllerUnpublishForBlockVolumeWatchTermination(t *testing.T) {
 			guestClient:         testclient.NewClientset(),
 			supervisorNamespace: namespace,
 			vmWatcher: &cache.ListWatch{
-				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				WatchFuncWithContext: func(_ context.Context, options metav1.ListOptions) (watch.Interface, error) {
 					return fakeWatch, nil
 				},
 			},
@@ -1459,7 +1459,7 @@ func TestControllerPublishStaleAfterPatch(t *testing.T) {
 		guestClient:         guestClient,
 		supervisorNamespace: namespace,
 		vmWatcher: &cache.ListWatch{
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFuncWithContext: func(_ context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				return fakeWatch, nil
 			},
 		},


### PR DESCRIPTION
staticcheck@2025.1 cannot decode the export data format emitted by Go 1.27, causing "export data version 4 is greater than maximum supported version 2" failures in CI. Bump the staticcheck install to @latest so it tracks newer Go toolchains.

This surfaces a genuine SA1019 finding: cache.ListWatch.WatchFunc is deprecated in favor of WatchFuncWithContext. Update both test call sites accordingly.

Testing Done: Yes