### PR TITLE
Fix stale CnsClient/PbmClient/VsanClient/VslmClient after a failed vCenter reconnect

### DIFF
--- a/pkg/common/cns-lib/vsphere/connect_rest_repair_test.go
+++ b/pkg/common/cns-lib/vsphere/connect_rest_repair_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	cnssim "github.com/vmware/govmomi/cns/simulator"
+	pbmsim "github.com/vmware/govmomi/pbm/simulator"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
@@ -33,7 +36,9 @@ func restClientTo(t *testing.T, rawURL string) *rest.Client {
 	return rest.NewClient(&vim25.Client{Client: soap.NewClient(u, true)})
 }
 
-// vcsimFor starts a vcsim instance and returns its host and port.
+// vcsimFor starts a vcsim instance, with the CNS and PBM APIs registered so
+// tests can build real, working clients against it, and returns its host and
+// port.
 func vcsimFor(t *testing.T) (string, int) {
 	t.Helper()
 	confPath := filepath.Join(t.TempDir(), "csi-vsphere.conf")
@@ -50,10 +55,25 @@ func vcsimFor(t *testing.T) (string, int) {
 	model.Service.RegisterEndpoints = true
 	server := model.Service.NewServer()
 	t.Cleanup(server.Close)
+	model.Service.RegisterSDK(cnssim.New())
+	model.Service.RegisterSDK(pbmsim.New())
 
 	port, err := strconv.Atoi(server.URL.Port())
 	require.NoError(t, err)
 	return server.URL.Hostname(), port
+}
+
+// unreachableAddr returns a host:port that refuses TCP connections, standing
+// in for vpxd being briefly unreachable mid-patch.
+func unreachableAddr(t *testing.T) (string, int) {
+	t.Helper()
+	server := httptest.NewServer(http.NotFoundHandler())
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	server.Close() // now refuses connections
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+	return u.Hostname(), port
 }
 
 // connectedVC returns a VirtualCenter with a live SOAP session against vcsim.
@@ -211,4 +231,82 @@ func TestRepairRestSessionTimesOut(t *testing.T) {
 
 	assert.Same(t, soapClient, vc.Client,
 		"giving up on the rest login should leave the SOAP session in place")
+}
+
+// TestConnectRecreatesStaleDependentClients reproduces a vCenter service
+// disruption (an in-place patch restarting vpxd/vsanvcmgmtd) that makes
+// exactly one reconnect attempt fail after the session has already gone
+// bad. Before this fix, NewClient()'s failure
+// nulled vc.Client (every one of its error paths returns (nil, nil, err),
+// and that was assigned straight into vc.Client/vc.RestClient), so the
+// *next*, successful connect() took the "client was never initialized"
+// branch and returned early without rebuilding CnsClient -- leaving it
+// bound to the vim25 client from before the disruption indefinitely, since
+// connect()'s own health check only ever looks at vc.Client, which by then
+// is healthy again. That is why the driver kept failing every CNS call with
+// NotAuthenticated long after vCenter itself had recovered.
+func TestConnectRecreatesStaleDependentClients(t *testing.T) {
+	ctx := context.Background()
+	host, port := vcsimFor(t)
+	vc := connectedVC(t, ctx, host, port)
+
+	require.NoError(t, vc.ConnectCns(ctx), "initial ConnectCns should succeed")
+
+	originalClient := vc.Client
+	staleCnsClient := vc.CnsClient
+	require.NotNil(t, staleCnsClient)
+
+	// Kill the session server-side, so the next connect() sees it as invalid
+	// and attempts a full re-login -- the same trigger a vCenter service
+	// restart produces.
+	require.NoError(t, vc.Client.Logout(ctx))
+
+	// Point at an address that refuses connections, so the reconnect
+	// NewClient() call fails exactly once.
+	downHost, downPort := unreachableAddr(t)
+	realHost, realPort := vc.Config.Host, vc.Config.Port
+	vc.Config.Host, vc.Config.Port = types.NewFQDN(downHost), downPort
+
+	err := vc.connect(ctx)
+	require.Error(t, err, "a reconnect attempt against an unreachable vCenter should fail")
+	assert.Same(t, originalClient, vc.Client,
+		"a failed reconnect attempt must not null out vc.Client -- that is what let connect() "+
+			"skip rebuilding CnsClient on the next, successful attempt")
+
+	// vCenter is back: restore the real address and let the next connect()
+	// succeed.
+	vc.Config.Host, vc.Config.Port = realHost, realPort
+	require.NoError(t, vc.connect(ctx))
+
+	assert.NotSame(t, originalClient, vc.Client,
+		"the session was invalid, so connect() should have built a fresh client")
+	require.NotNil(t, vc.CnsClient)
+	assert.NotSame(t, staleCnsClient, vc.CnsClient,
+		"CnsClient must be rebuilt on the fresh vim25 client, not left bound to the one "+
+			"that existed before the disruption")
+}
+
+// TestDisconnectClearsDependentClients covers the second path to the same
+// staleness: Disconnect() used to nil only vc.Client/vc.RestClient, leaving
+// PbmClient/CnsClient/VsanClient/VslmClient non-nil and bound to the session
+// it had just logged out. A subsequent connect() that takes the "client was
+// never initialized" branch (vc.Client == nil) has no reason to look at
+// them, so they would stay stale indefinitely.
+func TestDisconnectClearsDependentClients(t *testing.T) {
+	ctx := context.Background()
+	host, port := vcsimFor(t)
+	vc := connectedVC(t, ctx, host, port)
+
+	require.NoError(t, vc.ConnectCns(ctx))
+	require.NoError(t, vc.ConnectPbm(ctx))
+	require.NotNil(t, vc.CnsClient)
+	require.NotNil(t, vc.PbmClient)
+
+	require.NoError(t, vc.Disconnect(ctx))
+
+	assert.Nil(t, vc.Client)
+	assert.Nil(t, vc.RestClient)
+	assert.Nil(t, vc.CnsClient, "Disconnect must drop CnsClient too, or a future connect() "+
+		"that takes the initialisation branch would leave it bound to the session just logged out")
+	assert.Nil(t, vc.PbmClient)
 }

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -565,29 +565,19 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			}
 		}
 		log.Infof("VirtualCenter.connect() creating new client")
