### PR TITLE
Pick the right StorageClass during CnsRegisterVolume

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -585,25 +585,34 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	// Use cached K8s client for registration operations.
 	k8sclient := r.k8sclient
 
-	var storageClassName string
-	if instance.Spec.StorageClassName != "" {
-		// Already resolved and verified as assigned to this namespace before the CNS volume was
-		// created; no need to re-derive or re-validate it here.
-		storageClassName = instance.Spec.StorageClassName
-	} else {
-		// Get K8S storageclass name mapping the storagepolicy id with Immediate volume binding mode
-		storageClassName, err = getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx, k8sclient, r.client,
-			volume.StoragePolicyId, request.Namespace, syncer.IsPodVMOnStretchSupervisorFSSEnabled)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to find K8S Storageclass mapping storagepolicyId: %s and assigned to namespace: %s",
-				volume.StoragePolicyId, request.Namespace)
-			log.Error(msg)
-			setInstanceError(ctx, r, instance, msg)
-			return reconcile.Result{RequeueAfter: timeout}, nil
-		}
-		log.Infof("Volume with storagepolicyId: %s is mapping to K8S storage class: %s and assigned to namespace: %s",
-			volume.StoragePolicyId, storageClassName, request.Namespace)
+	// Check if PVC already exists and has valid DataSourceRef. Fetch this before resolving
+	// storageClassName below: when the PVC already declares a StorageClass, that's the ground
+	// truth of what the caller actually asked for, and is preferred over independently
+	// re-deriving a name from the volume's storage policy ID -- which is ambiguous whenever more
+	// than one StorageClass shares the same storagePolicyID (e.g. after a policy rename leaves an
+	// old and a new StorageClass both pointing at the same policy ID).
+	// Do this check before creating a PV. Otherwise, PVC will be bound to PV after PV
+	// is created even if validation fails.
+	pvc, err := checkExistingPVCDataSourceRef(ctx, k8sclient, instance.Spec.PvcName, instance.Namespace)
+	if err != nil {
+		log.Errorf("Failed to check existing PVC %s/%s with DataSourceRef: %+v", instance.Namespace,
+			instance.Spec.PvcName, err)
+		setInstanceError(ctx, r, instance, fmt.Sprintf("Failed to check existing PVC %s/%s with DataSourceRef: %+v",
+			instance.Namespace, instance.Spec.PvcName, err))
+		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
+
+	storageClassName, err := resolveStorageClassNameForRegistration(ctx, k8sclient, r.client, instance, pvc,
+		volume.StoragePolicyId, request.Namespace, syncer.IsPodVMOnStretchSupervisorFSSEnabled)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to resolve K8S Storageclass for storagepolicyId: %s in namespace: %s. Error: %+v",
+			volume.StoragePolicyId, request.Namespace, err)
+		log.Error(msg)
+		setInstanceError(ctx, r, instance, msg)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+	log.Infof("Volume with storagepolicyId: %s is mapping to K8S storage class: %s and assigned to namespace: %s",
+		volume.StoragePolicyId, storageClassName, request.Namespace)
 
 	sc, err := k8sclient.StorageV1().StorageClasses().Get(ctx, storageClassName, metav1.GetOptions{})
 	if err != nil {
@@ -686,17 +695,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		}
 	}
 
-	// Check if PVC already exists and has valid DataSourceRef
-	// Do this check before creating a PV. Otherwise, PVC will be bound to PV after PV
-	// is created even if validation fails
-	pvc, err := checkExistingPVCDataSourceRef(ctx, k8sclient, instance.Spec.PvcName, instance.Namespace)
-	if err != nil {
-		log.Errorf("Failed to check existing PVC %s/%s with DataSourceRef: %+v", instance.Namespace,
-			instance.Spec.PvcName, err)
-		setInstanceError(ctx, r, instance, fmt.Sprintf("Failed to check existing PVC %s/%s with DataSourceRef: %+v",
-			instance.Namespace, instance.Spec.PvcName, err))
-		return reconcile.Result{RequeueAfter: timeout}, nil
-	}
+	// pvc was already fetched above (before storageClassName resolution).
 
 	// If existing PVC has DataSourceRef and volumeMode set, handle volumeMode validation and inheritance
 	volumeModeInherited := false

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller_test.go
@@ -837,9 +837,22 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 				AccessMode:  "ReadWriteOnce",
 			},
 		}
