### PR TITLE
Wrap getMissingPVVolumeUpdateSpecs within the improved volume visibility FSS

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -520,17 +520,24 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc c
 	// Instead we label them with `pv_missing=true` on their existing PV-type
 	// CnsKubernetesEntityMetadata, after a two-cycle grace period to absorb
 	// transient races between PV deletion and full-sync execution.
-	missingPVUpdateSpecs, missingPVCount, err := getMissingPVVolumeUpdateSpecs(ctx, volumesWithMetadata,
-		k8sPVMap, metadataSyncer, migrationFeatureStateForFullSync, containerCluster, vc)
-	if err != nil {
-		log.Errorf("FullSync for VC %s: failed to compute pv_missing update specs with err %+v", vc, err)
-		return err
-	}
-	prometheus.CnsVolumePVMissingGaugeVec.WithLabelValues(vc.String()).Set(float64(missingPVCount))
-	if len(missingPVUpdateSpecs) > 0 {
-		log.Infof("FullSync for VC %s: applying pv_missing label to %d volume(s)",
-			vc, len(missingPVUpdateSpecs))
-		updateSpecArray = append(updateSpecArray, missingPVUpdateSpecs...)
+	//
+	// Gated behind ImprovedVolumeVisibility: this labeling is part of the CNS
+	// Health orphan-volume-visibility feature and must stay dark until the
+	// FSS is enabled, same as the other ImprovedVolumeVisibility-gated
+	// behaviors in this file.
+	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeVisibility) {
+		missingPVUpdateSpecs, missingPVCount, err := getMissingPVVolumeUpdateSpecs(ctx, volumesWithMetadata,
+			k8sPVMap, metadataSyncer, migrationFeatureStateForFullSync, containerCluster, vc)
+		if err != nil {
+			log.Errorf("FullSync for VC %s: failed to compute pv_missing update specs with err %+v", vc, err)
+			return err
+		}
+		prometheus.CnsVolumePVMissingGaugeVec.WithLabelValues(vc.String()).Set(float64(missingPVCount))
+		if len(missingPVUpdateSpecs) > 0 {
+			log.Infof("FullSync for VC %s: applying pv_missing label to %d volume(s)",
+				vc, len(missingPVUpdateSpecs))
+			updateSpecArray = append(updateSpecArray, missingPVUpdateSpecs...)
+		}
 	}
 
 	// On Supervisor clusters, label CNS volumes whose Kubernetes PV has

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -663,6 +663,23 @@ func runTestFullSyncWorkflows(t *testing.T) {
 	// Per the cns-health-initiative design, fullsync no longer unregisters
 	// such volumes; instead it labels them with pv_missing=true on their
 	// PV-type CnsKubernetesEntityMetadata after a two-cycle grace period.
+	// This labeling is gated behind ImprovedVolumeVisibility, so enable it
+	// for this scenario and restore the prior state afterward.
+	fssSetter, ok := metadataSyncer.coCommonInterface.(interface {
+		EnableFSS(context.Context, string) error
+		DisableFSS(context.Context, string) error
+	})
+	if !ok {
+		t.Fatalf("coCommonInterface does not support EnableFSS/DisableFSS")
+	}
+	if err := fssSetter.EnableFSS(ctx, common.ImprovedVolumeVisibility); err != nil {
+		t.Fatalf("failed to enable %s FSS: %v", common.ImprovedVolumeVisibility, err)
+	}
+	defer func() {
+		if err := fssSetter.DisableFSS(ctx, common.ImprovedVolumeVisibility); err != nil {
+			t.Errorf("failed to disable %s FSS: %v", common.ImprovedVolumeVisibility, err)
+		}
+	}()
 	waitForListerSync()
 	err = CsiFullSync(ctx, metadataSyncer, csiConfig.Global.VCenterIP)
 	if err != nil {


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Gates getMissingPVVolumeUpdateSpecs method within the improved volume visibility FSS since we need the orphan detection logic to be within this CSI FSS.


**Testing done**:
WCP Pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/wcp-instapp-e2e-pre-checkin/2003/
VKS Pipeline: https://jenkins-vcf-csifvt.devops.broadcom.net/job/vks-instapp-e2e-pre-checkin/1586/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Wrap getMissingPVVolumeUpdateSpecs within the improved volume visibility FSS
```