-		// Assign through locals: NewClient returns (nil, nil, err) on every one
-		// of its failure paths, so assigning its results straight into
-		// vc.Client/vc.RestClient would null them out on failure and break the
-		// invariant documented above.
-		var client *govmomi.Client
-		var restClient *rest.Client
-		if client, restClient, err = vc.NewClient(ctx, useragent); err != nil {
+		if vc.Client, vc.RestClient, err = vc.NewClient(ctx, useragent); err != nil {
 			log.Errorf("failed to create govmomi client with err: %v", err)
 			if !vc.Config.Insecure {
 				log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 			}
 			return err
 		}
-		vc.Client, vc.RestClient = client, restClient
 
-		// Rebuild the dependent clients here too, symmetric with the relogin
-		// branch below. Nothing today reaches this branch with a dependent
-		// client still bound to an earlier vc.Client -- Disconnect() nils them
-		// together, and a failed NewClient() above leaves vc.Client untouched
-		// -- but keeping both branches doing this rebuild means that
-		// invariant does not have to be re-verified by hand every time
-		// either one changes.
-		if err := vc.recreateDependentClients(ctx); err != nil {
+		// Keep this branch consistent with the relogin branch below: if a
+		// dependent client is somehow still set while vc.Client was nil, it is
+		// bound to a vim25 client that no longer exists, and nothing later in
+		// connect() would notice -- the session checks only look at vc.Client.
+		if err := vc.updateDependentClients(ctx); err != nil {
 			return err
 		}
 
@@ -697,15 +687,18 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 	vc.Client, vc.RestClient = client, restClient
 	vc.restLoginCooldownUntil = time.Time{}
 
-	return vc.recreateDependentClients(ctx)
+	return vc.updateDependentClients(ctx)
 }
 
-// recreateDependentClients rebuilds every client that was constructed on top of
-// vc.Client's vim25 client, so none of them keeps using a session that
-// vc.Client has already moved on from. Clients that were never created are left
-// nil: their ConnectXxx helpers build them on demand from the current
-// vc.Client.
-func (vc *VirtualCenter) recreateDependentClients(ctx context.Context) error {
+// updateDependentClients points every already-created dependent client at
+// vc.Client's current vim25 client, so none of them keeps using a session that
+// vc.Client has already moved on from.
+//
+// Call this only from connect(), immediately after vc.Client has been replaced
+// with a freshly built one -- it rebuilds against whatever vc.Client currently
+// holds. Clients that were never created are left nil: their ConnectXxx helpers
+// build them on demand from the current vc.Client.
+func (vc *VirtualCenter) updateDependentClients(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 	var err error
 

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -565,11 +565,29 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			}
 		}
 		log.Infof("VirtualCenter.connect() creating new client")
-		if vc.Client, vc.RestClient, err = vc.NewClient(ctx, useragent); err != nil {
+		// Assign through locals: NewClient returns (nil, nil, err) on every one
+		// of its failure paths, so assigning its results straight into
+		// vc.Client/vc.RestClient would null them out on failure and break the
+		// invariant documented above.
+		var client *govmomi.Client
+		var restClient *rest.Client
+		if client, restClient, err = vc.NewClient(ctx, useragent); err != nil {
 			log.Errorf("failed to create govmomi client with err: %v", err)
 			if !vc.Config.Insecure {
 				log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 			}
+			return err
+		}
+		vc.Client, vc.RestClient = client, restClient
+
+		// Rebuild the dependent clients here too, symmetric with the relogin
+		// branch below. Nothing today reaches this branch with a dependent
+		// client still bound to an earlier vc.Client -- Disconnect() nils them
+		// together, and a failed NewClient() above leaves vc.Client untouched
+		// -- but keeping both branches doing this rebuild means that
+		// invariant does not have to be re-verified by hand every time
+		// either one changes.
+		if err := vc.recreateDependentClients(ctx); err != nil {
 			return err
 		}
 
@@ -665,14 +683,32 @@ func (vc *VirtualCenter) connect(ctx context.Context) error {
 			return err
 		}
 	}
-	if vc.Client, vc.RestClient, err = vc.NewClient(ctx, useragent); err != nil {
+	// Assign through locals for the same reason as the initialisation branch
+	// above: a failed NewClient must not leave vc.Client nil.
+	var client *govmomi.Client
+	var restClient *rest.Client
+	if client, restClient, err = vc.NewClient(ctx, useragent); err != nil {
 		log.Errorf("failed to create govmomi client with err: %v", err)
 		if !vc.Config.Insecure {
 			log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 		}
 		return err
 	}
+	vc.Client, vc.RestClient = client, restClient
 	vc.restLoginCooldownUntil = time.Time{}
+
+	return vc.recreateDependentClients(ctx)
+}
+
+// recreateDependentClients rebuilds every client that was constructed on top of
+// vc.Client's vim25 client, so none of them keeps using a session that
+// vc.Client has already moved on from. Clients that were never created are left
+// nil: their ConnectXxx helpers build them on demand from the current
+// vc.Client.
+func (vc *VirtualCenter) recreateDependentClients(ctx context.Context) error {
+	log := logger.GetLogger(ctx)
+	var err error
+
 	// Recreate PbmClient if created using timed out VC Client.
 	if vc.PbmClient != nil {
 		if vc.PbmClient, err = pbm.NewClient(ctx, vc.Client.Client); err != nil {
@@ -923,8 +959,15 @@ func (vc *VirtualCenter) Disconnect(ctx context.Context) error {
 			log.Infof("failed to logout rest with err: %v", err)
 		}
 	}
+	// Drop the dependent clients too. They are built on the vim25 client that
+	// was just logged out, so leaving them non-nil while vc.Client is nil is
+	// exactly the state that strands them on a dead session.
 	vc.Client = nil
 	vc.RestClient = nil
+	vc.PbmClient = nil
+	vc.CnsClient = nil
+	vc.VsanClient = nil
+	vc.VslmClient = nil
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
After a vCenter service disruption, the CSI driver can be left with a valid main vCenter connection but a stale CNS connection. Every CNS operation then fails with ServerFaultCode: NotAuthenticated indefinitely — even though vCenter is fully healthy — until the vsphere-csi-controller pod is restarted.

This PR fixes the stale CnsClient/PbmClient/VsanClient/VslmClient after a failed vCenter reconnect by preserving vc.Client on NewClient() failure and always rebuilding dependent clients on success.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/2001/ (passed)
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/2006/ (passed)
VKS pre-check pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1573/ (passed)

Testing results are [here](https://gist.github.com/xing-yang/e5f3225b8a534536f1e49009ef53cc2e#file-cns-connection-md).

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix stale CnsClient/PbmClient/VsanClient/VslmClient after a failed vCenter reconnect by preserving vc.Client on NewClient() failure and always rebuilding dependent clients on success.
```