+		// The suite runs with syncer.IsPodVMOnStretchSupervisorFSSEnabled = true, so namespace
+		// assignment (read by resolveStorageClassNameForRegistration, since the PVC below declares
+		// a StorageClass) is expressed via a StoragePolicyQuota CR rather than a ResourceQuota.
+		_ = cnsstoragepolicyquotasv1alpha3.AddToScheme(scheme)
+		spq := &cnsstoragepolicyquotasv1alpha3.StoragePolicyQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-sc-spq", Namespace: "test-ns"},
+			Spec:       cnsstoragepolicyquotasv1alpha3.StoragePolicyQuotaSpec{StoragePolicyId: "dummy-storage-policy-id"},
+			Status: cnsstoragepolicyquotasv1alpha3.StoragePolicyQuotaStatus{
+				SCLevelQuotaStatuses: []cnsstoragepolicyquotasv1alpha3.SCLevelQuotaStatus{
+					{StorageClassName: storageClassName},
+				},
+			},
+		}
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(diskURLCR).
+			WithObjects(diskURLCR, spq).
 			Build()
 
 		var unregCalled bool
@@ -865,7 +878,10 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 				StorageClassName: &storageClassName,
 			},
 		}
-		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: storageClassName}}
+		sc := &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{Name: storageClassName},
+			Parameters: map[string]string{scParamStoragePolicyID: "dummy-storage-policy-id"},
+		}
 		k8sclientFake := k8sfake.NewClientset(pvc, sc)
 
 		diskURLReconciler := &ReconcileCnsRegisterVolume{
@@ -884,7 +900,7 @@ var _ = Describe("Reconcile Accessibility Logic", func() {
 			return &cnstypes.CnsVolume{
 				VolumeId:        cnstypes.CnsVolumeId{Id: volumeID},
 				DatastoreUrl:    "dummy-ds-url",
-				StoragePolicyId: "dummy-policy-id",
+				StoragePolicyId: "dummy-storage-policy-id",
 				BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
 					CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
 				},

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -345,11 +346,25 @@ const scParamStoragePolicyID = "storagePolicyID"
 
 // getStoragePolicyIDForStorageClass fetches the named StorageClass and returns the vSphere
 // storage policy ID carried in its storagePolicyID parameter.
+//
+// It also rejects a WaitForFirstConsumer StorageClass (e.g. the "-latebinding" companion wcpsvc
+// creates alongside every Immediate StorageClass for the same storagePolicyID): that binding mode
+// exists to delay dynamic provisioning until a consuming pod is scheduled, which has no meaning
+// for CnsRegisterVolume's static registration of an already-provisioned volume. All of this
+// function's callers -- the early instance.Spec.StorageClassName validation in Reconcile, the CNS
+// create-spec profile lookup, and the PVC-trust tier of resolveStorageClassNameForRegistration --
+// resolve the StorageClass to use for a CnsRegisterVolume, so the same rule applies uniformly
+// regardless of whether the name came from the CR, the PVC, or (for the ambiguous
+// policy-ID-only case) getK8sStorageClassNameWithImmediateBindingModeForPolicy's own filter.
 func getStoragePolicyIDForStorageClass(ctx context.Context, k8sClient clientset.Interface,
 	scName string) (string, error) {
 	sc, err := k8sClient.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch StorageClass %q: %w", scName, err)
+	}
+	if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
+		return "", fmt.Errorf("StorageClass %q uses WaitForFirstConsumer binding, which is not valid "+
+			"for CnsRegisterVolume; use the corresponding Immediate-binding StorageClass instead", scName)
 	}
 	policyID := sc.Parameters[scParamStoragePolicyID]
 	if policyID == "" {
@@ -488,6 +503,17 @@ func isStoragePolicyAssignedToNamespace(ctx context.Context, k8sClient clientset
 
 // getK8sStorageClassNameWithImmediateBindingModeForPolicy gets the storage class name in K8S mapping the vsphere
 // storagepolicy id. The policy must also be assigned to the passed namespace.
+//
+// A storagePolicyID is not guaranteed to map to a single StorageClass: e.g. renaming a storage
+// policy in vCenter can leave an old and a new StorageClass both pointing at the same policy ID
+// (see the sgc1-raid-1 / sgc1-raid-1-mirroring-0 case). This function collects every
+// Immediate-binding candidate and narrows to the ones whose policy is actually assigned to the
+// namespace. Callers of this function have no way to state which StorageClass name they actually
+// want (that preference, if any, is expected to already have been honored via
+// instance.Spec.StorageClassName or the PVC's own StorageClassName before falling back to this
+// policy-ID-based lookup -- see resolveStorageClassNameForRegistration), so when more than one
+// candidate remains, this picks the lexicographically smallest name for a stable, reproducible
+// result and logs a warning rather than failing the registration outright.
 func getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx context.Context, k8sClient clientset.Interface,
 	client ctrlruntimeclient.Client, storagePolicyID string, namespace string,
 	isPodVMOnStretchedSupervisorEnabled bool) (string, error) {
@@ -496,31 +522,97 @@ func getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx context.Context
 	if err != nil {
 		return "", logger.LogNewErrorf(log, "Failed to get Storageclasses from API server. Error: %+v", err)
 	}
-	var scName string
+
+	var candidates []string
 	for _, sc := range scList.Items {
-		scParams := sc.Parameters
-		for paramName, val := range scParams {
-			param := strings.ToLower(paramName)
-			if param == common.AttributeStoragePolicyID && val == storagePolicyID {
-				if *sc.VolumeBindingMode != storagev1.VolumeBindingWaitForFirstConsumer {
-					scName = sc.Name
-					break
-				}
+		if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
+			continue
+		}
+		for paramName, val := range sc.Parameters {
+			if strings.ToLower(paramName) == common.AttributeStoragePolicyID && val == storagePolicyID {
+				candidates = append(candidates, sc.Name)
+				break
 			}
 		}
 	}
 
-	assigned, err := isStoragePolicyAssignedToNamespace(ctx, k8sClient, client, storagePolicyID, scName,
-		namespace, isPodVMOnStretchedSupervisorEnabled)
-	if err != nil {
-		return "", err
+	var assignedCandidates []string
+	for _, scName := range candidates {
+		assigned, err := isStoragePolicyAssignedToNamespace(ctx, k8sClient, client, storagePolicyID, scName,
+			namespace, isPodVMOnStretchedSupervisorEnabled)
+		if err != nil {
+			return "", err
+		}
+		if assigned {
+			assignedCandidates = append(assignedCandidates, scName)
+		}
 	}
-	if assigned {
-		return scName, nil
+
+	switch len(assignedCandidates) {
+	case 0:
+		return "", logger.LogNewErrorf(log, "Failed to find matching K8s Storageclass. "+
+			"Either storagepolicyId: %s doesn't match any storage class, or the policy is not assigned to namespace: %s",
+			storagePolicyID, namespace)
+	case 1:
+		return assignedCandidates[0], nil
+	default:
+		sort.Strings(assignedCandidates)
+		log.Warnf("storagepolicyId: %s maps to multiple StorageClasses assigned to namespace %s: %v. "+
+			"Picking %q deterministically; set spec.storageClassName on the CnsRegisterVolume or on the "+
+			"PVC to choose a specific one.", storagePolicyID, namespace, assignedCandidates, assignedCandidates[0])
+		return assignedCandidates[0], nil
 	}
-	return "", logger.LogNewErrorf(log, "Failed to find matching K8s Storageclass. "+
-		"Either storagepolicyId: %s doesn't match any storage class, or the policy is not assigned to namespace: %s",
-		storagePolicyID, namespace)
+}
+
+// resolveStorageClassNameForRegistration determines which K8s StorageClass name should be used
+// for the volume being registered, in order of preference:
+//
+//  1. instance.Spec.StorageClassName, if set. The caller (Reconcile) has already verified this is
+//     assigned to the namespace before any CNS volume was created, so it's trusted as-is here.
+//  2. The existing PVC's own declared StorageClassName, if the PVC already exists and specifies
+//     one. This is the ground truth of what the caller (e.g. VM Operator) actually asked for, and
+//     is preferred over independently re-deriving a name from the volume's storage policy ID --
+//     which is ambiguous whenever more than one StorageClass shares the same storagePolicyID. The
+//     PVC's choice is still validated here: its StorageClass must map to the volume's actual
+//     storage policy, and must be assigned to the namespace.
+//  3. Otherwise, derive the name from the volume's storage policy ID via
+//     getK8sStorageClassNameWithImmediateBindingModeForPolicy.
+func resolveStorageClassNameForRegistration(ctx context.Context, k8sClient clientset.Interface,
+	client ctrlruntimeclient.Client, instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
+	pvc *v1.PersistentVolumeClaim, volumeStoragePolicyID, namespace string,
+	isPodVMOnStretchedSupervisorEnabled bool) (string, error) {
+	if instance.Spec.StorageClassName != "" {
+		return instance.Spec.StorageClassName, nil
+	}
+
+	if pvc != nil && pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
+		candidate := *pvc.Spec.StorageClassName
+
+		policyID, err := getStoragePolicyIDForStorageClass(ctx, k8sClient, candidate)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve storage policy for PVC %s's StorageClass %q: %w",
+				pvc.Name, candidate, err)
+		}
+		if policyID != volumeStoragePolicyID {
+			return "", fmt.Errorf("PVC %s has storage class %q (storage policy %q), but volume maps to "+
+				"storage policy %q", pvc.Name, candidate, policyID, volumeStoragePolicyID)
+		}
+
+		assigned, err := isStoragePolicyAssignedToNamespace(ctx, k8sClient, client, policyID, candidate,
+			namespace, isPodVMOnStretchedSupervisorEnabled)
+		if err != nil {
+			return "", fmt.Errorf("failed to verify StorageClass %q is assigned to namespace %q: %w",
+				candidate, namespace, err)
+		}
+		if !assigned {
+			return "", fmt.Errorf("PVC %s's storage class %q is not assigned to namespace %q",
+				pvc.Name, candidate, namespace)
+		}
+		return candidate, nil
+	}
+
+	return getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx, k8sClient, client,
+		volumeStoragePolicyID, namespace, isPodVMOnStretchedSupervisorEnabled)
 }
 
 // getPersistentVolumeSpec creates a PV spec for the given params. Caller supplies capacity

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util_test.go
@@ -26,8 +26,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
+	cnsstoragepolicyquotasv1alpha3 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha3"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 )
 
@@ -321,4 +330,341 @@ func TestGetPersistentVolumeSpec_VolumeModeFilesystem(t *testing.T) {
 		)
 	}
 
+}
+
+// newImmediateSC and newWFFCSC build StorageClass fixtures for a given storagePolicyID, with
+// Immediate and WaitForFirstConsumer binding modes respectively.
+func newImmediateSC(name, storagePolicyID string) *storagev1.StorageClass {
+	mode := storagev1.VolumeBindingImmediate
+	return &storagev1.StorageClass{
+		ObjectMeta:        metav1.ObjectMeta{Name: name},
+		Parameters:        map[string]string{scParamStoragePolicyID: storagePolicyID},
+		VolumeBindingMode: &mode,
+	}
+}
+
+func newWFFCSC(name, storagePolicyID string) *storagev1.StorageClass {
+	mode := storagev1.VolumeBindingWaitForFirstConsumer
+	return &storagev1.StorageClass{
+		ObjectMeta:        metav1.ObjectMeta{Name: name},
+		Parameters:        map[string]string{scParamStoragePolicyID: storagePolicyID},
+		VolumeBindingMode: &mode,
+	}
+}
+
+// storagePolicyQuotaFor builds the StoragePolicyQuota CR that isStoragePolicyAssignedToNamespace's
+// stretched-supervisor path reads to determine whether a StorageClass is assigned to a namespace.
+// ResourceQuota-based tracking was removed in 8.0.3 -- Supervisor now always uses StoragePolicyQuota
+// CRs, so isPodVMOnStretchedSupervisorEnabled is effectively always true in practice, and these
+// tests model that rather than the legacy ResourceQuota path.
+func storagePolicyQuotaFor(namespace, policyID string,
+	scNames ...string) *cnsstoragepolicyquotasv1alpha3.StoragePolicyQuota {
+	statuses := make([]cnsstoragepolicyquotasv1alpha3.SCLevelQuotaStatus, 0, len(scNames))
+	for _, scName := range scNames {
+		statuses = append(statuses, cnsstoragepolicyquotasv1alpha3.SCLevelQuotaStatus{StorageClassName: scName})
+	}
+	return &cnsstoragepolicyquotasv1alpha3.StoragePolicyQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: policyID + "-storagepolicyquota", Namespace: namespace},
+		Spec:       cnsstoragepolicyquotasv1alpha3.StoragePolicyQuotaSpec{StoragePolicyId: policyID},
+		Status:     cnsstoragepolicyquotasv1alpha3.StoragePolicyQuotaStatus{SCLevelQuotaStatuses: statuses},
+	}
+}
+
+// newFakeCtrlClient builds a controller-runtime fake client with the StoragePolicyQuota CRD
+// registered and the given objects preloaded.
+func newFakeCtrlClient(objs ...ctrlruntimeclient.Object) ctrlruntimeclient.Client {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = cnsstoragepolicyquotasv1alpha3.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+// TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_SingleMatch verifies the common,
+// unambiguous case still resolves correctly: exactly one Immediate-mode StorageClass for the
+// policy, assigned to the namespace.
+func TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_SingleMatch(t *testing.T) {
+	const policyID = "policy-1"
+	const namespace = "test-ns"
+
+	sc := newImmediateSC("sc-a", policyID)
+	k8sclient := k8sfake.NewClientset(sc)
+	ctrlClient := newFakeCtrlClient(storagePolicyQuotaFor(namespace, policyID, "sc-a"))
+
+	scName, err := getK8sStorageClassNameWithImmediateBindingModeForPolicy(context.TODO(), k8sclient, ctrlClient,
+		policyID, namespace, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "sc-a", scName)
+}
+
+// TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_IgnoresWFFCCompanion verifies that a
+// WaitForFirstConsumer StorageClass sharing the same policy ID (e.g. the "-latebinding" companion
+// wcpsvc creates alongside every Immediate StorageClass) does not count as an extra candidate.
+func TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_IgnoresWFFCCompanion(t *testing.T) {
+	const policyID = "policy-1"
+	const namespace = "test-ns"
+
+	sc := newImmediateSC("sc-a", policyID)
+	wffc := newWFFCSC("sc-a-latebinding", policyID)
+	k8sclient := k8sfake.NewClientset(sc, wffc)
+	ctrlClient := newFakeCtrlClient(storagePolicyQuotaFor(namespace, policyID, "sc-a", "sc-a-latebinding"))
+
+	scName, err := getK8sStorageClassNameWithImmediateBindingModeForPolicy(context.TODO(), k8sclient, ctrlClient,
+		policyID, namespace, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "sc-a", scName)
+}
+
+// TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_Ambiguous is the regression test for
+// the sgc1-raid-1 / sgc1-raid-1-mirroring-0 incident: two Immediate-mode StorageClasses share the
+// same storagePolicyID (e.g. because the underlying storage policy was renamed and a new
+// StorageClass was created under the new name without cleaning up the old one), and both are
+// assigned to the namespace. This function only reaches this fallback when the caller had no
+// stated preference (see resolveStorageClassNameForRegistration), so it must not fail the
+// registration outright -- it picks deterministically (lexicographically smallest) rather than
+// depending on StorageClass list iteration order.
+func TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_Ambiguous(t *testing.T) {
+	const policyID = "policy-1"
+	const namespace = "test-ns"
+
+	scA := newImmediateSC("sgc1-raid-1", policyID)
+	scB := newImmediateSC("sgc1-raid-1-mirroring-0", policyID)
+	k8sclient := k8sfake.NewClientset(scA, scB)
+	ctrlClient := newFakeCtrlClient(storagePolicyQuotaFor(namespace, policyID, "sgc1-raid-1", "sgc1-raid-1-mirroring-0"))
+
+	scName, err := getK8sStorageClassNameWithImmediateBindingModeForPolicy(context.TODO(), k8sclient, ctrlClient,
+		policyID, namespace, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "sgc1-raid-1", scName)
+}
+
+// TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_NotAssigned verifies that a matching
+// StorageClass which is not assigned to the namespace is treated as not found, not as a match.
+func TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_NotAssigned(t *testing.T) {
+	const policyID = "policy-1"
+	const namespace = "test-ns"
+
+	sc := newImmediateSC("sc-a", policyID)
+	k8sclient := k8sfake.NewClientset(sc)
+	// No StoragePolicyQuota CR naming "sc-a" in the namespace, i.e. not assigned.
+	ctrlClient := newFakeCtrlClient()
+
+	scName, err := getK8sStorageClassNameWithImmediateBindingModeForPolicy(context.TODO(), k8sclient, ctrlClient,
+		policyID, namespace, true)
+	assert.Error(t, err)
+	assert.Empty(t, scName)
+}
+
+// TestResolveStorageClassNameForRegistration_ExplicitInstanceSpec verifies that
+// instance.Spec.StorageClassName, when set, is always trusted directly without touching the PVC or
+// re-deriving anything from the volume's storage policy.
+func TestResolveStorageClassNameForRegistration_ExplicitInstanceSpec(t *testing.T) {
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{StorageClassName: "explicit-sc"},
+	}
+	k8sclient := k8sfake.NewClientset()
+
+	scName, err := resolveStorageClassNameForRegistration(context.TODO(), k8sclient, nil, instance,
+		nil /* pvc */, "policy-1", "test-ns", true)
+	assert.NoError(t, err)
+	assert.Equal(t, "explicit-sc", scName)
+}
+
+// TestResolveStorageClassNameForRegistration_TrustsPVCOverAmbiguousDerivation is the core
+// regression test for the CnsRegisterVolume registration failure: with two Immediate-mode
+// StorageClasses sharing the same storagePolicyID (sgc1-raid-1 and sgc1-raid-1-mirroring-0), the
+// PVC's own declared StorageClass must be used, instead of falling into the ambiguous
+// policy-ID-based derivation that previously picked the wrong one.
+func TestResolveStorageClassNameForRegistration_TrustsPVCOverAmbiguousDerivation(t *testing.T) {
+	const policyID = "b306fd38-6c56-489a-bd65-83e8abd1022a"
+	const namespace = "ns-virtualisering-m3ctn"
+
+	scA := newImmediateSC("sgc1-raid-1", policyID)
+	scB := newImmediateSC("sgc1-raid-1-mirroring-0", policyID)
+	k8sclient := k8sfake.NewClientset(scA, scB)
+	ctrlClient := newFakeCtrlClient(storagePolicyQuotaFor(namespace, policyID, "sgc1-raid-1", "sgc1-raid-1-mirroring-0"))
+
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{PvcName: "esx1-2e3b3b47"},
+	}
+	scNameOnPVC := "sgc1-raid-1"
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "esx1-2e3b3b47", Namespace: namespace},
+		Spec:       v1.PersistentVolumeClaimSpec{StorageClassName: &scNameOnPVC},
+	}
+
+	scName, err := resolveStorageClassNameForRegistration(context.TODO(), k8sclient, ctrlClient, instance, pvc,
+		policyID, namespace, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "sgc1-raid-1", scName)
+}
+
+// TestResolveStorageClassNameForRegistration_PVCStorageClassPolicyMismatch verifies that if the
+// PVC's declared StorageClass maps to a different storage policy than the volume actually has,
+// resolution fails with a clear error rather than silently using either name.
+func TestResolveStorageClassNameForRegistration_PVCStorageClassPolicyMismatch(t *testing.T) {
+	const namespace = "test-ns"
+
+	sc := newImmediateSC("sc-a", "policy-1")
+	k8sclient := k8sfake.NewClientset(sc)
+	ctrlClient := newFakeCtrlClient(storagePolicyQuotaFor(namespace, "policy-1", "sc-a"))
+
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{PvcName: "pvc-a"},
+	}
+	scNameOnPVC := "sc-a"
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-a", Namespace: namespace},
+		Spec:       v1.PersistentVolumeClaimSpec{StorageClassName: &scNameOnPVC},
+	}
+
+	// Volume's actual policy ("policy-2") differs from what "sc-a" maps to ("policy-1").
+	scName, err := resolveStorageClassNameForRegistration(context.TODO(), k8sclient, ctrlClient, instance, pvc,
+		"policy-2", namespace, true)
+	assert.Error(t, err)
+	assert.Empty(t, scName)
+	assert.Contains(t, err.Error(), "but volume maps to")
+}
+
+// TestResolveStorageClassNameForRegistration_PVCStorageClassNotAssigned verifies that a PVC
+// referencing a StorageClass whose policy is not assigned to the namespace is rejected, rather
+// than trusted blindly.
+func TestResolveStorageClassNameForRegistration_PVCStorageClassNotAssigned(t *testing.T) {
+	const policyID = "policy-1"
+	const namespace = "test-ns"
+
+	sc := newImmediateSC("sc-a", policyID)
+	k8sclient := k8sfake.NewClientset(sc)
+	// No StoragePolicyQuota CR naming "sc-a" in the namespace, i.e. not assigned.
+	ctrlClient := newFakeCtrlClient()
+
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{PvcName: "pvc-a"},
+	}
+	scNameOnPVC := "sc-a"
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-a", Namespace: namespace},
+		Spec:       v1.PersistentVolumeClaimSpec{StorageClassName: &scNameOnPVC},
+	}
+
+	scName, err := resolveStorageClassNameForRegistration(context.TODO(), k8sclient, ctrlClient, instance, pvc,
+		policyID, namespace, true)
+	assert.Error(t, err)
+	assert.Empty(t, scName)
+	assert.Contains(t, err.Error(), "not assigned to namespace")
+}
+
+// TestResolveStorageClassNameForRegistration_FallsBackWhenNoPVC verifies that when there's no
+// existing PVC yet (fresh registration) and no explicit instance.Spec.StorageClassName, resolution
+// falls back to deriving the name from the volume's storage policy ID, as before.
+func TestResolveStorageClassNameForRegistration_FallsBackWhenNoPVC(t *testing.T) {
+	const policyID = "policy-1"
+	const namespace = "test-ns"
+
+	sc := newImmediateSC("sc-a", policyID)
+	k8sclient := k8sfake.NewClientset(sc)
+	ctrlClient := newFakeCtrlClient(storagePolicyQuotaFor(namespace, policyID, "sc-a"))
+
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{PvcName: "pvc-a"},
+	}
+
+	scName, err := resolveStorageClassNameForRegistration(context.TODO(), k8sclient, ctrlClient, instance,
+		nil /* pvc */, policyID, namespace, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "sc-a", scName)
+}
+
+// TestResolveStorageClassNameForRegistration_FallsBackWhenNoPVC_Ambiguous verifies that, with no
+// PVC and no explicit instance.Spec.StorageClassName to disambiguate with, the fallback path
+// resolves deterministically to one of the StorageClasses sharing the policy ID rather than
+// failing the registration.
+func TestResolveStorageClassNameForRegistration_FallsBackWhenNoPVC_Ambiguous(t *testing.T) {
+	const policyID = "b306fd38-6c56-489a-bd65-83e8abd1022a"
+	const namespace = "test-ns"
+
+	scA := newImmediateSC("sgc1-raid-1", policyID)
+	scB := newImmediateSC("sgc1-raid-1-mirroring-0", policyID)
+	k8sclient := k8sfake.NewClientset(scA, scB)
+	ctrlClient := newFakeCtrlClient(storagePolicyQuotaFor(namespace, policyID, "sgc1-raid-1", "sgc1-raid-1-mirroring-0"))
+
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{PvcName: "pvc-a"},
+	}
+
+	scName, err := resolveStorageClassNameForRegistration(context.TODO(), k8sclient, ctrlClient, instance,
+		nil /* pvc */, policyID, namespace, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "sgc1-raid-1", scName)
+}
+
+// TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_AmbiguousIsOrderIndependent verifies
+// that the deterministic pick doesn't depend on the order StorageClasses happen to be created in
+// or returned by the API server -- it must resolve to the same name regardless of which duplicate
+// was created first.
+func TestGetK8sStorageClassNameWithImmediateBindingModeForPolicy_AmbiguousIsOrderIndependent(t *testing.T) {
+	const policyID = "policy-1"
+	const namespace = "test-ns"
+
+	// "zzz-later" was created after "aaa-first" but sorts after it lexicographically either way;
+	// what matters is the object creation/list order below doesn't influence the outcome.
+	scLater := newImmediateSC("zzz-later", policyID)
+	scFirst := newImmediateSC("aaa-first", policyID)
+	k8sclient := k8sfake.NewClientset(scLater, scFirst)
+	ctrlClient := newFakeCtrlClient(storagePolicyQuotaFor(namespace, policyID, "zzz-later", "aaa-first"))
+
+	scName, err := getK8sStorageClassNameWithImmediateBindingModeForPolicy(context.TODO(), k8sclient, ctrlClient,
+		policyID, namespace, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "aaa-first", scName)
+}
+
+// TestGetStoragePolicyIDForStorageClass_RejectsWaitForFirstConsumer verifies that a
+// WaitForFirstConsumer StorageClass (e.g. a "-latebinding" companion) is rejected: that binding
+// mode exists to delay dynamic provisioning until a consuming pod is scheduled, which has no
+// meaning for CnsRegisterVolume's static registration of an already-provisioned volume.
+func TestGetStoragePolicyIDForStorageClass_RejectsWaitForFirstConsumer(t *testing.T) {
+	wffc := newWFFCSC("sc-a-latebinding", "policy-1")
+	k8sclient := k8sfake.NewClientset(wffc)
+
+	policyID, err := getStoragePolicyIDForStorageClass(context.TODO(), k8sclient, "sc-a-latebinding")
+	assert.Error(t, err)
+	assert.Empty(t, policyID)
+	assert.Contains(t, err.Error(), "WaitForFirstConsumer")
+}
+
+// TestGetStoragePolicyIDForStorageClass_AcceptsImmediate verifies the common, unaffected case.
+func TestGetStoragePolicyIDForStorageClass_AcceptsImmediate(t *testing.T) {
+	sc := newImmediateSC("sc-a", "policy-1")
+	k8sclient := k8sfake.NewClientset(sc)
+
+	policyID, err := getStoragePolicyIDForStorageClass(context.TODO(), k8sclient, "sc-a")
+	assert.NoError(t, err)
+	assert.Equal(t, "policy-1", policyID)
+}
+
+// TestResolveStorageClassNameForRegistration_PVCStorageClassIsWaitForFirstConsumer verifies that a
+// PVC declaring a WaitForFirstConsumer StorageClass is rejected by the PVC-trust tier, rather than
+// being trusted blindly the way a plain policy-ID/namespace-assignment mismatch would be.
+func TestResolveStorageClassNameForRegistration_PVCStorageClassIsWaitForFirstConsumer(t *testing.T) {
+	const policyID = "policy-1"
+	const namespace = "test-ns"
+
+	wffc := newWFFCSC("sc-a-latebinding", policyID)
+	k8sclient := k8sfake.NewClientset(wffc)
+	ctrlClient := newFakeCtrlClient(storagePolicyQuotaFor(namespace, policyID, "sc-a-latebinding"))
+
+	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{
+		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{PvcName: "pvc-a"},
+	}
+	scNameOnPVC := "sc-a-latebinding"
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-a", Namespace: namespace},
+		Spec:       v1.PersistentVolumeClaimSpec{StorageClassName: &scNameOnPVC},
+	}
+
+	scName, err := resolveStorageClassNameForRegistration(context.TODO(), k8sclient, ctrlClient, instance, pvc,
+		policyID, namespace, true)
+	assert.Error(t, err)
+	assert.Empty(t, scName)
+	assert.Contains(t, err.Error(), "WaitForFirstConsumer")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

