### PR TITLE
Pin staticcheck to v0.8.1 to fix Go 1.26 build failure

### DIFF
--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -25,7 +25,7 @@ go version
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-go install honnef.co/go/tools/cmd/staticcheck@latest
+go install honnef.co/go/tools/cmd/staticcheck@v0.8.1
 
 GOOS=linux "$(go env GOPATH)"/bin/staticcheck --version
 


### PR DESCRIPTION
go install .../staticcheck@latest resolved to an old cached tag (v0.5.1) in CI, whose transitive golang.org/x/tools dependency fails to compile under Go 1.26's stricter constant-overflow checking (invalid array length -delta * delta in internal/tokeninternal). Pinning to v0.8.1 keeps a deterministic, known-good version that still supports the newer Go export data format needed since #4289.

Testing Done: Precheck passed
https://jenkins-vcf-csifvt.devops.broadcom.net/view/instapp/job/vks-instapp-e2e-pre-checkin/1580/