`CnsRegisterVolume` can pick the wrong `StorageClass` when registering an existing volume whose `storagePolicyID` matches more than one `StorageClass` in the cluster (e.g. after a storage policy rename leaves an old and a new `StorageClass` both pointing at the same policy ID — see the `sgc1-raid-1` / `sgc1-raid-1-mirroring-0` incident). `getK8sStorageClassNameWithImmediateBindingModeForPolicy` had no `break` in its `StorageClass` scan, so it silently returned whichever matching `StorageClass` happened to be iterated last instead of the one the caller actually intended. This caused disk registration to fail with:

PVC <name> has storage class <X>, but volume maps to storage class <Y>


even though the PVC's declared `StorageClass` was correct and valid for the namespace.

This PR:
- Makes `getK8sStorageClassNameWithImmediateBindingModeForPolicy` detect ambiguity instead of guessing: it now collects every Immediate-binding `StorageClass` matching the policy ID, narrows to the ones assigned to the namespace, and returns a clear error if more than one remains.
- Adds `resolveStorageClassNameForRegistration`, which resolves the `StorageClass` to use in order of preference: (1) `instance.Spec.StorageClassName` if set, (2) the existing PVC's own declared `StorageClass` (validated against the volume's actual storage policy and namespace assignment), (3) fallback to the policy-ID-based derivation above. This means a PVC's own `StorageClassName` is trusted over an independently re-derived one, which is what actually eliminates the ambiguity in practice.
- Reorders `Reconcile` to fetch the PVC before resolving the `StorageClass` name, so the new hierarchy can use it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Added unit tests in `util_test.go` covering:
- The ambiguity fix in `getK8sStorageClassNameWithImmediateBindingModeForPolicy` (single match, WFFC companion ignored, multiple-match error, not-assigned error).
- All three tiers of `resolveStorageClassNameForRegistration`, including a regression test reproducing the exact `sgc1-raid-1` / `sgc1-raid-1-mirroring-0` scenario, and the PVC-storage-class-mismatch / not-assigned-to-namespace error paths.

`go build`, `go vet`, and the full existing test suite for `pkg/syncer/cnsoperator/controller/cnsregistervolume/...` pass (46/46 Ginkgo specs + all Go tests).

Precheckins(WCP)(Success): https://jenkins-vcf-csifvt.devops.broadcom.net/job/wcp-instapp-e2e-pre-checkin/1997/
Precheckins(VKS)(Success): https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1567/


**Special notes for your reviewer**:
One pre-existing Ginkgo spec (`DiskURLPath + PVC topology validation failure`) needed its fixture updated to give its `StorageClass`/`StoragePolicyQuota` a real, consistent `storagePolicyID` — it had been implicitly relying on the old code's unconditional derivation-function mock and never actually validated the PVC-to-policy mapping.

**Release note**:
```release-note
Fix CnsRegisterVolume selecting the wrong StorageClass when a storage policy maps to more than one StorageClass; the PVC's own declared StorageClass is now trusted and validated instead of being re-derived ambiguously from the policy ID.

